### PR TITLE
fix: ensure botTemplate saved for workflow-template bot creation (#1021)

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/BotMaasServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/BotMaasServiceImpl.java
@@ -57,6 +57,19 @@ public class BotMaasServiceImpl implements BotMaasService {
         Long spaceId = SpaceInfoUtil.getSpaceId();
         // Create an event, consumed by /maasCopySynchronize
         Long maasId = maasDuplicate.getMaasId();
+        // Ensure botTemplate is present; it is used to populate chat_bot_base.bot_template.
+        // Some workflow template create flows don't provide botTemplate in request payload.
+        if (maasDuplicate.getBotTemplate() == null || maasDuplicate.getBotTemplate().trim().isEmpty()) {
+            MaasTemplate template = maasTemplateMapper.selectOne(
+                new LambdaQueryWrapper<MaasTemplate>().eq(MaasTemplate::getMaasId, maasId)
+            );
+            String resolved = resolveBotTemplateFromCoreScenarios(
+                template != null ? template.getCoreScenarios() : null
+            );
+            if (resolved != null && !resolved.trim().isEmpty()) {
+                maasDuplicate.setBotTemplate(resolved);
+            }
+        }
         UserLangChainInfo userLangChainInfo = userLangChainDataService.selectByMaasId(maasId);
         if (Objects.isNull(userLangChainInfo)) {
             log.info("----- Xinghuo did not find Astron workflow: {}", JSONObject.toJSONString(userLangChainInfo));
@@ -77,6 +90,27 @@ public class BotMaasServiceImpl implements BotMaasService {
         botService.addMaasInfo(uid, res, botId, spaceId);
         botInfoDto.setFlowId(res.getJSONObject("data").getLong("id"));
         return botInfoDto;
+    }
+
+    private String resolveBotTemplateFromCoreScenarios(JSONObject coreScenarios) {
+        if (coreScenarios == null) {
+            return null;
+        }
+        // Try common key names from template scenario config.
+        String[] keys = new String[] {
+            "botTemplate",
+            "bot_template",
+            "inputTemplate",
+            "input_template",
+            "description"
+        };
+        for (String key : keys) {
+            String value = coreScenarios.getString(key);
+            if (value != null && !value.trim().isEmpty()) {
+                return value;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/console/frontend/src/components/make-creation/index.tsx
+++ b/console/frontend/src/components/make-creation/index.tsx
@@ -51,6 +51,20 @@ const MakeCreateModal: React.FC<MakeCreateModalProps> = ({
     if (flag) {
       req['maasId'] = item.maasId;
       req['name'] = item.title + Date.now();
+      const coreScenarios = item?.coreScenarios as any;
+      const botTemplateFromTemplate =
+        coreScenarios?.botTemplate ??
+        coreScenarios?.bot_template ??
+        coreScenarios?.inputTemplate ??
+        coreScenarios?.input_template ??
+        coreScenarios?.description;
+
+      if (
+        typeof botTemplateFromTemplate === 'string' &&
+        botTemplateFromTemplate.trim()
+      ) {
+        req['botTemplate'] = botTemplateFromTemplate;
+      }
       await createFromTemplate(req)
         .then((res: any) => {
           navigate(`/work_flow/${res.flowId}/arrange`);


### PR DESCRIPTION
When creating an assistant from a workflow template, the request payload may miss botTemplate, causing chat_bot_base.bot_template not to be persisted.

This change populates botTemplate on the frontend when available and adds a backend fallback to resolve it from maas_template.core_scenarios.

Related: #1021