### PR TITLE
fix(ci): upgrade golangci-lint to v2.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
             go)
               echo "🔍 Running Go quality checks..."
               echo "🛠️ Installing golangci-lint..."
-              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.0
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
               export PATH=$PATH:$(go env GOPATH)/bin
               echo "✨ Checking go fmt compliance..."
               UNFORMATTED=$(gofmt -l .) && \


### PR DESCRIPTION
- Update golangci-lint from v1.57.0 to v2.5.0
- This version better supports Go 1.23 language features
- Should resolve type checking issues with new Go syntax
