### PR TITLE
feat: Add console backend auto-create DB param to default datasource URL

### DIFF
--- a/console/backend/hub/src/main/resources/application.yml
+++ b/console/backend/hub/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   application:
     name: astron-console-hub
   datasource:
-    url: ${MYSQL_URL:jdbc:mysql://db:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8}
+    url: ${MYSQL_URL:jdbc:mysql://db:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true}
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER:astron}
     password: ${MYSQL_PASSWORD:astron-dev-env-db}

--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -26,7 +26,7 @@ MYSQL_USER=root
 MYSQL_PASSWORD=${MYSQL_ROOT_PASSWORD:-root123}
 MYSQL_HOST=mysql
 MYSQL_PORT=3306
-MYSQL_URL=jdbc:mysql://mysql:3306/astron_console
+MYSQL_URL=jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true
 
 # Redis Configuration
 REDIS_PASSWORD=123

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -507,7 +507,7 @@ services:
       CONSOLE_CASDOOR_APP: "${CONSOLE_CASDOOR_APP:-}"
       CONSOLE_CASDOOR_ORG: "${CONSOLE_CASDOOR_ORG:-}"
       CONSOLE_DOMAIN: "${CONSOLE_DOMAIN:-https://your.deployment.domain}"
-      MYSQL_URL: "${MYSQL_URL:-jdbc:mysql://mysql:3306/astron_console}"
+      MYSQL_URL: "${MYSQL_URL:-jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true}"
       MYSQL_USER: "${MYSQL_USER:-root}"
       MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
       REDIS_HOST: "${REDIS_HOST:-redis}"

--- a/docker/astronAgent/mysql/console.sql
+++ b/docker/astronAgent/mysql/console.sql
@@ -1,2 +1,0 @@
-SELECT 'astron_console DATABASE initialization started' AS '';
-CREATE DATABASE IF NOT EXISTS astron_console;

--- a/helm/astron-agent/values.yaml
+++ b/helm/astron-agent/values.yaml
@@ -472,7 +472,7 @@ consoleHub:
     consoleCasdoorOrg: "built-in"
     consoleDomain: ""
     # MySQL Configuration
-    mysqlUrl: "jdbc:mysql://astron-agent-mysql:3306/astron_console"
+    mysqlUrl: "jdbc:mysql://astron-agent-mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true"
     mysqlUser: root
     mysqlPassword: ""
     # Redis Configuration


### PR DESCRIPTION
## Summary
Add console backend auto-create DB param to default datasource URL
remove db init script: docker/astronAgent/mysql/console.sql

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
- console backend's config
- docker compose config
- helm's values.yaml
- remove `docker/astronAgent/mysql/console.sql`

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Breaking changes documented
