### PR TITLE
refactor(ci): restrict image builds to main/master branches only

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
       - master
-      - feature/**
-  pull_request:
-    branches:
-      - main
-      - master
-      - feature/**
   workflow_dispatch:
     inputs:
       push_images:
@@ -55,15 +49,11 @@ jobs:
           # Version is always latest
           VERSION="latest"
 
-          # Determine if should push (main, master, feature branches, PR, or manual dispatch)
+          # Determine if should push (only main/master branches or manual dispatch)
           SHOULD_PUSH="false"
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             SHOULD_PUSH="true"
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/master" ]]; then
-            SHOULD_PUSH="true"
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == refs/heads/feature/* ]]; then
-            SHOULD_PUSH="true"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             SHOULD_PUSH="true"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.push_images }}" == "true" ]]; then
             SHOULD_PUSH="true"


### PR DESCRIPTION
- Remove pull_request trigger to avoid duplicate builds on PRs
- Remove feature/** branch trigger to save CI resources
- Keep workflow_dispatch for manual triggering
- Images now only build after code is merged to main/master

This prevents wasting resources by building 10 images on every PR