### PR TITLE
feat(helm): support cloud ingress deployment

### DIFF
--- a/helm/astron-agent/files/casdoor/conf/init_data.json.template
+++ b/helm/astron-agent/files/casdoor/conf/init_data.json.template
@@ -11,7 +11,7 @@
       "enableSignUp": true,
       "clientId": "astron-agent-client",
       "redirectUris": [
-        "${HOST_BASE_ADDRESS}/callback"
+        "${CONSOLE_DOMAIN}/callback"
       ],
       "tokenFormat": "JWT",
       "tokenFields": [],

--- a/helm/astron-agent/files/casdoor/entrypoint.sh
+++ b/helm/astron-agent/files/casdoor/entrypoint.sh
@@ -3,7 +3,6 @@ set -e
 
 echo "===== Initializing Casdoor Configuration ====="
 echo "CONSOLE_DOMAIN: ${CONSOLE_DOMAIN:-http://localhost}"
-echo "HOST_BASE_ADDRESS: ${HOST_BASE_ADDRESS:-http://localhost}"
 
 # Copy config files from ConfigMap (read-only) to writable directory
 echo "Copying config files..."
@@ -12,11 +11,11 @@ cp -v /conf-ro/* /conf/ 2>/dev/null || true
 # Generate init_data.json from template
 echo "Generating init_data.json from template..."
 sed -e "s|\${CONSOLE_DOMAIN}|${CONSOLE_DOMAIN}|g" \
-    -e "s|\${HOST_BASE_ADDRESS}|${HOST_BASE_ADDRESS}|g" \
     /conf-ro/init_data.json.template > /conf/init_data.json
 
 echo "Configuration ready!"
-echo "redirectUris: [${CONSOLE_DOMAIN}/callback, ${HOST_BASE_ADDRESS}/callback]"
+
+echo "redirectUris: [${CONSOLE_DOMAIN}/callback]"
 echo "=========================================="
 
 # Start Casdoor

--- a/helm/astron-agent/templates/_helpers.tpl
+++ b/helm/astron-agent/templates/_helpers.tpl
@@ -60,6 +60,100 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Return the public host base address without a trailing slash.
+Expected format: http://<public-ip-or-domain>
+*/}}
+{{- define "astron-agent.publicHostBase" -}}
+{{- trimSuffix "/" (.Values.global.hostBaseAddress | default "http://127.0.0.1") -}}
+{{- end }}
+
+{{/*
+Return the primary ingress host.
+*/}}
+{{- define "astron-agent.ingress.host" -}}
+{{- if and .Values.ingress.enabled .Values.ingress.hosts (gt (len .Values.ingress.hosts) 0) -}}
+{{- (index .Values.ingress.hosts 0).host | default "" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the public scheme for ingress access.
+*/}}
+{{- define "astron-agent.ingress.scheme" -}}
+{{- if .Values.ingress.tls -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the public base URL for ingress access.
+*/}}
+{{- define "astron-agent.ingress.publicUrl" -}}
+{{- $host := include "astron-agent.ingress.host" . -}}
+{{- if $host -}}
+{{- printf "%s://%s" (include "astron-agent.ingress.scheme" .) $host -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the public URL for the gateway entrypoint.
+*/}}
+{{- define "astron-agent.gateway.publicUrl" -}}
+{{- if .Values.gateway.publicUrl -}}
+{{- trimSuffix "/" .Values.gateway.publicUrl -}}
+{{- else if and .Values.ingress.enabled (include "astron-agent.ingress.host" .) -}}
+{{- include "astron-agent.ingress.publicUrl" . -}}
+{{- else if eq .Values.gateway.service.type "NodePort" -}}
+{{- printf "%s:%d" (include "astron-agent.publicHostBase" .) (.Values.gateway.service.nodePort | int) -}}
+{{- else -}}
+{{- include "astron-agent.publicHostBase" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the public URL for Casdoor.
+*/}}
+{{- define "astron-agent.casdoor.publicUrl" -}}
+{{- if .Values.casdoor.publicUrl -}}
+{{- trimSuffix "/" .Values.casdoor.publicUrl -}}
+{{- else if and .Values.ingress.enabled (include "astron-agent.ingress.host" .) -}}
+{{- include "astron-agent.ingress.publicUrl" . -}}
+{{- else if eq .Values.casdoor.service.type "NodePort" -}}
+{{- printf "%s:%d" (include "astron-agent.publicHostBase" .) (.Values.casdoor.service.nodePort | int) -}}
+{{- else -}}
+{{- include "astron-agent.publicHostBase" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the public URL for MinIO API access.
+*/}}
+{{- define "astron-agent.minio.publicUrl" -}}
+{{- if .Values.minio.publicUrl -}}
+{{- trimSuffix "/" .Values.minio.publicUrl -}}
+{{- else if eq .Values.minio.service.type "NodePort" -}}
+{{- printf "%s:%d" (include "astron-agent.publicHostBase" .) (.Values.minio.service.nodePort | int) -}}
+{{- else -}}
+{{- include "astron-agent.publicHostBase" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the public URL for MinIO console access.
+*/}}
+{{- define "astron-agent.minio.consolePublicUrl" -}}
+{{- if .Values.minio.consolePublicUrl -}}
+{{- trimSuffix "/" .Values.minio.consolePublicUrl -}}
+{{- else if eq .Values.minio.service.type "NodePort" -}}
+{{- printf "%s:%d" (include "astron-agent.publicHostBase" .) (.Values.minio.service.consoleNodePort | int) -}}
+{{- else -}}
+{{- include "astron-agent.publicHostBase" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 PostgreSQL host
 */}}
 {{- define "astron-agent.postgresql.host" -}}

