### PR TITLE
feat(link): add x-display response visibility filtering

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,72 @@
+## Summary
+Introduce a new OpenAPI response visibility feature based on `x-display`, including schema-aware filtering with `$ref` support and validation guardrails that align visible-field checks with runtime response handling.
+
+## Type of Change
+- [ ] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [x] Refactoring
+
+## Related Issue
+N/A
+
+## Changes
+
+### 1) Refactor `x-display` response filtering
+- Updated: `core/plugin/link/utils/open_api_schema/response_filter.py`
+- Added schema-driven `x-display` response filtering capability for OpenAPI JSON responses.
+- Implemented recursive traversal with local `$ref` resolution (`#/components/...`) for nested/array schemas.
+- Kept behavior contract explicit:
+  - Remove fields marked with `x-display: false` (supports boolean `false` and string `"false"`).
+  - If all children under an object/array container are hidden, keep structural type and return empty `{}` / `[]`.
+- Added/kept compatibility helpers:
+  - Hidden path collection (`get_need_be_poped_list`).
+  - Missing declared visible path detection (`get_missing_visible_declared_paths`).
+  - Validation error ignore decision for hidden required fields (`should_ignore_validation_error_by_x_display`).
+
+### 2) Adjust HTTP execution flow: validate first, then filter
+- Updated: `core/plugin/link/service/community/tools/http/execution_server.py`
+- Added end-to-end response processing flow for the new feature: validate first, then apply visibility filtering.
+- Applied filtering after validation in both request handling and tool debug paths.
+- Integrated missing-visible-field detection and hidden-field-aware ignore logic into validation flow.
+- Preserved existing exception handling and telemetry behavior.
+
+### 3) Add focused unit tests
+- Added: `core/plugin/link/tests/unit/test_response_filter.py`
+- Covered scenarios:
+  - Hidden field removal and parent-hidden precedence for object fields.
+  - Array container behavior: hide all elements when item schema is `x-display: false`.
+  - Keep empty object items in arrays when child fields are hidden.
+  - `$ref`-based schema resolution in filtering and missing-visible-path checks.
+  - Required-field validation ignore checks for hidden fields.
+
+## Testing
+- [x] New tests added (unit)
+- [ ] Existing full test suite executed
+- [ ] Manual testing completed
+
+Test scope added in this PR:
+- `test_filter_parent_hidden_takes_precedence`
+- `test_filter_keeps_empty_object_elements_in_array`
+- `test_filter_hides_array_elements_when_items_closed`
+- `test_filter_ref_items_closed_hides_all_elements`
+- `test_missing_visible_declared_paths_with_ref`
+
+## Compatibility / Risk
+- No API contract change in request shape.
+- Response payload visibility now supports declarative control via schema `x-display`.
+- Potential behavior change: previously returned hidden fields may now be removed or collapsed to `{}` / `[]` per schema.
+- Risk is controllable and covered by focused unit tests around nested arrays, refs, and required-field validation edge cases.
+
+## Rollback Plan
+If regressions are found:
+1. Revert `response_filter.py` implementation to the previous filtering logic.
+2. Revert execution order changes in `execution_server.py`.
+
+## Checklist
+- [x] Code follows project coding standards
+- [x] Self-review completed
+- [x] Documentation/comments updated where needed
+- [x] No breaking changes introduced
+

--- a/core/plugin/link/service/community/tools/http/execution_server.py
+++ b/core/plugin/link/service/community/tools/http/execution_server.py
@@ -36,6 +36,11 @@ from plugin.link.utils.json_schemas.read_json_schemas import (
     get_tool_debug_schema,
 )
 from plugin.link.utils.json_schemas.schema_validate import api_validate
+from plugin.link.utils.open_api_schema.response_filter import (
+    filter_response_by_x_display,
+    get_missing_visible_declared_paths,
+    should_ignore_validation_error_by_x_display,
+)
 from plugin.link.utils.open_api_schema.schema_parser import OpenapiSchemaParser
 from plugin.link.utils.uid.generate_uid import new_uid
 
