### PR TITLE
docs: optimize Quick Start section with Docker Compose and Helm

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,7 +21,8 @@
 - [🔭 星辰 Agent 是什么](#-星辰-agent-是什么)
 - [🛠️ 技术栈](#%EF%B8%8F-技术栈)
 - [🚀 快速开始](#-快速开始)
-  - [使用 Docker](#使用-docker)
+  - [方式一：Docker Compose](#方式一docker-compose推荐快速体验)
+  - [方式二：Helm](#方式二helm适用于-kubernetes-环境)
 - [📖 使用指南](#-使用指南)
 - [📚 文档](#-文档)
 - [🤝 参与贡献](#-参与贡献)
@@ -65,6 +66,10 @@
 
 ## 🚀 快速开始
 
+我们提供两种部署方式，满足不同场景需求:
+
+### 方式一：Docker Compose（推荐快速体验）
+
 ```bash
 # 克隆项目
 git clone https://github.com/iflytek/astron-agent.git
@@ -80,6 +85,18 @@ docker compose up -d
 ```
 
 访问平台：http://localhost/
+
+### 方式二：Helm（适用于 Kubernetes 环境）
+
+> 🚧 **注意**：Helm charts 正在完善中，敬请期待！
+
+```bash
+# 即将推出
+# helm repo add astron-agent https://iflytek.github.io/astron-agent
+# helm install astron-agent astron-agent/astron-agent
+```
+
+---
 
 > 📖 完整的部署说明和配置详情，请查看[部署指南](docs/DEPLOYMENT_GUIDE_zh.md)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ English | [简体中文](README-zh.md)
 - [🔭 What is Astron Agent?](#-What-is-Astron-Agent)
 - [🛠️ Tech Stack](#%EF%B8%8F-tech-stack)
 - [🚀 Quick Start](#-quick-start)
-  - [Using Docker](#using-docker)
+  - [Option 1: Docker Compose](#option-1-docker-compose-recommended-for-quick-start)
+  - [Option 2: Helm](#option-2-helm-for-kubernetes-environments)
 - [📖 Usage Guide](#-usage-guide)
 - [📚 Documentation](#-documentation)
 - [🤝 Contributing](#-contributing)
@@ -65,6 +66,10 @@ It not only provides full-lifecycle capabilities covering model hosting, applica
 
 ## 🚀 Quick Start
 
+We offer two deployment methods to meet different scenarios:
+
+### Option 1: Docker Compose (Recommended for Quick Start)
+
 ```bash
 # Clone the repository
 git clone https://github.com/iflytek/astron-agent.git
@@ -80,6 +85,18 @@ docker compose up -d
 ```
 
 Access the platform at http://localhost/
+
+### Option 2: Helm (For Kubernetes Environments)
+
+> 🚧 **Note**: Helm charts are currently under development. Stay tuned for updates!
+
+```bash
+# Coming soon
+# helm repo add astron-agent https://iflytek.github.io/astron-agent
+# helm install astron-agent astron-agent/astron-agent
+```
+
+---
 
 > 📖 For complete deployment instructions and configuration details, see [Deployment Guide](docs/DEPLOYMENT_GUIDE.md)
 


### PR DESCRIPTION
- Add two deployment methods: Docker Compose (recommended) and Helm (under development)
- Update TOC to reflect new deployment options structure
- Improve documentation clarity for different deployment scenarios
- Mark Helm deployment as work in progress with clear notice