--- a/helm/astron-agent/templates/auth/casdoor-deployment.yaml
+++ b/helm/astron-agent/templates/auth/casdoor-deployment.yaml
@@ -44,12 +44,12 @@ spec:
         env:
         - name: GIN_MODE
           value: {{ .Values.casdoor.env.ginMode | quote }}
+        - name: CONSOLE_DOMAIN
+          value: {{ include "astron-agent.gateway.publicUrl" . | quote }}
         - name: origin
-          value: {{ printf "%s:%d" .Values.global.hostBaseAddress (int .Values.casdoor.service.nodePort) | quote }}
+          value: {{ include "astron-agent.casdoor.publicUrl" . | quote }}
         - name: originFrontend
-          value: {{ printf "%s:%d" .Values.global.hostBaseAddress (int .Values.casdoor.service.nodePort) | quote }}
-        - name: HOST_BASE_ADDRESS
-          value: {{ .Values.global.hostBaseAddress | default "http://localhost" | quote }}
+          value: {{ include "astron-agent.casdoor.publicUrl" . | quote }}
         ports:
         - name: http
           containerPort: 8000

--- a/helm/astron-agent/templates/auth/casdoor-mysql-statefulset.yaml
+++ b/helm/astron-agent/templates/auth/casdoor-mysql-statefulset.yaml
@@ -88,5 +88,5 @@ spec:
       {{- end }}
       resources:
         requests:
-          storage: 10Gi
+          storage: {{ .Values.casdoor.mysql.persistence.size | default "10Gi" }}
 {{- end }}

--- a/helm/astron-agent/templates/console/console-frontend-deployment.yaml
+++ b/helm/astron-agent/templates/console/console-frontend-deployment.yaml
@@ -27,8 +27,10 @@ spec:
         image: "{{ .Values.global.imageRegistry }}/{{ .Values.consoleFrontend.image }}:{{ .Values.global.astronAgentVersion }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
+        - name: CONSOLE_API_URL
+          value: "/console-api"
         - name: CONSOLE_CASDOOR_URL
-          value: {{ printf "%s:%d" .Values.global.hostBaseAddress (.Values.casdoor.service.nodePort | int) | quote }}
+          value: {{ include "astron-agent.casdoor.publicUrl" . | quote }}
         - name: CONSOLE_CASDOOR_ID
           value: {{ .Values.consoleFrontend.env.casdoorId | quote }}
         - name: CONSOLE_CASDOOR_APP

--- a/helm/astron-agent/templates/console/console-hub-deployment.yaml
+++ b/helm/astron-agent/templates/console/console-hub-deployment.yaml
@@ -45,13 +45,16 @@ spec:
         {{- range $key, $value := .Values.consoleHub.env }}
         {{- if or (eq $key "consoleCasdoorUrl") (eq $key "oauth2IssuerUri") }}
         - name: {{ upper (snakecase $key) }}
