### PR TITLE
fix: Update nginx configuration to properly route workflow API endpoints including upload-file   

### DIFF
--- a/docker/astronAgent/nginx/nginx.conf
+++ b/docker/astronAgent/nginx/nginx.conf
@@ -105,6 +105,22 @@ http {
             add_header X-Accel-Buffering 'no';
         }
 
+        # SSE (Server-Sent Events) API proxy for workflow
+        location /workflow/v1/ {
+            proxy_pass http://core-workflow:7880/workflow/v1/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # SSE specific settings
+            proxy_http_version 1.1;
+            proxy_request_buffering off;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 1800s;
+            proxy_read_timeout 1800s;
+        }
+
         # SSE (Server-Sent Events) API proxy for chat messages
         location /console-api/chat-message/ {
             proxy_pass http://console-hub:8080/chat-message/;


### PR DESCRIPTION
## Summary
This PR fixes the nginx configuration to properly route all workflow API endpoints, specifically addressing the missing `/workflow/v1/upload-file` endpoint that was not being handled correctly.

## Type of Change
- [*] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
https://github.com/iflytek/astron-agent/issues/1022

## Changes
  - Updated nginx.conf to add proper routing for `/workflow/v1/` endpoints to the core-workflow service
  - Maintained specific SSE configuration for `/workflow/v1/chat/completions` endpoint
  - Ensured `/workflow/v1/upload-file` and other workflow v1 endpoints are now properly routed
  - Configured location priority order so specific paths are matched before generic ones

  ### Technical Details:

  - The generic `/workflow/v1/` location rule now correctly routes to `http://core-workflow:7880/workflow/v1/`
  - The specific `/workflow/v1/chat/completions` endpoint retains its specialized SSE settings
  - File upload functionality through `/workflow/v1/upload-file` is now accessible via the nginx proxy
  - Increased timeout settings appropriate for file upload operations

## Testing
  - Verified nginx configuration syntax is valid
  - Confirmed location priority order prevents path conflicts
  - Ensures backward compatibility with existing workflow endpoints

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
