### PR TITLE
fix(ci): restore mypy ignore-missing-imports flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
               echo "3. Checking black code format..."
               python3 -m black --check .
               echo "4. Running mypy type checking..."
-              python3 -m mypy --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --no-implicit-optional .
+              python3 -m mypy --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --no-implicit-optional --ignore-missing-imports --explicit-package-bases .
               echo "5. Running pylint code analysis..."
               find . -name "*.py" -type f -print0 | xargs -0 python3 -m pylint --disable=import-error --max-line-length=88 --max-args=7 --max-locals=15 --max-returns=6 --max-branches=12 --max-statements=50 --fail-under=8.0
               ;;

--- a/core/workflow/extensions/middleware/utils.py
+++ b/core/workflow/extensions/middleware/utils.py
@@ -67,8 +67,7 @@ def get_factories_and_deps() -> List[Tuple[Any, List[ServiceType]]]:
     ]
 
     try:
-        # Service automatic discovery is an enterprise-level feature
-        from workflow_business.extensions.middleware.watchdog import (  # type: ignore[import-not-found]
+        from workflow_business.extensions.middleware.watchdog import (  # type: ignore[import-not-found]  # isort: skip
             factory as watchdog_factory,
         )
 

--- a/makefiles/python.mk
+++ b/makefiles/python.mk
@@ -7,7 +7,7 @@ PYTHON := $(shell which python3 || which python)
 BLACK := black
 ISORT := isort --profile black
 FLAKE8 := flake8 --max-line-length 88 --ignore=E203,W503,E501 --max-complexity 10
-MYPY := mypy --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --no-implicit-optional
+MYPY := mypy --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --no-implicit-optional --ignore-missing-imports --explicit-package-bases
 PYLINT := pylint --disable=import-error --max-line-length=88 --max-args=7 --max-locals=15 --max-returns=6 --max-branches=12 --max-statements=50 --fail-under=8.0
 
 # Get all Python directories from config


### PR DESCRIPTION
- Restore --ignore-missing-imports and --explicit-package-bases to mypy command
- Add isort: skip directive to watchdog import in utils.py

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
- Added `# isort: skip` directive  to watchdog import in `core/workflow/extensions/middleware/utils.py`
- Restored `--ignore-missing-imports` flag** in `.github/workflows/ci.yml` and `makefiles/python.mk`

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
