### PR TITLE
refactor(ci): enforce check-only philosophy, remove auto-formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,10 +216,10 @@ jobs:
               echo "🔍 Running Python quality checks..."
               echo "1. Running flake8 code style check..."
               python3 -m flake8 --max-line-length 88 --ignore=E203,W503,E501 --max-complexity 10 .
-              echo "2. Running isort import formatting..."
-              python3 -m isort --profile black .
-              echo "3. Running black code formatting..."
-              python3 -m black .
+              echo "2. Checking isort import order..."
+              python3 -m isort --check-only --profile black .
+              echo "3. Checking black code format..."
+              python3 -m black --check .
               echo "4. Running mypy type checking..."
               python3 -m mypy --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --no-implicit-optional --ignore-missing-imports --explicit-package-bases .
               echo "5. Running pylint code analysis..."

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ go.work.sum
 bin/
 pkg/
 vendor/
+.gocache/
+.golangci-cache/
 
 # Java/Maven
 target/

--- a/Makefile
+++ b/Makefile
@@ -19,22 +19,21 @@ include makefiles/comment-check.mk
 # =============================================================================
 # Core command declarations
 # =============================================================================
-.PHONY: help setup format check test build push clean status info lint fix ci hooks enable-legacy
+.PHONY: help setup check test build push clean status info lint ci hooks
 
 # =============================================================================
-# Tier 1: Daily Core Commands (8) - These are all you need to remember!
+# Tier 1: Daily Core Commands (7) - These are all you need to remember!
 # =============================================================================
 
 # Default target - Intelligent help
 .DEFAULT_GOAL := help
-help: ## 📚 Show help information and project status  
+help: ## 📚 Show help information and project status
 	@echo "$(BLUE)🚀 Multi-language CI/CD Toolchain - Intelligent Version$(RESET)"
 	@echo "$(YELLOW)Active Projects:$(RESET) $(GREEN)$(ACTIVE_PROJECTS)$(RESET) | $(YELLOW)Current Context:$(RESET) $(GREEN)$(CURRENT_CONTEXT)$(RESET)"
 	@echo ""
 	@echo "$(BLUE)📋 Core Commands (Daily Development):$(RESET)"
 	@echo "  $(GREEN)make setup$(RESET)     🛠️  One-time environment setup (tools+hooks+branch strategy)"
-	@echo "  $(GREEN)make format$(RESET)    ✨  Format code (intelligent detection: $(ACTIVE_PROJECTS))"
-	@echo "  $(GREEN)make check$(RESET)     🔍  Quality check (intelligent detection: $(ACTIVE_PROJECTS))"  
+	@echo "  $(GREEN)make check$(RESET)     🔍  Quality check including format (intelligent detection: $(ACTIVE_PROJECTS))"
 	@echo "  $(GREEN)make test$(RESET)      🧪  Run tests (intelligent detection: $(ACTIVE_PROJECTS))"
 	@echo "  $(GREEN)make build$(RESET)     📦  Build projects (intelligent detection: $(ACTIVE_PROJECTS))"
 	@echo "  $(GREEN)make push$(RESET)      📤  Safe push to remote (with pre-checks)"
@@ -42,27 +41,24 @@ help: ## 📚 Show help information and project status
 	@echo ""
 	@echo "$(BLUE)🔧 Professional Commands:$(RESET)"
 	@echo "  $(GREEN)make status$(RESET)    📊  Show detailed project status"
-	@echo "  $(GREEN)make info$(RESET)      ℹ️   Show tools and dependency information"  
+	@echo "  $(GREEN)make info$(RESET)      ℹ️   Show tools and dependency information"
 	@echo "  $(GREEN)make lint$(RESET)      🔧  Run code linting (alias for check)"
-	@echo "  $(GREEN)make fix$(RESET)       🛠️  Auto-fix code issues"
-	@echo "  $(GREEN)make ci$(RESET)        🤖  Complete CI pipeline (format+check+test+build)"
-	@echo ""
-	@echo "$(BLUE)⚙️ Advanced Commands:$(RESET)"
+	@echo "  $(GREEN)make ci$(RESET)        🤖  Complete CI pipeline (check+test+build)"
 	@echo "  $(GREEN)make hooks$(RESET)     ⚙️  Git hooks management menu"
-	@echo "  $(GREEN)make enable-legacy$(RESET) 🔄  Enable complete legacy command set (backward compatibility)"
+	@echo ""
+	@echo "$(YELLOW)⚠️  CI Philosophy: Check-only, no auto-fix$(RESET)"
+	@echo "    CI systems detect issues, developers fix them manually"
 	@echo ""
 	@if [ "$(IS_MULTI_PROJECT)" = "true" ]; then \
 		echo "$(YELLOW)💡 Multi-project environment detected, all commands will intelligently handle multiple projects$(RESET)"; \
 	else \
-		echo "$(YELLOW)💡 Single project environment, please run common commands in corresponding subdirectories (setup/format/check/test/build)$(RESET)"; \
+		echo "$(YELLOW)💡 Single project environment, please run common commands in corresponding subdirectories (setup/check/test/build)$(RESET)"; \
 	fi
 
 # Core workflow commands - Direct calls to intelligent implementations
 setup: smart_setup ## 🛠️ One-time environment setup (tools+hooks+branch strategy)
 
-format: smart_format ## ✨ Intelligent code formatting (detect active projects)
-
-check: smart_check ## 🔍 Intelligent code quality check (detect active projects)  
+check: smart_check ## 🔍 Intelligent code quality check (detect active projects)
 
 test: smart_test ## 🧪 Intelligent test execution (detect active projects)
 
@@ -72,63 +68,33 @@ push: smart_push ## 📤 Intelligent safe push (branch check + quality check)
 
 clean: smart_clean ## 🧹 Intelligent cleanup of build artifacts
 
-# =============================================================================  
+# =============================================================================
 # Tier 2: Professional Commands (5)
 # =============================================================================
 
 status: smart_status ## 📊 Show detailed project status
 
