### PR TITLE
fix(api): resolve JSON serialization error for set objects

### DIFF
--- a/core/agent/api/v1/base_api.py
+++ b/core/agent/api/v1/base_api.py
@@ -21,6 +21,13 @@ from exceptions.agent_exc import AgentInternalExc, AgentNormalExc
 from infra import agent_config
 
 
+def json_serializer(obj: Any) -> Any:
+    """Custom JSON serializer to handle set objects."""
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
+
 @dataclass
 class RunContext:
     """Runtime context parameters"""
@@ -125,7 +132,7 @@ class CompletionBase(BaseModel, ABC):
                 span=context.span,
             )
             context.span.add_info_events(
-                {"node-trace": json.dumps(node_trace_log, ensure_ascii=False)}
+                {"node-trace": json.dumps(node_trace_log, ensure_ascii=False, default=json_serializer)}
             )
 
     async def run_runner(


### PR DESCRIPTION
- Add json_serializer function to handle set type conversion to list
- Update json.dumps call in CompletionBase.run_runner with default serializer
- Fixes TypeError when node_trace_log contains set objects that cannot be JSON serialized

Resolves JSON serialization issues in api/v1/base_api.py

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
