### PR TITLE
feat: add Ragflow-RAG support and enhance knowledge query logging

### DIFF
--- a/core/agent/api/schemas/workflow_agent_inputs.py
+++ b/core/agent/api/schemas/workflow_agent_inputs.py
@@ -26,7 +26,7 @@ class CustomCompletionPluginKnowledgeInputs(BaseModel):
     match: CustomCompletionPluginKnowledgeMatchInputs = Field(
         default_factory=CustomCompletionPluginKnowledgeMatchInputs
     )
-    repo_type: int = Field(..., ge=1, le=2)
+    repo_type: int = Field(..., ge=1, le=3)
 
 
 class CustomCompletionPluginInputs(BaseModel):

--- a/core/agent/service/builder/workflow_agent_builder.py
+++ b/core/agent/service/builder/workflow_agent_builder.py
@@ -112,13 +112,24 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
         repo_type_map = {
             "1": "AIUI-RAG2",
             "2": "CBG-RAG",
+            "3": "Ragflow-RAG",
         }
         tasks = []
 
         for knowledge in knowledge_list:
             repo_ids = knowledge.match.repo_ids or []
             doc_ids = knowledge.match.doc_ids or []
+
+            # 添加调试日志
+            span.add_info_events({
+                "knowledge_name": knowledge.name,
+                "repo_type": knowledge.repo_type,
+                "repo_ids": repo_ids,
+                "doc_ids": doc_ids
+            })
+
             if not (repo_ids or doc_ids):
+                span.add_info_events({"skip_reason": "no repo_ids or doc_ids"})
                 continue
 
             top_k = knowledge.top_k or 3
@@ -128,6 +139,11 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
                 if knowledge.repo_type
                 else "AIUI-RAG2"
             )
+
+            # 添加映射后的日志
+            span.add_info_events({
+                "mapped_rag_type": repo_type
+            })
 
             params = KnowledgeQueryParams(
                 repo_ids=repo_ids,


### PR DESCRIPTION
Added support for Ragflow-RAG (repo_type=3) to the workflow agent system.

Changes:
- Extended repo_type validation range from [1,2] to [1,3] in CustomCompletionPluginKnowledgeInputs
- Added "3": "Ragflow-RAG" mapping in repo_type_map
- Enhanced debugging with detailed span logging for knowledge query parameters:
  - Log knowledge name, repo_type, repo_ids, doc_ids before processing
  - Log skip reasons when repo_ids and doc_ids are empty
  - Log mapped RAG type after repo_type mapping

This improves observability and supports the new Ragflow-RAG integration.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
