### PR TITLE
fix: revert shared filter hook and use model-specific filter in offic…

### DIFF
--- a/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
+++ b/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
@@ -162,9 +162,9 @@ const OfficialModelContent: React.FC = () => {
     const keyword = state.searchInput.trim().toLowerCase();
 
     return providerCards.filter(card => {
-      const cardVendor = mapProviderToVendor(card.provider);
+      // 这里我们检查的是具体的模型提供商
       const matchedProvider =
-        !state.providerFilter || state.providerFilter === cardVendor;
+        !state.providerFilter || state.providerFilter === card.provider;
       const matchedKeyword =
         !keyword ||
         card.title.toLowerCase().includes(keyword) ||


### PR DESCRIPTION
…ial page

- Revert use-model-filters.ts to its original state to avoid breaking other pages
- Implement model-specific filtering logic directly in official model page
- Official model page now properly filters by specific provider options
- Keep all other improvements to UI and component logic

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
