### PR TITLE
fix(link): unify x-display nested field filtering and toggle restore

### DIFF
--- a/core/agent/Dockerfile
+++ b/core/agent/Dockerfile
@@ -14,6 +14,7 @@ COPY core/agent/uv.lock ./
 RUN uv sync -i https://pypi.tuna.tsinghua.edu.cn/simple/
 
 COPY core/common ./common
+COPY core/plugin ./plugin
 COPY core/agent ./agent
 
 CMD ["uv", "run", "agent/main.py"]

--- a/core/agent/pyproject.toml
+++ b/core/agent/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.25.0",
     "grpc-google-iam-v1==0.12.6",
     "googleapis-common-protos==1.60.0",
+    "jsonschema>=4.22.0",
     "websocket-client==1.8.0",
     "python-dotenv>=1.0.1",
     "toml>=0.10.2",

--- a/core/agent/service/plugin/link.py
+++ b/core/agent/service/plugin/link.py
@@ -1,8 +1,10 @@
 import asyncio
 import json
 import os
+import sys
 import time
 from base64 import b64encode
+from pathlib import Path
 from typing import Any, List, Optional, Union
 
 import aiohttp
@@ -11,6 +13,14 @@ from pydantic import BaseModel, Field
 
 from agent.exceptions.plugin_exc import GetToolSchemaExc, RunToolExc
 from agent.service.plugin.base import BasePlugin, PluginResponse
+
+try:
+    from plugin.link.utils.open_api_schema.response_filter import ResponseSchemaFilter
+except ModuleNotFoundError:
+    CORE_DIR = Path(__file__).resolve().parents[3]
+    if str(CORE_DIR) not in sys.path:
+        sys.path.insert(0, str(CORE_DIR))
+    from plugin.link.utils.open_api_schema.response_filter import ResponseSchemaFilter
 
 
 class LinkPluginRunner(BaseModel):
@@ -99,6 +109,56 @@ class LinkPluginRunner(BaseModel):
             return b64encode(json.dumps(payload, ensure_ascii=True).encode()).decode()
         return ""
 
+    def get_response_json_schema(self) -> dict[str, Any]:
+        return ResponseSchemaFilter.extract_response_json_schema(self.method_schema)
+
+    @classmethod
+    def collect_hidden_json_paths(
+        cls,
+        schema: dict[str, Any],
+        current_path: Optional[list[str]] = None,
+    ) -> list[list[str]]:
+        return ResponseSchemaFilter.collect_hidden_json_paths(schema, current_path)
+
+    @classmethod
+    def pop_hidden_fields(
+        cls, payload: Any, need_be_poped_list: list[list[str]]
+    ) -> Any:
+        return ResponseSchemaFilter.pop_hidden_fields(payload, need_be_poped_list)
+
+    @staticmethod
+    def validate_response(payload: Any, response_schema: dict[str, Any]) -> bool:
+        return ResponseSchemaFilter.validate_response(payload, response_schema)
+
+    def filter_response_by_schema(
+        self, payload: Any, response_schema: dict[str, Any], span: Span
+    ) -> Any:
+        """Filter tool response by OpenAPI schema `x-display` configuration.
+
+        Flow:
+        1. Collect hidden field paths from response schema.
+        2. Validate original payload and record warning on failure.
+        3. Remove hidden fields by json path and return filtered payload.
+        """
+        if not response_schema:
+            return payload
+
+        hidden_json_paths = self.collect_hidden_json_paths(response_schema)
+        if not hidden_json_paths:
+            return payload
+
+        is_valid = self.validate_response(payload, response_schema)
+        if not is_valid:
+            span.add_info_events(
+                attributes={
+                    "link-plugin-run-filter-warning": (
+                        "response validation failed, continue filtering by x-display"
+                    )
+                }
+            )
+
+        return self.pop_hidden_fields(payload, hidden_json_paths)
+
     async def run(self, action_input: dict[str, Any], span: Span) -> PluginResponse:
         """Call link"""
         with span.start("Run") as sp:
@@ -162,6 +222,12 @@ class LinkPluginRunner(BaseModel):
                         response.raise_for_status()
                         if response.status == 200:
                             result = await response.json()
