### PR TITLE
fix(ci): upgrade Go version from 1.21 to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         if: matrix.setup == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
           cache-dependency-path: core/tenant/go.sum
 
       - name: Setup Python
@@ -249,7 +249,7 @@ jobs:
         if: matrix.setup == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
           cache-dependency-path: core/tenant/go.sum
 
       - name: Setup Python


### PR DESCRIPTION
- Update CI workflow to use Go 1.23 to match project go.mod
- This resolves golangci-lint scanning dependency code instead of project code
- Version mismatch was causing type checking errors in toolchain
- Now CI environment matches development environment