@@ -223,18 +228,52 @@ def process_authentication(
             message_query.update(api_key_dict)
 
 
-def validate_response_schema(
+def validate_response_schema(  # noqa: C901
     result_json: Any, open_api_schema: Dict[str, Any]
 ) -> List[str]:
     """Validate response against schema and return error messages."""
     response_schema = get_response_schema(open_api_schema)
+    er_msgs: List[str] = []
+
+    try:
+        missing_visible_paths = get_missing_visible_declared_paths(
+            result_json,
+            response_schema,
+            open_api_schema,
+        )
+    except Exception as missing_paths_err:
+        logger.exception(
+            "get_missing_visible_declared_paths failed, "
+            f"fallback to []: {missing_paths_err}"
+        )
+        missing_visible_paths = []
+    for missing_path in missing_visible_paths:
+        er_msgs.append(
+            f"参数路径: {missing_path}, 错误信息: 字段在schema中已声明且可见，但在response中缺失"
+        )
+
     import jsonschema
 
     errs = list(jsonschema.Draft7Validator(response_schema).iter_errors(result_json))
-    er_msgs = []
     for err in errs:
+        try:
+            if should_ignore_validation_error_by_x_display(
+                err,
+                response_schema,
+                open_api_schema,
+            ):
+                continue
+        except Exception as ex:
+            logger.exception(
+                "should_ignore_validation_error_by_x_display failed, "
+                f"fallback to not ignore: {ex}"
+            )
+
         err_msg = err.message
         if err_msg.startswith("None is not of type"):
+            # Legacy compatibility behavior:
+            # when a field is null but schema expects a concrete type,
+            # patch the response in-place with a default value if possible.
             key_type = err_msg.split("None is not of type")[1]
             key_type = key_type.strip("")
             path = err.json_path
@@ -247,6 +286,7 @@ def validate_response_schema(
                     break
                 path_ = path_list[i]
                 if "[" in path_ and "]" in path_:
+                    # Navigate array segment like users[0].
                     array_name, array_index = process_array(path_)
                     root = root.get(array_name)
                     root = root[array_index]
@@ -454,6 +494,13 @@ async def process_http_result(
             m,
             tool_id,
             tool_type,
+        )
+
+    try:
+        result_json = filter_response_by_x_display(result_json, open_api_schema)
+    except Exception as err:
+        logger.exception(
+            f"filter_response_by_x_display failed, fallback to original result: {err}"
         )
 
     span_context.add_info_events({"before result": result})
@@ -714,7 +761,9 @@ async def http_run(run_params: HttpRunRequest) -> HttpRunResponse:
         )
 
 
-async def tool_debug(tool_debug_params: ToolDebugRequest) -> ToolDebugResponse:
+async def tool_debug(  # noqa: C901
+    tool_debug_params: ToolDebugRequest,
+) -> ToolDebugResponse:
     """Tool debugging interface."""
     run_params_list = tool_debug_params.dict()
     app_id, uid, caller = extract_request_params(run_params_list)
@@ -800,6 +849,13 @@ async def tool_debug(tool_debug_params: ToolDebugRequest) -> ToolDebugResponse:
                     m,
                     tool_id,
                     tool_type or "",
+                )
+
+            try:
+                result_json = filter_response_by_x_display(result_json, openapi_schema)
+            except Exception as err:
+                logger.exception(
+                    f"filter_response_by_x_display failed, fallback to original result: {err}"
                 )
 
             span_context.add_info_events({"before result": result})

--- a/core/plugin/link/tests/unit/test_response_filter.py
+++ b/core/plugin/link/tests/unit/test_response_filter.py
@@ -1,0 +1,301 @@
+from typing import Any, Dict
+
+from jsonschema import Draft7Validator
+from plugin.link.utils.open_api_schema.response_filter import (
+    filter_response_by_x_display,
+    get_missing_visible_declared_paths,
+    get_need_be_poped_list,
+    get_response_schema,
+    should_ignore_validation_error_by_x_display,
+)
+
+
+def _build_openapi_schema(response_schema: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "paths": {
+            "/demo": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": response_schema,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_get_response_schema_extracts_from_openapi() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+    }
+
+    assert (
+        get_response_schema(_build_openapi_schema(response_schema)) == response_schema
+    )
+
+
+def test_get_need_be_poped_list_collects_hidden_paths() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "secret": {"type": "string", "x-display": False},
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"internal": {"type": "string", "x-display": False}},
+                },
+            },
+        },
+    }
+
+    hidden_paths = get_need_be_poped_list(response_schema)
+
+    assert "$.secret" in hidden_paths
+    assert "$.items[*].internal" in hidden_paths
+
+
+def test_filter_parent_hidden_takes_precedence() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "x-display": False,
+                "properties": {
+                    "name": {"type": "string", "x-display": True},
+                    "secret": {"type": "string", "x-display": False},
+                },
+            },
+            "visible": {"type": "string", "x-display": True},
+        },
+    }
+    payload = {
+        "profile": {"name": "alice", "secret": "internal"},
+        "visible": "ok",
+    }
+
+    result = filter_response_by_x_display(
+        payload, _build_openapi_schema(response_schema)
+    )
+
+    assert result == {"visible": "ok"}
+
+
+def test_filter_keeps_empty_object_elements_in_array() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "users": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "x-display": False},
+                        "email": {"type": "string", "x-display": False},
+                    },
+                },
+            }
+        },
+    }
+    payload = {
+        "users": [
+            {"name": "a", "email": "a@x.com"},
+            {"name": "b", "email": "b@x.com"},
+        ]
+    }
+
+    result = filter_response_by_x_display(
+        payload, _build_openapi_schema(response_schema)
+    )
+
+    assert result == {"users": [{}, {}]}
+
+
+def test_filter_hides_array_elements_when_items_closed() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "users": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "x-display": False,
+                    "properties": {"name": {"type": "string", "x-display": True}},
+                },
+            }
+        },
+    }
+    payload = {"users": [{"name": "a", "extra": "x"}]}
+
+    result = filter_response_by_x_display(
+        payload, _build_openapi_schema(response_schema)
+    )
+
+    assert result == {"users": []}
+
+
+def test_filter_ref_items_closed_hides_all_elements() -> None:
+    open_api_schema = {
+        "paths": {
+            "/demo": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "users": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/UserItem"
+                                                },
+                                            }
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "UserItem": {
+                    "type": "object",
+                    "x-display": False,
+                    "properties": {"name": {"type": "string", "x-display": True}},
+                }
+            }
+        },
+    }
+    payload = {"users": [{"name": "a"}, {"name": "b"}]}
+
+    result = filter_response_by_x_display(payload, open_api_schema)
+
+    assert result == {"users": []}
+
+
+def test_should_ignore_validation_error_when_required_field_hidden() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "secret": {"type": "string", "x-display": False},
+                },
+                "required": ["secret"],
+            }
+        },
+    }
+    payload: Dict[str, Any] = {"profile": {}}
+
+    err = list(Draft7Validator(response_schema).iter_errors(payload))[0]
+
+    assert should_ignore_validation_error_by_x_display(err, response_schema) is True
+
+
+def test_should_not_ignore_validation_error_when_required_field_visible() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            }
+        },
+    }
+    payload: Dict[str, Any] = {"profile": {}}
+
+    err = list(Draft7Validator(response_schema).iter_errors(payload))[0]
+
+    assert should_ignore_validation_error_by_x_display(err, response_schema) is False
+
+
+def test_missing_visible_declared_paths_excludes_hidden() -> None:
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "visible": {"type": "string", "x-display": True},
+            "hidden": {"type": "string", "x-display": False},
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "x-display": True},
+                    "secret": {"type": "string", "x-display": False},
+                },
+            },
+        },
+    }
+    payload = {"profile": {}, "extra": "keep"}
+
+    missing_paths = get_missing_visible_declared_paths(payload, response_schema)
+
+    assert "$.visible" in missing_paths
+    assert "$.profile.name" in missing_paths
+    assert "$.hidden" not in missing_paths
+    assert "$.profile.secret" not in missing_paths
+
+
+def test_missing_visible_declared_paths_with_ref() -> None:
+    open_api_schema = {
+        "paths": {
+            "/demo": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "users": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/UserItem"
+                                                },
+                                            }
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "UserItem": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "x-display": True},
+                        "secret": {"type": "string", "x-display": False},
+                    },
+                }
+            }
+        },
+    }
+    response_schema = get_response_schema(open_api_schema)
+    payload = {"users": [{}, {"name": "b"}]}
+
+    missing_paths = get_missing_visible_declared_paths(
+        payload,
+        response_schema,
+        open_api_schema,
+    )
+
+    assert "$.users[*].name" in missing_paths
+    assert "$.users[*].secret" not in missing_paths

