### PR TITLE
fix(ci): correct golangci-lint command in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
               echo "🔍 Running go vet..."
               go vet ./...
               echo "📋 Running golangci-lint..."
-              golangci-lint run --timeout=5m
+              golangci-lint run ./... --timeout=5m
               ;;
             python)
               echo "🛠️ Installing Python quality tools..."


### PR DESCRIPTION
- Add './...' pattern to ensure proper module scanning
- This fixes the linting step in CI for Go projects