-info: smart_info ## ℹ️ Show tools and dependency information  
+info: smart_info ## ℹ️ Show tools and dependency information
 
 lint: smart_check ## 🔧 Run code linting (alias for check)
 
-fix: smart_fix ## 🛠️ Auto-fix code issues (format + partial lint fixes)
-
-ci: smart_ci ## 🤖 Complete CI pipeline (format + check + test + build)
-
-# =============================================================================
-# Tier 3: Advanced Commands (2) 
-# =============================================================================
+ci: smart_ci ## 🤖 Complete CI pipeline (check + test + build)
 
 hooks: ## ⚙️ Git hooks management menu
 	@echo "$(BLUE)⚙️ Git Hooks Management$(RESET)"
 	@echo ""
 	@echo "$(GREEN)Install Hooks:$(RESET)"
 	@echo "  make hooks-install       📌 Install all hooks (recommended)"
-	@echo "  make hooks-install-basic 📋 Install basic hooks (lightweight)"
-	@echo "  make hooks-fmt           ✨ Format hooks only"
 	@echo "  make hooks-commit-msg    💬 Commit message hooks only"
+	@echo "  make hooks-pre-push      🚀 Pre-push hooks only"
 	@echo ""
 	@echo "$(RED)Uninstall Hooks:$(RESET)"
 	@echo "  make hooks-uninstall     ❌ Uninstall all hooks"
 	@echo ""
+	@echo "$(YELLOW)⚠️  Note: Hooks only check code, no auto-formatting$(RESET)"
+	@echo ""
 	@echo "$(YELLOW)Current Hook Status:$(RESET)"
 	@ls -la .git/hooks/ | grep -E "(pre-commit|commit-msg|pre-push)" | head -3
-
-enable-legacy: ## 🔄 Enable complete legacy command set (backward compatibility)
-	@echo "$(YELLOW)🔄 Enabling legacy command set...$(RESET)"
-	@if [ ! -f "makefiles/legacy/enabled" ]; then \
-		echo "# Legacy commands enabled" > makefiles/legacy/enabled; \
-		echo "$(GREEN)✅ Legacy command set enabled$(RESET)"; \
-		echo ""; \
-		echo "$(BLUE)You can now use all original commands, for example:$(RESET)"; \
-		echo "  make fmt-go fmt-java fmt-python fmt-typescript"; \
-		echo "  make check-go check-java check-python check-typescript"; \
-		echo "  make install-tools-go install-tools-java ..."; \
-		echo ""; \
-		echo "$(YELLOW)Note: Recommended to prioritize new intelligent commands for better experience$(RESET)"; \
-	else \
-		echo "$(GREEN)✅ Legacy command set already enabled$(RESET)"; \
-	fi
-
-# =============================================================================
-# Backward compatibility: Conditional inclusion of legacy commands
-# =============================================================================
--include makefiles/legacy/enabled
-ifneq (,$(wildcard makefiles/legacy/enabled))
-    # If legacy mode is enabled, additional legacy command definitions can be included here
-    # In current version, legacy commands are directly available through original module files
-endif
 
 # =============================================================================
 # Hidden utility commands (for debugging and testing)

