### PR TITLE
feat: Add node detail template for variable aggregation node 

### DIFF
--- a/console/backend/hub/src/main/resources/db/migration/V1.23__add_variable_aggregation_node_template.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.23__add_variable_aggregation_node_template.sql
@@ -1,0 +1,28 @@
+-- Migration to add variable aggregation node template to the database
+-- Update Chinese version
+UPDATE config_info
+SET value = JSON_ARRAY_APPEND(
+    value,
+    '$',
+    JSON_OBJECT(
+        'idType', 'variable-aggregation',
+        'icon', 'https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/variable-aggregation-icon.png',
+        'name', '变量聚合器',
+        'markdown', '## 用途\n根据优先级和类型兼容性，从多个输入中聚合变量值，提供备用值以确保输出可靠性\n## 示例\n### 输入\n| 参数名 | 参数值 |\n|----------------|----------------------|\n| 候选变量1（引用）| 大模型-output |\n| 候选变量2（引用） | 知识库-output |\n| 候选变量3（引用）| 代码-result |\n\n### 输出\n| 变量名 | 变量值 |\n|------------|--------|\n| output（String）| 从候选变量中返回第一个有效值 |\n\n![占位图片](https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/template/node-variable-aggregation.png)'
+    )
+)
+WHERE category = 'TEMPLATE' AND code = 'node';
+
+-- Update English version
+UPDATE config_info_en
+SET value = JSON_ARRAY_APPEND(
+    value,
+    '$',
+    JSON_OBJECT(
+        'idType', 'variable-aggregation',
+        'icon', 'https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/variable-aggregation-icon.png',
+        'name', 'Variable Aggregator',
+        'markdown', '## Purpose\nAggregates variable values from multiple inputs based on priority and type compatibility, providing fallback values to ensure output reliability.\n\n## Example\n### Input\n| Parameter Name | Parameter Value |\n|----------------|-----------------|\n| Candidate 1 (reference) | LLM-output |\n| Candidate 2 (reference) | Knowledge Base-output |\n| Candidate 3 (reference) | Code-result |\n\n### Output\n| Variable Name | Variable Value |\n|---------------|----------------|\n| output (String) | Returns the first valid value from candidate variables |\n\n![Placeholder Image](https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/template/node-variable-aggregation.png)'
+    )
+)
+WHERE category = 'TEMPLATE' AND code = 'node';

--- a/docs/DEPLOYMENT_GUIDE_WITH_AUTH.md
+++ b/docs/DEPLOYMENT_GUIDE_WITH_AUTH.md
@@ -99,14 +99,13 @@ RAGFLOW_DEFAULT_GROUP=星辰知识库
 3. Click API to generate an API KEY
 4. Update the generated API KEY to RAGFLOW_API_TOKEN in the .env file
 
-#### 2.2 Configure iFLYTEK Open Platform APP_ID, API_KEY, and Related Information
+#### 2.2 Configure iFLYTEK Open Platform APP_ID, API_KEY, and Related Information (Optional, some built-in features require the use of capabilities from the Open Platform)
 
 For documentation, see: https://www.xfyun.cn/doc/platform/quickguide.html
 
 After creating your application, you may need to purchase or claim API authorization service quotas for the corresponding capabilities:
 - Spark LLM API: https://xinghuo.xfyun.cn/sparkapi
