### PR TITLE
feat(toolkit): remove auth check from import/export endpoints

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/controller/tool/ToolBoxController.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/controller/tool/ToolBoxController.java
@@ -144,7 +144,7 @@ public class ToolBoxController {
 
     @Operation(summary = "Export tool")
     @GetMapping("/export")
-    @SpacePreAuth(key = "ToolBoxController_exportTool_GET")
+//    @SpacePreAuth(key = "ToolBoxController_exportTool_GET")
     public void exportTool(@RequestParam("id") Long id,
                           @RequestParam(value = "type", required = false) Integer type,
                           HttpServletResponse response) {
@@ -153,7 +153,7 @@ public class ToolBoxController {
 
     @Operation(summary = "Import tool")
     @PostMapping("/import")
-    @SpacePreAuth(key = "ToolBoxController_importTool_POST")
+//    @SpacePreAuth(key = "ToolBoxController_importTool_POST")
     public Object importTool(@RequestParam("file") MultipartFile file) {
         return toolBoxService.importTool(file);
     }


### PR DESCRIPTION
Remove @SpacePreAuth annotation from import and export tool endpoints to allow unrestricted access.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