--- a/makefiles/check-comments.sh
+++ b/makefiles/check-comments.sh
@@ -277,7 +277,7 @@ main() {
         if [ -d "$go_dir" ]; then
             while IFS= read -r -d '' file; do
                 source_files+=("$file")
-            done < <(find "$go_dir" -name "*.go" -print0 2>/dev/null || true)
+            done < <(find "$go_dir" -name "*.go" ! -path "*/vendor/*" -print0 2>/dev/null || true)
         fi
     done
 
@@ -286,7 +286,7 @@ main() {
         if [ -d "$java_dir" ]; then
             while IFS= read -r -d '' file; do
                 source_files+=("$file")
-            done < <(find "$java_dir" -name "*.java" -print0 2>/dev/null || true)
+            done < <(find "$java_dir" -name "*.java" ! -path "*/target/*" -print0 2>/dev/null || true)
         fi
     done
 
@@ -295,7 +295,7 @@ main() {
         if [ -d "$python_dir" ]; then
             while IFS= read -r -d '' file; do
                 source_files+=("$file")
-            done < <(find "$python_dir" -name "*.py" -print0 2>/dev/null || true)
+            done < <(find "$python_dir" -name "*.py" ! -path "*/.venv/*" ! -path "*/venv/*" ! -path "*/__pycache__/*" ! -path "*.egg-info/*" -print0 2>/dev/null || true)
         fi
     done
 
@@ -304,7 +304,7 @@ main() {
         if [ -d "$ts_dir" ]; then
             while IFS= read -r -d '' file; do
                 source_files+=("$file")
-            done < <(find "$ts_dir" -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" | grep -v node_modules | head -20 | tr '\n' '\0' 2>/dev/null || true)
+            done < <(find "$ts_dir" \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \) ! -path "*/node_modules/*" ! -path "*/dist/*" ! -path "*/build/*" -print0 2>/dev/null | head -z -20 || true)
         fi
     done
 

--- a/makefiles/comment-check.mk
+++ b/makefiles/comment-check.mk
@@ -39,7 +39,7 @@ check-comments-go: ## Check Go comments for English language
 		for dir in $(GO_DIRS); do \
 			if [ -d "$$dir" ]; then \
 				echo "  Processing $$dir..."; \
-				find $$dir -name "*.go" -exec grep -l '//' {} \; 2>/dev/null | while read file; do \
+				find $$dir -name "*.go" ! -path "*/vendor/*" -exec grep -l '//' {} \; 2>/dev/null | while read file; do \
 					echo "    Checking: $$file"; \
 					grep -n '//' "$$file" | while IFS=: read -r line_num comment; do \
 						comment_text=$$(echo "$$comment" | sed 's|^\s*//\s*||'); \
@@ -70,7 +70,7 @@ check-comments-java: ## Check Java comments for English language
 		for dir in $(JAVA_DIRS); do \
 			if [ -d "$$dir" ]; then \
 				echo "  Processing $$dir..."; \
-				find $$dir -name "*.java" -exec grep -l '//' {} \; 2>/dev/null | while read file; do \
+				find $$dir -name "*.java" ! -path "*/target/*" -exec grep -l '//' {} \; 2>/dev/null | while read file; do \
 					echo "    Checking: $$file"; \
 					grep -n '//' "$$file" | while IFS=: read -r line_num comment; do \
 						comment_text=$$(echo "$$comment" | sed 's|^\s*//\s*||'); \
@@ -101,7 +101,7 @@ check-comments-python: ## Check Python comments for English language
 		for dir in $(PYTHON_DIRS); do \
 			if [ -d "$$dir" ]; then \
 				echo "  Processing $$dir..."; \
-				find $$dir -name "*.py" -exec grep -l '#' {} \; 2>/dev/null | while read file; do \
+				find $$dir -name "*.py" ! -path "*/.venv/*" ! -path "*/venv/*" ! -path "*/__pycache__/*" ! -path "*.egg-info/*" -exec grep -l '#' {} \; 2>/dev/null | while read file; do \
 					echo "    Checking: $$file"; \
 					grep -n '#' "$$file" | while IFS=: read -r line_num comment; do \
 						comment_text=$$(echo "$$comment" | sed 's|^\s*#\s*||'); \
@@ -132,7 +132,7 @@ check-comments-typescript: ## Check TypeScript comments for English language
 		for dir in $(TS_DIRS); do \
 			if [ -d "$$dir" ]; then \
 				echo "  Processing $$dir..."; \
-				find $$dir -name "*.ts" -o -name "*.tsx" | grep -v node_modules | while read file; do \
+				find $$dir \( -name "*.ts" -o -name "*.tsx" \) ! -path "*/node_modules/*" ! -path "*/dist/*" ! -path "*/build/*" | while read file; do \
 					echo "    Checking: $$file"; \
 					grep -n '//' "$$file" 2>/dev/null | while IFS=: read -r line_num comment; do \
 						comment_text=$$(echo "$$comment" | sed 's|^\s*//\s*||'); \
@@ -165,7 +165,7 @@ check-comments-typescript: ## Check TypeScript comments for English language
 smart_check_with_comments: smart_check check-comments ## Smart check including comment language verification
 
 # Add comment check to CI workflow
-smart_ci_with_comments: smart_format smart_check check-comments smart_test smart_build ## Full CI with comment checks
+smart_ci_with_comments: smart_check check-comments smart_test smart_build ## Full CI with comment checks
 
 # =============================================================================
 # Help and Info

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -29,7 +29,7 @@ project-status: ## Show detected project status
 	@if [ -d "backend-python" ]; then echo "  $(GREEN)✓ Python Backend$(RESET)    (backend-python/)"; else echo "  $(RED)✗ Python Backend$(RESET)    (backend-python/)"; fi
 
 # Multi-language tool installation aggregate command
-install-tools: ## Install formatting and checking tools for all languages
+install-tools: ## Install development and checking tools for all languages
 	@echo "$(YELLOW)Installing multi-language development tools...$(RESET)"
 	@make --no-print-directory install-tools-go
 	@make --no-print-directory install-tools-typescript
@@ -46,17 +46,6 @@ check-tools: ## Check if development tools for all languages are installed
 	@make --no-print-directory check-tools-python
 	@echo "$(GREEN)Multi-language tools check completed!$(RESET)"
 
-# Multi-language formatting aggregate command
-fmt: fmt-all ## Format all project code
-
-fmt-all: ## Format code for all language projects
-	@echo "$(YELLOW)Formatting all projects...$(RESET)"
-	@make --no-print-directory fmt-go
-	@make --no-print-directory fmt-typescript
-	@make --no-print-directory fmt-console-backend
-	@make --no-print-directory fmt-python
-	@echo "$(GREEN)All projects formatted!$(RESET)"
-
 check-all: ## Check code quality for all language projects
 	@echo "$(YELLOW)Running code quality checks for all projects...$(RESET)"
 	@make --no-print-directory check-go
@@ -64,15 +53,6 @@ check-all: ## Check code quality for all language projects
 	@make --no-print-directory check-console-backend
 	@make --no-print-directory check-python
 	@echo "$(GREEN)All code quality checks completed!$(RESET)"
-
-# Format check (without modifying files)
-fmt-check: ## Check if code format meets standards (without modifying files)
-	@echo "$(YELLOW)Checking code formatting...$(RESET)"
-	@make --no-print-directory fmt-check-go
-	@make --no-print-directory fmt-check-typescript
-	@make --no-print-directory fmt-check-console-backend
-	@make --no-print-directory fmt-check-python
-	@echo "$(GREEN)Code formatting checks passed$(RESET)"
 
 # Development environment setup
 dev-setup: install-tools hooks-install branch-setup ## Setup complete development environment
@@ -87,11 +67,9 @@ dev-setup: install-tools hooks-install branch-setup ## Setup complete developmen
 	@echo ""
 	@echo "$(BLUE)Available Git Hook commands:$(RESET)"
 	@echo "  Installation commands:"
-	@echo "    make hooks-install       - Install all hooks (recommended)"
-	@echo "    make hooks-install-basic - Install basic hooks (lightweight)"
-	@echo "    make hooks-check-all     - Pre-commit only (full checks)"
-	@echo "    make hooks-fmt           - Pre-commit only (formatting)"
+	@echo "    make hooks-install       - Install all hooks (check-only mode)"
 	@echo "    make hooks-commit-msg    - Commit-msg validation only"
+	@echo "    make hooks-pre-push      - Pre-push branch validation"
 	@echo "  Uninstall commands:"
 	@echo "    make hooks-uninstall     - Uninstall all hooks"
 	@echo "    make hooks-uninstall-pre - Uninstall pre-commit hook"

--- a/makefiles/core/workflows.mk
+++ b/makefiles/core/workflows.mk
@@ -37,43 +37,6 @@ smart_install_tools:
 	done
 
 # =============================================================================
-# Intelligent Formatting - format
-# =============================================================================
-smart_format: ## ✨ Intelligent code formatting (detects active projects)
-	@if [ -z "$(ACTIVE_PROJECTS)" ]; then \
-		echo "$(RED)❌ No active projects detected$(RESET)"; \
-		exit 1; \
-	fi
-	@echo "$(BLUE)✨ Intelligent formatting: $(GREEN)$(ACTIVE_PROJECTS)$(RESET)"
-	@if [ -n "$(LOCALCI_CONFIG)" ]; then \
-		echo "$(YELLOW)Using configuration: $(LOCALCI_CONFIG)$(RESET)"; \
-		for lang in $(ACTIVE_PROJECTS); do \
-			apps="$$(makefiles/parse_localci.sh enabled $$lang $(LOCALCI_CONFIG) | cut -d'|' -f2)"; \
-			if [ -n "$$apps" ]; then \
-				for dir in $$apps; do \
-					echo "  - Formatting($$lang): $$dir"; \
-					case $$lang in \
-						go) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory fmt-go; fi ;; \
-						java) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory fmt-java; fi ;; \
-						python) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory fmt-python; fi ;; \
-						typescript) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory fmt-typescript; fi ;; \
-					esac; \
-				done; \
-			fi; \
-		done; \
-	else \
-		for project in $(ACTIVE_PROJECTS); do \
-			case $$project in \
-				go) echo "  - Formatting Go code..." && $(MAKE) --no-print-directory fmt-go ;; \
-				java) echo "  - Formatting Java code..." && $(MAKE) --no-print-directory fmt-java ;; \
-				python) echo "  - Formatting Python code..." && $(MAKE) --no-print-directory fmt-python ;; \
-				typescript) echo "  - Formatting TypeScript code..." && $(MAKE) --no-print-directory fmt-typescript ;; \
-			esac; \
-		done; \
-	fi
-	@echo "$(GREEN)✅ Formatting complete: $(ACTIVE_PROJECTS)$(RESET)"
-
-# =============================================================================
 # Intelligent Quality Check - check
 # =============================================================================
 smart_check: ## 🔍 Intelligent code quality check (detect active projects)
