### PR TITLE
fix: resolve workflow node input pollution by history param and empty non-stream output; refine prompt template splitting, log path, and build script

### DIFF
--- a/core/workflow/Dockerfile
+++ b/core/workflow/Dockerfile
@@ -2,11 +2,11 @@
 FROM python:3.11-slim
 
 # Set the working directory for the application
-WORKDIR /opt/openstellar
+WORKDIR /opt/core
 
 # Configure environment variables for Python path and UV cache
-ENV PATH=$PATH:/opt/openstellar
-ENV PYTHONPATH /opt/openstellar
+ENV PATH=$PATH:/opt/core
+ENV PYTHONPATH /opt/core
 ENV UV_NO_CACHE=1
 
 # Install curl and dependencies (commented out - not currently needed)

--- a/core/workflow/engine/nodes/flow/flow_node.py
+++ b/core/workflow/engine/nodes/flow/flow_node.py
@@ -354,6 +354,7 @@ class FlowNode(BaseNode):
                     item if isinstance(item, dict) else item.__dict__
                     for item in history_v2.origin_history
                 ]
+        origin_inputs = copy.deepcopy(inputs)
 
         # Add chat history to inputs if available
         if history:
@@ -363,7 +364,7 @@ class FlowNode(BaseNode):
         req_body = {
             "flow_id": self.flowId,
             "uid": self.uid,
-            "parameters": inputs,
+            "parameters": origin_inputs,
             "ext": {},
             "stream": True,
             "history": history,

--- a/core/workflow/engine/nodes/util/frame_processor.py
+++ b/core/workflow/engine/nodes/util/frame_processor.py
@@ -67,7 +67,6 @@ def extract_tool_calls_content(tool_calls: List[Dict[str, Any]]) -> str:
         function = cast(Dict[str, Any], tool.get("function") or {})
         response_json_str = function.get("response") or "{}"
         response_json = json.loads(response_json_str)
-        response_dict: dict = {}
         if type_value == ToolType.TOOL.value:
             if response_json.get("header"):
                 # Handle tool type response

--- a/core/workflow/engine/nodes/util/prompt.py
+++ b/core/workflow/engine/nodes/util/prompt.py
@@ -264,9 +264,16 @@ class PromptUtils:
         ]
 
         # Build the regularity to capture all delimiters
-        pattern = "(" + "|".join(map(re.escape, placeholders_with_brackets)) + ")"
-        parts = re.split(pattern, template)
+        if placeholders_with_brackets:
+            pattern = "(" + "|".join(map(re.escape, placeholders_with_brackets)) + ")"
+            parts = re.split(pattern, template)
+        else:
+            parts = [template]
+
         for i, part in enumerate(parts):
+
+            if part == "":
+                continue
 
             # Handle placeholder information
             if part in placeholders_with_brackets:

--- a/core/workflow/extensions/middleware/log/factory.py
+++ b/core/workflow/extensions/middleware/log/factory.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from loguru import logger
 
@@ -35,7 +36,10 @@ class LogServiceFactory(ServiceFactory):
 
         :return: Configured LogService instance
         """
-        log_dir = os.getenv("LOG_PATH", "../..")
+        log_dir = os.path.join(
+            Path(__file__).parent.parent.parent.parent.parent,
+            os.getenv("LOG_PATH", "logs"),
+        )
         os.makedirs(log_dir, exist_ok=True)  # Ensure log directory exists
 
         # Configure log storage path and log level

--- a/core/workflow/service/chat_service.py
+++ b/core/workflow/service/chat_service.py
@@ -804,6 +804,9 @@ def _filter_response_frame(
 
     if is_stop:
         response_frame.workflow_step.seq = last_workflow_step.seq + 1
+        if not is_stream:
+            delta.content = "".join(message_cache)
+            delta.reasoning_content = "".join(reasoning_content_cache)
         return response_frame
 
     # Only process specific node types (flow_obj or MESSAGE/END/QUESTION_ANSWER)
@@ -828,11 +831,7 @@ def _filter_response_frame(
     )
 
     if not is_stream and not is_interrupted:
-        if is_stop:
-            delta.content = "".join(message_cache)
-            delta.reasoning_content = "".join(reasoning_content_cache)
-        else:
-            return None
+        return None
 
     # Standardize index
     choice.index = 0
@@ -889,7 +888,7 @@ def _cache_content_and_reasoning_content(
     :param reasoning_content_cache: Cached reasoning content for non-streaming mode
     :return: None
     """
-    if is_stream:
+    if not is_stream:
         message_cache.append(response_frame.choices[0].delta.content)
         reasoning_content_cache.append(
             response_frame.choices[0].delta.reasoning_content

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -474,7 +474,8 @@ services:
       minio:
         condition: service_healthy
     volumes:
-      - ./config/workflow/config.env:/opt/openstellar/workflow/config.env
+      - ./config/workflow/config.env:/opt/core/workflow/config.env
+      - ./config/workflow/logs/:/opt/core/logs
     networks:
       - astron-agent-network
     restart: always


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->
Fixes workflow node input pollution caused by the `history` parameter and resolves the issue of empty non-stream outputs.
Also refines prompt template splitting, log path configuration, and removes brand names from the build script.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [x] Chore

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
- Fixed workflow node input pollution caused by the `history` parameter
- Fixed issue where non-stream output content was empty
- Optimized Prompt template splitting to remove empty strings
- Improved log path configuration
- Updated build script to remove brand references

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Breaking changes documented