--- a/core/plugin/link/utils/open_api_schema/response_filter.py
+++ b/core/plugin/link/utils/open_api_schema/response_filter.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _is_x_display_false(schema: Dict[str, Any]) -> bool:
+    value = schema.get("x-display")
+    if value is False:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() == "false"
+    return False
+
+
+def extract_response_schema(openapi_schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Extract the 200 response JSON schema from a single-endpoint OpenAPI schema."""
+    if not isinstance(openapi_schema, dict):
+        return {}
+
+    paths = openapi_schema.get("paths")
+    if not isinstance(paths, dict) or not paths:
+        return {}
+
+    for _, method_dict in paths.items():
+        if not isinstance(method_dict, dict):
+            continue
+        for _, method_schema in method_dict.items():
+            if not isinstance(method_schema, dict):
+                continue
+            response_schema = (
+                method_schema.get("responses", {})
+                .get("200", {})
+                .get("content", {})
+                .get("application/json", {})
+                .get("schema", {})
+            )
+            return response_schema if isinstance(response_schema, dict) else {}
+    return {}
+
+
+def get_response_schema(openapi_schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Backward-compatible entry for extracting response schema."""
+    try:
+        from plugin.link.service.community.tools.http.execution_server import (
+            get_response_schema as execution_server_get_response_schema,
+        )
+
+        return execution_server_get_response_schema(openapi_schema)
+    except Exception:
+        return extract_response_schema(openapi_schema)
+
+
+def _infer_schema_type(schema: Dict[str, Any]) -> Optional[str]:
+    node_type = schema.get("type")
+    if isinstance(node_type, str):
+        return node_type
+    if isinstance(node_type, list):
+        explicit_types = [item for item in node_type if isinstance(item, str)]
+        if explicit_types:
+            if "object" in explicit_types:
+                return "object"
+            if "array" in explicit_types:
+                return "array"
+            return explicit_types[0]
+    if isinstance(schema.get("properties"), dict):
+        return "object"
+    if "items" in schema:
+        return "array"
+    return None
+
+
+def _extract_items_schema(schema: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    items = schema.get("items")
+    if isinstance(items, dict):
+        return items
+    if isinstance(items, list) and items and isinstance(items[0], dict):
+        return items[0]
+    return None
+
+
+def _resolve_local_ref(
+    openapi_schema: Dict[str, Any], ref: str
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return None
+
+    node: Any = openapi_schema
+    for token in ref[2:].split("/"):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(token)
+
+    if not isinstance(node, dict):
+        return None
+    return node
+
+
+def _resolve_schema_refs(
+    schema: Dict[str, Any],
+    openapi_schema: Dict[str, Any],
+    seen_refs: Optional[set[str]] = None,
+) -> Dict[str, Any]:
+    if not isinstance(schema, dict):
+        return {}
+
+    if seen_refs is None:
+        seen_refs = set()
+
+    schema = _resolve_current_schema_ref(schema, openapi_schema, seen_refs)
+
+    resolved_schema: Dict[str, Any] = dict(schema)
+
+    _resolve_properties_in_place(resolved_schema, openapi_schema, seen_refs)
+    _resolve_items_in_place(resolved_schema, openapi_schema, seen_refs)
+
+    return resolved_schema
+
+
+def _resolve_current_schema_ref(
+    schema: Dict[str, Any],
+    openapi_schema: Dict[str, Any],
+    seen_refs: set[str],
+) -> Dict[str, Any]:
+    # Resolve local $ref first, then let inline fields override resolved fields.
+    # This follows JSON Schema/OpenAPI merge behavior and keeps extension keys.
+    ref = schema.get("$ref")
+    if not isinstance(ref, str):
+        return schema
+    if ref in seen_refs:
+        return {k: v for k, v in schema.items() if k != "$ref"}
+
+    resolved = _resolve_local_ref(openapi_schema, ref)
+    if not isinstance(resolved, dict):
+        return schema
+
+    merged = dict(_resolve_schema_refs(resolved, openapi_schema, seen_refs | {ref}))
+    for key, value in schema.items():
+        if key != "$ref":
+            merged[key] = value
+    return merged
+
+
+def _resolve_properties_in_place(
+    schema: Dict[str, Any],
+    openapi_schema: Dict[str, Any],
+    seen_refs: set[str],
+) -> None:
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return
+
+    schema["properties"] = {
+        key: (
+            _resolve_schema_refs(value, openapi_schema, seen_refs)
+            if isinstance(value, dict)
+            else value
+        )
+        for key, value in properties.items()
+    }
+
+
+def _resolve_items_in_place(
+    schema: Dict[str, Any],
+    openapi_schema: Dict[str, Any],
+    seen_refs: set[str],
+) -> None:
+    items = schema.get("items")
+    if isinstance(items, dict):
+        schema["items"] = _resolve_schema_refs(items, openapi_schema, seen_refs)
+        return
+    if isinstance(items, list):
+        schema["items"] = [
+            (
+                _resolve_schema_refs(item, openapi_schema, seen_refs)
+                if isinstance(item, dict)
+                else item
+            )
+            for item in items
+        ]
+
+
+def _prepare_response_schema(
+    response_schema: Dict[str, Any], openapi_schema: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Normalize response schema before filtering/validation checks."""
+    if not isinstance(response_schema, dict) or not response_schema:
+        return {}
+    if isinstance(openapi_schema, dict):
+        return _resolve_schema_refs(response_schema, openapi_schema)
+    return response_schema
+
+
+def _join_path(parent: str, token: str) -> str:
+    # Keep a normalized JSONPath-like form used by hidden-path collection
+    # and missing-visible-path checks (e.g. $.users[*].name).
+    if token == "[*]":
+        return f"{parent}[*]"
+    if parent == "$":
+        return f"$.{token}"
+    return f"{parent}.{token}"
+
+
+def _collect_hidden_paths(
+    schema: Dict[str, Any], current_path: str, paths: List[str]
+) -> None:
+    if not isinstance(schema, dict):
+        return
+
+    if _is_x_display_false(schema):
+        paths.append(current_path)
+        return
+
+    node_type = _infer_schema_type(schema)
+    if node_type == "object":
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return
+        for name, prop_schema in properties.items():
+            if not isinstance(prop_schema, dict):
+                continue
+            _collect_hidden_paths(prop_schema, _join_path(current_path, name), paths)
+        return
+
+    if node_type == "array":
+        items = _extract_items_schema(schema)
+        if not isinstance(items, dict):
+            return
+        if _is_x_display_false(items):
+            paths.append(_join_path(current_path, "[*]"))
+            return
+        _collect_hidden_paths(items, _join_path(current_path, "[*]"), paths)
+
+
+def get_need_be_poped_list(response_schema: Dict[str, Any]) -> List[str]:
+    """Backward-compatible name for hidden paths computed from response schema."""
+    if not isinstance(response_schema, dict) or not response_schema:
+        return []
+    hidden_paths: List[str] = []
+    _collect_hidden_paths(response_schema, "$", hidden_paths)
+    return hidden_paths
+
+
+def _filter_value(value: Any, schema: Dict[str, Any]) -> Any:
+    if not isinstance(schema, dict):
+        return value
+
+    if _is_x_display_false(schema):
+        return _Removed
+
+    node_type = _infer_schema_type(schema)
+
+    if node_type == "object":
+        return _filter_object_value(value, schema)
+
+    if node_type == "array":
+        return _filter_array_value(value, schema)
+
+    return value
+
+
+def _filter_object_value(value: Any, schema: Dict[str, Any]) -> Any:
+    if not isinstance(value, dict):
+        return value
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return value
+
+    filtered: Dict[str, Any] = {}
+    for key, val in value.items():
+        prop_schema = properties.get(key)
+        if not isinstance(prop_schema, dict):
+            filtered[key] = val
+            continue
+
+        child = _filter_value(val, prop_schema)
+        if child is _Removed:
+            continue
+        filtered[key] = child
+    return filtered
+
+
+def _filter_array_value(value: Any, schema: Dict[str, Any]) -> Any:
+    items_schema = _extract_items_schema(schema)
+    if not isinstance(items_schema, dict):
+        return value
+    if _is_x_display_false(items_schema):
+        return []
+    if not isinstance(value, list):
+        return value
+
+    filtered_items: List[Any] = []
+    for item in value:
+        child = _filter_value(item, items_schema)
+        if child is _Removed:
+            continue
+        # Keep empty dict items by design. When all item fields are hidden,
+        # callers may still need positional consistency of array elements.
+        filtered_items.append(child)
+    return filtered_items
+
+
+class _RemovedMarker:
+    pass
+
+
+_Removed = _RemovedMarker()
+
+
+def filter_response_by_x_display(
+    result_json: Any, openapi_schema: Optional[Dict[str, Any]]
+) -> Any:
+    """Filter response payload by x-display settings in response schema."""
+    response_schema = _prepare_response_schema(
+        get_response_schema(openapi_schema),
+        openapi_schema,
+    )
+    if not response_schema:
+        return result_json
+    filtered = _filter_value(result_json, response_schema)
+    return {} if filtered is _Removed else filtered
+
+
+def _parse_required_property_name(message: str) -> Optional[str]:
+    marker = "is a required property"
+    if marker not in message:
+        return None
+    parts = message.split("'", 2)
+    if len(parts) < 3:
+        return None
+    return parts[1]
+
+
+def _build_token_path_for_missing_required(
+    err_path: List[Any], missing_required: str
+) -> List[str]:
+    token_path: List[str] = []
+    for path_token in err_path:
+        if isinstance(path_token, int):
+            token_path.append("[*]")
+        else:
+            token_path.append(str(path_token))
+    token_path.append(missing_required)
+    return token_path
+
+
+def _token_path_to_json_path(token_path: List[str]) -> str:
+    current_path = "$"
+    for token in token_path:
+        current_path = _join_path(current_path, token)
+    return current_path
+
+
+def _path_is_same_or_descendant(target_path: str, ancestor_path: str) -> bool:
+    if target_path == ancestor_path:
+        return True
+    return target_path.startswith(f"{ancestor_path}.") or target_path.startswith(
+        f"{ancestor_path}["
+    )
+
+
+def _hidden_paths_from_response_schema(
+    response_schema: Dict[str, Any], openapi_schema: Optional[Dict[str, Any]] = None
+) -> List[str]:
+    prepared_schema = _prepare_response_schema(response_schema, openapi_schema)
+    if not prepared_schema:
+        return []
+
+    hidden_paths: List[str] = []
+    _collect_hidden_paths(prepared_schema, "$", hidden_paths)
+    return hidden_paths
+
+
+def should_ignore_validation_error_by_x_display(
+    err: Any,
+    response_schema: Dict[str, Any],
+    openapi_schema: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return True when a schema error should be ignored because target field is hidden."""
+    # Only "required property missing" errors are eligible for ignore.
+    # Other schema violations should still be reported.
+    missing_required = _parse_required_property_name(getattr(err, "message", ""))
+    if not missing_required:
+        return False
+
+    token_path = _build_token_path_for_missing_required(
+        list(getattr(err, "path", [])), missing_required
+    )
+    target_path = _token_path_to_json_path(token_path)
+    hidden_paths = _hidden_paths_from_response_schema(response_schema, openapi_schema)
+    for hidden_path in hidden_paths:
+        # If the missing field itself (or one of its parents) is hidden,
+        # validation noise should not fail the response processing.
+        if _path_is_same_or_descendant(target_path, hidden_path):
+            return True
+    return False
+
+
+def _collect_missing_visible_declared_paths(
+    value: Any,
+    schema: Dict[str, Any],
+    current_path: str,
+    missing_paths: List[str],
+) -> None:
+    if not isinstance(schema, dict):
+        return
+
+    if _is_x_display_false(schema):
+        return
+
+    node_type = _infer_schema_type(schema)
+
+    if node_type == "object":
+        _collect_missing_for_object(value, schema, current_path, missing_paths)
+        return
+
+    if node_type == "array":
+        _collect_missing_for_array(value, schema, current_path, missing_paths)
+
+
+def _collect_missing_for_object(
+    value: Any,
+    schema: Dict[str, Any],
+    current_path: str,
+    missing_paths: List[str],
+) -> None:
+    if not isinstance(value, dict):
+        return
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return
+
+    for name, property_schema in properties.items():
+        if not isinstance(property_schema, dict):
+            continue
+
+        property_path = _join_path(current_path, name)
+        if name not in value:
+            if not _is_x_display_false(property_schema):
+                missing_paths.append(property_path)
+            continue
+
+        _collect_missing_visible_declared_paths(
+            value[name],
+            property_schema,
+            property_path,
+            missing_paths,
+        )
+
+
+def _collect_missing_for_array(
+    value: Any,
+    schema: Dict[str, Any],
+    current_path: str,
+    missing_paths: List[str],
+) -> None:
+    items_schema = _extract_items_schema(schema)
+    if not isinstance(items_schema, dict):
+        return
+    if _is_x_display_false(items_schema):
+        return
+    if not isinstance(value, list):
+        return
+
+    item_path = _join_path(current_path, "[*]")
+    for item in value:
+        _collect_missing_visible_declared_paths(
+            item,
+            items_schema,
+            item_path,
+            missing_paths,
+        )
+
+
+def get_missing_visible_declared_paths(
+    result_json: Any,
+    response_schema: Dict[str, Any],
+    openapi_schema: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """Return declared visible field paths that are missing in response payload."""
+    prepared_schema = _prepare_response_schema(response_schema, openapi_schema)
+    if not prepared_schema:
+        return []
+
+    missing_paths: List[str] = []
+    _collect_missing_visible_declared_paths(
+        result_json,
+        prepared_schema,
+        "$",
+        missing_paths,
+    )
+    return sorted(set(missing_paths))


### PR DESCRIPTION
## Summary
Introduce a new OpenAPI response visibility feature based on `x-display`, including schema-aware filtering with `$ref` support and validation guardrails that align visible-field checks with runtime response handling.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Related Issue
N/A

## Changes

### 1) Refactor `x-display` response filtering
- Updated: `core/plugin/link/utils/open_api_schema/response_filter.py`
- Added schema-driven `x-display` response filtering capability for OpenAPI JSON responses.
- Implemented recursive traversal with local `$ref` resolution (`#/components/...`) for nested/array schemas.
- Kept behavior contract explicit:
  - Remove fields marked with `x-display: false` (supports boolean `false` and string `"false"`).
  - If all children under an object/array container are hidden, keep structural type and return empty `{}` / `[]`.
- Added/kept compatibility helpers:
  - Hidden path collection (`get_need_be_poped_list`).
  - Missing declared visible path detection (`get_missing_visible_declared_paths`).
  - Validation error ignore decision for hidden required fields (`should_ignore_validation_error_by_x_display`).

### 2) Adjust HTTP execution flow: validate first, then filter
- Updated: `core/plugin/link/service/community/tools/http/execution_server.py`
- Added end-to-end response processing flow for the new feature: validate first, then apply visibility filtering.
- Applied filtering after validation in both request handling and tool debug paths.
- Integrated missing-visible-field detection and hidden-field-aware ignore logic into validation flow.
- Preserved existing exception handling and telemetry behavior.

### 3) Add focused unit tests
- Added: `core/plugin/link/tests/unit/test_response_filter.py`
- Covered scenarios:
  - Hidden field removal and parent-hidden precedence for object fields.
  - Array container behavior: hide all elements when item schema is `x-display: false`.
  - Keep empty object items in arrays when child fields are hidden.
  - `$ref`-based schema resolution in filtering and missing-visible-path checks.
  - Required-field validation ignore checks for hidden fields.

## Testing
- [x] New tests added (unit)
- [ ] Existing full test suite executed
- [ ] Manual testing completed

Test scope added in this PR:
- `test_filter_parent_hidden_takes_precedence`
- `test_filter_keeps_empty_object_elements_in_array`
- `test_filter_hides_array_elements_when_items_closed`
- `test_filter_ref_items_closed_hides_all_elements`
- `test_missing_visible_declared_paths_with_ref`

## Compatibility / Risk
- No API contract change in request shape.
- Response payload visibility now supports declarative control via schema `x-display`.
- Potential behavior change: previously returned hidden fields may now be removed or collapsed to `{}` / `[]` per schema.
- Risk is controllable and covered by focused unit tests around nested arrays, refs, and required-field validation edge cases.

## Rollback Plan
If regressions are found:
1. Revert `response_filter.py` implementation to the previous filtering logic.
2. Revert execution order changes in `execution_server.py`.

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation/comments updated where needed
- [x] No breaking changes introduced