@@ -82,45 +45,23 @@ smart_check: ## 🔍 Intelligent code quality check (detect active projects)
 		exit 1; \
 	fi
 	@echo "$(BLUE)🔍 Intelligent quality check: $(GREEN)$(ACTIVE_PROJECTS)$(RESET)"
-	@if [ -n "$(LOCALCI_CONFIG)" ]; then \
-		echo "$(YELLOW)Using configuration: $(LOCALCI_CONFIG)$(RESET)"; \
-		for lang in $(ACTIVE_PROJECTS); do \
-			apps="$$(makefiles/parse_localci.sh enabled $$lang $(LOCALCI_CONFIG) | cut -d'|' -f2)"; \
-			if [ -n "$$apps" ]; then \
-				for dir in $$apps; do \
-					echo "  - Checking($$lang): $$dir"; \
-					case $$lang in \
-						go) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory check-go; fi ;; \
-						java) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory check-java; fi ;; \
-						python) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory check-python; fi ;; \
-						typescript) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory check-typescript; fi ;; \
-					esac; \
-				done; \
-			fi; \
-		done; \
-	else \
-		for project in $(ACTIVE_PROJECTS); do \
-			case $$project in \
-				go) echo "  - Checking Go code..." && $(MAKE) --no-print-directory check-go ;; \
-				java) echo "  - Checking Java code..." && $(MAKE) --no-print-directory check-java ;; \
-				python) echo "  - Checking Python code..." && $(MAKE) --no-print-directory check-python ;; \
-				typescript) echo "  - Checking TypeScript code..." && $(MAKE) --no-print-directory check-typescript ;; \
-			esac; \
-		done; \
-	fi
+	@for project in $(ACTIVE_PROJECTS); do \
+		case $$project in \
+			go) echo "  - Checking Go code..." && $(MAKE) --no-print-directory check-go ;; \
+			java) echo "  - Checking Java code..." && $(MAKE) --no-print-directory check-java ;; \
+			python) echo "  - Checking Python code..." && $(MAKE) --no-print-directory check-python ;; \
+			typescript) echo "  - Checking TypeScript code..." && $(MAKE) --no-print-directory check-typescript ;; \
+		esac; \
+	done
 	@echo "$(YELLOW)Checking comment language compliance...$(RESET)"
-	@if [ -n "$(LOCALCI_CONFIG)" ]; then \
-		for lang in $(ACTIVE_PROJECTS); do \
-			case $$lang in \
-				go) $(MAKE) --no-print-directory check-comments-go ;; \
-				java) $(MAKE) --no-print-directory check-comments-java ;; \
-				python) $(MAKE) --no-print-directory check-comments-python ;; \
-				typescript) $(MAKE) --no-print-directory check-comments-typescript ;; \
-			esac; \
-		done; \
-	else \
-		$(MAKE) --no-print-directory check-comments; \
-	fi
+	@for lang in $(ACTIVE_PROJECTS); do \
+		case $$lang in \
+			go) $(MAKE) --no-print-directory check-comments-go ;; \
+			java) $(MAKE) --no-print-directory check-comments-java ;; \
+			python) $(MAKE) --no-print-directory check-comments-python ;; \
+			typescript) $(MAKE) --no-print-directory check-comments-typescript ;; \
+		esac; \
+	done
 	@echo "$(GREEN)✅ Quality check complete: $(ACTIVE_PROJECTS)$(RESET)"
 
 # =============================================================================
@@ -132,31 +73,14 @@ smart_test: ## 🧪 Intelligent test execution (detect active projects)
 		exit 1; \
 	fi
 	@echo "$(BLUE)🧪 Intelligent testing: $(GREEN)$(ACTIVE_PROJECTS)$(RESET)"
