### PR TITLE
fix(api): resolve list index out of range errors in agent execution

### DIFF
--- a/core/agent/api/schemas/base_inputs.py
+++ b/core/agent/api/schemas/base_inputs.py
@@ -4,6 +4,7 @@ from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, Field, model_validator
 
 from api.schemas.llm_message import LLMMessage
+from exceptions.agent_exc import AgentInternalExc
 
 
 class MetaDataInputs(BaseModel):
@@ -88,3 +89,53 @@ class BaseInputs(BaseModel):
             )
 
         return values
+
+    def get_last_message_content(self) -> str:
+        """
+        Safely get the content of the last message.
+        
+        Returns:
+            str: Content of the last message
+            
+        Raises:
+            AgentInternalExc: If messages list is empty
+        """
+        if not self.messages:
+            raise AgentInternalExc(
+                "Messages list is empty, cannot get last message content"
+            )
+        return self.messages[-1].content
+
+    def get_last_message_content_safe(self, default: str = "") -> str:
+        """
+        Safely get the content of the last message with a default value.
+        
+        Args:
+            default: Default value to return if messages list is empty
+            
+        Returns:
+            str: Content of the last message or default value
+        """
+        if not self.messages:
+            return default
+        return self.messages[-1].content
+
+    def get_chat_history(self) -> list[LLMMessage]:
+        """
+        Safely get chat history (all messages except the last one).
+        
+        Returns:
+            list[LLMMessage]: Chat history messages, empty list if no history
+        """
+        if len(self.messages) <= 1:
+            return []
+        return self.messages[:-1]
+
+    def get_chat_history_safe(self) -> list[LLMMessage]:
+        """
+        Safely get chat history with additional safety checks.
+        
+        Returns:
+            list[LLMMessage]: Chat history messages, always returns a list
+        """
+        return self.get_chat_history()

--- a/core/agent/api/v1/base_api.py
+++ b/core/agent/api/v1/base_api.py
@@ -62,7 +62,7 @@ class CompletionBase(BaseModel, ABC):
                 sub="Agent",
                 caller=self.inputs.meta_data.caller,
                 log_caller=self.log_caller,
-                question=self.inputs.messages[-1].content,
+                question=self.inputs.get_last_message_content(),
             )
             node_trace.record_start()
 

--- a/core/agent/api/v1/openapi.py
+++ b/core/agent/api/v1/openapi.py
@@ -49,7 +49,7 @@ class ChatCompletion(CompletionBase):
                     "app_id": self.app_id,
                     "bot_id": self.inputs.bot_id,
                     "uid": self.inputs.uid,
-                    "question": self.inputs.messages[-1].content,
+                    "question": self.inputs.get_last_message_content(),
                     "caller": self.inputs.meta_data.caller,
                     "caller_sid": self.inputs.meta_data.caller_sid,
                 }
@@ -89,6 +89,8 @@ class ChatCompletion(CompletionBase):
                 continue
             chunk_data = json.loads(line.lstrip("data: ").strip())
             chunk = ReasonChatCompletionChunk(**chunk_data)
+            if not chunk.choices:
+                continue
             if chunk.choices[0].delta.reasoning_content:
                 if response.choices[0].message.reasoning_content is None:
                     response.choices[0].message.reasoning_content = ""

--- a/core/agent/api/v1/workflow_agent.py
+++ b/core/agent/api/v1/workflow_agent.py
@@ -89,7 +89,7 @@ async def custom_chat_completions(
         span=span,
         bot_id="",
         uid=completion_inputs.uid,
-        question=completion_inputs.messages[-1].content,
+        question=completion_inputs.get_last_message_content(),
     )
 
     async def generate() -> AsyncGenerator[str, None]:

--- a/core/agent/engine/nodes/base.py
+++ b/core/agent/engine/nodes/base.py
@@ -57,6 +57,8 @@ class RunnerBase(BaseModel):
             node_data_config: dict[str, Any] = {}
             node_data_usage = NodeDataUsage()
             async for chunk in self.model.stream(messages, True, sp):
+                if not chunk.choices:
+                    continue
                 delta = chunk.choices[0].delta.model_dump()
                 reasoning_content = delta.get("reasoning_content")
                 content = delta.get("content")

--- a/core/agent/engine/nodes/cot/cot_runner.py
+++ b/core/agent/engine/nodes/cot/cot_runner.py
@@ -141,6 +141,8 @@ class CotRunner(RunnerBase):
             node_data_usage = NodeDataUsage()
 
             async for chunk in self.model.stream(messages.list(), True, sp):
+                if not chunk.choices:
+                    continue
                 delta = chunk.choices[0].delta.model_dump()
                 reasoning_content = delta.get("reasoning_content", "") or ""
                 content: str = delta.get("content", "") or ""

