### PR TITLE
chore: enhance .gitignore configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ yarn-error.log*
 __pycache__/
 *.py[cod]
 *$py.class
+*.pyc
+*.pyo
 build/
 develop-eggs/
 dist/
@@ -56,9 +58,13 @@ parts/
 sdist/
 var/
 wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
+pip-log.txt
+pip-delete-this-directory.txt
 
 # =============================================================================
 # Build & Output Directories
@@ -79,6 +85,15 @@ tmp/
 .cursor/
 *.swp
 *.swo
+*.swn
+*~
+.project
+.classpath
+.c9/
+.settings/
+.loadpath
+.vimrc.local
+.exrc
 
 # Claude Code (user-specific)
 .claude/
@@ -96,6 +111,14 @@ tmp/
 ._*
 .Spotlight-V100
 .Trashes
+.AppleDouble
+.LSOverride
+Icon
+.DocumentRevisions-V100
+.fseventsd
+.TemporaryItems
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
 
 # Windows
 Thumbs.db
@@ -174,13 +197,47 @@ coverage.out
 core/.serena/project.yml
 
 
+# Python Virtual Environments
+venv/
+env/
+ENV/
+.venv/
+.env/
+virtualenv/
 *.venv*
+.python-version
+
+# Python Tools Cache
+.ruff_cache/
+.uv/
+.pdm-python
+.pdm-build/
+.tox/
+.nox/
+.hypothesis/
+.pytype/
 
 # local ci
 .localci.toml
 
 # =============================================================================
-# cache
+# Cache & Testing
 # =============================================================================
-.mypy_cache
-.pytest_cache
+.mypy_cache/
+.pytest_cache/
+.cache/
+.benchmarks/
+htmlcov/
+.coverage
+.coverage.*
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# =============================================================================
+# Docker & Containers
+# =============================================================================
+docker-compose.override.yml
+.dockerignore.local
+*.dockerignore.local


### PR DESCRIPTION
Improve coverage for various development environments and tools:

- Python: add .pyc, .pyo, MANIFEST and more cache files
- Virtual environments: add venv/, env/, virtualenv/ directories
- Python tools: add cache for ruff, uv, pdm, tox, nox
- IDEs: add vim, Eclipse temporary files
- macOS: add more system-specific files (.AppleDouble, .fseventsd, etc)
- Test coverage: consolidate and expand test-related cache directories
- Docker: add local override configuration ignore rules