### PR TITLE
fix(backend): include isThink and multiMode properties in model info

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/LLMService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/LLMService.java
@@ -256,6 +256,9 @@ public class LLMService {
             llmInfoVo.setLlmSource(0);
             llmInfoVo.setDomain(model.getDomain());
             llmInfoVo.setProvider(resolveProvider(model));
+            // Copy the isThink and multiMode properties from the model
+            llmInfoVo.setIsThink(model.getIsThink());
+            llmInfoVo.setMultiMode(model.getMultiMode());
             JSONArray config = JSONArray.parseArray(model.getConfig());
             for (Object o : config) {
                 JSONObject obj = (JSONObject) o;


### PR DESCRIPTION
- Add isThink and multiMode properties when constructing LLMInfoVo in dealWithSelfModel
- These properties are needed for frontend to properly detect model capabilities
- Fixes issue where REASONING_CONTENT output and multimedia input weren't showing

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