-          value: {{ printf "%s:%d" $.Values.global.hostBaseAddress ($.Values.casdoor.service.nodePort | int) | quote }}
+          value: {{ include "astron-agent.casdoor.publicUrl" $ | quote }}
         {{- else if eq $key "consoleDomain" }}
         - name: {{ upper (snakecase $key) }}
-          value: {{ $.Values.global.hostBaseAddress | quote }}
+          value: {{ include "astron-agent.gateway.publicUrl" $ | quote }}
         {{- else if eq $key "ossRemoteEndpoint" }}
         - name: {{ upper (snakecase $key) }}
-          value: {{ printf "%s:%d" $.Values.global.hostBaseAddress ($.Values.minio.service.nodePort | int) | quote }}
+          value: {{ include "astron-agent.minio.publicUrl" $ | quote }}
+        {{- else if eq $key "oauth2JwkSetUri" }}
+        - name: {{ upper (snakecase $key) }}
+          value: {{ printf "http://%s:%d/.well-known/jwks" (include "astron-agent.casdoor.host" $) ($.Values.casdoor.service.port | int) | quote }}
         {{- else if or (eq $key "platformAppId") (eq $key "sparkAppId") (eq $key "sparkRtasrAppid") (eq $key "sparkImageAppId") }}
         - name: {{ upper (snakecase $key) }}
           value: {{ $.Values.global.platformAppId | quote }}
@@ -78,7 +81,7 @@ spec:
           value: {{ $.Values.global.sparkVirtualManApiSecret | quote }}
         {{- else if eq $key "botApiMaasBaseUrl" }}
         - name: {{ upper (snakecase $key) }}
-          value: {{ printf "%s/workflow/v1/chat/completions" $.Values.global.hostBaseAddress | quote }}
+          value: {{ include "astron-agent.gateway.publicUrl" $ | quote }}
         {{- else if eq $key "mysqlPassword" }}
         - name: {{ upper (snakecase $key) }}
           valueFrom:

--- a/helm/astron-agent/templates/core/core-services.yaml
+++ b/helm/astron-agent/templates/core/core-services.yaml
@@ -50,7 +50,7 @@ spec:
         {{- range $key, $value := $serviceConfig.env }}
         {{- if and (eq $key "ossDownloadHost") (or (eq $serviceName "coreAitools") (eq $serviceName "coreWorkflow")) }}
         - name: {{ upper (snakecase $key) }}
-          value: {{ printf "%s:%d" $.Values.global.hostBaseAddress ($.Values.minio.service.nodePort | int) | quote }}
+          value: {{ include "astron-agent.minio.publicUrl" $ | quote }}
         {{- else if and (eq $key "aiAppId") (eq $serviceName "coreAitools") }}
         - name: {{ upper (snakecase $key) }}
           value: {{ $.Values.global.platformAppId | quote }}