-	@if [ -n "$(LOCALCI_CONFIG)" ]; then \
-		for lang in $(ACTIVE_PROJECTS); do \
-			apps="$$(makefiles/parse_localci.sh enabled $$lang $(LOCALCI_CONFIG) | cut -d'|' -f2)"; \
-			if [ -n "$$apps" ]; then \
-				for dir in $$apps; do \
-					echo "  - Testing($$lang): $$dir"; \
-					case $$lang in \
-						go) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory test-go; fi ;; \
-						java) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory test-java; fi ;; \
-						python) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory test-python; fi ;; \
-						typescript) echo "    Skipping TypeScript tests (not configured yet)" ;; \
-					esac; \
-				done; \
-			fi; \
-		done; \
-	else \
-		for project in $(ACTIVE_PROJECTS); do \
-			case $$project in \
-				go) echo "  - Running Go tests..." && $(MAKE) --no-print-directory test-go ;; \
-				java) echo "  - Running Java tests..." && $(MAKE) --no-print-directory test-java ;; \
-				python) echo "  - Running Python tests..." && $(MAKE) --no-print-directory test-python ;; \
-				typescript) echo "  - Skipping TypeScript tests (not configured yet)" ;; \
-			esac; \
-		done; \
-	fi
+	@for project in $(ACTIVE_PROJECTS); do \
+		case $$project in \
+			go) echo "  - Running Go tests..." && $(MAKE) --no-print-directory test-go ;; \
+			java) echo "  - Running Java tests..." && $(MAKE) --no-print-directory test-java ;; \
+			python) echo "  - Running Python tests..." && $(MAKE) --no-print-directory test-python ;; \
+			typescript) echo "  - Skipping TypeScript tests (not configured yet)" ;; \
+		esac; \
+	done
 	@echo "$(GREEN)✅ Testing complete: $(ACTIVE_PROJECTS)$(RESET)"
 
 # =============================================================================
@@ -168,31 +92,14 @@ smart_build: ## 📦 Intelligent project build (detect active projects)
 		exit 1; \
 	fi
 	@echo "$(BLUE)📦 Intelligent build: $(GREEN)$(ACTIVE_PROJECTS)$(RESET)"
-	@if [ -n "$(LOCALCI_CONFIG)" ]; then \
-		for lang in $(ACTIVE_PROJECTS); do \
-			apps="$$(makefiles/parse_localci.sh enabled $$lang $(LOCALCI_CONFIG) | cut -d'|' -f2)"; \
-			if [ -n "$$apps" ]; then \
-				for dir in $$apps; do \
-					echo "  - Building($$lang): $$dir"; \
-					case $$lang in \
-						go) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory build-go; fi ;; \
-						java) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory build-java; fi ;; \
-						python) echo "    (Python doesn't need building)" ;; \
-						typescript) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory build-typescript; fi ;; \
-					esac; \
-				done; \
-			fi; \
-		done; \
-	else \
-		for project in $(ACTIVE_PROJECTS); do \
-			case $$project in \
-				go) echo "  - Building Go project..." && $(MAKE) --no-print-directory build-go ;; \
-				java) echo "  - Building Java project..." && $(MAKE) --no-print-directory build-java ;; \
-				python) echo "  - Python doesn't need building (interpreted execution)" ;; \
-				typescript) echo "  - Building TypeScript project..." && cd frontend-ts && npm run build ;; \
-			esac; \
-		done; \
-	fi
+	@for project in $(ACTIVE_PROJECTS); do \
+		case $$project in \
+			go) echo "  - Building Go project..." && $(MAKE) --no-print-directory build-go ;; \
+			java) echo "  - Building Java project..." && $(MAKE) --no-print-directory build-java ;; \
+			python) echo "  - Python doesn't need building (interpreted execution)" ;; \
+			typescript) echo "  - Building TypeScript project..." && $(MAKE) --no-print-directory build-typescript ;; \
+		esac; \
+	done
 	@echo "$(GREEN)✅ Build complete: $(ACTIVE_PROJECTS)$(RESET)"
 
 # (dev series commands have been removed)
@@ -205,7 +112,6 @@ smart_push: ## 📤 Intelligent safe push (branch check + quality check)
 	@echo "$(YELLOW)Checking branch naming convention...$(RESET)"
 	@$(MAKE) --no-print-directory check-branch
 	@echo "$(YELLOW)Running pre-push quality check...$(RESET)"
-	@$(MAKE) --no-print-directory smart_format
 	@$(MAKE) --no-print-directory smart_check
 	@echo "$(YELLOW)Pushing to remote repository...$(RESET)"
 	@$(MAKE) --no-print-directory safe-push
@@ -216,55 +122,25 @@ smart_push: ## 📤 Intelligent safe push (branch check + quality check)
 # =============================================================================
 smart_clean: ## 🧹 Intelligent cleanup of build artifacts
 	@echo "$(BLUE)🧹 Intelligent cleanup: $(GREEN)$(ACTIVE_PROJECTS)$(RESET)"
