### PR TITLE
docs: fix README grammar in quick-start and cloud sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We offer two deployment methods to meet different scenarios:
 # Clone the repository
 git clone https://github.com/iflytek/astron-agent.git
 
-# Navigate to astronAgent directory
+# Navigate to the astronAgent directory
 cd docker/astronAgent
 
 # Copy environment configuration
@@ -91,7 +91,7 @@ After startup, you can access the services at the following addresses:
 
 ## 📖 Using Astron Cloud
 
-**Try Astron**：Astron Cloud provides a ready-to-use environment for creating and managing Agents.Free quick access [https://agent.xfyun.cn](https://agent.xfyun.cn).
+**Try Astron**：Astron Cloud provides a ready-to-use environment for creating and managing Agents. Free quick access [https://agent.xfyun.cn](https://agent.xfyun.cn).
 
 **Using Guide**：For detailed usage instructions, please refer to [Quick Start Guide](https://www.xfyun.cn/doc/spark/Agent03-%E5%BC%80%E5%8F%91%E6%8C%87%E5%8D%97.html).
 


### PR DESCRIPTION
## Summary\n- fix missing space in the Astron Cloud paragraph ()\n- improve quick-start wording ()\n\n## Why\nThese are small but user-facing README issues that affect first-read clarity.\n\n## Type\n- Documentation