### PR TITLE
fix(agent): fix empty usage field in LLM responses

### DIFF
--- a/core/agent/api/app.py
+++ b/core/agent/api/app.py
@@ -33,11 +33,17 @@ async def validation_exception_handler(
     except (IndexError, AttributeError):
         err = exc.body or {}
     message = f"{err['type']}, {err['loc'][-1]}, {err['msg']}"
+
+    # Generate ID safely - fallback if sid_generator2 not initialized
+    request_id = (
+        sid_generator2.gen() if sid_generator2 is not None else "validation-error"
+    )
+
     rs = JSONResponse(
         content=ReasonChatCompletionChunk(
             code=40002,
             message=message,
-            id=sid_generator2.gen(),
+            id=request_id,
             choices=[],
             created=int(time.time()),
             model="",

--- a/core/agent/api/schemas/agent_response.py
+++ b/core/agent/api/schemas/agent_response.py
@@ -1,6 +1,7 @@
 import time
 from typing import Any, Literal, Optional
 
+from openai.types.completion_usage import CompletionUsage
 from pydantic import BaseModel, Field
 
 from service.plugin.base import BasePlugin
@@ -29,3 +30,4 @@ class AgentResponse(BaseModel):
     content: str | CotStep | list
     model: str
     created: int = Field(default_factory=cur_timestamp)
+    usage: Optional[CompletionUsage] = Field(default=None)

--- a/core/agent/engine/nodes/base.py
+++ b/core/agent/engine/nodes/base.py
@@ -51,11 +51,14 @@ class RunnerBase(BaseModel):
             node_start_time = int(round(time.time() * 1000))
             node_running_status = True
             node_data_input = {
-                "model_general_stream_input": json.dumps(messages, ensure_ascii=False)
+                "model_general_stream_input": json.dumps(
+                    messages, ensure_ascii=False
+                )
             }
             node_data_output: dict[str, Any] = {}
             node_data_config: dict[str, Any] = {}
             node_data_usage = NodeDataUsage()
+            last_chunk_has_content = False
             async for chunk in self.model.stream(messages, True, sp):
                 if not chunk.choices:
                     continue
@@ -63,29 +66,47 @@ class RunnerBase(BaseModel):
                 reasoning_content = delta.get("reasoning_content")
                 content = delta.get("content")
 
-                node_data_usage.completion_tokens = 0
-                node_data_usage.prompt_tokens = 0
-                node_data_usage.total_tokens = 0
-                if chunk.usage and chunk.usage.model_dump().get("total_tokens") != 0:
+                # Accumulate usage from chunks instead of resetting
+                if chunk.usage:
                     usage_data = chunk.usage.model_dump()
-                    node_data_usage.completion_tokens = usage_data.get(
+                    node_data_usage.completion_tokens += usage_data.get(
                         "completion_tokens", 0
                     )
-                    node_data_usage.prompt_tokens = usage_data.get("prompt_tokens", 0)
-                    node_data_usage.total_tokens = usage_data.get("total_tokens", 0)
+                    node_data_usage.prompt_tokens += usage_data.get(
+                        "prompt_tokens", 0
+                    )
+                    node_data_usage.total_tokens += (
+                        usage_data.get("total_tokens", 0)
+                    )
 
+                # For intermediate chunks, don't send usage yet
                 if reasoning_content:
                     yield AgentResponse(
                         typ="reasoning_content",
                         content=reasoning_content,
                         model=self.model.name,
+                        usage=None,
                     )
                     thinks += reasoning_content
+                    last_chunk_has_content = True
                 if content:
                     yield AgentResponse(
-                        typ="content", content=content, model=self.model.name
+                        typ="content",
+                        content=content,
+                        model=self.model.name,
+                        usage=None,
                     )
                     answers += content
+                    last_chunk_has_content = True
+
+            # Usage will be attached to stop chunk in _finalize_run
+            sp.add_info_events({
+                "accumulated_usage": {
+                    "completion_tokens": node_data_usage.completion_tokens,
+                    "prompt_tokens": node_data_usage.prompt_tokens,
+                    "total_tokens": node_data_usage.total_tokens
+                }
+            })
 
             node_end_time = int(round(time.time() * 1000))
             data_llm_output = answers

--- a/core/agent/service/runner/openapi_runner.py
+++ b/core/agent/service/runner/openapi_runner.py
@@ -75,6 +75,7 @@ class OpenAPIRunner(BaseModel):
             created=message.created,
             model=message.model,
             object="chat.completion.chunk",
+            usage=message.usage,
         )
 
         if message.typ == "reasoning_content":


### PR DESCRIPTION
Fixed Issues:
- Usage field in client responses was always empty or null
- workflow_step.node.usage in upstream workflow service was 0

Root Causes:
1. Usage data accumulated in node_data_usage but not passed to clients
2. Stop chunk (finish_reason="stop") had no usage information

Solution:
1. Collect usage from node_trace.trace in _finalize_run
2. Attach accumulated usage to final stop chunk
3. Fix AttributeError when sid_generator2 is None

Changes:
- api/v1/base_api.py: Attach usage to stop chunk from node_trace
- api/v1/openapi.py: Add _update_usage method for non-streaming
- api/schemas/agent_response.py: Add usage field to AgentResponse
- engine/nodes/base.py: Accumulate usage in node_data_usage
- engine/nodes/cot/cot_runner.py: Same as base.py
- service/runner/openapi_runner.py: Pass usage to chunk
- api/app.py: Fix sid_generator2 null pointer exception

Testing:
Clients should receive complete usage data in finish_reason="stop" chunk

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
