### PR TITLE
refactor: standardize environment variable naming conventions

### DIFF
--- a/core/agent/api/app.py
+++ b/core/agent/api/app.py
@@ -57,11 +57,11 @@ if __name__ == "__main__":
 
     uvicorn_server = uvicorn.Server(
         uvicorn.Config(
-            app=agent_config.uvicorn_app,
-            host=agent_config.uvicorn_host,
-            port=agent_config.uvicorn_port,
-            workers=agent_config.uvicorn_workers,
-            reload=agent_config.uvicorn_reload,
+            app=agent_config.UVICORN_APP,
+            host=agent_config.UVICORN_HOST,
+            port=agent_config.UVICORN_PORT,
+            workers=agent_config.UVICORN_WORKERS,
+            reload=agent_config.UVICORN_RELOAD,
             ws_ping_interval=None,
             ws_ping_timeout=None,
         )

--- a/core/agent/api/v1/base_api.py
+++ b/core/agent/api/v1/base_api.py
@@ -108,7 +108,7 @@ class CompletionBase(BaseModel, ABC):
         yield await self.create_chunk(stop_chunk)
         yield await self.create_done()
 
-        if agent_config.upload_metrics:
+        if agent_config.UPLOAD_METRICS:
             context.meter.in_error_count(context.error.c)
             # context.meter.in_error_count(
             #     context.error.c, lables={"msg": context.error.m}
@@ -118,7 +118,7 @@ class CompletionBase(BaseModel, ABC):
         context.span.add_info_events({"message": context.error.m})
 
         context.node_trace.record_end()
-        if agent_config.upload_node_trace:
+        if agent_config.UPLOAD_NODE_TRACE:
             node_trace_log = context.node_trace.upload(
                 status=TraceStatus(code=context.error.c, message=context.error.m),
                 log_caller=self.log_caller,

--- a/core/agent/config.env.example
+++ b/core/agent/config.env.example
@@ -6,82 +6,85 @@
 PYTHONUNBUFFERED=1
 
 # Runtime Environment Configuration
-run_environ=dev
-use_polaris=false
+RUN_ENVIRON=dev
+USE_POLARIS=false
 
 ## xingchen-utils
-service_name=Agent
-
-# When use_polaris is false, the following configurations take effect
-
-# Metrics Configuration
-metric_endpoint=YOUR_METRIC_ENDPOINT:4317
-metric_timeout=3000
-metric_export_interval_millis=3000
-metric_export_timeout_millis=3000
-
-# Service Identification
-sid_sub=sag
-sid_location=hf
-sid_local_port=17870
-
-# Tracing Configuration
-trace_endpoint=YOUR_TRACE_ENDPOINT:4317
-trace_timeout=3000
-trace_max_queue_size=2048
-trace_schedule_delay_millis=3000
-trace_max_export_batch_size=2048
-trace_export_timeout_millis=3000
-
-# Kafka Configuration for Node Tracing
-node_trace_kafka_servers=YOUR_KAFKA_SERVERS
-node_trace_kafka_timeout=10
-node_trace_kafka_topic=spark-agent-builder
+SERVICE_NAME=Agent
 
 # Uvicorn Configuration
-uvicorn_app=app:app
-uvicorn_host=0.0.0.0
-uvicorn_port=17870
-uvicorn_workers=1
-uvicorn_reload=false
-uvicorn_ws_ping_interval=false
-uvicorn_ws_ping_timeout=false
+UVICORN_APP=app:app
+UVICORN_HOST=0.0.0.0
+UVICORN_PORT=17870
+UVICORN_WORKERS=1
+UVICORN_RELOAD=false
+UVICORN_WS_PING_INTERVAL=false
+UVICORN_WS_PING_TIMEOUT=false
+
+# When USE_POLARIS is false, the following configurations take effect
 
 # Redis Configuration
-redis_nodes=YOUR_REDIS_NODES
-redis_password=YOUR_REDIS_PASSWORD
-is_cluster=true
+REDIS_NODES=YOUR_REDIS_NODES
+REDIS_PASSWORD=YOUR_REDIS_PASSWORD
+IS_CLUSTER=true
 
 # MySQL Configuration
-mysql_host=YOUR_MYSQL_HOST
-mysql_port=YOUR_MYSQL_PORT
-mysql_user=YOUR_MYSQL_USER
-mysql_password=YOUR_MYSQL_PASSWORD
-mysql_db=YOUR_DATABASE_NAME
+MYSQL_HOST=YOUR_MYSQL_HOST
+MYSQL_PORT=YOUR_MYSQL_PORT
+MYSQL_USER=YOUR_MYSQL_USER
+MYSQL_PASSWORD=YOUR_MYSQL_PASSWORD
+MYSQL_DB=YOUR_DATABASE_NAME
 
-# Link Service URLs
-get_link_url=http://YOUR_LINK_HOST:18888/api/v1/tools
-versions_link_url=http://YOUR_LINK_HOST:18888/api/v1/tools/versions
-run_link_url=http://YOUR_LINK_HOST:18888/api/v1/tools/http_run
+# Metrics Configuration
+METRIC_ENDPOINT=YOUR_METRIC_ENDPOINT:4317
+METRIC_TIMEOUT=3000
+METRIC_EXPORT_INTERVAL_MILLIS=3000
+METRIC_EXPORT_TIMEOUT_MILLIS=3000
 
-# Workflow Service URLs
-get_workflows_url=http://YOUR_WORKFLOW_HOST:7880/sparkflow/v1/protocol/get
-workflow_sse_base_url=http://YOUR_WORKFLOW_HOST:7880/workflow/v1
-
-# Knowledge Service URLs
-chunk_query_url=http://YOUR_KNOWLEDGE_HOST:10007/knowledge/v1/chunk/query
-
-# MCP Plugin URLs
-list_mcp_plugin_url=http://YOUR_MCP_HOST:18888/api/v1/mcp/tool_list
-run_mcp_plugin_url=http://YOUR_MCP_HOST:18888/api/v1/mcp/call_tool
-
-# App Authentication Configuration
-app_auth_host=YOUR_APP_AUTH_HOST
-app_auth_router=/api-services/v2/app/details
-app_auth_prot=http
-app_auth_api_key=YOUR_APP_AUTH_API_KEY
-app_auth_secret=YOUR_APP_AUTH_SECRET
+# Service Identification
+SID_SUB=sag
+SID_LOCATION=hf
+SID_LOCAL_PORT=17870
+SERVICE_SUB=sag
+SERVICE_LOCATION=hf
+SERVICE_PORT=17870
 
 # ELK Upload Configuration
-upload_node_trace=true
-upload_metrics=true
+UPLOAD_NODE_TRACE=true
+UPLOAD_METRICS=true
+
+# Tracing Configuration
+TRACE_ENDPOINT=YOUR_TRACE_ENDPOINT:4317
+TRACE_TIMEOUT=3000
+TRACE_MAX_QUEUE_SIZE=2048
+TRACE_SCHEDULE_DELAY_MILLIS=3000
+TRACE_MAX_EXPORT_BATCH_SIZE=2048
+TRACE_EXPORT_TIMEOUT_MILLIS=3000
+
+# Kafka Configuration for Node Tracing
+NODE_TRACE_KAFKA_SERVERS=YOUR_KAFKA_SERVERS
+NODE_TRACE_KAFKA_TIMEOUT=10
+NODE_TRACE_KAFKA_TOPIC=spark-agent-builder
+
+# Link Service URLs
+GET_LINK_URL=http://YOUR_LINK_HOST:18888/api/v1/tools
+VERSIONS_LINK_URL=http://YOUR_LINK_HOST:18888/api/v1/tools/versions
+RUN_LINK_URL=http://YOUR_LINK_HOST:18888/api/v1/tools/http_run
+
+# Workflow Service URLs
+GET_WORKFLOWS_URL=http://YOUR_WORKFLOW_HOST:7880/sparkflow/v1/protocol/get
+WORKFLOW_SSE_BASE_URL=http://YOUR_WORKFLOW_HOST:7880/workflow/v1
+
+# Knowledge Service URLs
+CHUNK_QUERY_URL=http://YOUR_KNOWLEDGE_HOST:10007/knowledge/v1/chunk/query
+
+# MCP Plugin URLs
+LIST_MCP_PLUGIN_URL=http://YOUR_MCP_HOST:18888/api/v1/mcp/tool_list
+RUN_MCP_PLUGIN_URL=http://YOUR_MCP_HOST:18888/api/v1/mcp/call_tool
+
+# App Authentication Configuration
+APP_AUTH_HOST=YOUR_APP_AUTH_HOST
+APP_AUTH_ROUTER=/api-services/v2/app/details
+APP_AUTH_PROT=http
+APP_AUTH_API_KEY=YOUR_APP_AUTH_API_KEY
+APP_AUTH_SECRET=YOUR_APP_AUTH_SECRET

--- a/core/agent/infra/app_auth.py
+++ b/core/agent/infra/app_auth.py
@@ -71,11 +71,11 @@ class APPAuth:
 
     def __init__(self) -> None:
         self.config = AuthConfig(
-            host=agent_config.app_auth_host,
-            route=agent_config.app_auth_router,
-            prot=agent_config.app_auth_prot,
-            api_key=agent_config.app_auth_api_key,
-            secret=agent_config.app_auth_secret,
+            host=agent_config.APP_AUTH_HOST,
+            route=agent_config.APP_AUTH_ROUTER,
+            prot=agent_config.APP_AUTH_PROT,
+            api_key=agent_config.APP_AUTH_API_KEY,
+            secret=agent_config.APP_AUTH_SECRET,
         )
         # Set current time
         self.date = http_date(datetime.datetime.utcnow())

--- a/core/agent/infra/config/__init__.py
+++ b/core/agent/infra/config/__init__.py
@@ -48,8 +48,8 @@ class PolarisSettingsSourceFactory(PydanticBaseSettingsSource):
         Load remote configuration and override environment variables
         """
 
-        use_polaris = os.getenv("use_polaris") or self.dotenv_settings.get(
-            "use_polaris"
+        use_polaris = os.getenv("USE_POLARIS") or self.dotenv_settings.get(
+            "USE_POLARIS"
         )
 
         if use_polaris == "false":
@@ -70,8 +70,8 @@ class PolarisSettingsSourceFactory(PydanticBaseSettingsSource):
             or "hy-spark-agent-builder"
         )
         service_name = (
-            os.getenv("service_name")
-            or self.dotenv_settings.get("service_name")
+            os.getenv("SERVICE_NAME")
+            or self.dotenv_settings.get("SERVICE_NAME")
             or "spark-agent"
         )
         version = os.getenv("version") or self.dotenv_settings.get("version") or "1.0.0"
@@ -111,10 +111,10 @@ class PolarisSettingsSourceFactory(PydanticBaseSettingsSource):
 
 
 class EnvConfig(BaseSettings):
-    run_environ: str = Field(default=DevelopmentEnv)
+    RUN_ENVIRON: str = Field(default=DevelopmentEnv)
 
     def is_dev(self) -> bool:
-        return bool(self.run_environ != ProductionEnv)
+        return bool(self.RUN_ENVIRON != ProductionEnv)
 
 
 class AgentConfig(  # pylint: disable=too-many-ancestors
@@ -125,7 +125,7 @@ class AgentConfig(  # pylint: disable=too-many-ancestors
 ):
     """Agent configuration combining all necessary settings."""
 
-    service_name: str = Field(description="Service name", default="Agent")
+    SERVICE_NAME: str = Field(description="Service name", default="Agent")
 
     model_config = SettingsConfigDict(
         env_file="env/.env", env_file_encoding="utf-8", extra="ignore"
@@ -156,7 +156,7 @@ agent_config = AgentConfig()
 
 if __name__ == "__main__":
     agent_config = AgentConfig()
-    print(agent_config.service_name)
-    print(agent_config.run_environ)
-    print(agent_config.metric_endpoint)
-    print(type(agent_config.metric_timeout))
+    print(agent_config.SERVICE_NAME)
+    print(agent_config.RUN_ENVIRON)
+    print(agent_config.METRIC_ENDPOINT)
+    print(type(agent_config.METRIC_TIMEOUT))

--- a/core/agent/infra/config/fast_uvi.py
+++ b/core/agent/infra/config/fast_uvi.py
@@ -3,10 +3,10 @@ from pydantic_settings import BaseSettings
 
 
 class UvicornConfig(BaseSettings):
-    uvicorn_app: str = Field(default="api.app:app")
-    uvicorn_host: str = Field(default="0.0.0.0")
-    uvicorn_port: int = Field(default=17870)
-    uvicorn_workers: int = Field(default=1)
-    uvicorn_reload: bool = Field(default=False)
-    uvicorn_ws_ping_interval: bool = Field(default=False)
-    uvicorn_ws_ping_timeout: bool = Field(default=False)
+    UVICORN_APP: str = Field(default="api.app:app")
+    UVICORN_HOST: str = Field(default="0.0.0.0")
+    UVICORN_PORT: int = Field(default=17870)
+    UVICORN_WORKERS: int = Field(default=1)
+    UVICORN_RELOAD: bool = Field(default=False)
+    UVICORN_WS_PING_INTERVAL: bool = Field(default=False)
+    UVICORN_WS_PING_TIMEOUT: bool = Field(default=False)

--- a/core/agent/infra/config/middleware.py
+++ b/core/agent/infra/config/middleware.py
@@ -3,49 +3,49 @@ from pydantic_settings import BaseSettings
 
 
 class RedisClusterConfig(BaseSettings):
-    redis_nodes: str = Field(default="")
-    redis_password: str = Field(default="")
+    REDIS_NODES: str = Field(default="")
+    REDIS_PASSWORD: str = Field(default="")
 
 
 class MysqlClusterConfig(BaseSettings):
-    mysql_host: str = Field(default="")
-    mysql_port: str = Field(default="")
-    mysql_user: str = Field(default="")
-    mysql_password: str = Field(default="")
-    mysql_db: str = Field(default="")
+    MYSQL_HOST: str = Field(default="")
+    MYSQL_PORT: str = Field(default="")
+    MYSQL_USER: str = Field(default="")
+    MYSQL_PASSWORD: str = Field(default="")
+    MYSQL_DB: str = Field(default="")
 
 
 class LinkConfig(BaseSettings):
-    get_link_url: str = Field(default="")
-    versions_link_url: str = Field(default="")
-    run_link_url: str = Field(default="")
+    GET_LINK_URL: str = Field(default="")
+    VERSIONS_LINK_URL: str = Field(default="")
+    RUN_LINK_URL: str = Field(default="")
 
 
 class WorkflowConfig(BaseSettings):
-    get_workflows_url: str = Field(default="")
-    workflow_sse_base_url: str = Field(default="")
+    GET_WORKFLOWS_URL: str = Field(default="")
+    WORKFLOW_SSE_BASE_URL: str = Field(default="")
 
 
 class KnowledgeConfig(BaseSettings):
-    chunk_query_url: str = Field(default="")
+    CHUNK_QUERY_URL: str = Field(default="")
 
 
 class McpConfig(BaseSettings):
-    list_mcp_plugin_url: str = Field(default="")
-    run_mcp_plugin_url: str = Field(default="")
+    LIST_MCP_PLUGIN_URL: str = Field(default="")
+    RUN_MCP_PLUGIN_URL: str = Field(default="")
 
 
 class AppAuthConfig(BaseSettings):
-    app_auth_host: str = Field(default="")
-    app_auth_router: str = Field(default="")
-    app_auth_prot: str = Field(default="")
-    app_auth_api_key: str = Field(default="")
-    app_auth_secret: str = Field(default="")
+    APP_AUTH_HOST: str = Field(default="")
+    APP_AUTH_ROUTER: str = Field(default="")
+    APP_AUTH_PROT: str = Field(default="")
+    APP_AUTH_API_KEY: str = Field(default="")
+    APP_AUTH_SECRET: str = Field(default="")
 
 
 class ElkUploadConfig(BaseSettings):
-    upload_node_trace: bool = Field(default=False)
-    upload_metrics: bool = Field(default=False)
+    UPLOAD_NODE_TRACE: bool = Field(default=False)
+    UPLOAD_METRICS: bool = Field(default=False)
 
 
 class MiddlewareConfig(

--- a/core/agent/infra/config/xc_utils.py
+++ b/core/agent/infra/config/xc_utils.py
@@ -7,21 +7,26 @@ from common_imports import ip
 
 class XChenUtilsConfig(BaseSettings):
     # metrics
-    metric_endpoint: str = Field(default="127.0.0.1:4317")
-    metric_timeout: int = Field(default=3000)
-    metric_export_interval_millis: int = Field(default=3000)
-    metric_export_timeout_millis: int = Field(default=3000)
+    METRIC_ENDPOINT: str = Field(default="127.0.0.1:4317")
+    METRIC_TIMEOUT: int = Field(default=3000)
+    METRIC_EXPORT_INTERVAL_MILLIS: int = Field(default=3000)
+    METRIC_EXPORT_TIMEOUT_MILLIS: int = Field(default=3000)
 
     # sid
-    sid_sub: str = Field(default="sag")
-    sid_location: str = Field(default="dx")
-    sid_local_ip: str = Field(default=ip)
-    sid_local_port: str = Field(default="17870")
+    SID_SUB: str = Field(default="sag")
+    SID_LOCATION: str = Field(default="dx")
+    SID_LOCAL_IP: str = Field(default=ip)
+    SID_LOCAL_PORT: str = Field(default="17870")
 
     # trace
-    trace_endpoint: str = Field(default="127.0.0.1:4317")
-    trace_timeout: int = Field(default=3000)
-    trace_max_queue_size: int = Field(default=2048)
-    trace_schedule_delay_millis: int = Field(default=3000)
-    trace_max_export_batch_size: int = Field(default=500)
-    trace_export_timeout_millis: int = Field(default=3000)
+    TRACE_ENDPOINT: str = Field(default="127.0.0.1:4317")
+    TRACE_TIMEOUT: int = Field(default=3000)
+    TRACE_MAX_QUEUE_SIZE: int = Field(default=2048)
+    TRACE_SCHEDULE_DELAY_MILLIS: int = Field(default=3000)
+    TRACE_MAX_EXPORT_BATCH_SIZE: int = Field(default=500)
+    TRACE_EXPORT_TIMEOUT_MILLIS: int = Field(default=3000)
+
+    # kafka for node tracing
+    NODE_TRACE_KAFKA_SERVERS: str = Field(default="")
+    NODE_TRACE_KAFKA_TIMEOUT: int = Field(default=10)
+    NODE_TRACE_KAFKA_TOPIC: str = Field(default="spark-agent-builder")

--- a/core/agent/main.py
+++ b/core/agent/main.py
@@ -29,8 +29,14 @@ def load_env_file(env_file: str) -> None:
             # Parse environment variables
             if "=" in line:
                 key, value = line.split("=", 1)
-                os.environ[key.strip()] = value.strip()
-                print(f"  ✅ {key.strip()}={value.strip()}")
+                key = key.strip()
+                value = value.strip()
+
+                if key in os.environ:
+                    print(f"  🔄 {key}={os.environ[key]} (using existing env var)")
+                else:
+                    os.environ[key] = value
+                    print(f"  ✅ {key}={value} (loaded from config)")
             else:
                 print(f"  ⚠️  Line {line_num} format error: {line}")
 
@@ -58,8 +64,8 @@ def start_service() -> None:
         "polaris_cluster",
         "polaris_url",
         "polaris_username",
-        "run_environ",
-        "use_polaris",
+        "RUN_ENVIRON",
+        "USE_POLARIS",
     ]
 
     print("📋 Environment configuration:")

--- a/core/agent/repository/bot_config_client.py
+++ b/core/agent/repository/bot_config_client.py
@@ -28,15 +28,15 @@ class BotConfigClient(BaseModel):
 
     redis_client: RedisClusterClient = Field(
         default=RedisClusterClient(
-            nodes=agent_config.redis_nodes, password=agent_config.redis_password
+            nodes=agent_config.REDIS_NODES, password=agent_config.REDIS_PASSWORD
         )
     )
     mysql_client: MysqlClient = Field(
         default=MysqlClient(
             database_url=(
-                f"mysql+pymysql://{agent_config.mysql_user}:"
-                f"{agent_config.mysql_password}@{agent_config.mysql_host}:"
-                f"{agent_config.mysql_port}/{agent_config.mysql_db}?charset=utf8mb4"
+                f"mysql+pymysql://{agent_config.MYSQL_USER}:"
+                f"{agent_config.MYSQL_PASSWORD}@{agent_config.MYSQL_HOST}:"
+                f"{agent_config.MYSQL_PORT}/{agent_config.MYSQL_DB}?charset=utf8mb4"
             )
         )
     )

--- a/core/agent/service/plugin/knowledge.py
+++ b/core/agent/service/plugin/knowledge.py
@@ -58,7 +58,7 @@ class KnowledgePluginFactory(BaseModel):
                 async with aiohttp.ClientSession() as session:
                     timeout = aiohttp.ClientTimeout(total=40)
                     async with session.post(
-                        agent_config.chunk_query_url, json=data, timeout=timeout
+                        agent_config.CHUNK_QUERY_URL, json=data, timeout=timeout
                     ) as response:
 
                         sp.add_info_events(

--- a/core/agent/service/plugin/link.py
+++ b/core/agent/service/plugin/link.py
@@ -149,7 +149,7 @@ class LinkPluginRunner(BaseModel):
                 timeout = aiohttp.ClientTimeout(total=40)
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
-                        agent_config.run_link_url,
+                        agent_config.RUN_LINK_URL,
                         data=json.dumps(run_link_payload),
                         timeout=timeout,
                         headers={"Content-Type": "application/json"},
@@ -221,7 +221,7 @@ class LinkPluginFactory(BaseModel):
             if not self.tool_ids:
                 return []
 
-            url = agent_config.versions_link_url + "?" + f"app_id={self.app_id}"
+            url = agent_config.VERSIONS_LINK_URL + "?" + f"app_id={self.app_id}"
 
             for tool_id in self.tool_ids:
                 if isinstance(tool_id, str):

--- a/core/agent/service/plugin/mcp.py
+++ b/core/agent/service/plugin/mcp.py
@@ -42,7 +42,7 @@ class McpPluginRunner(BaseModel):
                 async with aiohttp.ClientSession() as session:
                     timeout = aiohttp.ClientTimeout(total=40)
                     async with session.post(
-                        agent_config.run_mcp_plugin_url,
+                        agent_config.RUN_MCP_PLUGIN_URL,
                         json=data,
                         headers={"Content-Type": "application/json"},
                         timeout=timeout,
@@ -132,7 +132,7 @@ class McpPluginFactory(BaseModel):
                 async with aiohttp.ClientSession() as session:
                     timeout = aiohttp.ClientTimeout(total=40)
                     async with session.post(
-                        agent_config.list_mcp_plugin_url,
+                        agent_config.LIST_MCP_PLUGIN_URL,
                         json=data,
                         timeout=timeout,
                     ) as response:

--- a/core/agent/service/plugin/workflow.py
+++ b/core/agent/service/plugin/workflow.py
@@ -105,7 +105,7 @@ class WorkflowPluginRunner(BaseModel):
             )
 
             flow_client = AsyncOpenAI(
-                base_url=agent_config.workflow_sse_base_url, api_key="no_need"
+                base_url=agent_config.WORKFLOW_SSE_BASE_URL, api_key="no_need"
             )
 
             try:
@@ -175,7 +175,7 @@ class WorkflowPluginFactory(BaseModel):
             )
             async with aiohttp.ClientSession() as session:
                 async with session.post(
-                    agent_config.get_workflows_url, json={"flow_id": workflow_id}
+                    agent_config.GET_WORKFLOWS_URL, json={"flow_id": workflow_id}
                 ) as response:
                     response.raise_for_status()
                     result = await response.json()

--- a/core/agent/tests/conftest.py
+++ b/core/agent/tests/conftest.py
@@ -252,11 +252,11 @@ def mock_agent_config() -> Generator[Mock, None, None]:
         mock_config.spark_x1_model_name = "x1"
         mock_config.spark_x1_model_sk = "x1_test_sk"
         mock_config.maas_sk_auth_url = "https://test.maas.url"
-        mock_config.app_auth_host = "test.auth.host"
-        mock_config.app_auth_router = "/auth"
-        mock_config.app_auth_prot = "https"
-        mock_config.app_auth_api_key = "test_api_key"
-        mock_config.app_auth_secret = "test_secret"
+        mock_config.APP_AUTH_HOST = "test.auth.host"
+        mock_config.APP_AUTH_ROUTER = "/auth"
+        mock_config.APP_AUTH_PROT = "https"
+        mock_config.APP_AUTH_API_KEY = "test_api_key"
+        mock_config.APP_AUTH_SECRET = "test_secret"
         yield mock_config
 
 

--- a/core/agent/tests/unit/infra/test_app_auth.py
+++ b/core/agent/tests/unit/infra/test_app_auth.py
@@ -257,11 +257,11 @@ class TestAPPAuth:
         # pylint: disable=attribute-defined-outside-init
         # Mock agent_config values for testing
         with patch("infra.app_auth.agent_config") as mock_config:
-            mock_config.app_auth_host = "test.host.com"
-            mock_config.app_auth_router = "/auth"
-            mock_config.app_auth_prot = "https"
-            mock_config.app_auth_api_key = "test_api_key"
-            mock_config.app_auth_secret = "test_secret"
+            mock_config.APP_AUTH_HOST = "test.host.com"
+            mock_config.APP_AUTH_ROUTER = "/auth"
+            mock_config.APP_AUTH_PROT = "https"
+            mock_config.APP_AUTH_API_KEY = "test_api_key"
+            mock_config.APP_AUTH_SECRET = "test_secret"
 
             self.app_auth = APPAuth()
             self.config = self.app_auth.config

--- a/core/agent/tests/unit/service/plugin/test_knowledge_plugin.py
+++ b/core/agent/tests/unit/service/plugin/test_knowledge_plugin.py
@@ -161,7 +161,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act
                 result = await knowledge_factory.retrieve(mock_span)
@@ -219,7 +219,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act
                 result = await factory.retrieve(mock_span)
@@ -285,7 +285,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(type(KnowledgeQueryExc)) as exc_info:
@@ -324,7 +324,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(aiohttp.ClientError):
@@ -354,7 +354,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(type(KnowledgeQueryExc)) as exc_info:
@@ -406,7 +406,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act
                 result = await factory.retrieve(mock_span)
@@ -453,7 +453,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act
                 await knowledge_factory.retrieve(mock_span)
@@ -534,7 +534,7 @@ class TestKnowledgePluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.knowledge.agent_config") as mock_config:
-                mock_config.chunk_query_url = "http://test-url"
+                mock_config.CHUNK_QUERY_URL = "http://test-url"
 
                 # Act
                 await knowledge_factory.retrieve(mock_span)

--- a/core/agent/tests/unit/service/plugin/test_link_plugin.py
+++ b/core/agent/tests/unit/service/plugin/test_link_plugin.py
@@ -347,7 +347,7 @@ class TestLinkPluginRunner:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.link.agent_config") as mock_config:
-                mock_config.run_link_url = "http://test-url"
+                mock_config.RUN_LINK_URL = "http://test-url"
 
                 # Act
                 result = await link_runner.run(action_input, mock_span)
@@ -389,7 +389,7 @@ class TestLinkPluginRunner:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.link.agent_config") as mock_config:
-                mock_config.run_link_url = "http://test-url"
+                mock_config.RUN_LINK_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(type(RunToolExc)) as exc_info:
@@ -421,7 +421,7 @@ class TestLinkPluginRunner:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.link.agent_config") as mock_config:
-                mock_config.run_link_url = "http://test-url"
+                mock_config.RUN_LINK_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(type(RunToolExc)) as exc_info:
@@ -509,7 +509,7 @@ class TestLinkPluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.link.agent_config") as mock_config:
-                mock_config.versions_link_url = "http://test-url"
+                mock_config.VERSIONS_LINK_URL = "http://test-url"
 
                 # Act
                 result = await link_factory.tool_schema_list(mock_span)
@@ -573,7 +573,7 @@ class TestLinkPluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.link.agent_config") as mock_config:
-                mock_config.versions_link_url = "http://test-url"
+                mock_config.VERSIONS_LINK_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(type(GetToolSchemaExc)) as exc_info:
@@ -611,7 +611,7 @@ class TestLinkPluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.link.agent_config") as mock_config:
-                mock_config.versions_link_url = "http://test-url"
+                mock_config.VERSIONS_LINK_URL = "http://test-url"
 
                 # Act & Assert
                 with pytest.raises(type(GetToolSchemaExc)) as exc_info:

--- a/core/agent/tests/unit/service/plugin/test_mcp_plugin.py
+++ b/core/agent/tests/unit/service/plugin/test_mcp_plugin.py
@@ -139,7 +139,7 @@ class TestMcpPluginRunner:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.run_mcp_plugin_url = "http://mcp-api/run"
+                mock_config.RUN_MCP_PLUGIN_URL = "http://mcp-api/run"
 
                 # Act
                 result = await mcp_runner.run(action_input, mock_span)
@@ -196,7 +196,7 @@ class TestMcpPluginRunner:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.run_mcp_plugin_url = "http://mcp-api/run"
+                mock_config.RUN_MCP_PLUGIN_URL = "http://mcp-api/run"
 
                 # Act
                 await mcp_runner.run(action_input, mock_span)
@@ -250,7 +250,7 @@ class TestMcpPluginRunner:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.run_mcp_plugin_url = "http://mcp-api/run"
+                mock_config.RUN_MCP_PLUGIN_URL = "http://mcp-api/run"
 
                 # Act & Assert
                 with pytest.raises(Exception):
@@ -283,7 +283,7 @@ class TestMcpPluginRunner:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.run_mcp_plugin_url = "http://mcp-api/run"
+                mock_config.RUN_MCP_PLUGIN_URL = "http://mcp-api/run"
 
                 # Act & Assert
                 with pytest.raises(type(RunMcpPluginExc)):
@@ -326,7 +326,7 @@ class TestMcpPluginRunner:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.run_mcp_plugin_url = "http://mcp-api/run"
+                mock_config.RUN_MCP_PLUGIN_URL = "http://mcp-api/run"
 
                 # Act
                 await mcp_runner.run(action_input, mock_span)
@@ -404,7 +404,7 @@ class TestMcpPluginFactory:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.list_mcp_plugin_url = "http://mcp-api/list"
+                mock_config.LIST_MCP_PLUGIN_URL = "http://mcp-api/list"
 
                 # Act
                 result = await factory.query_servers(mock_span)
@@ -452,7 +452,7 @@ class TestMcpPluginFactory:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.list_mcp_plugin_url = "http://mcp-api/list"
+                mock_config.LIST_MCP_PLUGIN_URL = "http://mcp-api/list"
 
                 # Act
                 await factory.query_servers(mock_span)
@@ -506,7 +506,7 @@ class TestMcpPluginFactory:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.list_mcp_plugin_url = "http://mcp-api/list"
+                mock_config.LIST_MCP_PLUGIN_URL = "http://mcp-api/list"
 
                 # Act & Assert
                 with pytest.raises(type(GetMcpPluginExc)):
@@ -545,7 +545,7 @@ class TestMcpPluginFactory:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.list_mcp_plugin_url = "http://mcp-api/list"
+                mock_config.LIST_MCP_PLUGIN_URL = "http://mcp-api/list"
 
                 # Act & Assert
                 with pytest.raises(Exception):
@@ -577,7 +577,7 @@ class TestMcpPluginFactory:
             "service.plugin.mcp.aiohttp.ClientSession", return_value=session_context
         ):
             with patch("service.plugin.mcp.agent_config") as mock_config:
-                mock_config.list_mcp_plugin_url = "http://mcp-api/list"
+                mock_config.LIST_MCP_PLUGIN_URL = "http://mcp-api/list"
 
                 # Act & Assert
                 with pytest.raises(type(GetMcpPluginExc)):

--- a/core/agent/tests/unit/service/plugin/test_workflow_plugin.py
+++ b/core/agent/tests/unit/service/plugin/test_workflow_plugin.py
@@ -238,7 +238,7 @@ class TestWorkflowPluginRunner:
 
         with patch("service.plugin.workflow.AsyncOpenAI", return_value=mock_client):
             with patch("service.plugin.workflow.agent_config") as mock_config:
-                mock_config.workflow_sse_base_url = "http://workflow-api"
+                mock_config.WORKFLOW_SSE_BASE_URL = "http://workflow-api"
 
                 # Act
                 responses = []
@@ -286,7 +286,7 @@ class TestWorkflowPluginRunner:
 
         with patch("service.plugin.workflow.AsyncOpenAI", return_value=mock_client):
             with patch("service.plugin.workflow.agent_config") as mock_config:
-                mock_config.workflow_sse_base_url = "http://workflow-api"
+                mock_config.WORKFLOW_SSE_BASE_URL = "http://workflow-api"
 
                 # Act
                 responses = []
@@ -321,7 +321,7 @@ class TestWorkflowPluginRunner:
 
         with patch("service.plugin.workflow.AsyncOpenAI", return_value=mock_client):
             with patch("service.plugin.workflow.agent_config") as mock_config:
-                mock_config.workflow_sse_base_url = "http://workflow-api"
+                mock_config.WORKFLOW_SSE_BASE_URL = "http://workflow-api"
 
                 # Act & Assert
                 with pytest.raises(type(RunWorkflowExc)) as exc_info:
@@ -365,7 +365,7 @@ class TestWorkflowPluginRunner:
 
         with patch("service.plugin.workflow.AsyncOpenAI", return_value=mock_client):
             with patch("service.plugin.workflow.agent_config") as mock_config:
-                mock_config.workflow_sse_base_url = "http://workflow-api"
+                mock_config.WORKFLOW_SSE_BASE_URL = "http://workflow-api"
 
                 # Act
                 async for _ in workflow_runner.run(action_input, mock_span):
@@ -461,7 +461,7 @@ class TestWorkflowPluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.workflow.agent_config") as mock_config:
-                mock_config.get_workflows_url = "http://workflow-api/get"
+                mock_config.GET_WORKFLOWS_URL = "http://workflow-api/get"
 
                 # Act
                 result = await WorkflowPluginFactory.do_query_workflow_schema(
@@ -762,7 +762,7 @@ class TestWorkflowPluginFactory:
 
         with patch("aiohttp.ClientSession", return_value=session_context):
             with patch("service.plugin.workflow.agent_config") as mock_config:
-                mock_config.get_workflows_url = "http://workflow-api/get"
+                mock_config.GET_WORKFLOWS_URL = "http://workflow-api/get"
 
                 # Act & Assert
                 with pytest.raises(aiohttp.ClientError):


### PR DESCRIPTION
- Convert all config keys from lowercase to UPPERCASE format
- Update config.env.example with standardized variable names
- Refactor Pydantic settings classes to use uppercase field names
- Update all service implementations to use new config key format
- Modify test configurations to match new naming conventions
- Improve environment variable handling in main.py startup
- Add backward compatibility checks for existing environment variables

This standardization improves consistency across the codebase and follows common environment variable naming conventions.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