+                            response_schema = self.get_response_json_schema()
+                            result = self.filter_response_by_schema(
+                                result,
+                                response_schema,
+                                sp,
+                            )
                             sp.add_info_events(
                                 attributes={
                                     "link-plugin-run-outputs": json.dumps(

--- a/core/agent/tests/test_plugin_base_link_mcp_workflow.py
+++ b/core/agent/tests/test_plugin_base_link_mcp_workflow.py
@@ -127,6 +127,348 @@ class TestLinkPluginRunner:
         # Empty payload returns empty string
         assert LinkPluginRunner.dumps({}) == ""
 
+    def test_collect_hidden_json_paths(self, runner: LinkPluginRunner) -> None:
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "visible": {"type": "string", "x-display": True},
+                "hidden": {"type": "string", "x-display": False},
+                "nested": {
+                    "type": "object",
+                    "properties": {
+                        "inner_hidden": {"type": "string", "x-display": False},
+                        "inner_visible": {"type": "number", "x-display": True},
+                    },
+                },
+            },
+        }
+
+        hidden_paths = runner.collect_hidden_json_paths(response_schema)
+        assert ["hidden"] in hidden_paths
+        assert ["nested", "inner_hidden"] in hidden_paths
+
+    def test_pop_hidden_fields_supports_array_path(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        payload = {
+            "items": [
+                {"id": 1, "secret": "a"},
+                {"id": 2, "secret": "b"},
+            ],
+            "secret": "root",
+        }
+        filtered = runner.pop_hidden_fields(
+            payload,
+            [["secret"], ["items", "*", "secret"]],
+        )
+
+        assert "secret" not in filtered
+        assert filtered["items"][0] == {"id": 1}
+        assert filtered["items"][1] == {"id": 2}
+
+    def test_filter_response_by_schema_validate_and_filter(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "x-display": True},
+                "secret": {"type": "string", "x-display": False},
+            },
+            "required": ["name"],
+            "additionalProperties": True,
+        }
+
+        payload = {"name": "ok", "secret": "hidden", "not_declared": "keep"}
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert filtered == {"name": "ok", "not_declared": "keep"}
+
+    def test_filter_response_by_schema_on_validation_failure(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "must": {"type": "string", "x-display": True},
+                "secret": {"type": "string", "x-display": False},
+            },
+            "required": ["must"],
+            "additionalProperties": True,
+        }
+
+        payload = {"secret": "hidden", "legacy_field": "keep"}
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert filtered == {"legacy_field": "keep"}
+
+    def test_get_response_json_schema(self, runner: LinkPluginRunner) -> None:
+        runner.method_schema = {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string", "x-display": True}
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        schema = runner.get_response_json_schema()
+        assert schema.get("type") == "object"
+        assert "name" in schema.get("properties", {})
+
+    def test_filter_object_becomes_empty_dict_when_all_children_hidden(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "x-display": True},
+                "profile": {
+                    "type": "object",
+                    "properties": {
+                        "private_a": {"type": "string", "x-display": False},
+                        "private_b": {"type": "string", "x-display": False},
+                    },
+                },
+            },
+            "additionalProperties": True,
+        }
+
+        payload = {
+            "name": "ok",
+            "profile": {"private_a": "a", "private_b": "b"},
+        }
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert "profile" in filtered
+        assert filtered["profile"] == {}
+
+    def test_filter_array_item_becomes_empty_dict_when_all_children_hidden(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "private": {"type": "string", "x-display": False}
+                        },
+                    },
+                }
+            },
+            "additionalProperties": True,
+        }
+
+        payload = {
+            "items": [
+                {"private": "a"},
+                {"private": "b"},
+            ]
+        }
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert filtered["items"] == [{}, {}]
+
+    def test_filter_remove_primitive_field_but_keep_container_empty_value(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "secret": {"type": "string", "x-display": False},
+                "obj": {
+                    "type": "object",
+                    "properties": {"hidden": {"type": "string", "x-display": False}},
+                },
+                "arr": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "hidden": {"type": "string", "x-display": False}
+                        },
+                    },
+                },
+            },
+            "additionalProperties": True,
+        }
+
+        payload = {
+            "secret": "x",
+            "obj": {"hidden": "x"},
+            "arr": [{"hidden": "a"}, {"hidden": "b"}],
+        }
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert "secret" not in filtered
+        assert filtered["obj"] == {}
+        assert filtered["arr"] == [{}, {}]
+
+    def test_filter_deep_nested_array_object_single_pass_behavior(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string", "x-display": True},
+                            "members": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "public": {
+                                            "type": "string",
+                                            "x-display": True,
+                                        },
+                                        "private": {
+                                            "type": "string",
+                                            "x-display": False,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }
+            },
+            "additionalProperties": True,
+        }
+
+        payload = {
+            "groups": [
+                {
+                    "name": "g1",
+                    "members": [
+                        {"public": "p1", "private": "s1"},
+                        {"private": "s2"},
+                    ],
+                }
+            ]
+        }
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert filtered["groups"][0]["members"][0] == {"public": "p1"}
+        assert filtered["groups"][0]["members"][1] == {}
+
+    def test_filter_parent_hidden_object_removed_even_if_child_visible(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "geo": {
+                            "type": "object",
+                            "x-display": False,
+                            "properties": {
+                                "lat": {"type": "string", "x-display": True},
+                                "lng": {"type": "string", "x-display": False},
+                            },
+                        }
+                    },
+                }
+            },
+            "additionalProperties": True,
+        }
+
+        payload = {"address": {"geo": {"lat": "-37.3159", "lng": "81.1496"}}}
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert filtered == {"address": {}}
+
+    def test_filter_parent_hidden_array_removed_even_if_items_visible(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "type": "array",
+                            "x-display": False,
+                            "items": {"type": "string", "x-display": True},
+                        }
+                    },
+                }
+            },
+            "additionalProperties": True,
+        }
+
+        payload = {"address": {"tags": ["a", "b"]}}
+        filtered = runner.filter_response_by_schema(payload, response_schema, span)
+
+        assert filtered == {"address": {}}
+
+    def test_filter_can_restore_field_after_toggle_to_visible(
+        self, runner: LinkPluginRunner
+    ) -> None:
+        span = Span(app_id="app", uid="u")
+        payload = {"address": {"geo": {"lat": "-37.3159", "lng": "81.1496"}}}
+
+        hidden_schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {"geo": {"type": "object", "x-display": False}},
+                }
+            },
+            "additionalProperties": True,
+        }
+        visible_schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "geo": {
+                            "type": "object",
+                            "x-display": True,
+                            "properties": {
+                                "lat": {"type": "string", "x-display": True},
+                                "lng": {"type": "string", "x-display": True},
+                            },
+                        }
+                    },
+                }
+            },
+            "additionalProperties": True,
+        }
+
+        first = runner.filter_response_by_schema(payload, hidden_schema, span)
+        second = runner.filter_response_by_schema(payload, visible_schema, span)
+
+        assert first == {"address": {}}
+        assert second["address"]["geo"] == {"lat": "-37.3159", "lng": "81.1496"}
+
 
 class TestLinkPluginFactoryParseSchemas:
     """Test LinkPluginFactory schema parsing logic (without real link service request)"""