--- a/core/agent/service/builder/openapi_builder.py
+++ b/core/agent/service/builder/openapi_builder.py
@@ -40,20 +40,20 @@ class OpenAPIRunnerBuilder(BaseApiBuilder):
             chat_runner = await self.build_chat_runner(
                 RunnerParams(
                     model=summary_model,
-                    chat_history=self.inputs.messages[:-1],
+                    chat_history=self.inputs.get_chat_history(),
                     instruct=bot_config.model_config_.instruct,
                     knowledge=knowledge,
-                    question=self.inputs.messages[-1].content,
+                    question=self.inputs.get_last_message_content(),
                 )
             )
 
             process_runner = await self.build_process_runner(
                 RunnerParams(
                     model=summary_model,
-                    chat_history=self.inputs.messages[:-1],
+                    chat_history=self.inputs.get_chat_history(),
                     instruct=bot_config.model_config_.instruct,
                     knowledge=knowledge,
-                    question=self.inputs.messages[-1].content,
+                    question=self.inputs.get_last_message_content(),
                 )
             )
 
@@ -61,10 +61,10 @@ class OpenAPIRunnerBuilder(BaseApiBuilder):
                 CotRunnerParams(
                     model=plan_model,
                     plugins=cast(list[BasePlugin], plugins),
-                    chat_history=self.inputs.messages[:-1],
+                    chat_history=self.inputs.get_chat_history(),
                     instruct=bot_config.model_config_.instruct,
                     knowledge=knowledge,
-                    question=self.inputs.messages[-1].content,
+                    question=self.inputs.get_last_message_content(),
                     process_runner=process_runner,
                 )
             )
@@ -90,7 +90,7 @@ class OpenAPIRunnerBuilder(BaseApiBuilder):
                 return [], ""
 
             knowledge_plugin = KnowledgePluginFactory(
-                query=self.inputs.messages[-1].content,
+                query=self.inputs.get_last_message_content(),
                 top_k=bot_config.knowledge_config.top_k,
                 repo_ids=repo_ids,
                 doc_ids=doc_ids,

--- a/core/agent/service/builder/workflow_agent_builder.py
+++ b/core/agent/service/builder/workflow_agent_builder.py
@@ -49,27 +49,27 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
 
             chat_params = RunnerParams(
                 model=model,
-                chat_history=self.inputs.messages[:-1],
+                chat_history=self.inputs.get_chat_history(),
                 instruct=self.inputs.instruction.answer,
                 knowledge=knowledge,
-                question=self.inputs.messages[-1].content,
+                question=self.inputs.get_last_message_content(),
             )
             chat_runner = await self.build_chat_runner(chat_params)
             process_params = RunnerParams(
                 model=model,
-                chat_history=self.inputs.messages[:-1],
+                chat_history=self.inputs.get_chat_history(),
                 instruct=self.inputs.instruction.answer,
                 knowledge=knowledge,
-                question=self.inputs.messages[-1].content,
+                question=self.inputs.get_last_message_content(),
             )
             process_runner = await self.build_process_runner(process_params)
             cot_params = CotRunnerParams(
                 model=model,
                 plugins=plugins,
-                chat_history=self.inputs.messages[:-1],
+                chat_history=self.inputs.get_chat_history(),
                 instruct=self.inputs.instruction.reasoning,
                 knowledge=knowledge,
-                question=self.inputs.messages[-1].content,
+                question=self.inputs.get_last_message_content(),
                 process_runner=process_runner,
                 max_loop=self.inputs.max_loop_count,
             )
@@ -201,7 +201,7 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
         span: Span,
     ) -> dict[str, Any]:
         knowledge_plugin = KnowledgePluginFactory(
-            query=self.inputs.messages[-1].content,
+            query=self.inputs.get_last_message_content(),
             top_k=params.top_k,
             repo_ids=params.repo_ids,
             doc_ids=params.doc_ids,

--- a/core/agent/service/plugin/workflow.py
+++ b/core/agent/service/plugin/workflow.py
@@ -132,6 +132,8 @@ class WorkflowPluginRunner(BaseModel):
 
                     if ctx.code != 0:
                         yield self._create_error_response(ctx, chunk_data)
+                    elif not chunk.choices:
+                        continue
                     else:
                         content = chunk.choices[0].delta.content
                         reasoning_content = (


### PR DESCRIPTION
- Add safe message access methods to BaseInputs class:
  * get_last_message_content() - throws AgentInternalExc for empty lists
  * get_last_message_content_safe() - returns default for empty lists
  * get_chat_history() - safely gets all messages except last
  * get_chat_history_safe() - additional safety wrapper

- Replace all direct messages[-1] and messages[:-1] access with safe methods:
  * workflow_agent.py - use get_last_message_content()
  * base_api.py - use get_last_message_content()
  * openapi.py - use get_last_message_content()
  * workflow_agent_builder.py - use safe message and history access
  * openapi_builder.py - use safe message and history access

- Add empty choices validation in streaming response handlers:
  * openapi.py - check chunk.choices before accessing choices[0]
  * cot_runner.py - validate choices exist in stream processing
  * base.py - add choices validation in base node stream handling
  * workflow.py - check choices before delta content access

Fixes "Agent node execution failed(Agent internal service error,list index out of range)" error that occurred when API received empty messages lists or malformed streaming responses.

All edge cases now handled gracefully with proper error messages.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
