### PR TITLE
fix: resolve model validation failure during chat debugging

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
@@ -202,7 +202,7 @@ public class BotChatServiceImpl implements BotChatService {
                 ModelConfigResult modelConfig = getModelConfiguration(request.getModelId(), sseEmitter);
                 messageList = buildDebugMessageList(request.getText(), prompt, request.getMessages(), modelConfig.maxInputTokens(), request.getMaasDatasetList());
                 Long spaceId = SpaceInfoUtil.getSpaceId();
-                if (!modelService.checkModelBase(LLMService.generate9DigitRandomFromId(modelConfig.llmInfoVo.getLlmId()),
+                if (!modelService.checkModelBase(modelConfig.llmInfoVo.getLlmId(),
                         modelConfig.llmInfoVo().getServiceId(), modelConfig.llmInfoVo.getUrl(), request.getUid(), spaceId)) {
                     throw new BusinessException(ResponseEnum.MODEL_CHECK_FAILED);
                 }


### PR DESCRIPTION
## Issue Description
  Fixed the "模型校验失败，请检查后重试" (Model validation failed, please check and retry) error that occurred during chat debugging (bot-debug).

  ## Root Cause
  In the `BotChatServiceImpl.debugChatMessageBot` method, the `checkModelBase` call was incorrectly applying duplicate ID generation:
  - `modelConfig.llmInfoVo.getLlmId()` was already a 9-digit random ID generated via `generate9DigitRandomFromId(model.getId())`
  - However, the code applied `LLMService.generate9DigitRandomFromId()` again to this already-randomized ID
  - This caused double-randomization: `generate9DigitRandomFromId(generate9DigitRandomFromId(original_model_id))`
  - As a result, `checkModelBase` could not find the correct model in the lookup map, leading to the `MODEL_CHECK_FAILED` exception

  ## Solution
  Removed the redundant `LLMService.generate9DigitRandomFromId` call and used the properly generated LLM ID directly.

  ## Impact
  - Fixes validation errors when using custom models during chat debugging
  - Enables isThink field functionality to work properly with custom models
  - Does not affect other normal operational flows
  - Resolves the model check failure that prevented proper chat debugging