### PR TITLE
fix: allow model provider selection in official model config modal

### DIFF
--- a/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
+++ b/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
@@ -276,7 +276,7 @@ const OfficialModelContent: React.FC = () => {
           setCreateModal={() => setSelectedCard(null)}
           initialProvider={selectedCard.provider}
           initialEndpoint={selectedCard.endpoint}
-          lockProvider={true}
+          lockProvider={false}
           hideLocalModel={true}
           showCategoryForm={false}
         />


### PR DESCRIPTION
- Remove lockProvider={true} constraint in official model page
- Allow users to change model provider (OpenAI/Anthropic/Google) when configuring official models
- Each official model can now be configured with any of the 3 main API types

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
