### PR TITLE
fix: resolve mypy unreachable code error in test_mysql_client.py

### DIFF
--- a/core/agent/tests/unit/repository/test_mysql_client.py
+++ b/core/agent/tests/unit/repository/test_mysql_client.py
@@ -218,7 +218,7 @@ class TestMysqlClient:
                     raise RuntimeError("Database error")
 
             # Assert
-            assert "Database error" in str(exc_info.value)
+            assert "Database error" in str(exc_info.value)  # type: ignore[unreachable]
             mock_session.rollback.assert_called_once()
             mock_session.close.assert_called_once()
             # commit should not be called when exception occurs


### PR DESCRIPTION
Add type: ignore[unreachable] annotation to assert statement that mypy incorrectly identifies as unreachable. The assert statement is actually reachable as it executes after the pytest.raises context manager exits.

Resolves mypy error: Statement is unreachable [unreachable]

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
