### PR TITLE
feat(security): add gitleaks secret scanning to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -282,6 +282,15 @@ repos:
         pass_filenames: false
 
   # =============================================================================
+  # Security Scanning
+  # =============================================================================
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        name: Detect secrets with gitleaks
+
+  # =============================================================================
   # Commit Message Validation
   # =============================================================================
   - repo: https://github.com/compilerla/conventional-pre-commit


### PR DESCRIPTION
Add gitleaks hook to detect hardcoded secrets and credentials in the codebase before commits are made.