### PR TITLE
fix: remove unused type ignore comment in redis_client

### DIFF
--- a/core/agent/cache/redis_client.py
+++ b/core/agent/cache/redis_client.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
-import redis  # type: ignore[import-untyped]
+import redis
 from pydantic import BaseModel, ConfigDict, Field
 from rediscluster import ClusterConnectionPool, RedisCluster
 


### PR DESCRIPTION
Remove unnecessary type: ignore[import-untyped] comment from redis import to fix mypy unused-ignore error

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
