### PR TITLE
fix(logging): prevent loguru logs from being lost in uvicorn multi-worker mode by isolating handlers per PID

### DIFF
--- a/core/workflow/extensions/middleware/log/factory.py
+++ b/core/workflow/extensions/middleware/log/factory.py
@@ -42,7 +42,7 @@ class LogServiceFactory(ServiceFactory):
         os.makedirs(log_dir, exist_ok=True)  # Ensure log directory exists
 
         # Configure log storage path and log level
-        log_path = os.path.join(log_dir, "app.log")
+        log_path = os.path.join(log_dir, f"app_{os.getpid()}.log")
         log_level = os.getenv("LOG_LEVEL", "ERROR")
 
         # Initialize loguru


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->
Fix an issue where loguru logs could be lost when running uvicorn with multiple workers by isolating logging handlers using the process ID (PID).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
- Isolated loguru logger configuration per worker process using PID
- Prevented log handler conflicts in uvicorn multi-worker environments
- Improved logging reliability and stability under concurrent workers

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