--- a/helm/astron-agent/templates/gateway/gateway-configmap.yaml
+++ b/helm/astron-agent/templates/gateway/gateway-configmap.yaml
@@ -1,0 +1,217 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "astron-agent.fullname" . }}-gateway-config
+  labels:
+    {{- include "astron-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+data:
+  nginx.conf: |
+    worker_processes auto;
+    worker_rlimit_nofile 65535;
+
+    events {
+        worker_connections 65535;
+        multi_accept on;
+    }
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log /var/log/nginx/access.log main;
+        error_log /var/log/nginx/error.log warn;
+
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        client_max_body_size 20m;
+
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1000;
+        gzip_types
+            text/plain
+            text/css
+            text/xml
+            text/javascript
+            application/xml+rss
+            application/javascript
+            application/json;
+
+        server {
+            listen {{ .Values.gateway.service.port }};
+            server_name _;
+
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header X-Content-Type-Options "nosniff" always;
+
+            location = /runtime-config.js {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-console-frontend:{{ .Values.consoleFrontend.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                expires -1;
+                add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+                add_header Pragma "no-cache";
+            }
+
+            location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-console-frontend:{{ .Values.consoleFrontend.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+
+            location /workflow/v1/chat/completions {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-core-workflow:{{ .Values.coreWorkflow.service.port }}/workflow/v1/chat/completions;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                proxy_buffering off;
+                proxy_cache off;
+                proxy_set_header Connection '';
+                proxy_http_version 1.1;
+                chunked_transfer_encoding on;
+                proxy_set_header X-Accel-Buffering no;
+                proxy_connect_timeout 60s;
+                proxy_send_timeout 1800s;
+                proxy_read_timeout 1800s;
+
+                add_header Cache-Control 'no-cache';
+                add_header X-Accel-Buffering 'no';
+            }
+
+            location /console-api/chat-message/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-console-hub:{{ .Values.consoleHub.service.port }}/chat-message/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                proxy_buffering off;
+                proxy_cache off;
+                proxy_set_header Connection '';
+                proxy_http_version 1.1;
+                chunked_transfer_encoding on;
+                proxy_set_header X-Accel-Buffering no;
+                proxy_connect_timeout 60s;
+                proxy_send_timeout 1800s;
+                proxy_read_timeout 1800s;
+
+                add_header Cache-Control 'no-cache';
+                add_header X-Accel-Buffering 'no';
+            }
+
+            location /console-api/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-console-hub:{{ .Values.consoleHub.service.port }}/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location ^~ /.well-known/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-casdoor:{{ .Values.casdoor.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location ^~ /api/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-casdoor:{{ .Values.casdoor.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location ^~ /login/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-casdoor:{{ .Values.casdoor.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location /logout {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-casdoor:{{ .Values.casdoor.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location ^~ /signup/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-casdoor:{{ .Values.casdoor.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location ^~ /static/ {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-casdoor:{{ .Values.casdoor.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location / {
+                proxy_pass http://{{ include "astron-agent.fullname" . }}-console-frontend:{{ .Values.consoleFrontend.service.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+            }
+
+            location /nginx-health {
+                access_log off;
+                return 200 "nginx is healthy\n";
+                add_header Content-Type text/plain;
+            }
+        }
+    }
+{{- end }}

--- a/helm/astron-agent/templates/gateway/gateway.yaml
+++ b/helm/astron-agent/templates/gateway/gateway.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "astron-agent.fullname" . }}-gateway
+  labels:
+    {{- include "astron-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: {{ .Values.gateway.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "astron-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/gateway/gateway-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "astron-agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: gateway
+        image: "{{ .Values.gateway.image }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.gateway.service.port }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /nginx-health
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          httpGet:
+            path: /nginx-health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        resources:
+          {{- toYaml .Values.gateway.resources | nindent 10 }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "astron-agent.fullname" . }}-gateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "astron-agent.fullname" . }}-gateway
+  labels:
+    {{- include "astron-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  type: {{ .Values.gateway.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.gateway.service.port }}
+    targetPort: http
+    protocol: TCP
+    {{- if and (eq .Values.gateway.service.type "NodePort") .Values.gateway.service.nodePort }}
+    nodePort: {{ .Values.gateway.service.nodePort }}
+    {{- end }}
+  selector:
+    {{- include "astron-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+{{- end }}

--- a/helm/astron-agent/templates/infrastructure/minio-statefulset.yaml
+++ b/helm/astron-agent/templates/infrastructure/minio-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
               name: {{ include "astron-agent.fullname" . }}-minio-secret
               key: root-password
         - name: MINIO_SERVER_URL
-          value: {{ printf "%s:%d" .Values.global.hostBaseAddress (.Values.minio.service.nodePort | int) | quote }}
+          value: {{ include "astron-agent.minio.publicUrl" . | quote }}
         ports:
         - name: api
           containerPort: 9000

--- a/helm/astron-agent/templates/ingress.yaml
+++ b/helm/astron-agent/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.gateway.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,19 +6,12 @@ metadata:
   labels:
     {{- include "astron-agent.labels" . | nindent 4 }}
   annotations:
-    # SSE support for long-lived connections
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
-    # Upload size limit
     nginx.ingress.kubernetes.io/proxy-body-size: "20m"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-    # Security headers
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-XSS-Protection "1; mode=block" always;
-      add_header X-Content-Type-Options "nosniff" always;
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -37,107 +30,30 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- if .Values.ingress.hosts }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
       http:
         paths:
-          # SSE API for workflow chat completions
-          - path: /workflow/v1/chat/completions
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "astron-agent.fullname" $ }}-core-workflow
-                port:
-                  number: {{ $.Values.coreWorkflow.service.port }}
-          # Frontend (default)
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ include "astron-agent.fullname" $ }}-console-frontend
+                name: {{ include "astron-agent.fullname" $ }}-gateway
                 port:
-                  number: {{ $.Values.consoleFrontend.service.port }}
+                  number: {{ $.Values.gateway.service.port }}
     {{- end }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ include "astron-agent.fullname" . }}-console-api-chat
-  labels:
-    {{- include "astron-agent.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /chat-message/$2
-    nginx.ingress.kubernetes.io/proxy-buffering: "off"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
-    # Upload size limit
-    nginx.ingress.kubernetes.io/proxy-body-size: "20m"
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-XSS-Protection "1; mode=block" always;
-      add_header X-Content-Type-Options "nosniff" always;
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
+    {{- else }}
+    - http:
         paths:
-          - path: /console-api/chat-message(/|$)(.*)
-            pathType: ImplementationSpecific
+          - path: /
+            pathType: Prefix
             backend:
               service:
-                name: {{ include "astron-agent.fullname" $ }}-console-hub
+                name: {{ include "astron-agent.fullname" . }}-gateway
                 port:
-                  number: {{ $.Values.consoleHub.service.port }}
-    {{- end }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ include "astron-agent.fullname" . }}-console-api
-  labels:
-    {{- include "astron-agent.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/proxy-buffering: "off"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
-    # Upload size limit
-    nginx.ingress.kubernetes.io/proxy-body-size: "20m"
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-XSS-Protection "1; mode=block" always;
-      add_header X-Content-Type-Options "nosniff" always;
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          - path: /console-api(/|$)(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ include "astron-agent.fullname" $ }}-console-hub
-                port:
-                  number: {{ $.Values.consoleHub.service.port }}
+                  number: {{ .Values.gateway.service.port }}
     {{- end }}
 {{- end }}

--- a/helm/astron-agent/values-aliyun.yaml
+++ b/helm/astron-agent/values-aliyun.yaml
@@ -1,0 +1,56 @@
+global:
+  # 公网访问地址。
+  # 如果通过公网 IP 访问，填写公网 IP，例如：http://47.250.187.146
+  # 如果通过域名访问，填写域名，例如：http://astron-agent.example.com
+  hostBaseAddress: "http://your-public-ip-or-domain"
+
+  # 讯飞平台参数。
+  # 这里不要提交个人真实配置，部署前按实际环境填写。
+  platformAppId: "your-app-id"
+  platformApiKey: "your-api-key"
+  platformApiSecret: "your-api-secret"
+
+  # ACK 集群常用的存储类。
+  # 如果你的集群使用其他 StorageClass，请按实际情况修改。
+  storageClass: "alicloud-disk-topology-alltype"
+
+ingress:
+  # 通过 Ingress 暴露服务。
+  enabled: true
+
+  # IngressClass 名称。
+  # ACK 中安装 ingress-nginx 时通常使用 nginx。
+  className: nginx
+
+  # 如需补充阿里云 SLB 或 ingress-nginx 注解，可在这里追加。
+  annotations: {}
+
+  # 如果通过公网 IP 访问，保持空数组即可。
+  # 如果通过域名访问，改成下面这种形式：
+  # hosts:
+  #   - host: astron-agent.example.com
+  hosts: []
+
+  # 当前默认不启用 TLS。
+  tls: []
+
+casdoor:
+  mysql:
+    persistence:
+      # Casdoor MySQL 数据盘大小。
+      size: 20Gi
+
+postgresql:
+  persistence:
+    # PostgreSQL 数据盘大小。
+    size: 20Gi
+
+mysql:
+  persistence:
+    # MySQL 数据盘大小。
+    size: 20Gi
+
+redis:
+  persistence:
+    # Redis 数据盘大小。
+    size: 20Gi

--- a/helm/astron-agent/values-huaweicloud.yaml
+++ b/helm/astron-agent/values-huaweicloud.yaml
@@ -1,0 +1,57 @@
+global:
+  # 公网访问地址。
+  # 如果通过公网 IP 访问，填写公网 IP，例如：http://1.2.3.4
+  # 如果通过域名访问，填写域名，例如：http://astron-agent.example.com
+  hostBaseAddress: "http://your-public-ip-or-domain"
+
+  # 讯飞平台参数。
+  # 部署前按实际环境填写。
+  platformAppId: "your-app-id"
+  platformApiKey: "your-api-key"
+  platformApiSecret: "your-api-secret"
+
+  # 华为云 CCE 常见存储类。
+  # 如果你的集群使用其他 StorageClass，请按实际情况修改。
+  storageClass: "csi-disk"
+
+ingress:
+  # 通过 Ingress 暴露服务。
+  enabled: true
+
+  # IngressClass 名称。
+  # 如果使用 NGINX Ingress Controller，通常为 nginx。
+  # 如果你的 CCE 使用其他 ingress class，例如 cce，请改成对应值。
+  className: nginx
+
+  # 如需补充 ELB 或 ingress 注解，可在这里追加。
+  annotations: {}
+
+  # 如果通过公网 IP 访问，保持空数组即可。
+  # 如果通过域名访问，改成下面这种形式：
+  # hosts:
+  #   - host: astron-agent.example.com
+  hosts: []
+
+  # 当前默认不启用 TLS。
+  tls: []
+
+casdoor:
+  mysql:
+    persistence:
+      # Casdoor MySQL 数据盘大小。
+      size: 20Gi
+
+postgresql:
+  persistence:
+    # PostgreSQL 数据盘大小。
+    size: 20Gi
+
+mysql:
+  persistence:
+    # MySQL 数据盘大小。
+    size: 20Gi
+
+redis:
+  persistence:
+    # Redis 数据盘大小。
+    size: 20Gi

--- a/helm/astron-agent/values.yaml
+++ b/helm/astron-agent/values.yaml
@@ -31,6 +31,24 @@ fullnameOverride: "astron-agent"
 # Image pull secrets
 imagePullSecrets: []
 
+# Gateway settings
+gateway:
+  enabled: true
+  image: nginx:1.25-alpine
+  replicaCount: 1
+  publicUrl: ""
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "500m"
+  service:
+    type: ClusterIP
+    port: 80
+    nodePort: 30080
+
 # Network settings
 networkPolicy:
   enabled: false
@@ -118,6 +136,8 @@ minio:
   auth:
     rootUser: minioadmin
     rootPassword: minioadmin123
+  publicUrl: ""
+  consolePublicUrl: ""
   service:
     type: NodePort
     apiPort: 9000
@@ -141,8 +161,9 @@ casdoor:
     limits:
       memory: "1Gi"
       cpu: "1000m"
+  publicUrl: ""
   service:
-    type: NodePort
+    type: ClusterIP
     port: 8000
     nodePort: 30800
   env:
@@ -152,6 +173,8 @@ casdoor:
     username: casdoor
     password: casdoor123
     rootPassword: casdoor_root123
+    persistence:
+      size: 10Gi
   persistence:
     logs:
       enabled: true
@@ -204,6 +227,9 @@ coreDatabase:
     pgsqlUser: spark
     pgsqlPassword: ""
     pgsqlDatabase: sparkdb_manager
+    redisClusterAddr: ""
+    redisAddr: astron-agent-redis:6379
+    redisPassword: ""
     otlpEndpoint: "127.0.0.1:4317"
     otlpEnable: "0"
 
@@ -559,17 +585,9 @@ consoleHub:
 ingress:
   enabled: true
   className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: astron-agent.example.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: astron-agent-tls
-      hosts:
-        - astron-agent.example.com
+  annotations: {}
+  hosts: []
+  tls: []
 
 # Service Account
 serviceAccount:


### PR DESCRIPTION
## 概述

本次 PR 对 Helm Chart 进行了云环境部署相关改造，使基于 Ingress 的部署路径可以在云上 Kubernetes 环境中正常使用。

## 变更内容

- 新增 gateway nginx 组件，作为统一入口层
- 通过 gateway 统一转发前端、console 后端、Casdoor 和 workflow 请求
- 修复 Casdoor 回调地址和公网访问地址生成逻辑
- 修复 Casdoor 登录页静态资源路由问题
- 新增阿里云 ACK 和华为云 CCE 的独立 values 配置文件
- 将云环境默认部署方式调整为 Ingress + ClusterIP
- 为 core-database 补充 Redis 环境变量，修复启动失败问题

## 验证情况

- 使用 `values-aliyun.yaml` 执行 `helm lint`
- 使用 `values-huaweicloud.yaml` 执行 `helm lint`
- 使用 `values-aliyun.yaml` 执行 `helm template`
- 使用 `values-huaweicloud.yaml` 执行 `helm template`
- 已在阿里云 ACK 上验证部署流程
- 已在华为云 CCE 上验证部署流程

## 说明
- 用户在部署前仍需要填写自己的平台参数

可供参考的文档和模板下载链接