### PR TITLE
fix: use internal network to access casdoor to get jwt set by default

### DIFF
--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -202,7 +202,7 @@ REDIS_DATABASE_CONSOLE=1
 
 # OAuth2 Configuration for Console Backend Api Server (as OAuth2 Resource Server)
 OAUTH2_ISSUER_URI=${CONSOLE_CASDOOR_URL:-http://auth-server:8000}
-OAUTH2_JWK_SET_URI=${CONSOLE_CASDOOR_URL:-http://auth-server:8000}/.well-known/jwks
+OAUTH2_JWK_SET_URI=http://casdoor:8000/.well-known/jwks
 OAUTH2_AUDIENCE=${CONSOLE_CASDOOR_ID:-your-oauth2-client-id}
 
 # Open Platform API Configuration


### PR DESCRIPTION
## Summary
let the backend use the internal network to access casdoor to obtain jwt set by default

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
