### PR TITLE
fixSimplify Model Provider Selection to Three Main Vendors (Anthropic, OpenAI, Google)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The platform supports **high-availability** deployment, enabling organizations t
 ### 🔄 Ongoing
 
 - **[Astron Industrial Intelligence Hackathon](https://awesome-astron-workflow.dev/activities/astron-industrial-intelligence-hackathon)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/horizon220222"><img src="https://github.com/horizon220222.png" width="20" align="center" /> @horizon220222</a>
-- **[Astron Agent & RPA · Hefei Meetup](https://mp.weixin.qq.com/s/tDJaoOLUrjBlgMLDurvHCw)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/doctorbruce"><img src="https://github.com/doctorbruce.png" width="20" align="center" /> @doctorbruce</a>
 
 ### 📅 Past
 
@@ -42,6 +41,7 @@ The platform supports **high-availability** deployment, enabling organizations t
 - **[Astron Training Camp · Cohort #1](https://www.aidaxue.com/astronCamp)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/Thomas1024-Astron"><img src="https://github.com/Thomas1024-Astron.png" width="20" align="center" /> @Thomas1024-Astron</a> <a href="https://github.com/abelzha"><img src="https://github.com/abelzha.png" width="20" align="center" /> @abelzha</a>
 - **[Astron Talk @ Chongqing Mini Tech Fest](https://mp.weixin.qq.com/s/HROf1zZpkPVDSsCQrv2jRg)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a>
 - **[Astron Agent @ MWC Barcelona 2026](https://www.iflytek.com/en/news-events/mwc2026.html)**
+- **[Astron Agent & RPA · Hefei Meetup](https://mp.weixin.qq.com/s/tDJaoOLUrjBlgMLDurvHCw)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/doctorbruce"><img src="https://github.com/doctorbruce.png" width="20" align="center" /> @doctorbruce</a>
 
 ## 🚀 Quick Start
 

--- a/console/frontend/src/pages/model-management/components/category-aside.tsx
+++ b/console/frontend/src/pages/model-management/components/category-aside.tsx
@@ -15,6 +15,7 @@ import {
   CategoryAsideProps,
   CategorySource,
 } from '@/types/model';
+import { getVendorOptions } from '../utils/provider-group';
 
 interface RenderNodeParams {
   node: CategoryNode;

--- a/console/frontend/src/pages/model-management/components/grouped-provider-cards.tsx
+++ b/console/frontend/src/pages/model-management/components/grouped-provider-cards.tsx
@@ -1,0 +1,195 @@
+import React, { useMemo } from 'react';
+import { Button } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { ModelProviderType } from '@/types/model';
+import { getModelProviderLabel } from '../utils/provider';
+import { mapProviderToVendor, getVendorDisplayName } from '../utils/provider-group';
+import chatgptIcon from '@/assets/imgs/modelManage/providers/custom/chatgpt.svg';
+import anthropicIcon from '@/assets/imgs/modelManage/providers/custom/anthropic.svg';
+import googleIcon from '@/assets/imgs/modelManage/providers/custom/google.svg';
+
+interface ProviderCard {
+  provider: ModelProviderType;
+  title: string;
+  subtitle: string;
+  description: string;
+  accentClass: string;
+  endpoint: string;
+}
+
+interface VendorGroupCardProps {
+  vendor: string;
+  providers: ProviderCard[];
+  onOpenProviderModal: (card: ProviderCard) => void;
+}
+
+const ProviderLogoGlyph: React.FC<{ provider: ModelProviderType }> = ({ provider }) => {
+  const imageLogoMap: Record<ModelProviderType, string> = {
+    [ModelProviderType.CHATGPT]: chatgptIcon,
+    [ModelProviderType.OPENAI]: chatgptIcon,
+    [ModelProviderType.ANTHROPIC]: anthropicIcon,
+    [ModelProviderType.DEEPSEEK]: chatgptIcon, // 使用ChatGPT图标，因为也是OpenAI兼容
+    [ModelProviderType.GOOGLE]: googleIcon,
+    [ModelProviderType.MINIMAX]: chatgptIcon, // 使用ChatGPT图标，因为也是OpenAI兼容
+    [ModelProviderType.ZHIPU]: chatgptIcon, // 使用ChatGPT图标，因为也是OpenAI兼容
+    [ModelProviderType.QWEN]: chatgptIcon, // 使用ChatGPT图标，因为也是OpenAI兼容
+    [ModelProviderType.MOONSHOT]: chatgptIcon, // 使用ChatGPT图标，因为也是OpenAI兼容
+    [ModelProviderType.DOUBAO]: chatgptIcon, // 使用ChatGPT图标，因为也是OpenAI兼容
+  };
+
+  return (
+    <img
+      src={imageLogoMap[provider]}
+      alt={getModelProviderLabel(provider)}
+      className="h-8 w-8 object-contain"
+    />
+  );
+};
+
+const ProviderCardComponent: React.FC<{
+  card: ProviderCard;
+  onConfigure: () => void;
+}> = ({ card, onConfigure }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <div className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">
+            {getModelProviderLabel(card.provider)}
+          </div>
+          <h4 className="mt-2 text-lg font-semibold text-gray-900">
+            {card.title}
+          </h4>
+          <p className="text-sm text-gray-600">
+            {card.subtitle}
+          </p>
+        </div>
+        <div className="w-10 h-10 flex items-center justify-center">
+          <ProviderLogoGlyph provider={card.provider} />
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-700 mb-3">
+        {card.description}
+      </p>
+
+      <Button
+        type="primary"
+        size="small"
+        className="w-full"
+        onClick={onConfigure}
+      >
+        {t('model.configureProvider')}
+      </Button>
+    </div>
+  );
+};
+
+const VendorGroupCard: React.FC<VendorGroupCardProps> = ({
+  vendor,
+  providers,
+  onOpenProviderModal,
+}) => {
+  const { t } = useTranslation();
+
+  const vendorName = getVendorDisplayName(vendor);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-900">
+          {vendorName}
+        </h3>
+      </div>
+
+      <div className="p-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {providers.map((card, index) => (
+            <ProviderCardComponent
+              key={index}
+              card={card}
+              onConfigure={() => onOpenProviderModal(card)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface GroupedProviderCardsProps {
+  providerCards: ProviderCard[];
+  searchInput: string;
+  providerFilter: string;
+  onOpenProviderModal: (card: ProviderCard) => void;
+}
+
+const GroupedProviderCards: React.FC<GroupedProviderCardsProps> = ({
+  providerCards,
+  searchInput,
+  providerFilter,
+  onOpenProviderModal,
+}) => {
+  const { t } = useTranslation();
+
+  // 根据搜索和筛选条件过滤卡片
+  const filteredCards = useMemo(() => {
+    const keyword = searchInput.trim().toLowerCase();
+
+    return providerCards.filter(card => {
+      const cardVendor = mapProviderToVendor(card.provider);
+      const matchedProvider = !providerFilter || providerFilter === cardVendor;
+      const matchedKeyword =
+        !keyword ||
+        card.title.toLowerCase().includes(keyword) ||
+        card.subtitle.toLowerCase().includes(keyword) ||
+        card.description.toLowerCase().includes(keyword) ||
+        getModelProviderLabel(card.provider).toLowerCase().includes(keyword);
+
+      return matchedProvider && matchedKeyword;
+    });
+  }, [providerCards, searchInput, providerFilter]);
+
+  // 按厂商分组卡片
+  const groupedCards = useMemo(() => {
+    const groups: Record<string, ProviderCard[]> = {};
+
+    filteredCards.forEach(card => {
+      const vendor = mapProviderToVendor(card.provider);
+      if (!groups[vendor]) {
+        groups[vendor] = [];
+      }
+      groups[vendor].push(card);
+    });
+
+    return Object.entries(groups).map(([vendor, cards]) => ({
+      vendor,
+      cards,
+    }));
+  }, [filteredCards]);
+
+  if (groupedCards.length === 0) {
+    return (
+      <div className="flex h-[320px] items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 text-sm text-gray-500">
+        {t('model.searchNoResults')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {groupedCards.map(({ vendor, cards }) => (
+        <VendorGroupCard
+          key={vendor}
+          vendor={vendor}
+          providers={cards}
+          onOpenProviderModal={onOpenProviderModal}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default GroupedProviderCards;

--- a/console/frontend/src/pages/model-management/components/modal-component.tsx
+++ b/console/frontend/src/pages/model-management/components/modal-component.tsx
@@ -54,6 +54,7 @@ import {
   getModelProviderLabel,
   normalizeModelProvider,
 } from '../utils/provider';
+import { mapProviderToVendor } from '../utils/provider-group';
 
 const { TextArea } = Input;
 
@@ -644,66 +645,29 @@ const ModelBasicForm = ({
 }): JSX.Element => {
   const { t } = useTranslation();
   const currentProvider = normalizeModelProvider(modelInfo?.provider);
-  const providerHint =
-    currentProvider === ModelProviderType.MINIMAX
-      ? t('model.providerHintMiniMax')
-      : currentProvider === ModelProviderType.ZHIPU
-        ? t('model.providerHintZhipu')
-        : currentProvider === ModelProviderType.QWEN
-          ? t('model.providerHintQwen')
-          : currentProvider === ModelProviderType.MOONSHOT
-            ? t('model.providerHintMoonshot')
-            : currentProvider === ModelProviderType.CHATGPT
-              ? t('model.providerHintChatGPT')
-              : currentProvider === ModelProviderType.DOUBAO
-                ? t('model.providerHintDoubao')
-                : currentProvider === ModelProviderType.DEEPSEEK
-      ? t('model.providerHintDeepSeek')
-      : currentProvider === ModelProviderType.ANTHROPIC
-        ? t('model.providerHintAnthropic')
-        : currentProvider === ModelProviderType.GOOGLE
-          ? t('model.providerHintGoogle')
-          : t('model.providerHintOpenAI');
-  const modelPlaceholder =
-    currentProvider === ModelProviderType.MINIMAX
-      ? t('model.minimaxModelPlaceholder')
-      : currentProvider === ModelProviderType.ZHIPU
-        ? t('model.zhipuModelPlaceholder')
-        : currentProvider === ModelProviderType.QWEN
-          ? t('model.qwenModelPlaceholder')
-          : currentProvider === ModelProviderType.MOONSHOT
-            ? t('model.moonshotModelPlaceholder')
-            : currentProvider === ModelProviderType.CHATGPT
-              ? t('model.chatgptModelPlaceholder')
-              : currentProvider === ModelProviderType.DOUBAO
-                ? t('model.doubaoModelPlaceholder')
-                : currentProvider === ModelProviderType.DEEPSEEK
-      ? t('model.deepseekModelPlaceholder')
-      : currentProvider === ModelProviderType.ANTHROPIC
-        ? t('model.anthropicModelPlaceholder')
-        : currentProvider === ModelProviderType.GOOGLE
-          ? t('model.googleModelPlaceholder')
-          : t('model.enterModelFieldValue');
-  const endpointPlaceholder =
-    currentProvider === ModelProviderType.MINIMAX
-      ? t('model.minimaxEndpointPlaceholder')
-      : currentProvider === ModelProviderType.ZHIPU
-        ? t('model.zhipuEndpointPlaceholder')
-        : currentProvider === ModelProviderType.QWEN
-          ? t('model.qwenEndpointPlaceholder')
-          : currentProvider === ModelProviderType.MOONSHOT
-            ? t('model.moonshotEndpointPlaceholder')
-            : currentProvider === ModelProviderType.CHATGPT
-              ? t('model.chatgptEndpointPlaceholder')
-              : currentProvider === ModelProviderType.DOUBAO
-                ? t('model.doubaoEndpointPlaceholder')
-                : currentProvider === ModelProviderType.DEEPSEEK
-      ? t('model.deepseekEndpointPlaceholder')
-      : currentProvider === ModelProviderType.ANTHROPIC
-        ? t('model.anthropicEndpointPlaceholder')
-        : currentProvider === ModelProviderType.GOOGLE
-          ? t('model.googleEndpointPlaceholder')
-          : t('model.interfaceAddressPlaceholder');
+  // 根据供应商类型决定显示什么提示信息
+  const isAnthropicProvider = currentProvider === ModelProviderType.ANTHROPIC;
+  const isGoogleProvider = currentProvider === ModelProviderType.GOOGLE;
+  // 所有其他提供商都被视为OpenAI兼容
+  const isOpenAICompatibleProvider = !isAnthropicProvider && !isGoogleProvider;
+
+  const providerHint = isAnthropicProvider
+    ? t('model.providerHintAnthropic')
+    : isGoogleProvider
+      ? t('model.providerHintGoogle')
+      : t('model.providerHintOpenAI');
+
+  const modelPlaceholder = isAnthropicProvider
+    ? t('model.anthropicModelPlaceholder')
+    : isGoogleProvider
+      ? t('model.googleModelPlaceholder')
+      : t('model.enterModelFieldValue');
+
+  const endpointPlaceholder = isAnthropicProvider
+    ? t('model.anthropicEndpointPlaceholder')
+    : isGoogleProvider
+      ? t('model.googleEndpointPlaceholder')
+      : t('model.interfaceAddressPlaceholder');
   return (
     <>
       {modelCreateType === ModelCreateType.THIRD_PARTY && (
@@ -727,34 +691,6 @@ const ModelBasicForm = ({
               {
                 label: t('model.providerGoogle'),
                 value: ModelProviderType.GOOGLE,
-              },
-              {
-                label: t('model.providerMiniMax'),
-                value: ModelProviderType.MINIMAX,
-              },
-              {
-                label: t('model.providerZhipu'),
-                value: ModelProviderType.ZHIPU,
-              },
-              {
-                label: t('model.providerQwen'),
-                value: ModelProviderType.QWEN,
-              },
-              {
-                label: t('model.providerMoonshot'),
-                value: ModelProviderType.MOONSHOT,
-              },
-              {
-                label: t('model.providerChatGPT'),
-                value: ModelProviderType.CHATGPT,
-              },
-              {
-                label: t('model.providerDoubao'),
-                value: ModelProviderType.DOUBAO,
-              },
-              {
-                label: t('model.providerDeepSeek'),
-                value: ModelProviderType.DEEPSEEK,
               },
             ]}
             onChange={value =>
@@ -1448,7 +1384,7 @@ const useCreateModal = (
       interfaceAddress: initialEndpoint || '',
       apiKEY: '',
       domain: '',
-      provider: normalizeModelProvider(initialProvider),
+      provider: mapProviderToVendor(initialProvider),
       isThink: false,
     });
     formState.setTags([]);
@@ -1520,7 +1456,7 @@ const useCreateModal = (
       formState.setModelInfo({
         ...formState.modelInfo,
         interfaceAddress: initialEndpoint || formState.modelInfo.interfaceAddress,
-        provider: normalizeModelProvider(initialProvider),
+        provider: mapProviderToVendor(initialProvider),
         isThink: formState.modelInfo.isThink ?? false,
       });
     }

--- a/console/frontend/src/pages/model-management/hooks/use-model-filters.ts
+++ b/console/frontend/src/pages/model-management/hooks/use-model-filters.ts
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import { useModelContext } from '../context/model-context';
 import { ModelInfo, CategoryNode, ShelfStatus } from '@/types/model';
-import { getModelProviderFromInfo } from '../utils/provider';
+import { getModelProviderFromInfo, getModelVendorIdentifier } from '../utils/provider';
 
 export const useModelFilters = (): {
   filteredModels: ModelInfo[];
@@ -127,7 +127,7 @@ export const useModelFilters = (): {
 
     if (state.providerFilter) {
       models = models.filter(
-        model => getModelProviderFromInfo(model) === state.providerFilter
+        model => getModelVendorIdentifier(model) === state.providerFilter
       );
     }
 

--- a/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
+++ b/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
@@ -3,20 +3,13 @@ import { Button } from 'antd';
 import { useTranslation } from 'react-i18next';
 import ModelManagementHeader from '../components/model-management-header';
 import CategoryAside from '../components/category-aside';
+import GroupedProviderCards from '../components/grouped-provider-cards';
 import { CreateModal } from '../components/modal-component';
 import { ModelProvider, useModelContext } from '../context/model-context';
 import { useModelFilters } from '../hooks/use-model-filters';
 import { ModelProviderType } from '@/types/model';
 import { getModelProviderLabel } from '../utils/provider';
-import chatgptIcon from '@/assets/imgs/modelManage/providers/custom/chatgpt.svg';
-import anthropicIcon from '@/assets/imgs/modelManage/providers/custom/anthropic.svg';
-import deepseekIcon from '@/assets/imgs/modelManage/providers/custom/deepseek.svg';
-import googleIcon from '@/assets/imgs/modelManage/providers/custom/google.svg';
-import minimaxIcon from '@/assets/imgs/modelManage/providers/custom/minimax.svg';
-import zhipuIcon from '@/assets/imgs/modelManage/providers/custom/zhipu.svg';
-import qwenIcon from '@/assets/imgs/modelManage/providers/custom/qwen.svg';
-import moonshotIcon from '@/assets/imgs/modelManage/providers/custom/moonshot.svg';
-import doubaoIcon from '@/assets/imgs/modelManage/providers/custom/doubao.svg';
+import { mapProviderToVendor, getVendorOptions } from '../utils/provider-group';
 
 interface OfficialProviderCard {
   provider: ModelProviderType;
@@ -26,43 +19,6 @@ interface OfficialProviderCard {
   accentClass: string;
   endpoint: string;
 }
-
-const ProviderLogoGlyph: React.FC<{ provider: ModelProviderType }> = ({
-  provider,
-}) => {
-  const imageLogoMap: Record<ModelProviderType, string> = {
-    [ModelProviderType.CHATGPT]: chatgptIcon,
-    [ModelProviderType.OPENAI]: chatgptIcon,
-    [ModelProviderType.ANTHROPIC]: anthropicIcon,
-    [ModelProviderType.DEEPSEEK]: deepseekIcon,
-    [ModelProviderType.GOOGLE]: googleIcon,
-    [ModelProviderType.MINIMAX]: minimaxIcon,
-    [ModelProviderType.ZHIPU]: zhipuIcon,
-    [ModelProviderType.QWEN]: qwenIcon,
-    [ModelProviderType.MOONSHOT]: moonshotIcon,
-    [ModelProviderType.DOUBAO]: doubaoIcon,
-  };
-
-  return (
-    <img
-      src={imageLogoMap[provider]}
-      alt={getModelProviderLabel(provider)}
-      className="h-8 w-8 object-contain"
-    />
-  );
-};
-
-const ProviderLogoBadge: React.FC<{ provider: ModelProviderType }> = ({
-  provider,
-}) => {
-  return (
-    <div className="rounded-2xl border border-[#E7EBF4] bg-white px-3 py-3 shadow-[0_10px_24px_rgba(31,35,41,0.06)]">
-      <div className="flex h-11 w-11 items-center justify-center overflow-hidden rounded-[14px] border border-[#EEF1F7] bg-white">
-        <ProviderLogoGlyph provider={provider} />
-      </div>
-    </div>
-  );
-};
 
 const OfficialModelContent: React.FC = () => {
   const { t } = useTranslation();
@@ -150,22 +106,6 @@ const OfficialModelContent: React.FC = () => {
     [t]
   );
 
-  const visibleCards = useMemo(() => {
-    const keyword = state.searchInput.trim().toLowerCase();
-
-    return providerCards.filter(card => {
-      const matchedProvider =
-        !state.providerFilter || state.providerFilter === card.provider;
-      const matchedKeyword =
-        !keyword ||
-        card.title.toLowerCase().includes(keyword) ||
-        card.subtitle.toLowerCase().includes(keyword) ||
-        card.description.toLowerCase().includes(keyword) ||
-        getModelProviderLabel(card.provider).toLowerCase().includes(keyword);
-
-      return matchedProvider && matchedKeyword;
-    });
-  }, [providerCards, state.providerFilter, state.searchInput]);
 
   const handleOpenProviderModal = (card: OfficialProviderCard): void => {
     actions.setCurrentEditModel(undefined);
@@ -190,44 +130,7 @@ const OfficialModelContent: React.FC = () => {
             <CategoryAside
               tree={[]}
               providerFilter={state.providerFilter}
-              providerOptions={[
-                {
-                  label: t('model.providerChatGPT'),
-                  value: ModelProviderType.CHATGPT,
-                },
-                {
-                  label: t('model.providerDeepSeek'),
-                  value: ModelProviderType.DEEPSEEK,
-                },
-                {
-                  label: t('model.providerAnthropic'),
-                  value: ModelProviderType.ANTHROPIC,
-                },
-                {
-                  label: t('model.providerGoogle'),
-                  value: ModelProviderType.GOOGLE,
-                },
-                {
-                  label: t('model.providerMiniMax'),
-                  value: ModelProviderType.MINIMAX,
-                },
-                {
-                  label: t('model.providerZhipu'),
-                  value: ModelProviderType.ZHIPU,
-                },
-                {
-                  label: t('model.providerQwen'),
-                  value: ModelProviderType.QWEN,
-                },
-                {
-                  label: t('model.providerMoonshot'),
-                  value: ModelProviderType.MOONSHOT,
-                },
-                {
-                  label: t('model.providerDoubao'),
-                  value: ModelProviderType.DOUBAO,
-                },
-              ]}
+              providerOptions={getVendorOptions()}
               onProviderChange={filters.handleProviderFilterChange}
               showContextLength={false}
               showModelStatus={false}

--- a/console/frontend/src/pages/model-management/utils/provider-group.ts
+++ b/console/frontend/src/pages/model-management/utils/provider-group.ts
@@ -1,0 +1,70 @@
+import { ModelInfo, ModelProviderType } from '@/types/model';
+
+/**
+ * 将模型提供商映射到实际厂商
+ */
+export function mapProviderToVendor(provider?: string | null): string {
+  if (!provider) return ModelProviderType.OPENAI;
+
+  // OpenAI兼容的厂商
+  const openaiCompatibleProviders = [
+    ModelProviderType.OPENAI,
+    ModelProviderType.CHATGPT,
+    ModelProviderType.DEEPSEEK,
+    ModelProviderType.MINIMAX,
+    ModelProviderType.ZHIPU,
+    ModelProviderType.QWEN,
+    ModelProviderType.MOONSHOT,
+    ModelProviderType.DOUBAO,
+  ];
+
+  if (openaiCompatibleProviders.includes(provider as ModelProviderType)) {
+    return ModelProviderType.OPENAI;
+  }
+
+  // Anthropic厂商
+  if (provider === ModelProviderType.ANTHROPIC) {
+    return ModelProviderType.ANTHROPIC;
+  }
+
+  // Google厂商
+  if (provider === ModelProviderType.GOOGLE) {
+    return ModelProviderType.GOOGLE;
+  }
+
+  // 默认返回OpenAI兼容厂商
+  return ModelProviderType.OPENAI;
+}
+
+/**
+ * 获取实际厂商的显示名称
+ */
+export function getVendorDisplayName(vendor: string): string {
+  switch (vendor) {
+    case ModelProviderType.ANTHROPIC:
+      return 'Anthropic'; // Claude
+    case ModelProviderType.GOOGLE:
+      return 'Google';    // Gemini
+    case ModelProviderType.OPENAI:
+    default:
+      return 'OpenAI Compatible'; // ChatGPT, MiniMax, Zhipu AI, Qwen, Moonshot, Doubao, DeepSeek
+  }
+}
+
+/**
+ * 获取所有可用的实际厂商选项
+ */
+export function getVendorOptions(): Array<{ label: string; value: string }> {
+  return [
+    { label: 'Anthropic (Claude)', value: ModelProviderType.ANTHROPIC },
+    { label: 'Google (Gemini)', value: ModelProviderType.GOOGLE },
+    { label: 'OpenAI Compatible (ChatGPT, MiniMax, Zhipu, Qwen, etc.)', value: ModelProviderType.OPENAI },
+  ];
+}
+
+/**
+ * 获取模型所属的实际厂商
+ */
+export function getModelVendor(model: ModelInfo): string {
+  return mapProviderToVendor(model.provider);
+}

--- a/console/frontend/src/pages/model-management/utils/provider.ts
+++ b/console/frontend/src/pages/model-management/utils/provider.ts
@@ -1,5 +1,6 @@
 import { ModelInfo, ModelProviderType } from '@/types/model';
 import i18next from 'i18next';
+import { mapProviderToVendor } from './provider-group';
 
 export const DEFAULT_MODEL_PROVIDER = ModelProviderType.OPENAI;
 
@@ -44,4 +45,26 @@ export function getModelProviderLabel(provider?: string | null): string {
 
 export function getModelProviderFromInfo(model: ModelInfo): string {
   return String(normalizeModelProvider(model.provider));
+}
+
+/**
+ * 获取模型的厂商分组标识符
+ */
+export function getModelVendorIdentifier(model: ModelInfo): string {
+  return mapProviderToVendor(model.provider);
+}
+
+/**
+ * 获取厂商分组的显示标签
+ */
+export function getVendorGroupLabel(vendor: string): string {
+  switch (vendor) {
+    case ModelProviderType.ANTHROPIC:
+      return i18next.t('model.providerAnthropic');
+    case ModelProviderType.GOOGLE:
+      return i18next.t('model.providerGoogle');
+    case ModelProviderType.OPENAI:
+    default:
+      return i18next.t('model.providerOpenAI'); // 使用"OpenAI兼容"作为统一分组
+  }
 }

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -32,7 +32,6 @@
 ### 🔄 进行中
 
 - **[Astron 产业智变黑客松](https://awesome-astron-workflow.dev/activities/astron-industrial-intelligence-hackathon)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/horizon220222"><img src="https://github.com/horizon220222.png" width="20" align="center" /> @horizon220222</a>
-- **[Astron Agent & RPA 合肥城市行](https://mp.weixin.qq.com/s/tDJaoOLUrjBlgMLDurvHCw)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/doctorbruce"><img src="https://github.com/doctorbruce.png" width="20" align="center" /> @doctorbruce</a>
 
 ### 📅 往期
 
@@ -43,6 +42,7 @@
 - **[Astron训练营·第一期](https://www.aidaxue.com/astronCamp)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/Thomas1024-Astron"><img src="https://github.com/Thomas1024-Astron.png" width="20" align="center" /> @Thomas1024-Astron</a> <a href="https://github.com/abelzha"><img src="https://github.com/abelzha.png" width="20" align="center" /> @abelzha</a>
 - **[Astron Talk @ 重庆 Mini Tech Fest](https://mp.weixin.qq.com/s/HROf1zZpkPVDSsCQrv2jRg)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a>
 - **[Astron Agent 亮相 MWC Barcelona 2026](https://www.iflytek.com/en/news-events/mwc2026.html)**
+- **[Astron Agent & RPA 合肥城市行](https://mp.weixin.qq.com/s/tDJaoOLUrjBlgMLDurvHCw)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/doctorbruce"><img src="https://github.com/doctorbruce.png" width="20" align="center" /> @doctorbruce</a>
 
 ## 🚀 快速开始
 


### PR DESCRIPTION
This PR simplifies the model provider selection interface by reducing the options from 9 individual providers to 3 main vendor categories: Anthropic, OpenAI, and Google.                         
  
  Changes:
  - Limited the model provider dropdown in the configuration modal to three main options: Anthropic, OpenAI Compatible, and Google
  - Created new utility functions to map specific providers (ChatGPT, Claude, Gemini, Qwen, etc.) to their respective main vendors
  - Updated the modal component to use the simplified provider selection while maintaining all functionality
  - Preserved the official model page with detailed provider cards for user visibility
  - Implemented proper mapping logic so that when users click specific provider cards, they're automatically mapped to the appropriate vendor category
  - Added new components and utility files to support the improved user experience

  Benefits:
  - Reduces cognitive load for users when selecting a model provider
  - Groups compatible APIs under logical vendor categories (e.g., all OpenAI-compatible APIs under one option)
  - Maintains functionality while simplifying the UI
  - Keeps detailed provider information visible on the official model page for reference