### PR TITLE
fix(docker): prevent docker compose from modifying local files

### DIFF
--- a/docker/astronAgent/casdoor/entrypoint.sh
+++ b/docker/astronAgent/casdoor/entrypoint.sh
@@ -1,17 +1,21 @@
 #!/bin/sh
 set -e
 
-chmod -R 777 /conf 2>/dev/null || true
-
 echo "===== Initializing Casdoor Configuration ====="
 echo "CONSOLE_DOMAIN: ${CONSOLE_DOMAIN:-http://localhost}"
 echo "HOST_BASE_ADDRESS: ${HOST_BASE_ADDRESS:-http://localhost}"
 
-# Generate config from template using sed (replace all environment variables)
+# Create runtime config directory (inside container, not on host)
+mkdir -p /conf
+
+# Copy static config files to runtime directory
+cp /conf-templates/app.conf /conf/app.conf
+
+# Generate init_data.json from template using sed (replace all environment variables)
 echo "Generating init_data.json from template..."
 sed -e "s|\${CONSOLE_DOMAIN}|${CONSOLE_DOMAIN}|g" \
     -e "s|\${HOST_BASE_ADDRESS}|${HOST_BASE_ADDRESS}|g" \
-    /conf/init_data.json.template > /conf/init_data.json
+    /conf-templates/init_data.json.template > /conf/init_data.json
 
 echo "Configuration updated successfully!"
 echo "redirectUris: [${CONSOLE_DOMAIN}/callback, ${HOST_BASE_ADDRESS}/callback]"

--- a/docker/astronAgent/docker-compose-auth.yml
+++ b/docker/astronAgent/docker-compose-auth.yml
@@ -13,7 +13,7 @@ services:
       - origin=${CONSOLE_CASDOOR_URL:-http://localhost:8000}
       - originFrontend=${CONSOLE_CASDOOR_URL:-http://localhost:8000}
     volumes:
-      - ./casdoor/conf:/conf
+      - ./casdoor/conf:/conf-templates:ro
       - ./casdoor/entrypoint.sh:/entrypoint.sh:ro
       - casdoor-logs:/logs
     networks:


### PR DESCRIPTION
- Mount casdoor config directory as read-only to /conf-templates
- Generate runtime config inside container at /conf instead of host
- Remove unnecessary chmod command that changed file permissions
