### PR TITLE
chore: exclude enterprise watchdog feature from mypy checks

### DIFF
--- a/core/workflow/extensions/middleware/utils.py
+++ b/core/workflow/extensions/middleware/utils.py
@@ -78,7 +78,7 @@ def get_factories_and_deps() -> List[Tuple[Any, List[ServiceType]]]:
                 [ServiceType.WATCHDOG_SERVICE],
             )
         )
-    except Exception:
+    except ImportError:
         pass
 
     return factories


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->
Exclude the enterprise-only watchdog feature from mypy type checking to avoid unnecessary analysis in the community edition.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
- Excluded the enterprise watchdog module from mypy type checks
- Clarified separation between community and enterprise-only features

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
