### PR TITLE
fix: add default empty string for chat_id and uid params in FlowNode

### DIFF
--- a/core/workflow/engine/nodes/flow/flow_node.py
+++ b/core/workflow/engine/nodes/flow/flow_node.py
@@ -315,8 +315,8 @@ class FlowNode(BaseNode):
         # Initialize request headers
         headers = {"Content-Type": "application/json"}
 
-        chat_id: str = variable_pool.system_params.get(ParamKey.ChatId)
-        uid: str = variable_pool.system_params.get(ParamKey.Uid)
+        chat_id: str = variable_pool.system_params.get(ParamKey.ChatId, default="")
+        uid: str = variable_pool.system_params.get(ParamKey.Uid, default="")
 
         # Process chat history if enabled
         history = []


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Changes
<!-- Key changes made in this PR -->
- Fix: Add default empty string values for `chat_id` and `uid` parameters in FlowNode to prevent None values

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
