### PR TITLE
fix(frontend): prevent browser caching for runtime-config.js

### DIFF
--- a/console/frontend/index.html
+++ b/console/frontend/index.html
@@ -11,7 +11,17 @@
 
   <body>
     <div id="root"></div>
-    <script src="/runtime-config.js"></script>
+    <script>
+      // Dynamic loading with cache busting for runtime-config.js
+      (function () {
+        const script = document.createElement('script');
+        script.src = '/runtime-config.js?t=' + Date.now();
+        script.onerror = function () {
+          console.error('Failed to load runtime-config.js');
+        };
+        document.head.appendChild(script);
+      })();
+    </script>
     <script>
       const RELOAD_FLAG = '__VITE_PRELOAD_FIXED_AT__';
       let reloading = false;

--- a/docker/astronAgent/nginx/nginx.conf
+++ b/docker/astronAgent/nginx/nginx.conf
@@ -44,6 +44,19 @@ http {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
 
+        # Runtime config - no cache (dynamic config file)
+        location = /runtime-config.js {
+            proxy_pass http://console-frontend:1881;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable caching for runtime config
+            expires -1;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        }
+
         # Static resource caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             proxy_pass http://console-frontend:1881;


### PR DESCRIPTION
Resolve the issue where environment variables in runtime-config.js were not updating due to aggressive browser caching (memory cache and disk cache).

Changes:
- Add dynamic loading with timestamp query parameter (?t=Date.now()) in index.html to force fresh requests
- Add dedicated nginx location block for runtime-config.js with no-cache headers
- Ensure runtime config updates take effect immediately without manual cache clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
