### PR TITLE
fix: 修复智能体对话界面在未配置星火的情况下错误显示星火大模型的问题

### DIFF
--- a/console/frontend/src/pages/chat-page/components/chat-side.tsx
+++ b/console/frontend/src/pages/chat-page/components/chat-side.tsx
@@ -95,11 +95,28 @@ const ChatSide: React.FC<ChatSideProps> = ({ botInfo }) => {
       };
     }
 
+    // 处理自定义模型：尝试从 advancedConfig 中获取模型名称
+    try {
+      if (botInfo?.advancedConfig) {
+        const advancedConfig = JSON.parse(botInfo.advancedConfig);
+        const modelName = advancedConfig?.model?.modelName;
+        if (modelName) {
+          return {
+            name: `${modelName} · ${t('chatPage.chatSide.toolCalling')}`,
+            tooltip: modelName,
+          };
+        }
+      }
+    } catch (error) {
+      console.error('Failed to parse advancedConfig:', error);
+    }
+
+    // 如果无法获取自定义模型名称，默认显示星火大模型
     return {
       name: `${t('chatPage.chatSide.sparkModel')} · ${t('chatPage.chatSide.toolCalling')}`,
       tooltip: t('chatPage.chatSide.sparkModel'),
     };
-  }, [botInfo?.config, t]);
+  }, [botInfo?.config, botInfo?.advancedConfig, t]);
 
   // 获取唯一的工具配置
   const uniqueTools = useMemo((): ModelConfig[] => {


### PR DESCRIPTION
### 问题描述

修复 #874 - 在工作流中设置大模型为自定义的 MiniMax 时，对话界面错误显示为“星火大模型”。

### 修复方案

- 在 `chat-side.tsx` 中添加对自定义模型的支持
- 尝试从 `advancedConfig` 中获取自定义模型名称
- 如果配置了自定义模型，则显示实际的模型名称

### 测试步骤

1. 编辑智能体
2. 设置大模型为用户自定义的 MiniMax
3. 保存退出
4. 从智能体列表中点击该智能体的对话按钮
5. 验证对话界面显示的模型名称是否正确

Generated with [Claude Code](https://claude.ai/code)