### PR TITLE
feat: add SSE proxy support for workflow chat completions endpoint

### DIFF
--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -285,7 +285,7 @@ MAAS_AUTH_API=http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/auth
 MAAS_MCP_REGISTER=http://127.0.0.1:8080/workflow/release
 MAAS_WORKFLOW_CONFIG=http://127.0.0.1:8080/workflow/get-flow-advanced-config
 BOT_API_CBM_BASE_URL=ws(s)://spark-api-open.xf-yun.com
-BOT_API_MAAS_BASE_URL=http(s)://xingchen-api.xf-yun.com
+BOT_API_MAAS_BASE_URL=${CONSOLE_DOMAIN}/workflow/v1/chat/completions
 
 TENANT_CREATE_APP=http://core-tenant:${CORE_TENANT_PORT:-5052}/v2/app
 TENANT_GET_APP_DETAIL=http://core-tenant:${CORE_TENANT_PORT:-5052}/v2/app/details

--- a/docker/astronAgent/nginx/nginx.conf
+++ b/docker/astronAgent/nginx/nginx.conf
@@ -56,6 +56,34 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
+        # SSE (Server-Sent Events) API proxy for workflow chat completions
+        location /workflow/v1/chat/completions {
+            proxy_pass http://core-workflow:7880/workflow/v1/chat/completions;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # SSE specific settings
+            proxy_buffering off;                    # Disable buffering for real-time data transmission
+            proxy_cache off;                        # Disable caching
+            proxy_set_header Connection '';         # SSE uses persistent connections
+            proxy_http_version 1.1;                 # Use HTTP/1.1
+            chunked_transfer_encoding on;           # Enable chunked transfer encoding
+
+            # Prevent nginx from buffering responses
+            proxy_set_header X-Accel-Buffering no;
+
+            # Timeout settings - SSE requires long-lived connections
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 1800s;                # 30 minutes send timeout
+            proxy_read_timeout 1800s;                # 30 minutes read timeout
+
+            # Set correct headers for SSE
+            add_header Cache-Control 'no-cache';
+            add_header X-Accel-Buffering 'no';
+        }
+
         # SSE (Server-Sent Events) API proxy for chat messages
         location /console-api/chat-message/ {
             proxy_pass http://console-hub:8080/chat-message/;


### PR DESCRIPTION
- Add nginx proxy configuration for /workflow/v1/chat/completions with SSE support
- Update BOT_API_MAAS_BASE_URL to use CONSOLE_DOMAIN environment variable
- Configure proper SSE settings: disable buffering, enable chunked encoding, set 30min timeouts

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Breaking changes documented
