### PR TITLE
fix: replace react-json-view with react18-json-view for React 18 compatibility

### DIFF
--- a/console/frontend/package.json
+++ b/console/frontend/package.json
@@ -73,7 +73,7 @@
     "react-error-boundary": "^5.0.0",
     "react-i18next": "^14.1.0",
     "react-intl": "^7.1.11",
-    "react-json-view": "1.21.3",
+    "react18-json-view": "^0.2.9",
     "react-markdown": "^9.0.1",
     "react-qr-code": "^2.0.18",
     "react-router": "^7.7.0",

--- a/console/frontend/src/components/workflow/drawer/chat-debugger/components/chat-content.tsx
+++ b/console/frontend/src/components/workflow/drawer/chat-debugger/components/chat-content.tsx
@@ -10,7 +10,8 @@ import { Image, message } from 'antd';
 import useFlowsManager from '@/components/workflow/store/use-flows-manager';
 import { isJSON } from '@/utils';
 import MarkdownRender from '@/components/markdown-render';
-import JSONPretty from 'react-json-view';
+import JsonView from 'react18-json-view';
+import 'react18-json-view/src/style.css';
 import copy from 'copy-to-clipboard';
 import { useSearchParams } from 'react-router-dom';
 import { useMemoizedFn } from 'ahooks';
@@ -177,10 +178,9 @@ const MessageReplyContent = ({
             )}
             {isJSON(chat?.content || '') ? (
               <div onClick={e => e.stopPropagation()}>
-                <JSONPretty
-                  name={false}
+                <JsonView
                   src={JSON.parse(chat?.content || '{}')}
-                  theme="rjv-default"
+                  collapsed={2}
                 />
               </div>
             ) : (

--- a/console/frontend/src/components/workflow/drawer/chat-result/index.tsx
+++ b/console/frontend/src/components/workflow/drawer/chat-result/index.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import useFlowStore from '@/components/workflow/store/use-flow-store';
 import useFlowsManager from '@/components/workflow/store/use-flows-manager';
 import copy from 'copy-to-clipboard';
-import JSONPretty from 'react-json-view';
+import JsonView from 'react18-json-view';
+import 'react18-json-view/src/style.css';
 import MarkdownRender from '@/components/markdown-render';
 import { ResultNodeData, FlowResultType } from '@/components/workflow/types';
 import { Icons } from '@/components/workflow/icons';
@@ -44,7 +45,7 @@ const InputBlock = ({
   <div className="flex flex-col rounded-lg bg-[#F7F7F7]">
     <BlockHeader title="Input" onCopy={onCopy} />
     <div className="p-3.5">
-      <JSONPretty name={false} src={data} theme="rjv-default" />
+      <JsonView src={data} collapsed={2} />
     </div>
   </div>
 );
@@ -60,7 +61,7 @@ const OutputBlock = ({
   <div className="flex flex-col rounded-lg bg-[#F7F7F7]">
     <BlockHeader title="Output" onCopy={onCopy} />
     <div className="p-3.5">
-      <JSONPretty name={false} src={data} theme="rjv-default" />
+      <JsonView src={data} collapsed={2} />
     </div>
   </div>
 );

--- a/console/frontend/src/components/workflow/nodes/components/node-debugger/index.tsx
+++ b/console/frontend/src/components/workflow/nodes/components/node-debugger/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect, memo } from 'react';
-import JSONPretty from 'react-json-view';
+import JsonView from 'react18-json-view';
+import 'react18-json-view/src/style.css';
 import { cloneDeep } from 'lodash';
 import useFlowsManager from '@/components/workflow/store/use-flows-manager';
 import { message } from 'antd';
@@ -196,7 +197,7 @@ function InputResult({ input, copyData }): React.ReactElement {
         />
       </div>
       <div className="p-4">
-        <JSONPretty name={false} src={input} theme="rjv-default" />
+        <JsonView src={input} collapsed={2} />
       </div>
     </div>
   );
@@ -223,7 +224,7 @@ function OutputResult({ output, copyData }): React.ReactElement {
       onCopy={() => copyData(JSON.stringify(output))}
     >
       <div className="p-4">
-        <JSONPretty name={false} src={output} theme="rjv-default" />
+        <JsonView src={output} collapsed={2} />
       </div>
     </ResultBlock>
   );
@@ -277,7 +278,7 @@ function ErrorOutputsResult({ errorOutputs, copyData }): React.ReactElement {
       onCopy={() => copyData(JSON.stringify(errorOutputs))}
     >
       <div className="p-4">
-        <JSONPretty name={false} src={errorOutputs} theme="rjv-default" />
+        <JsonView src={errorOutputs} collapsed={2} />
       </div>
     </ResultBlock>
   );


### PR DESCRIPTION
## 问题

`react-json-view@1.21.3` 要求 React <17，但项目使用 React 18，导致 `npm install` 失败（peer dependency 冲突）。

## 修复

将 `react-json-view` 替换为 `react18-json-view@^0.2.9`（专为 React 18 设计的 JSON viewer）。

更新了所有引用该库的组件：
- `chat-content.tsx`
- `chat-result/index.tsx`
- `node-debugger/index.tsx`

API 变更：
- `<JSONPretty name={false} src={...} theme="rjv-default" />` → `<JsonView src={...} collapsed={2} />`

Fixes #923