### PR TITLE
fix: set uid when copying agent in space

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/BotChainServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/BotChainServiceImpl.java
@@ -52,9 +52,8 @@ public class BotChainServiceImpl implements BotChainService {
         chainInfo.setId(null);
         chainInfo.setBotId(Math.toIntExact(targetId));
         chainInfo.setFlowId(null);
-        if (null == spaceId) {
-            chainInfo.setUid(uid);
-        } else {
+        chainInfo.setUid(uid);
+        if (spaceId != null) {
             chainInfo.setSpaceId(spaceId);
         }
         chainInfo.setUpdateTime(LocalDateTime.now());
@@ -92,9 +91,8 @@ public class BotChainServiceImpl implements BotChainService {
         chain.setBotId(Math.toIntExact(targetId));
         chain.setMaasId(currentMass);
         chain.setFlowId(flowId);
-        if (null == spaceId) {
-            chain.setUid(uid);
-        } else {
+        chain.setUid(uid);
+        if (spaceId != null) {
             chain.setSpaceId(spaceId);
         }
         chain.setUpdateTime(LocalDateTime.now());

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/workflow/impl/BotChainServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/workflow/impl/BotChainServiceImplTest.java
@@ -86,6 +86,7 @@ class BotChainServiceImplTest {
         assertNull(captured.getId());
         assertEquals(Math.toIntExact(targetId), captured.getBotId());
         assertNull(captured.getFlowId());
+        assertEquals(uid, captured.getUid());
         assertEquals(spaceId, captured.getSpaceId());
         assertNotNull(captured.getUpdateTime());
 
@@ -165,6 +166,7 @@ class BotChainServiceImplTest {
         assertEquals(Math.toIntExact(targetId), captured.getBotId());
         assertEquals(111L, captured.getMaasId());
         assertEquals("newFlow123", captured.getFlowId());
+        assertEquals(uid, captured.getUid());
         assertEquals(spaceId, captured.getSpaceId());
         assertNotNull(captured.getUpdateTime());
     }


### PR DESCRIPTION
## Summary
Fixes the non-personal space agent copy failure caused by missing `uid` when inserting `user_lang_chain_info`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Fixes #941

## Changes
- Always set `uid` when copying bot chain data in `BotChainServiceImpl`
- Keep setting `spaceId` for non-personal space copies
- Added test assertions to cover `uid` persistence for space copy scenarios

## Testing
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented