### PR TITLE
fix: replace nonexistent USER_NOT_LOGIN enum with UNAUTHORIZED

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
@@ -888,7 +888,7 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
             // Get current user context
             UserInfo userInfo = UserInfoManagerHandler.get();
             if (userInfo == null) {
-                return ApiResult.error(ResponseEnum.USER_NOT_LOGIN);
+                return ApiResult.error(ResponseEnum.UNAUTHORIZED);
             }
 
             String currentUid = userInfo.getUid();


### PR DESCRIPTION
The ResponseEnum.USER_NOT_LOGIN does not exist in ResponseEnum.java. Using ResponseEnum.UNAUTHORIZED which is the appropriate enum for unauthenticated/authorization failure scenarios.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
