### PR TITLE
fix(agent): add conditional initialization in BotConfigClient.model_p…

### DIFF
--- a/core/agent/repository/bot_config_client.py
+++ b/core/agent/repository/bot_config_client.py
@@ -32,18 +32,20 @@ class BotConfigClient(BaseModel):
 
     def model_post_init(self, __context: Any) -> None:
         """Initialize Redis and MySQL clients after instance creation."""
-        self.redis_client = create_redis_client(
-            cluster_addr=agent_config.REDIS_CLUSTER_ADDR,
-            standalone_addr=agent_config.REDIS_ADDR,
-            password=agent_config.REDIS_PASSWORD,
-        )
-        self.mysql_client = MysqlClient(
-            database_url=(
-                f"mysql+pymysql://{agent_config.MYSQL_USER}:"
-                f"{agent_config.MYSQL_PASSWORD}@{agent_config.MYSQL_HOST}:"
-                f"{agent_config.MYSQL_PORT}/{agent_config.MYSQL_DB}?charset=utf8mb4"
+        if self.redis_client is None:
+            self.redis_client = create_redis_client(
+                cluster_addr=agent_config.REDIS_CLUSTER_ADDR,
+                standalone_addr=agent_config.REDIS_ADDR,
+                password=agent_config.REDIS_PASSWORD,
             )
-        )
+        if self.mysql_client is None:
+            self.mysql_client = MysqlClient(
+                database_url=(
+                    f"mysql+pymysql://{agent_config.MYSQL_USER}:"
+                    f"{agent_config.MYSQL_PASSWORD}@{agent_config.MYSQL_HOST}:"
+                    f"{agent_config.MYSQL_PORT}/{agent_config.MYSQL_DB}?charset=utf8mb4"
+                )
+            )
 
     def redis_key(self) -> str:
         return f"spark_bot:bot_config:{self.bot_id}"


### PR DESCRIPTION
…ost_init

Restores conditional checks to prevent overriding existing redis_client and mysql_client instances during test execution. This fix resolves validation errors in BotConfigClient test suite by preserving mock clients injected during testing scenarios.

- Add None checks before initializing redis_client and mysql_client
- Ensures test compatibility while maintaining production functionality
- All 20 BotConfigClient tests now pass successfully

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
