### PR TITLE
docs: add DeepWiki badge to README files

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -4,6 +4,7 @@
 
 [![License](https://img.shields.io/badge/license-apache2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/iflytek/astron-agent?style=social)](https://github.com/iflytek/astron-agent/stargazers)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/iflytek/astron-agent)
 
 [English](README.md) | 简体中文
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![License](https://img.shields.io/badge/license-apache2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/iflytek/astron-agent?style=social)](https://github.com/iflytek/astron-agent/stargazers)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/iflytek/astron-agent)
 
 English | [简体中文](README-zh.md)
 


### PR DESCRIPTION
Add DeepWiki documentation badge to both README.md and README-zh.md to help users access interactive documentation at deepwiki.com