-		@if [ -n "$(LOCALCI_CONFIG)" ]; then \
-			for lang in $(ACTIVE_PROJECTS); do \
-			apps="$$(makefiles/parse_localci.sh enabled $$lang $(LOCALCI_CONFIG) | cut -d'|' -f2)"; \
-			if [ -n "$$apps" ]; then \
-				for dir in $$apps; do \
-					echo "  - Cleaning($$lang): $$dir"; \
-					case $$lang in \
-						go) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory clean-go; fi ;; \
-						java) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory clean-java; fi ;; \
-						python) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory clean-python; fi ;; \
-						typescript) if [ -d "$$dir" ]; then $(MAKE) --no-print-directory clean-typescript; fi ;; \
-					esac; \
-				done; \
-			fi; \
-		done; \
-	else \
-		for project in $(ACTIVE_PROJECTS); do \
-			case $$project in \
-				go) echo "  - Cleaning Go build artifacts..." && \
-					if [ -d "backend-go" ]; then cd backend-go && go clean && rm -f bin/* || true; else echo "    Go directory does not exist"; fi ;; \
-				java) echo "  - Cleaning Java build artifacts..." && \
-					if [ -d "backend-java" ]; then $(MAKE) --no-print-directory clean-java; else echo "    Java directory does not exist"; fi ;; \
-				python) echo "  - Cleaning Python cache..." && \
-						if [ -d "backend-python" ]; then find backend-python -type d -name "__pycache__" -exec rm -rf {} \; 2>/dev/null || true; else echo "    Python directory does not exist"; fi ;; \
-				typescript) echo "  - Cleaning TypeScript build artifacts..." && \
-					if [ -d "frontend-ts" ]; then cd frontend-ts && rm -rf dist node_modules/.cache || true; else echo "    TypeScript directory does not exist"; fi ;; \
-			esac; \
-		done; \
-	fi
+	@for project in $(ACTIVE_PROJECTS); do \
+		case $$project in \
+			go) echo "  - Cleaning Go build artifacts..." && $(MAKE) --no-print-directory clean-go ;; \
+			java) echo "  - Cleaning Java build artifacts..." && $(MAKE) --no-print-directory clean-java ;; \
+			python) echo "  - Cleaning Python cache..." && $(MAKE) --no-print-directory clean-python ;; \
+			typescript) echo "  - Cleaning TypeScript build artifacts..." && $(MAKE) --no-print-directory clean-typescript ;; \
+		esac; \
+	done
 	@echo "$(GREEN)✅ Cleanup complete: $(ACTIVE_PROJECTS)$(RESET)"
 
 # =============================================================================
 # Intelligent CI Pipeline - ci
 # =============================================================================
-smart_ci: ## 🤖 Complete CI pipeline (format + check + test + build)
+smart_ci: ## 🤖 Complete CI pipeline (check + test + build)
 	@echo "$(BLUE)🤖 Complete CI pipeline starting$(RESET)"
-	@$(MAKE) --no-print-directory smart_format
-	@$(MAKE) --no-print-directory smart_check  
+	@$(MAKE) --no-print-directory smart_check
 	@$(MAKE) --no-print-directory smart_test
 	@$(MAKE) --no-print-directory smart_build
 	@echo "$(GREEN)✅ CI pipeline complete$(RESET)"
-
-# =============================================================================
-# Intelligent Fix - fix  
-# =============================================================================
-smart_fix: ## 🛠️ Intelligent code fix (formatting + partial auto-fixes)
-	@echo "$(BLUE)🛠️ Intelligent code fix$(RESET)"
-	@$(MAKE) --no-print-directory smart_format
-	@echo "$(GREEN)✅ Auto-fix complete (mainly formatting)$(RESET)"
 
 # =============================================================================
 # Utility Functions

--- a/makefiles/git.mk
+++ b/makefiles/git.mk
@@ -6,63 +6,24 @@
 # Git Hooks Installation
 # =============================================================================
 
-hooks-check-all: ## Install pre-commit hook (formatting + code quality checks)
-	@echo "$(YELLOW)Installing Git pre-commit hook (fmt + checks)...$(RESET)"
+hooks-check-all: ## Install pre-commit hook (code quality checks only, no auto-format)
+	@echo "$(YELLOW)Installing Git pre-commit hook (checks only)...$(RESET)"
 	@mkdir -p .git/hooks
 	@echo '#!/bin/sh' > .git/hooks/pre-commit
-	@echo '# Auto-format code and run quality checks before commit' >> .git/hooks/pre-commit
-	@echo 'echo "$(YELLOW)Running code formatting...$(RESET)"' >> .git/hooks/pre-commit
-	@echo '' >> .git/hooks/pre-commit
-	@echo '# Run formatting' >> .git/hooks/pre-commit
-	@echo 'make fmt' >> .git/hooks/pre-commit
-	@echo '' >> .git/hooks/pre-commit
-	@echo '# Check if any files were modified by formatting' >> .git/hooks/pre-commit
-	@echo 'if [ -n "$$(git diff --name-only)" ]; then' >> .git/hooks/pre-commit
-	@echo '    echo "$(GREEN)Code formatting completed. Adding formatted files to commit...$(RESET)"' >> .git/hooks/pre-commit
-	@echo '    git add -u' >> .git/hooks/pre-commit
-	@echo '    echo "$(GREEN)Formatted files added to commit.$(RESET)"' >> .git/hooks/pre-commit
-	@echo 'else' >> .git/hooks/pre-commit
-	@echo '    echo "$(GREEN)No formatting changes needed.$(RESET)"' >> .git/hooks/pre-commit
-	@echo 'fi' >> .git/hooks/pre-commit
-	@echo '' >> .git/hooks/pre-commit
-	@echo '# Run multi-language code quality checks' >> .git/hooks/pre-commit
-	@echo 'echo "$(YELLOW)Running multi-language code quality checks...$(RESET)"' >> .git/hooks/pre-commit
+	@echo '# Run quality checks before commit - NO AUTO-FORMATTING' >> .git/hooks/pre-commit
+	@echo 'echo "$(YELLOW)Running code quality checks (including format checks)...$(RESET)"' >> .git/hooks/pre-commit
 	@echo '' >> .git/hooks/pre-commit
 	@echo '# Run all project quality checks' >> .git/hooks/pre-commit
-	@echo 'if ! make check >/dev/null 2>&1; then' >> .git/hooks/pre-commit
-	@echo '    echo "$(RED)Code quality checks failed. Please fix the issues.$(RESET)"' >> .git/hooks/pre-commit
+	@echo 'if ! make check; then' >> .git/hooks/pre-commit
+	@echo '    echo "$(RED)Code quality checks failed. Please fix the issues manually.$(RESET)"' >> .git/hooks/pre-commit
 	@echo '    echo "$(YELLOW)Tip: Run '\''make check'\'' to see detailed error messages$(RESET)"' >> .git/hooks/pre-commit
-	@echo '    echo "$(YELLOW)Or run language-specific checks: make check-go/check-console-frontend/check-java/check-python$(RESET)"' >> .git/hooks/pre-commit
+	@echo '    echo "$(YELLOW)Format issues should be fixed manually, not by CI$(RESET)"' >> .git/hooks/pre-commit
 	@echo '    exit 1' >> .git/hooks/pre-commit
 	@echo 'fi' >> .git/hooks/pre-commit
 	@echo '' >> .git/hooks/pre-commit
 	@echo 'echo "$(GREEN)All pre-commit checks passed!$(RESET)"' >> .git/hooks/pre-commit
 	@chmod +x .git/hooks/pre-commit
-	@echo "$(GREEN)Git pre-commit hook (fmt + checks) installed$(RESET)"
-
-hooks-fmt: ## Install pre-commit hook (formatting only)
-	@echo "$(YELLOW)Installing Git pre-commit hook (fmt only)...$(RESET)"
-	@mkdir -p .git/hooks
-	@echo '#!/bin/sh' > .git/hooks/pre-commit
-	@echo '# Auto-format code before commit (no quality checks)' >> .git/hooks/pre-commit
-	@echo 'echo "$(YELLOW)Running code formatting...$(RESET)"' >> .git/hooks/pre-commit
-	@echo '' >> .git/hooks/pre-commit
-	@echo '# Run formatting' >> .git/hooks/pre-commit
-	@echo 'make fmt' >> .git/hooks/pre-commit
-	@echo '' >> .git/hooks/pre-commit
-	@echo '# Check if any files were modified by formatting' >> .git/hooks/pre-commit
-	@echo 'if [ -n "$$(git diff --name-only)" ]; then' >> .git/hooks/pre-commit
-	@echo '    echo "$(GREEN)Code formatting completed. Adding formatted files to commit...$(RESET)"' >> .git/hooks/pre-commit
-	@echo '    git add -u' >> .git/hooks/pre-commit
-	@echo '    echo "$(GREEN)Formatted files added to commit.$(RESET)"' >> .git/hooks/pre-commit
-	@echo 'else' >> .git/hooks/pre-commit
-	@echo '    echo "$(GREEN)No formatting changes needed.$(RESET)"' >> .git/hooks/pre-commit
-	@echo 'fi' >> .git/hooks/pre-commit
-	@echo '' >> .git/hooks/pre-commit
-	@echo 'echo "$(GREEN)Pre-commit formatting completed!$(RESET)"' >> .git/hooks/pre-commit
-	@echo 'echo "$(YELLOW)Note: Run '\''make check-all'\'' manually for quality checks$(RESET)"' >> .git/hooks/pre-commit
-	@chmod +x .git/hooks/pre-commit
-	@echo "$(GREEN)Git pre-commit hook (fmt only) installed$(RESET)"
+	@echo "$(GREEN)Git pre-commit hook (check-only mode) installed$(RESET)"
 
 hooks-commit-msg: ## Install commit-msg hook for commit message format validation
 	@echo "$(YELLOW)Installing Git commit-msg hook...$(RESET)"
@@ -149,11 +110,9 @@ hooks-uninstall-msg: ## Uninstall commit-msg hook
 	fi
 
 # Combined installation commands
-hooks-install: hooks-check-all hooks-commit-msg hooks-pre-push ## Install all Git hooks (pre-commit full mode + commit-msg + pre-push)
+hooks-install: hooks-check-all hooks-commit-msg hooks-pre-push ## Install all Git hooks (pre-commit check + commit-msg + pre-push)
 	@echo "$(GREEN)All Git hooks installed!$(RESET)"
-
-hooks-install-basic: hooks-fmt hooks-commit-msg hooks-pre-push ## Install basic Git hooks (pre-commit lightweight mode + commit-msg + pre-push)
-	@echo "$(GREEN)Basic Git hooks installed!$(RESET)"
+	@echo "$(YELLOW)Note: Hooks check code quality but don't auto-fix$(RESET)"
 
 # =============================================================================
 # Branch Management

--- a/makefiles/go.mk
+++ b/makefiles/go.mk
@@ -63,35 +63,6 @@ check-tools-go: ## ✅ Check Go development tools availability
 		echo "  Go version: $$($(GO) version)"; \
 	fi
 
-fmt-go: ## ✨ Format Go code
-	@if [ -n "$(GO_DIRS)" ]; then \
-		echo "$(YELLOW)Formatting Go code in: $(GO_DIRS)$(RESET)"; \
-		for dir in $(GO_DIRS); do \
-			if [ -d "$$dir" ]; then \
-				echo "$(YELLOW)  Processing $$dir...$(RESET)"; \
-				gofiles="$$(find $$dir -name "*.go" 2>/dev/null || true)"; \
-				if [ -n "$$gofiles" ]; then \
-					if command -v $(GOIMPORTS) >/dev/null 2>&1; then \
-						$(GOIMPORTS) -w $$gofiles >/dev/null 2>&1 || true; \
-					fi; \
-					if command -v $(GOFUMPT) >/dev/null 2>&1; then \
-						$(GOFUMPT) -w $$gofiles >/dev/null 2>&1 || true; \
-					fi; \
-					if command -v $(GOLINES) >/dev/null 2>&1; then \
-						$(GOLINES) -w -m 120 $$gofiles >/dev/null 2>&1 || true; \
-					fi; \
-				else \
-					echo "$(BLUE)    No Go files found in $$dir$(RESET)"; \
-				fi; \
-			else \
-				echo "$(RED)    Directory $$dir does not exist$(RESET)"; \
-			fi; \
-		done; \
-		echo "$(GREEN)Go code formatting completed$(RESET)"; \
-	else \
-		echo "$(BLUE)Skipping Go formatting (no Go projects configured)$(RESET)"; \
-	fi
-
 check-go: ## 🔍 Check Go code quality
 	@if [ -n "$(GO_DIRS)" ]; then \
 		echo "$(YELLOW)Checking Go code quality in: $(GO_DIRS)$(RESET)"; \
@@ -106,7 +77,7 @@ check-go: ## 🔍 Check Go code quality
 						unformatted="$$($(GOIMPORTS) -l $$gofiles)"; \
 						if [ -n "$$unformatted" ]; then \
 							echo "$(RED)    Files not formatted: $$unformatted$(RESET)"; \
-							echo "$(YELLOW)    Run 'make fmt-go' to fix$(RESET)"; \
+							echo "$(YELLOW)    Run 'goimports -w .' to fix formatting issues$(RESET)"; \
 							exit 1; \
 						fi; \
 					fi; \

--- a/makefiles/java.mk
+++ b/makefiles/java.mk
@@ -58,24 +58,6 @@ check-tools-java: ## ✅ Check Java development tools availability
 		echo "  Maven version: $$(mvn --version | head -n 1)"; \
 	fi
 
-fmt-java: ## ✨ Format Java code
-	@if [ -n "$(JAVA_DIRS)" ]; then \
-		echo "$(YELLOW)Formatting Java code in: $(JAVA_DIRS)$(RESET)"; \
-		for dir in $(JAVA_DIRS); do \
-			if [ -d "$$dir" ]; then \
-				echo "$(YELLOW)  Processing $$dir...$(RESET)"; \
-				cd $$dir && $(MVN) spotless:apply $(MAVEN_DEFAULT_OPTS); \
-				cd - > /dev/null; \
-			else \
-				echo "$(RED)    Directory $$dir does not exist$(RESET)"; \
-			fi; \
-		done; \
-		echo "$(GREEN)Java code formatting completed$(RESET)"; \
-	else \
-		echo "$(BLUE)Skipping Java formatting (no Java projects configured)$(RESET)"; \
-	fi
-	@echo "$(GREEN)Console backend code formatting checks passed$(RESET)"
-
 check-java: ## 🔍 Check Java code quality
 	@if [ -n "$(JAVA_DIRS)" ]; then \
 		echo "$(YELLOW)Checking Java code quality in: $(JAVA_DIRS)$(RESET)"; \

--- a/makefiles/python.mk
+++ b/makefiles/python.mk
@@ -62,25 +62,6 @@ check-tools-python: ## ✅ Check Python development tools availability
 		echo "  Pip version: $$($(PYTHON) -m pip --version)"; \
 	fi
 
-fmt-python: ## ✨ Format Python code
-	@if [ -n "$(PYTHON_DIRS)" ]; then \
-		echo "$(YELLOW)Formatting Python code in: $(PYTHON_DIRS)$(RESET)"; \
-		for dir in $(PYTHON_DIRS); do \
-			if [ -d "$$dir" ]; then \
-				echo "$(YELLOW)  Processing $$dir...$(RESET)"; \
-				cd $$dir && \
-				$(PYTHON) -m $(ISORT) . && \
-				$(PYTHON) -m $(BLACK) .; \
-				cd - > /dev/null; \
-			else \
-				echo "$(RED)    Directory $$dir does not exist$(RESET)"; \
-			fi; \
-		done; \
-		echo "$(GREEN)Python code formatting completed$(RESET)"; \
-	else \
-		echo "$(BLUE)Skipping Python formatting (no Python projects configured)$(RESET)"; \
-	fi
-
 check-python: ## 🔍 Check Python code quality
 	@if [ -n "$(PYTHON_DIRS)" ]; then \
 		echo "$(YELLOW)Checking Python code quality in: $(PYTHON_DIRS)$(RESET)"; \
@@ -91,10 +72,10 @@ check-python: ## 🔍 Check Python code quality
 				if (cd $$dir && \
 				echo "$(YELLOW)    1. Running flake8 code style check...$(RESET)" && \
 				$(PYTHON) -m $(FLAKE8) . && \
-				echo "$(YELLOW)    2. Running isort import formatting...$(RESET)" && \
-				$(PYTHON) -m $(ISORT) . && \
-				echo "$(YELLOW)    3. Running black code formatting...$(RESET)" && \
-				$(PYTHON) -m $(BLACK) . && \
+				echo "$(YELLOW)    2. Checking isort import order...$(RESET)" && \
+				$(PYTHON) -m isort --check-only --profile black . && \
+				echo "$(YELLOW)    3. Checking black code format...$(RESET)" && \
+				$(PYTHON) -m black --check . && \
 				echo "$(YELLOW)    4. Running mypy type checking...$(RESET)" && \
 				$(PYTHON) -m $(MYPY) . && \
 				echo "$(YELLOW)    5. Running pylint code analysis...$(RESET)" && \

--- a/makefiles/typescript.mk
+++ b/makefiles/typescript.mk
@@ -58,23 +58,6 @@ check-tools-typescript: ## ✅ Check TypeScript development tools availability
 	@echo "  Prettier version: $$(prettier --version)"
 	@echo "  ESLint version: $$(eslint --version)"
 
-fmt-typescript: ## ✨ Format TypeScript code
-	@if [ -n "$(TS_DIRS)" ]; then \
-		echo "$(YELLOW)Formatting TypeScript code in: $(TS_DIRS)$(RESET)"; \
-		for dir in $(TS_DIRS); do \
-			if [ -d "$$dir" ]; then \
-				echo "$(YELLOW)  Processing $$dir...$(RESET)"; \
-				cd $$dir && prettier --write "**/*.{ts,tsx,js,jsx,json,md}"; \
-				cd - > /dev/null; \
-			else \
-				echo "$(RED)    Directory $$dir does not exist$(RESET)"; \
-			fi; \
-		done; \
-		echo "$(GREEN)TypeScript code formatting completed$(RESET)"; \
-	else \
-		echo "$(BLUE)Skipping TypeScript formatting (no TypeScript projects configured)$(RESET)"; \
-	fi
-
 check-typescript: ## 🔍 Check TypeScript code quality
 	@if [ -n "$(TS_DIRS)" ]; then \
 		echo "$(YELLOW)Checking TypeScript code quality in: $(TS_DIRS)$(RESET)"; \


### PR DESCRIPTION
- Remove all format commands (make format, fmt-*, smart_format)
- Remove enable-legacy command (unused placeholder)
- Fix Python check to be check-only (isort --check-only, black --check)
- Fix duplicate execution in smart_* commands (each project checked N times)
- Skip build directories in comment checks (.venv, node_modules, target, vendor)
- Add Go cache directories to gitignore (.gocache, .golangci-cache)