-  (For the LLM API, you'll need an additional SPARK_API_PASSWORD available on the page)
-  (The text AI generation/optimization feature for instructional assistants requires enabling Spark Ultra capability at https://console.xfyun.cn/services/bm4)
+  (For the LLM API, you'll need an additional SPARK_API_PASSWORD available on the page : https://console.xfyun.cn/services/bm4)
 - Real-time Speech Recognition API: https://console.xfyun.cn/services/rta
 - Image Generation API: https://www.xfyun.cn/services/wtop
 
@@ -120,7 +119,16 @@ SPARK_API_PASSWORD=your-api-password
 SPARK_RTASR_API_KEY=your-rtasr-api-key
 ```
 
-#### 2.3 Configure Spark RAG Cloud Service (Optional)
+#### 2.3 Configure the default model interface (OpenAI protocol) for the Agent
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+AI_ABILITY_CHAT_BASE_URL=https://spark-api-open.xf-yun.com/v1
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 2.4 Configure Spark RAG Cloud Service (Optional)
 
 Spark RAG cloud service provides two usage methods:
 
@@ -152,7 +160,7 @@ After obtaining the dataset ID, please update it in the docker/astronAgent/.env 
 XINGHUO_DATASET_ID=
 ```
 
-#### 2.4 Configure Service Host Address
+#### 2.5 Configure Service Host Address
 
 Edit the docker/astronAgent/.env file to configure the AstronAgent service host address:
 

--- a/docs/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
+++ b/docs/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
@@ -62,22 +62,22 @@ docker compose logs -f ragflow
 
 ### Step 2: Configure AstronAgent Environment Variables
 
-Before starting the AstronAgent service, you need to configure the relevant connection information.
+Before starting AstronAgent services, you need to configure the relevant connection information.
 
 ```bash
-# Navigate to the astronAgent directory
+# Navigate to astronAgent directory
 cd docker/astronAgent
 
 # Copy environment variable configuration
 cp .env.example .env
 ```
 
-#### 2.1 Configure Knowledge Base Service Connection (if RagFlow is deployed)
+#### 2.1 Configure Knowledge Base Service Connection (Optional,If RagFlow is deployed)
 
 Edit the docker/astronAgent/.env file to configure RagFlow connection information:
 
 ```bash
-# Navigate to the astronAgent directory
+# Navigate to astronAgent directory
 cd docker/astronAgent
 
 # Edit environment variable configuration
@@ -87,28 +87,27 @@ vim .env
 **Key Configuration Items:**
 
 ```env
-# RAGFlow configuration
+# RAGFlow Configuration
 RAGFLOW_BASE_URL=http://localhost:18080
 RAGFLOW_API_TOKEN=ragflow-your-api-token-here
 RAGFLOW_TIMEOUT=60
 RAGFLOW_DEFAULT_GROUP=星辰知识库
 ```
 
-**Get RagFlow API Token:**
-1. Visit the RagFlow Web interface: http://localhost:18080
+**Obtaining RagFlow API Token:**
+1. Visit RagFlow Web Interface: http://localhost:18080
 2. Log in and click on your avatar to enter user settings
 3. Click API to generate an API KEY
-4. Update the generated API KEY to the RAGFLOW_API_TOKEN in the .env file
+4. Update the generated API KEY to RAGFLOW_API_TOKEN in the .env file
 
-#### 2.2 Configure iFlytek Open Platform APP_ID, API_KEY, and other information
+#### 2.2 Configure iFLYTEK Open Platform APP_ID, API_KEY, and Related Information (Optional, some built-in features require the use of capabilities from the Open Platform)
 
-Documentation available at: https://www.xfyun.cn/doc/platform/quickguide.html
+For documentation, see: https://www.xfyun.cn/doc/platform/quickguide.html
 
-After creating an application, you may need to purchase or claim API authorization service quotas for the corresponding capabilities:
+After creating your application, you may need to purchase or claim API authorization service quotas for the corresponding capabilities:
 - Spark LLM API: https://xinghuo.xfyun.cn/sparkapi
-  (For LLM API, there's an additional SPARK_API_PASSWORD that needs to be obtained from the page)
-  (The text AI generation/optimization function for instructional assistants requires enabling the Spark Ultra capability, page address: https://console.xfyun.cn/services/bm4)
-- Real-time Speech Transcription API: https://console.xfyun.cn/services/rta
+  (For the LLM API, you'll need an additional SPARK_API_PASSWORD available on the page : https://console.xfyun.cn/services/bm4)
+- Real-time Speech Recognition API: https://console.xfyun.cn/services/rta
 - Image Generation API: https://www.xfyun.cn/services/wtop
 
 Edit the docker/astronAgent/.env file and update the relevant environment variables:
@@ -121,16 +120,25 @@ SPARK_API_PASSWORD=your-api-password
 SPARK_RTASR_API_KEY=your-rtasr-api-key
 ```
 
-#### 2.3 Configure Spark RAG Cloud Service (Optional)
+#### 2.3 Configure the default model interface (OpenAI protocol) for the Agent
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+AI_ABILITY_CHAT_BASE_URL=https://spark-api-open.xf-yun.com/v1
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 2.4 Configure Spark RAG Cloud Service (Optional)
 
 Spark RAG cloud service provides two usage methods:
 
-##### Method 1: Obtain from the webpage
+##### Method 1: Obtain from the Web Interface
 
-1. Use the APP_ID and API_SECRET created on the iFlytek Open Platform
-2. Obtain the Spark dataset ID directly from the page, see: [xinghuo_rag_tool.html](/docs/xinghuo_rag_tool.html)
+1. Use the APP_ID and API_SECRET created on the iFLYTEK Open Platform
+2. Directly obtain the Spark dataset ID from the web interface, see: [xinghuo_rag_tool.html](/docs/xinghuo_rag_tool.html)
 
-##### Method 2: Use cURL command-line method
+##### Method 2: Using cURL Command Line
 
 If you prefer using command-line tools, you can create a dataset with the following cURL command:
 
@@ -145,25 +153,25 @@ curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
 ```
 
 **Notes:**
-- Replace `your_app_id` with your actual APP ID
-- Replace `your_api_secret` with your actual API Secret
+- Please replace `your_app_id` with your actual APP ID
+- Please replace `your_api_secret` with your actual API Secret
 
-After obtaining the dataset ID, update it in the docker/astronAgent/.env file:
+After obtaining the dataset ID, please update it in the docker/astronAgent/.env file:
 ```env
 XINGHUO_DATASET_ID=
 ```
 
-#### 2.4 Configure Service Host Address
+#### 2.5 Configure Service Host Address
 
-Edit the docker/astronAgent/.env file to configure the host address for the AstronAgent service:
+Edit the docker/astronAgent/.env file to configure the AstronAgent service host address:
 
 ```env
 HOST_BASE_ADDRESS=http://localhost
 ```
 
-**Notes:**
-- If you're using domain access, replace `localhost` with your domain name
-- Ensure that nginx and minio ports are properly opened
+**Note:**
+- If you're using a domain name for access, replace `localhost` with your domain name
+- Ensure nginx and minio ports are properly exposed
 
 ### Step 3: Start AstronAgent Core Services (includes Casdoor authentication service, RPA backend service)
 

--- a/docs/DEPLOYMENT_GUIDE_WITH_AUTH_RPA_zh.md
+++ b/docs/DEPLOYMENT_GUIDE_WITH_AUTH_RPA_zh.md
@@ -72,7 +72,7 @@ cd docker/astronAgent
 cp .env.example .env
 ```
 
-#### 2.1 配置知识库服务连接（如已部署 RagFlow）
+#### 2.1 配置知识库服务连接（可选,如已部署 RagFlow）
 
 编辑 docker/astronAgent/.env 文件，配置 RagFlow 连接信息：
 
@@ -100,14 +100,13 @@ RAGFLOW_DEFAULT_GROUP=星辰知识库
 3. 点击API生成 API KEY
 4. 将生成的 API KEY 更新到.env文件中的RAGFLOW_API_TOKEN
 
-#### 2.2 配置 讯飞开放平台 相关 APP_ID API_KEY 等信息
+#### 2.2 配置 讯飞开放平台 相关 APP_ID API_KEY 等信息（可选，内置的部分功能需要使用开放平台的能力）
 
 获取文档详见：https://www.xfyun.cn/doc/platform/quickguide.html
 
 创建应用完成后可能需要购买或领取相应能力的API授权服务量
 - 星火大模型API: https://xinghuo.xfyun.cn/sparkapi
-  (对于大模型API会有额外的SPARK_API_PASSWORD需要在页面上获取)
-  (指令型助手对应的文本AI生成/优化功能需要开通Spark Ultra能力，页面地址为https://console.xfyun.cn/services/bm4)
+  (对于大模型API会有额外的SPARK_API_PASSWORD需要在页面上获取，页面地址为https://console.xfyun.cn/services/bm4)
 - 实时语音转写API: https://console.xfyun.cn/services/rta
 - 图片生成API: https://www.xfyun.cn/services/wtop
 
@@ -121,7 +120,16 @@ SPARK_API_PASSWORD=your-api-password
 SPARK_RTASR_API_KEY=your-rtasr-api-key
 ```
 
-#### 2.3 配置星火 RAG 云服务（可选）
+#### 2.3 配置 Agent 内部默认模型接口（OpenAI协议）
+
+编辑 docker/astronAgent/.env 文件，更新相关环境变量：
+```env
+AI_ABILITY_CHAT_BASE_URL=https://spark-api-open.xf-yun.com/v1
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 2.4 配置星火 RAG 云服务（可选）
 
 星火RAG云服务提供两种使用方式：
 
@@ -153,7 +161,7 @@ curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
 XINGHUO_DATASET_ID=
 ```
 
-#### 2.4 配置服务主机地址
+#### 2.5 配置服务主机地址
 
 编辑 docker/astronAgent/.env 文件，配置 AstronAgent 服务的主机地址：
 

--- a/docs/DEPLOYMENT_GUIDE_WITH_AUTH_zh.md
+++ b/docs/DEPLOYMENT_GUIDE_WITH_AUTH_zh.md
@@ -99,14 +99,13 @@ RAGFLOW_DEFAULT_GROUP=星辰知识库
 3. 点击API生成 API KEY
 4. 将生成的 API KEY 更新到.env文件中的RAGFLOW_API_TOKEN
 
-#### 2.2 配置 讯飞开放平台 相关 APP_ID API_KEY 等信息
+#### 2.2 配置 讯飞开放平台 相关 APP_ID API_KEY 等信息（可选，内置的部分功能需要使用开放平台的能力）
 
 获取文档详见：https://www.xfyun.cn/doc/platform/quickguide.html
 
 创建应用完成后可能需要购买或领取相应能力的API授权服务量
 - 星火大模型API: https://xinghuo.xfyun.cn/sparkapi
-  (对于大模型API会有额外的SPARK_API_PASSWORD需要在页面上获取)
-  (指令型助手对应的文本AI生成/优化功能需要开通Spark Ultra能力，页面地址为https://console.xfyun.cn/services/bm4)
+  (对于大模型API会有额外的SPARK_API_PASSWORD需要在页面上获取，页面地址为https://console.xfyun.cn/services/bm4)
 - 实时语音转写API: https://console.xfyun.cn/services/rta
 - 图片生成API: https://www.xfyun.cn/services/wtop
 
@@ -120,7 +119,16 @@ SPARK_API_PASSWORD=your-api-password
 SPARK_RTASR_API_KEY=your-rtasr-api-key
 ```
 
-#### 2.3 配置星火 RAG 云服务（可选）
+#### 2.3 配置 Agent 内部默认模型接口（OpenAI协议）
+
+编辑 docker/astronAgent/.env 文件，更新相关环境变量：
+```env
+AI_ABILITY_CHAT_BASE_URL=https://spark-api-open.xf-yun.com/v1
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 2.4 配置星火 RAG 云服务（可选）
 
 星火RAG云服务提供两种使用方式：
 
@@ -152,7 +160,7 @@ curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
 XINGHUO_DATASET_ID=
 ```
 
-#### 2.4 配置服务主机地址
+#### 2.5 配置服务主机地址
 
 编辑 docker/astronAgent/.env 文件，配置 AstronAgent 服务的主机地址：
 


### PR DESCRIPTION
## Summary
This PR adds the missing node detail template for the variable aggregation node, which was previously not displaying information when clicking the "详情" (Details) button in the workflow canvas.

## Type of Change
- [*] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
  - Created a new database migration (`V1.23__add_variable_aggregation_node_template.sql`) to add the variable aggregation node template to the `config_info` and `config_info_en` tables
  - Added both Chinese and English versions of the node template with proper markdown documentation
  - Included usage examples, input/output specifications for the variable aggregation node
  - Provided proper icon URL and node identification (`idType: 'variable-aggregation'`)

### Technical Details

  - The node details panel fetches templates from the backend via `getCommonConfig` API with category 'TEMPLATE' and code 'node'
  - Templates are stored in the `config_info` table in the database
  - Both localized versions (Chinese and English) are updated to ensure proper display
  - The markdown content follows the same structure as other node templates

## Testing
  - Verified the migration script syntax is valid
  - Confirmed the template structure matches existing node templates
  - Ensured both Chinese and English versions are properly formatted

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
