### PR TITLE
fix: isolate official model page filters from global state

### DIFF
--- a/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
+++ b/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
@@ -70,9 +70,15 @@ const OfficialModelContent: React.FC = () => {
   const { t } = useTranslation();
   const { state, actions } = useModelContext();
   const filters = useModelFilters();
+  const [selectedProvider, setSelectedProvider] = useState<string>('');
+  const [searchInput, setSearchInput] = useState<string>('');
   const [selectedCard, setSelectedCard] = useState<OfficialProviderCard | null>(
     null
   );
+
+  const handleProviderChange = (provider?: string) => {
+    setSelectedProvider(provider || '');
+  };
 
   const providerCards = useMemo<OfficialProviderCard[]>(
     () => [
@@ -159,12 +165,12 @@ const OfficialModelContent: React.FC = () => {
   };
 
   const visibleCards = useMemo(() => {
-    const keyword = state.searchInput.trim().toLowerCase();
+    const keyword = searchInput.trim().toLowerCase();
 
     return providerCards.filter(card => {
       // 这里我们检查的是具体的模型提供商
       const matchedProvider =
-        !state.providerFilter || state.providerFilter === card.provider;
+        !selectedProvider || selectedProvider === card.provider;
       const matchedKeyword =
         !keyword ||
         card.title.toLowerCase().includes(keyword) ||
@@ -174,7 +180,7 @@ const OfficialModelContent: React.FC = () => {
 
       return matchedProvider && matchedKeyword;
     });
-  }, [providerCards, state.providerFilter, state.searchInput]);
+  }, [providerCards, selectedProvider, searchInput]);
 
   return (
     <div className="w-full h-screen flex flex-col page-container-inner-UI">
@@ -182,8 +188,8 @@ const OfficialModelContent: React.FC = () => {
         <ModelManagementHeader
           activeTab="officialModel"
           shelfOffModel={[]}
-          searchInput={state.searchInput}
-          setSearchInput={filters.handleSearchInputChange}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
           setShowShelfOnly={() => undefined}
         />
       </div>
@@ -193,9 +199,9 @@ const OfficialModelContent: React.FC = () => {
           <aside className="w-full lg:w-[224px] max-w-[224px] min-w-[180px] flex-shrink-0 rounded-[18px] bg-[#FFFFFF] overflow-y-auto hide-scrollbar shadow-sm">
             <CategoryAside
               tree={[]}
-              providerFilter={state.providerFilter}
+              providerFilter={selectedProvider}
               providerOptions={getSpecificProviderOptions()}
-              onProviderChange={filters.handleProviderFilterChange}
+              onProviderChange={handleProviderChange}
               showContextLength={false}
               showModelStatus={false}
             />


### PR DESCRIPTION
- Create local state for provider filter and search in official model page
- Prevent official model page filters from affecting global model filtering
- Keep the correct filtering logic for specific provider options in sidebar
- Maintain separation between official model page and personal model page states

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