--- a/core/plugin/link/utils/open_api_schema/response_filter.py
+++ b/core/plugin/link/utils/open_api_schema/response_filter.py
@@ -1,0 +1,183 @@
+from typing import Any, Optional
+
+from jsonschema.exceptions import SchemaError, ValidationError
+from jsonschema.validators import validator_for
+from plugin.link.utils.open_api_schema.schema_parser import OpenapiSchemaParser
+
+
+class ResponseSchemaFilter:
+    HIDDEN_LEAF = "__hidden_leaf__"
+    ARRAY_WILDCARD = "*"
+    REMOVED = object()
+
+    @classmethod
+    def extract_response_json_schema(
+        cls, method_schema: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Extract response JSON schema from OpenAPI method schema."""
+        return OpenapiSchemaParser.extract_response_json_schema(method_schema)
+
+    @classmethod
+    def collect_hidden_json_paths(
+        cls,
+        schema: dict[str, Any] | Any,
+        current_path: Optional[list[str]] = None,
+    ) -> list[list[str]]:
+        """Collect json paths where `x-display` is explicitly set to false."""
+        if not isinstance(schema, dict):
+            return []
+
+        if current_path is None:
+            current_path = []
+
+        hidden_paths: list[list[str]] = []
+        x_display = schema.get("x-display")
+        if x_display is False and current_path:
+            hidden_paths.append(current_path.copy())
+
+        schema_properties = schema.get("properties", {})
+        if isinstance(schema_properties, dict):
+            for property_name, property_schema in schema_properties.items():
+                if isinstance(property_schema, dict):
+                    hidden_paths.extend(
+                        cls.collect_hidden_json_paths(
+                            property_schema,
+                            current_path + [property_name],
+                        )
+                    )
+
+        schema_items = schema.get("items")
+        if isinstance(schema_items, dict):
+            hidden_paths.extend(
+                cls.collect_hidden_json_paths(
+                    schema_items, current_path + [cls.ARRAY_WILDCARD]
+                )
+            )
+
+        return hidden_paths
+
+    @classmethod
+    def build_hidden_path_tree(cls, hidden_paths: list[list[str]]) -> dict[str, Any]:
+        """Build a trie for hidden paths to support single-pass pruning."""
+        tree: dict[str, Any] = {}
+
+        for path_segments in hidden_paths:
+            node: dict[str, Any] = tree
+            for segment in path_segments:
+                child_node = node.get(segment)
+                if not isinstance(child_node, dict):
+                    child_node = {}
+                    node[segment] = child_node
+                node = child_node
+            node[cls.HIDDEN_LEAF] = True
+
+        return tree
+
+    @classmethod
+    def prune_payload_by_path_tree(
+        cls,
+        payload: Any,
+        path_tree: dict[str, Any] | Any,
+    ) -> Any:
+        """Prune payload by hidden-path trie in one recursive traversal.
+
+        This function does not mutate the input payload object.
+        """
+        if not isinstance(path_tree, dict):
+            return payload
+
+        if cls._is_hidden_leaf_node(path_tree):
+            return cls.REMOVED
+
+        if isinstance(payload, dict):
+            return cls._prune_dict_payload(payload, path_tree)
+
+        if isinstance(payload, list):
+            return cls._prune_list_payload(payload, path_tree)
+
+        return payload
+
+    @classmethod
+    def _is_hidden_leaf_node(cls, path_tree: dict[str, Any]) -> bool:
+        return bool(path_tree.get(cls.HIDDEN_LEAF))
+
+    @classmethod
+    def _prune_dict_payload(
+        cls,
+        payload: dict[str, Any],
+        path_tree: dict[str, Any],
+    ) -> dict[str, Any]:
+        filtered_payload: dict[str, Any] = {}
+
+        for field_name, field_value in payload.items():
+            field_tree = path_tree.get(field_name)
+            if not isinstance(field_tree, dict):
+                filtered_payload[field_name] = field_value
+                continue
+
+            pruned_value = cls.prune_payload_by_path_tree(field_value, field_tree)
+            if pruned_value is cls.REMOVED:
+                continue
+            filtered_payload[field_name] = pruned_value
+
+        return filtered_payload
+
+    @classmethod
+    def _prune_list_payload(
+        cls,
+        payload: list[Any],
+        path_tree: dict[str, Any],
+    ) -> list[Any]:
+        item_tree = path_tree.get(cls.ARRAY_WILDCARD)
+        if not isinstance(item_tree, dict):
+            return list(payload)
+
+        kept_items: list[Any] = []
+        for item in payload:
+            pruned_item = cls.prune_payload_by_path_tree(item, item_tree)
+            if pruned_item is cls.REMOVED:
+                continue
+            kept_items.append(pruned_item)
+
+        return kept_items
+
+    @classmethod
+    def pop_hidden_fields(cls, payload: Any, hidden_paths: list[list[str]]) -> Any:
+        """Prune payload with hidden fields removed (without mutating input)."""
+        if not hidden_paths:
+            return payload
+
+        path_tree = cls.build_hidden_path_tree(hidden_paths)
+        filtered = cls.prune_payload_by_path_tree(payload, path_tree)
+        return {} if filtered is cls.REMOVED else filtered
+
+    @staticmethod
+    def validate_response(payload: Any, response_schema: dict[str, Any]) -> bool:
+        """Validate payload against response schema with schema-aware validator."""
+        if not isinstance(response_schema, dict) or not response_schema:
+            return True
+
+        try:
+            validator_cls = validator_for(response_schema)
+            validator_cls.check_schema(response_schema)
+            validator = validator_cls(response_schema)
+            validator.validate(payload)
+            return True
+        except (ValidationError, SchemaError):
+            return False
+
+    @classmethod
+    def filter_payload_by_schema(
+        cls,
+        payload: Any,
+        response_schema: dict[str, Any],
+    ) -> Any:
+        """Filter payload by OpenAPI schema `x-display` settings."""
+        if not response_schema:
+            return payload
+
+        hidden_json_paths = cls.collect_hidden_json_paths(response_schema)
+        if not hidden_json_paths:
+            return payload
+
+        return cls.pop_hidden_fields(payload, hidden_json_paths)

--- a/core/plugin/link/utils/open_api_schema/schema_parser.py
+++ b/core/plugin/link/utils/open_api_schema/schema_parser.py
@@ -154,6 +154,83 @@ class OpenapiSchemaParser:
         return properties
 
     @classmethod
+    def extract_response_json_schema(
+        cls, method_schema: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Extract response JSON schema from OpenAPI method schema.
+
+        Priority: 200/201/202/203/204/default -> remaining status codes.
+        Prefer `application/json`; fallback to first media type with schema.
+        """
+        responses = cls._get_responses_map(method_schema)
+        if responses is None:
+            return {}
+
+        candidates = cls._ordered_response_candidates(responses)
+        for response_schema in candidates:
+            schema = cls._extract_schema_from_response(response_schema)
+            if schema is not None:
+                return schema
+
+        return {}
+
+    @classmethod
+    def _get_responses_map(
+        cls, method_schema: Dict[str, Any] | Any
+    ) -> Optional[Dict[str, Any]]:
+        if not isinstance(method_schema, dict):
+            return None
+
+        responses = method_schema.get("responses", {})
+        if not isinstance(responses, dict):
+            return None
+
+        return responses
+
+    @classmethod
+    def _ordered_response_candidates(
+        cls, responses: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        preferred_status_codes = ["200", "201", "202", "203", "204", "default"]
+        response_candidates: List[Dict[str, Any]] = []
+
+        for status_code in preferred_status_codes:
+            response_schema = responses.get(status_code)
+            if isinstance(response_schema, dict):
+                response_candidates.append(response_schema)
+
+        for status_code, response_schema in responses.items():
+            if status_code in preferred_status_codes:
+                continue
+            if isinstance(response_schema, dict):
+                response_candidates.append(response_schema)
+
+        return response_candidates
+
+    @classmethod
+    def _extract_schema_from_response(
+        cls, response_schema: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        content = response_schema.get("content", {})
+        if not isinstance(content, dict):
+            return None
+
+        app_json_content = content.get("application/json")
+        if isinstance(app_json_content, dict):
+            app_json_schema = app_json_content.get("schema")
+            if isinstance(app_json_schema, dict):
+                return app_json_schema
+
+        for media_schema in content.values():
+            if not isinstance(media_schema, dict):
+                continue
+            schema = media_schema.get("schema")
+            if isinstance(schema, dict):
+                return schema
+
+        return None
+
+    @classmethod
     def schema_body_json_parser(
         cls, body: Dict[str, Any], span: Optional[Span]
     ) -> Optional[Dict[str, Any]]:

--- a/core/workflow/Dockerfile
+++ b/core/workflow/Dockerfile
@@ -29,6 +29,7 @@ RUN uv sync -i https://mirrors.aliyun.com/pypi/simple/
 # Copy the entire workflow source code to the container
 COPY core/workflow ./workflow
 COPY core/common ./common
+COPY core/plugin ./plugin
 
 # Set the default command to run the main application using UV
 CMD ["uv", "run", "workflow/main.py"]

--- a/core/workflow/engine/nodes/plugin_tool/link_client.py
+++ b/core/workflow/engine/nodes/plugin_tool/link_client.py
@@ -1,12 +1,22 @@
 import json
+import sys
 import time
 from base64 import b64encode
+from pathlib import Path
 from typing import Any, Dict, List, Set, Tuple
 
 from workflow.exception.e import CustomException
 from workflow.exception.errors.code_convert import CodeConvert
 from workflow.exception.errors.err_code import CodeEnum
 from workflow.extensions.otlp.trace.span import Span
+
+try:
+    from plugin.link.utils.open_api_schema.response_filter import ResponseSchemaFilter
+except ModuleNotFoundError:
+    CORE_DIR = Path(__file__).resolve().parents[4]
+    if str(CORE_DIR) not in sys.path:
+        sys.path.insert(0, str(CORE_DIR))
+    from plugin.link.utils.open_api_schema.response_filter import ResponseSchemaFilter
 
 
 class Tool:
@@ -168,6 +178,41 @@ class Tool:
             return b64encode(json.dumps(payload, ensure_ascii=True).encode()).decode()
         return payload
 
+    def get_response_json_schema(self) -> dict[str, Any]:
+        return ResponseSchemaFilter.extract_response_json_schema(self.method_schema)
+
+    @staticmethod
+    def validate_response(payload: Any, response_schema: dict[str, Any]) -> bool:
+        return ResponseSchemaFilter.validate_response(payload, response_schema)
+
+    async def filter_response_by_schema(
+        self,
+        payload: Any,
+        response_schema: dict[str, Any],
+        span: Span,
+    ) -> Any:
+        """Filter tool response payload by OpenAPI schema `x-display`."""
+        if not response_schema:
+            return payload
+
+        hidden_json_paths = ResponseSchemaFilter.collect_hidden_json_paths(
+            response_schema
+        )
+        if not hidden_json_paths:
+            return payload
+
+        is_valid = self.validate_response(payload, response_schema)
+        if not is_valid:
+            await span.add_info_events_async(
+                {
+                    "link-plugin-run-filter-warning": (
+                        "response validation failed, continue filtering by x-display"
+                    )
+                }
+            )
+
+        return ResponseSchemaFilter.pop_hidden_fields(payload, hidden_json_paths)
+
     async def run(
         self, action_input: dict, business_input: dict, span: Span, **kwargs: Any
     ) -> Dict[str, Any]:
@@ -316,7 +361,13 @@ class Tool:
             else:
                 # Extract and parse successful response
                 tool_response_text = link_response["payload"]["text"]["text"]
-                return json.loads(tool_response_text)
+                tool_response = json.loads(tool_response_text)
+                response_schema = self.get_response_json_schema()
+                return await self.filter_response_by_schema(
+                    tool_response,
+                    response_schema,
+                    link_tool_span,
+                )
 
 
 class Link:

--- a/core/workflow/tests/engine/nodes/test_link_client_filter.py
+++ b/core/workflow/tests/engine/nodes/test_link_client_filter.py
@@ -1,0 +1,367 @@
+import json
+import sys
+import types
+from typing import Any, Literal
+
+import pytest
+
+_kafka_stub = types.ModuleType("confluent_kafka")
+setattr(_kafka_stub, "Producer", object)
+setattr(_kafka_stub, "Consumer", object)
+
+Tool: Any = None
+
+
+@pytest.fixture(autouse=True)
+def _kafka_module_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub confluent_kafka per test and restore automatically."""
+    monkeypatch.setitem(sys.modules, "confluent_kafka", _kafka_stub)
+    sys.modules.pop("workflow.engine.nodes.plugin_tool.link_client", None)
+    from workflow.engine.nodes.plugin_tool.link_client import Tool as _Tool
+
+    globals()["Tool"] = _Tool
+
+
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def start(self, _name: str) -> "_FakeSpan":
+        return self
+
+    def __enter__(self) -> "_FakeSpan":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        return False
+
+    async def add_info_events_async(self, attributes: dict[str, Any]) -> None:
+        self.events.append(attributes)
+
+
+class _FakeResponse:
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        return False
+
+    async def json(self) -> dict[str, Any]:
+        payload = {
+            "id": 1,
+            "name": "Leanne Graham",
+            "email": "Sincere@april.biz",
+            "address": {
+                "street": "Kulas Light",
+                "suite": "Apt. 556",
+                "city": "Gwenborough",
+            },
+        }
+        return {
+            "header": {"code": 0, "message": "ok"},
+            "payload": {"text": {"text": json.dumps(payload, ensure_ascii=False)}},
+        }
+
+
+class _FakeSession:
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        return False
+
+    def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_tool_run_filters_hidden_fields_for_nested_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _FakeSession)
+
+    method_schema = {
+        "responses": {
+            "200": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "number", "x-display": True},
+                                "name": {"type": "string", "x-display": True},
+                                "email": {"type": "string", "x-display": False},
+                                "address": {
+                                    "type": "object",
+                                    "properties": {
+                                        "street": {
+                                            "type": "string",
+                                            "x-display": False,
+                                        },
+                                        "suite": {
+                                            "type": "string",
+                                            "x-display": True,
+                                        },
+                                        "city": {
+                                            "type": "string",
+                                            "x-display": True,
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    tool = Tool(
+        app_id="app",
+        tool_id="tool",
+        operation_id="op",
+        method_schema=method_schema,
+        parameters={},
+        get_url="http://unused",
+        run_url="http://unused",
+        version="V1.0",
+    )
+
+    result = await tool.run({}, {}, _FakeSpan())
+
+    assert "email" not in result
+    assert "street" not in result["address"]
+    assert result["address"]["suite"] == "Apt. 556"
+    assert result["address"]["city"] == "Gwenborough"
+
+
+@pytest.mark.asyncio
+async def test_tool_run_keeps_empty_object_when_all_nested_fields_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _FakeSession)
+
+    method_schema = {
+        "responses": {
+            "200": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "number", "x-display": True},
+                                "address": {
+                                    "type": "object",
+                                    "properties": {
+                                        "street": {
+                                            "type": "string",
+                                            "x-display": False,
+                                        },
+                                        "suite": {
+                                            "type": "string",
+                                            "x-display": False,
+                                        },
+                                        "city": {
+                                            "type": "string",
+                                            "x-display": False,
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    tool = Tool(
+        app_id="app",
+        tool_id="tool",
+        operation_id="op",
+        method_schema=method_schema,
+        parameters={},
+        get_url="http://unused",
+        run_url="http://unused",
+        version="V1.0",
+    )
+
+    result = await tool.run({}, {}, _FakeSpan())
+
+    assert result["address"] == {}
+
+
+@pytest.mark.asyncio
+async def test_filter_response_logs_warning_on_validation_failure() -> None:
+    tool = Tool(
+        app_id="app",
+        tool_id="tool",
+        operation_id="op",
+        method_schema={},
+        parameters={},
+        get_url="http://unused",
+        run_url="http://unused",
+        version="V1.0",
+    )
+
+    span = _FakeSpan()
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "must": {"type": "string", "x-display": True},
+            "secret": {"type": "string", "x-display": False},
+        },
+        "required": ["must"],
+        "additionalProperties": True,
+    }
+    payload = {"secret": "hidden", "legacy": "keep"}
+
+    filtered = await tool.filter_response_by_schema(payload, response_schema, span)
+
+    assert filtered == {"legacy": "keep"}
+    assert any("link-plugin-run-filter-warning" in event for event in span.events)
+
+
+@pytest.mark.asyncio
+async def test_filter_response_parent_hidden_takes_precedence_over_children() -> None:
+    tool = Tool(
+        app_id="app",
+        tool_id="tool",
+        operation_id="op",
+        method_schema={},
+        parameters={},
+        get_url="http://unused",
+        run_url="http://unused",
+        version="V1.0",
+    )
+
+    span = _FakeSpan()
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "address": {
+                "type": "object",
+                "properties": {
+                    "geo": {
+                        "type": "object",
+                        "x-display": False,
+                        "properties": {
+                            "lat": {"type": "string", "x-display": True},
+                            "lng": {"type": "string", "x-display": False},
+                        },
+                    }
+                },
+            }
+        },
+        "additionalProperties": True,
+    }
+    payload = {
+        "address": {
+            "geo": {"lat": "-37.3159", "lng": "81.1496"},
+        }
+    }
+
+    filtered = await tool.filter_response_by_schema(payload, response_schema, span)
+
+    assert filtered == {"address": {}}
+
+
+@pytest.mark.asyncio
+async def test_filter_response_hidden_array_field_removed_completely() -> None:
+    tool = Tool(
+        app_id="app",
+        tool_id="tool",
+        operation_id="op",
+        method_schema={},
+        parameters={},
+        get_url="http://unused",
+        run_url="http://unused",
+        version="V1.0",
+    )
+
+    span = _FakeSpan()
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "address": {
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "x-display": False,
+                        "items": {"type": "string", "x-display": True},
+                    }
+                },
+            }
+        },
+        "additionalProperties": True,
+    }
+    payload = {
+        "address": {
+            "tags": ["a", "b"],
+        }
+    }
+
+    filtered = await tool.filter_response_by_schema(payload, response_schema, span)
+
+    assert filtered == {"address": {}}
+
+
+@pytest.mark.asyncio
+async def test_filter_response_can_restore_field_after_toggle_to_visible() -> None:
+    tool = Tool(
+        app_id="app",
+        tool_id="tool",
+        operation_id="op",
+        method_schema={},
+        parameters={},
+        get_url="http://unused",
+        run_url="http://unused",
+        version="V1.0",
+    )
+
+    payload = {
+        "address": {
+            "geo": {"lat": "-37.3159", "lng": "81.1496"},
+        }
+    }
+
+    hidden_schema = {
+        "type": "object",
+        "properties": {
+            "address": {
+                "type": "object",
+                "properties": {"geo": {"type": "object", "x-display": False}},
+            }
+        },
+        "additionalProperties": True,
+    }
+    visible_schema = {
+        "type": "object",
+        "properties": {
+            "address": {
+                "type": "object",
+                "properties": {
+                    "geo": {
+                        "type": "object",
+                        "x-display": True,
+                        "properties": {
+                            "lat": {"type": "string", "x-display": True},
+                            "lng": {"type": "string", "x-display": True},
+                        },
+                    }
+                },
+            }
+        },
+        "additionalProperties": True,
+    }
+
+    first = await tool.filter_response_by_schema(payload, hidden_schema, _FakeSpan())
+    second = await tool.filter_response_by_schema(payload, visible_schema, _FakeSpan())
+
+    assert first == {"address": {}}
+    assert second["address"]["geo"] == {"lat": "-37.3159", "lng": "81.1496"}

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -252,7 +252,10 @@ services:
 
   # Link Plugin Service
   core-link:
-    image: ghcr.io/iflytek/astron-agent/core-link:${ASTRON_AGENT_VERSION:-latest}
+    image: astron-agent/core-link:local
+    build:
+      context: ../..
+      dockerfile: core/plugin/link/Dockerfile
     container_name: astron-agent-core-link
     environment:
       SERVICE_PORT: "${CORE_LINK_PORT:-18888}"
@@ -321,7 +324,10 @@ services:
 
   # Agent Service
   core-agent:
-    image: ghcr.io/iflytek/astron-agent/core-agent:${ASTRON_AGENT_VERSION:-latest}
+    image: astron-agent/core-agent:local
+    build:
+      context: ../..
+      dockerfile: core/agent/Dockerfile
     container_name: astron-agent-core-agent
     environment:
       SERVICE_LOCATION: "${SERVICE_LOCATION:-hf}"
@@ -417,7 +423,10 @@ services:
 
   # Workflow Service
   core-workflow:
-    image: ghcr.io/iflytek/astron-agent/core-workflow:${ASTRON_AGENT_VERSION:-latest}
+    image: astron-agent/core-workflow:local
+    build:
+      context: ../..
+      dockerfile: core/workflow/Dockerfile
     container_name: astron-agent-core-workflow
     environment:
       RUNTIME_ENV: "${RUNTIME_ENV:-dev}"

--- a/docs/PR_link_xdisplay_filter_fix.md
+++ b/docs/PR_link_xdisplay_filter_fix.md
@@ -1,0 +1,46 @@
+# PR：x-display 响应字段过滤缺失修复流程
+
+## 一、问题现象
+- 在托管工具中将对象/数组的子参数设置为关闭后，工作流单步执行结果仍返回这些字段。
+- 复现场景使用 `https://jsonplaceholder.typicode.com/users/1`，预期关闭 `email` 与 `address.street` 后，响应中不应再出现这两个字段。
+
+## 二、定位过程
+- 先检查 agent 链路，发现 agent 侧已有响应过滤能力。
+- 再检查 workflow 执行链路，确认 workflow 的 `Tool.run` 返回路径缺少同等过滤步骤。
+- 结论：根因是两条链路过滤逻辑不一致，workflow 链路漏掉了 `x-display=false` 的响应裁剪。
+
+## 三、修复方案
+- 将响应过滤能力统一到 OpenAPI 相关目录：
+  - [core/plugin/link/utils/open_api_schema/response_filter.py](core/plugin/link/utils/open_api_schema/response_filter.py)
+- 复用现有 OpenAPI 解析能力提取 response schema：
+  - [core/plugin/link/utils/open_api_schema/schema_parser.py](core/plugin/link/utils/open_api_schema/schema_parser.py)
+  - 新增 `extract_response_json_schema`，统一 `200/201/202/203/204/default` 优先级，并优先 `application/json`。
+- 两条执行链路统一调用同一实现：
+  - [core/agent/service/plugin/link.py](core/agent/service/plugin/link.py)
+  - [core/workflow/engine/nodes/plugin_tool/link_client.py](core/workflow/engine/nodes/plugin_tool/link_client.py)
+
+## 四、优化点
+- 性能：
+  - 使用 trie 单次递归裁剪，避免多次路径遍历。
+  - 删除无意义分支计算，减少每层递归开销。
+- 兼容性：
+  - 对非 dict 的 schema 输入做早返回保护，避免异常输入导致报错。
+  - 校验器采用 `validator_for` 动态匹配 schema draft。
+- 健壮性：
+  - `hidden_paths` 为空时直接返回原 payload。
+  - 路径树/响应 schema 非法类型时安全降级，不中断主流程。
+
+## 五、验证结果
+- 自动化测试：
+  - `pytest -q core/workflow/tests/engine/nodes/test_link_client_filter.py` 通过（6 passed）。
+  - `pytest -q core/agent/tests/test_plugin_base_link_mcp_workflow.py -k "response_filter or x_display or filter or hidden or toggle"` 通过（11 passed, 15 deselected）。
+  - `pytest -q core/workflow/tests/engine/nodes/test_link_client_filter.py core/agent/tests/test_plugin_base_link_mcp_workflow.py -k "filter or x_display or response_filter or hidden or toggle"` 通过（17 passed, 15 deselected）。
+- 业务结果：
+  - `email` 与 `address.street` 在关闭后可被正确移除（字段名和值均不展示）。
+  - 当子字段全部关闭时，父容器可保留空对象结构（如 `address: {}`）。
+  - 父级节点关闭时，优先级高于子级开关（父关则该字段整体不展示）。
+  - 同一份源响应中，字段从关闭切回开启后可恢复展示。
+  - 本地 Docker 重建并启动验证通过。
+    
+
+


### PR DESCRIPTION
# PR：x-display 响应字段过滤缺失修复流程

## 一、问题现象
- 在托管工具中将对象/数组的子参数设置为关闭后，工作流单步执行结果仍返回这些字段。
- 复现场景使用 `https://jsonplaceholder.typicode.com/users/1`，预期关闭 `email` 与 `address.street` 后，响应中不应再出现这两个字段。

## 二、定位过程
- 先检查 agent 链路，发现 agent 侧已有响应过滤能力。
- 再检查 workflow 执行链路，确认 workflow 的 `Tool.run` 返回路径缺少同等过滤步骤。
- 结论：根因是两条链路过滤逻辑不一致，workflow 链路漏掉了 `x-display=false` 的响应裁剪。

## 三、修复方案
- 将响应过滤能力统一到 OpenAPI 相关目录：
  - [core/plugin/link/utils/open_api_schema/response_filter.py](core/plugin/link/utils/open_api_schema/response_filter.py)
- 复用现有 OpenAPI 解析能力提取 response schema：
  - [core/plugin/link/utils/open_api_schema/schema_parser.py](core/plugin/link/utils/open_api_schema/schema_parser.py)
  - 新增 `extract_response_json_schema`，统一 `200/201/202/203/204/default` 优先级，并优先 `application/json`。
- 两条执行链路统一调用同一实现：
  - [core/agent/service/plugin/link.py](core/agent/service/plugin/link.py)
  - [core/workflow/engine/nodes/plugin_tool/link_client.py](core/workflow/engine/nodes/plugin_tool/link_client.py)

## 四、优化点
- 性能：
  - 使用 trie 单次递归裁剪，避免多次路径遍历。
  - 删除无意义分支计算，减少每层递归开销。
- 兼容性：
  - 对非 dict 的 schema 输入做早返回保护，避免异常输入导致报错。
  - 校验器采用 `validator_for` 动态匹配 schema draft。
- 健壮性：
  - `hidden_paths` 为空时直接返回原 payload。
  - 路径树/响应 schema 非法类型时安全降级，不中断主流程。

## 五、验证结果
- 自动化测试：
  - `pytest -q core/workflow/tests/engine/nodes/test_link_client_filter.py` 通过（6 passed）。
  - `pytest -q core/agent/tests/test_plugin_base_link_mcp_workflow.py -k "response_filter or x_display or filter or hidden or toggle"` 通过（11 passed, 15 deselected）。
  - `pytest -q core/workflow/tests/engine/nodes/test_link_client_filter.py core/agent/tests/test_plugin_base_link_mcp_workflow.py -k "filter or x_display or response_filter or hidden or toggle"` 通过（17 passed, 15 deselected）。
- 业务结果：
  - `email` 与 `address.street` 在关闭后可被正确移除（字段名和值均不展示）。
  - 当子字段全部关闭时，父容器可保留空对象结构（如 `address: {}`）。
  - 父级节点关闭时，优先级高于子级开关（父关则该字段整体不展示）。
  - 同一份源响应中，字段从关闭切回开启后可恢复展示。
  - 本地 Docker 重建并启动验证通过。
    