### PR TITLE
feat(engine): add parallel execution support for iteration nodes

### DIFF
--- a/core/workflow/engine/callbacks/callback_handler.py
+++ b/core/workflow/engine/callbacks/callback_handler.py
@@ -46,8 +46,15 @@ class ChatCallBackStreamResult:
     node_answer_content: LLMGenerate
     """Generated content from the node execution."""
 
+    ordered_stream_key: str = ""
+    """Internal queue key used to isolate ordered streaming sessions."""
+
     finish_reason: str = ""
     """Reason for node completion. 'stop' indicates normal completion, empty string otherwise."""
+
+    def __post_init__(self) -> None:
+        if not self.ordered_stream_key:
+            self.ordered_stream_key = self.node_id
 
 
 class ChatCallBacks:
@@ -74,6 +81,7 @@ class ChatCallBacks:
         chains: Chains,
         event_id: str,
         flow_id: str,
+        ordered_stream_namespace: str = "",
     ):
         """
         Initialize the chat callback handler.
@@ -97,6 +105,7 @@ class ChatCallBacks:
         self.chains = chains
         self.event_id = event_id
         self.flow_id = flow_id
+        self.ordered_stream_namespace = ordered_stream_namespace
 
         if chains:
             self.all_simple_paths_node_cnt = chains.get_all_simple_paths_node_cnt()
@@ -411,12 +420,21 @@ class ChatCallBacks:
             await self.order_stream_result_q.put(
                 ChatCallBackStreamResult(
                     node_id=node_id,
+                    ordered_stream_key=self._build_ordered_stream_key(node_id),
                     node_answer_content=resp,
                     finish_reason=finish_reason,
                 )
             )
         else:
             await self.stream_queue.put(resp)
+
+    def _build_ordered_stream_key(self, node_id: str) -> str:
+        """
+        Build the internal ordered-stream queue key for one node execution session.
+        """
+        if not self.ordered_stream_namespace:
+            return node_id
+        return f"{self.ordered_stream_namespace}::{node_id}"
 
 
 class ChatCallBackConsumer:
@@ -464,11 +482,12 @@ class ChatCallBackConsumer:
                 result: ChatCallBackStreamResult = (
                     await self.need_order_stream_result_q.get()
                 )
-                if result.node_id not in self.support_stream_node_id_set:
-                    await self._add_node_in_q(result.node_id)
-                if result.node_id not in self.structured_data:
-                    self.structured_data[result.node_id] = Queue()
-                await self.structured_data[result.node_id].put(result)
+                stream_key = result.ordered_stream_key
+                if stream_key not in self.support_stream_node_id_set:
+                    await self._add_node_in_q(stream_key)
+                if stream_key not in self.structured_data:
+                    self.structured_data[stream_key] = Queue()
+                await self.structured_data[stream_key].put(result)
                 # Workflow execution completed
                 if (
                     result.node_id.split("::")[0] == NodeType.END.value
@@ -577,7 +596,7 @@ class StructuredConsumer:
                 if isinstance(result, ChatCallBackStreamResult):
                     await self.stream_queue.put(result.node_answer_content)
                     if result.finish_reason == ChatStatus.FINISH_REASON.value:
-                        self.support_stream_node_id_set.remove(node_id)
+                        self.support_stream_node_id_set.discard(node_id)
                         self.structured_data.pop(node_id)
                         break
                 else:

--- a/core/workflow/engine/dsl_engine.py
+++ b/core/workflow/engine/dsl_engine.py
@@ -931,13 +931,14 @@ class WorkflowEngine(BaseModel):
             # Node start callback
             await self._handle_node_start_callback(node)
 
-            # Execute node
-            run_result, fail_branch = await self._execute_node_with_retry(
-                node, span_context
-            )
-
-            # Mark node as complete
-            self.engine_ctx.node_run_status[node.node_id].complete.set()
+            try:
+                # Execute node
+                run_result, fail_branch = await self._execute_node_with_retry(
+                    node, span_context
+                )
+            finally:
+                # Message/end nodes may be waiting on this event even when execution fails.
+                self.engine_ctx.node_run_status[node.node_id].complete.set()
 
         # Get next batch of active nodes
         next_active_nodes, next_inactive_nodes = await self._get_next_nodes(
@@ -1427,17 +1428,52 @@ class WorkflowEngine(BaseModel):
         if not self.engine_ctx.dfs_tasks:
             return
 
-        done, pending = await asyncio.wait(
-            self.engine_ctx.dfs_tasks, return_when=asyncio.FIRST_EXCEPTION
-        )
-
-        # Cancel all pending tasks and ensure they are awaited
-        await self._cancel_pending_task(pending)
-
         exceptions: List[Exception] = []
+        handled_tasks: Set[Task] = set()
 
-        # Check if completed tasks have exceptions
-        for task in done:
+        await self._process_dfs_tasks(exceptions, handled_tasks)
+        self._validate_responses(exceptions)
+        self._raise_exceptions_if_any(exceptions, span)
+
+    async def _process_dfs_tasks(
+        self, exceptions: List[Exception], handled_tasks: Set[Task]
+    ) -> None:
+        """
+        Process all DFS tasks until completion or first exception.
+        """
+        while True:
+            current_tasks = {
+                task for task in self.engine_ctx.dfs_tasks if task not in handled_tasks
+            }
+            if not current_tasks:
+                break
+
+            done, pending = await asyncio.wait(
+                current_tasks, return_when=asyncio.FIRST_EXCEPTION
+            )
+
+            handled_tasks.update(done)
+            await self._cancel_pending_task(pending)
+            handled_tasks.update(pending)
+
+            await self._collect_task_results(done, exceptions)
+
+            if exceptions:
+                await self._cleanup_remaining_tasks(handled_tasks)
+                handled_tasks.update(
+                    task
+                    for task in self.engine_ctx.dfs_tasks
+                    if task not in handled_tasks and not task.done()
+                )
+                break
+
+    async def _collect_task_results(
+        self, done_tasks: Set[Task], exceptions: List[Exception]
+    ) -> None:
+        """
+        Collect results from completed tasks and handle end nodes.
+        """
+        for task in done_tasks:
             try:
                 if task.cancelled():
                     continue
@@ -1446,6 +1482,21 @@ class WorkflowEngine(BaseModel):
             except Exception as e:
                 exceptions.append(e)
 
+    async def _cleanup_remaining_tasks(self, handled_tasks: Set[Task]) -> None:
+        """
+        Cancel and await all remaining unhandled tasks.
+        """
+        remaining_tasks = {
+            task
+            for task in self.engine_ctx.dfs_tasks
+            if task not in handled_tasks and not task.done()
+        }
+        await self._cancel_pending_task(remaining_tasks)
+
+    def _validate_responses(self, exceptions: List[Exception]) -> None:
+        """
+        Validate that at least one response was collected.
+        """
         if not self.engine_ctx.responses:
             exceptions.append(
                 CustomException(
@@ -1453,11 +1504,14 @@ class WorkflowEngine(BaseModel):
                 )
             )
 
+    def _raise_exceptions_if_any(self, exceptions: List[Exception], span: Span) -> None:
+        """
+        Record and raise the first exception if any occurred.
+        """
         if exceptions:
             for exception in exceptions:
                 span.record_exception(exception)
             raise exceptions[0]
-        return None
 
     def _validate_start_node(self) -> None:
         """
@@ -1630,6 +1684,23 @@ class WorkflowEngine(BaseModel):
             node = self.engine_ctx.built_nodes[msg_node_id]
             strategy = self.strategy_manager.get_strategy(node.node_id.split("::")[0])
             return await strategy.execute_node(node, self.engine_ctx, span_context)
+        except asyncio.CancelledError:
+            node = self.engine_ctx.built_nodes[msg_node_id]
+            result = NodeRunResult(
+                node_id=node.node_id,
+                alias_name=node.node_alias_name,
+                node_type=node.node_id.split("::")[0],
+                status=WorkflowNodeExecutionStatus.CANCELLED,
+                inputs={},
+                outputs={},
+                node_answer_content="",
+            )
+            await self.engine_ctx.callback.on_node_end(
+                node_id=node.node_id,
+                alias_name=node.node_alias_name,
+                message=result,
+            )
+            return result
         finally:
             self.engine_ctx.node_run_status[msg_node_id].complete.set()
 
@@ -1837,6 +1908,25 @@ class WorkflowEngineFactory:
             )
 
             return builder.build()
+
+    @staticmethod
+    def create_iteration_engine(
+        sparkflow_dsl: WorkflowDSL,
+        iteration_node_id: str,
+        span: Span,
+        sub_dsl: WorkflowDSL | None = None,
+    ) -> WorkflowEngine:
+        """
+        Create an isolated workflow engine for a single iteration subgraph.
+
+        :param sparkflow_dsl: Full workflow DSL definition
+        :param iteration_node_id: Iteration container node ID
+        :param span: Tracing span for observability
+        :return: WorkflowEngine instance for the iteration subgraph
+        """
+        if sub_dsl is None:
+            sub_dsl = sparkflow_dsl.extract_iteration_sub_dsl(iteration_node_id)
+        return WorkflowEngineFactory.create_engine(sub_dsl, span)
 
     @staticmethod
     def create_debug_node(
@@ -2099,6 +2189,8 @@ class WorkflowEngineBuilder:
 
         if node_type == NodeType.START.value:
             self.start_node_id = node.id
+        elif node_type == NodeType.ITERATION_START.value and not self.start_node_id:
+            self.start_node_id = node.id
         elif node_type == NodeType.DECISION_MAKING.value:
             self._handle_decision_making_node(node.id, node)
         elif node_type == NodeType.LLM.value:
@@ -2229,6 +2321,7 @@ class WorkflowEngineBuilder:
 
             inputs = node.data.inputs
             for input_item in inputs:
+                ref_node_id = None
                 var_type = input_item.input_schema.value.type
                 if var_type == ValueType.LITERAL.value:
                     continue
@@ -2236,10 +2329,12 @@ class WorkflowEngineBuilder:
                 content = input_item.input_schema.value.content
                 if isinstance(content, NodeRef):
                     ref_node_id = content.nodeId
-
-                if ref_node_id:
+                if (
+                    ref_node_id
+                    and ref_node_id != node.id
+                    and node.id in self.msg_or_end_node_deps
+                ):
                     self.msg_or_end_node_deps[node.id].data_dep.add(ref_node_id)
-
                     # Check if normal path exists
                     if self._has_normal_path(ref_node_id, node.id):
                         self.msg_or_end_node_deps[node.id].data_dep_path_info[

--- a/core/workflow/engine/entities/chains.py
+++ b/core/workflow/engine/entities/chains.py
@@ -108,39 +108,94 @@ class Chains(BaseModel):
         """
 
         edge_dict: Dict[str, List[str]] = {}
-        node_dict: Dict[str, Node] = {}
+        node_dict = self._build_node_dict()
         iteration_dict: Dict[str, str] = {}
 
         start_node_id = ""
         end_node_id = ""
 
-        for node in self.workflow_schema.nodes:
-            node_dict[node.id] = node
-
         for edge in self.workflow_schema.edges:
-
             source_node_id = edge.sourceNodeId
             target_node_id = edge.targetNodeId
-            if source_node_id not in edge_dict:
-                edge_dict[source_node_id] = []
-            if target_node_id not in edge_dict[source_node_id]:
-                edge_dict[source_node_id].append(target_node_id)
-
-            source_node_id_prefix = source_node_id.split("::")[0]
-            target_node_id_prefix = target_node_id.split("::")[0]
-            if source_node_id_prefix == "node-start":
-                start_node_id = source_node_id
-            if target_node_id_prefix == "node-end":
-                end_node_id = target_node_id
-
-            if source_node_id_prefix == "iteration":
-                iter_node: Node | None = node_dict.get(source_node_id)
-                if iter_node is None:
-                    raise ValueError(f"{source_node_id} node is not exist")
-                start_id = iter_node.data.nodeParam.get("IterationStartNodeId")
-                iteration_dict[source_node_id] = str(start_id or "")
+            self._append_edge(edge_dict, source_node_id, target_node_id)
+            start_node_id = self._resolve_start_node_id(start_node_id, source_node_id)
+            end_node_id = self._resolve_end_node_id(end_node_id, target_node_id)
+            self._record_iteration_start(
+                iteration_dict=iteration_dict,
+                node_dict=node_dict,
+                source_node_id=source_node_id,
+            )
 
         return start_node_id, end_node_id, edge_dict, iteration_dict
+
+    def _build_node_dict(self) -> Dict[str, Node]:
+        """
+        Build a node lookup map keyed by node ID.
+        """
+        return {node.id: node for node in self.workflow_schema.nodes}
+
+    def _append_edge(
+        self,
+        edge_dict: Dict[str, List[str]],
+        source_node_id: str,
+        target_node_id: str,
+    ) -> None:
+        """
+        Store a source-to-target edge without duplicates.
+        """
+        if source_node_id not in edge_dict:
+            edge_dict[source_node_id] = []
+        if target_node_id not in edge_dict[source_node_id]:
+            edge_dict[source_node_id].append(target_node_id)
+
+    def _resolve_start_node_id(
+        self, current_start_node_id: str, source_node_id: str
+    ) -> str:
+        """
+        Resolve the workflow start node ID while preferring the main start node.
+        """
+        source_node_id_prefix = source_node_id.split("::")[0]
+        if source_node_id_prefix == "node-start":
+            return source_node_id
+        if (
+            source_node_id_prefix == "iteration-node-start"
+            and not current_start_node_id
+        ):
+            return source_node_id
+        return current_start_node_id
+
+    def _resolve_end_node_id(
+        self, current_end_node_id: str, target_node_id: str
+    ) -> str:
+        """
+        Resolve the workflow end node ID while preferring the main end node.
+        """
+        target_node_id_prefix = target_node_id.split("::")[0]
+        if target_node_id_prefix == "node-end":
+            return target_node_id
+        if target_node_id_prefix == "iteration-node-end" and not current_end_node_id:
+            return target_node_id
+        return current_end_node_id
+
+    def _record_iteration_start(
+        self,
+        iteration_dict: Dict[str, str],
+        node_dict: Dict[str, Node],
+        source_node_id: str,
+    ) -> None:
+        """
+        Record the start node configured for an iteration node.
+        """
+        source_node_id_prefix = source_node_id.split("::")[0]
+        if source_node_id_prefix != "iteration":
+            return
+
+        iter_node: Node | None = node_dict.get(source_node_id)
+        if iter_node is None:
+            raise ValueError(f"{source_node_id} node is not exist")
+
+        start_id = iter_node.data.nodeParam.get("IterationStartNodeId")
+        iteration_dict[source_node_id] = str(start_id or "")
 
     def _get_next_node(
         self, node_id: str, edge_dict: Dict[str, List[str]]

--- a/core/workflow/engine/entities/variable_pool.py
+++ b/core/workflow/engine/entities/variable_pool.py
@@ -291,10 +291,20 @@ class VariablePool:
         new_vp.input_variable_mapping = copy.deepcopy(src.input_variable_mapping)
         new_vp.output_variable_mapping = copy.deepcopy(src.output_variable_mapping)
         new_vp.history_mapping = copy.deepcopy(src.history_mapping)
-        new_vp.stream_data = src.stream_data
+
+        # Deep copy stream_data to prevent queue sharing in parallel iterations
+        # Each iteration needs its own set of queues to avoid data mixing
+        new_vp.stream_data = {}
+        for node_id, queues_dict in src.stream_data.items():
+            new_vp.stream_data[node_id] = {
+                key: asyncio.Queue() for key in queues_dict.keys()
+            }
+
         new_vp.chat_id = src.chat_id
         new_vp.history_v2 = copy.deepcopy(src.history_v2)
-        new_vp.system_params = src.system_params
+
+        # Deep copy system_params to prevent shared state in parallel iterations
+        new_vp.system_params = copy.deepcopy(src.system_params)
 
         return new_vp
 
@@ -418,7 +428,7 @@ class VariablePool:
         :param history_lists: List of HistoryItem objects to initialize history
         """
         self.history_v2 = History()
-        self.history_v2.init_history(history=history_lists)
+        self.history_v2.init_history(history=copy.deepcopy(history_lists))
 
     def get_history(self, node_id: str) -> list[SparkAiMessage]:
         """

--- a/core/workflow/engine/entities/workflow_dsl.py
+++ b/core/workflow/engine/entities/workflow_dsl.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Union
+from typing import Any, Dict, List, Literal, Set, Union
 
 from pydantic import BaseModel, Field
 
@@ -159,3 +159,44 @@ class WorkflowDSL(BaseModel):
         raise CustomException(
             CodeEnum.PROTOCOL_BUILD_ERROR, err_msg=f"Node {node_id} does not exist"
         )
+
+    def extract_iteration_sub_dsl(self, iteration_node_id: str) -> "WorkflowDSL":
+        """
+        Extract the standalone DSL for an iteration subgraph.
+
+        :param iteration_node_id: The iteration container node ID
+        :return: WorkflowDSL containing only the iteration subgraph
+        :raises CustomException: If the iteration node or subgraph is invalid
+        """
+        from workflow.engine.entities.chains import Chains
+
+        chains = Chains(workflow_schema=self)
+        chains.gen()
+
+        iteration_chains = chains.iteration_chains.get(iteration_node_id)
+        if iteration_chains is None:
+            raise CustomException(
+                CodeEnum.PROTOCOL_BUILD_ERROR,
+                err_msg=f"Iteration node {iteration_node_id} sub dsl does not exist",
+            )
+
+        sub_node_ids: Set[str] = set()
+        for master_chain in iteration_chains.master_chains:
+            sub_node_ids.update(master_chain.node_id_list)
+
+        if not sub_node_ids:
+            raise CustomException(
+                CodeEnum.PROTOCOL_BUILD_ERROR,
+                err_msg=f"Iteration node {iteration_node_id} sub dsl is empty",
+            )
+
+        sub_nodes = [
+            node.model_copy(deep=True) for node in self.nodes if node.id in sub_node_ids
+        ]
+        sub_edges = [
+            edge.model_copy(deep=True)
+            for edge in self.edges
+            if edge.sourceNodeId in sub_node_ids and edge.targetNodeId in sub_node_ids
+        ]
+
+        return WorkflowDSL(nodes=sub_nodes, edges=sub_edges)

--- a/core/workflow/engine/nodes/iteration/iteration_node.py
+++ b/core/workflow/engine/nodes/iteration/iteration_node.py
@@ -1,10 +1,12 @@
 import asyncio
 import copy
-from typing import Any, Dict
+from enum import Enum
+from typing import Any, Dict, Literal
 
-from pydantic import PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr
 
 from workflow.engine.callbacks.callback_handler import ChatCallBacks
+from workflow.engine.callbacks.openai_types_sse import GenerateUsage
 from workflow.engine.entities.chains import Chains
 from workflow.engine.entities.node_entities import NodeType
 from workflow.engine.entities.node_running_status import NodeRunningStatus
@@ -22,6 +24,40 @@ from workflow.extensions.otlp.log_trace.workflow_log import WorkflowLog
 from workflow.extensions.otlp.trace.span import Span
 
 
+class ErrorStrategy(Enum):
+    FAIL_FAST = "fail_fast"
+    CONTINUE = "continue"
+    IGNORE_ERROR_OUTPUT = "ignore_error_output"
+
+
+class IterationBatchOutcome(BaseModel):
+    """
+    Execution outcome for a single iteration batch item.
+    """
+
+    index: int
+    result: NodeRunResult | None = None
+    error: Exception | None = None
+    cancelled: bool = False
+    usage: GenerateUsage | None = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class IterationChildQueues(BaseModel):
+    """
+    Per-batch queues used to isolate and relay child engine events.
+    """
+
+    stream_queue: asyncio.Queue
+    order_queue: asyncio.Queue
+    relay_queue: asyncio.Queue
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
 class IterationNode(BaseNode):
     """
     Iteration node that executes a workflow subgraph for each item in a batch.
@@ -32,9 +68,14 @@ class IterationNode(BaseNode):
 
     # Node ID of the first node in the workflow subgraph within this iteration
     IterationStartNodeId: str
+    isParallel: bool = False
+    maxConcurrency: int = Field(default=5, ge=1)
+    errorStrategy: Literal["fail_fast", "continue", "ignore_error_output"] = "fail_fast"
+    timeout: int = Field(default=300, ge=1)
     _private_config: PrivateConfig = PrivateAttr(
         default_factory=lambda: PrivateConfig(timeout=None)
     )
+    _contains_question_answer: bool = PrivateAttr(default=False)
 
     async def async_execute(
         self,
@@ -78,6 +119,9 @@ class IterationNode(BaseNode):
                         self.node_id
                     ]
                 )
+                self._contains_question_answer = (
+                    self._iteration_chain_has_question_answer(source_iteration_chains)
+                )
                 # built_nodes = copy.deepcopy(iteration_one_engine.engine_ctx.built_nodes)
 
                 batch_datas = variable_pool.get_variable(
@@ -88,25 +132,15 @@ class IterationNode(BaseNode):
                 inputs = {self.input_identifier[0]: batch_datas}
                 await span_context.add_info_events_async({"inputs": f"{inputs}"})
 
-                batch_result_dict: dict[str, list] = {}
-                temp_variable_pool = copy.deepcopy(variable_pool)
-                for batch_data in batch_datas:
-                    # iteration_one_engine.engine_ctx.built_nodes = built_nodes
-                    res = await self._process_single_batch(
-                        batch_data,
-                        temp_variable_pool,
-                        source_iteration_chains,
-                        span_context,
-                        iteration_one_engine,
-                        variable_pool,
-                        callbacks,
-                        event_log_trace,
-                    )
-                    cur_batch_res = res.outputs
-                    for res_k, res_v in cur_batch_res.items():
-                        if res_k not in batch_result_dict:
-                            batch_result_dict[res_k] = []
-                        batch_result_dict[res_k].append(res_v)
+                batch_result_dict = await self._execute_batches(
+                    batch_datas=batch_datas,
+                    span=span_context,
+                    iteration_one_engine=iteration_one_engine,
+                    source_iteration_chains=source_iteration_chains,
+                    variable_pool=variable_pool,
+                    callbacks=callbacks,
+                    event_log_trace=event_log_trace,
+                )
 
                 return_result = {}
                 for out_put_key_name in self.output_identifier:
@@ -149,6 +183,798 @@ class IterationNode(BaseNode):
                 node_type=self.node_type,
             )
 
+    async def _execute_batches(
+        self,
+        batch_datas: list[Any],
+        span: Span,
+        iteration_one_engine: Any,
+        source_iteration_chains: Chains,
+        variable_pool: VariablePool,
+        callbacks: ChatCallBacks,
+        event_log_trace: WorkflowLog,
+    ) -> dict[str, list[Any]]:
+        """
+        Execute iteration batches in serial or parallel mode.
+        """
+        if self._should_run_parallel(batch_datas):
+            return await self._execute_batches_in_parallel(
+                batch_datas=batch_datas,
+                span=span,
+                iteration_one_engine=iteration_one_engine,
+                variable_pool=variable_pool,
+                callbacks=callbacks,
+                event_log_trace=event_log_trace,
+            )
+
+        return await self._execute_batches_serially(
+            batch_datas=batch_datas,
+            span=span,
+            iteration_one_engine=iteration_one_engine,
+            source_iteration_chains=source_iteration_chains,
+            variable_pool=variable_pool,
+            callbacks=callbacks,
+            event_log_trace=event_log_trace,
+        )
+
+    async def _execute_batches_serially(
+        self,
+        batch_datas: list[Any],
+        span: Span,
+        iteration_one_engine: Any,
+        source_iteration_chains: Chains,
+        variable_pool: VariablePool,
+        callbacks: ChatCallBacks,
+        event_log_trace: WorkflowLog,
+    ) -> dict[str, list[Any]]:
+        """
+        Execute iteration batches sequentially with error strategy support.
+        """
+        error_strategy = self._get_error_strategy()
+        batch_result_dict: dict[str, list[Any]] = {}
+        temp_variable_pool = copy.deepcopy(variable_pool)
+        canonical_keys = set(self.output_identifier)
+
+        for batch_data in batch_datas:
+            try:
+                res = await self._process_single_batch(
+                    batch_data,
+                    temp_variable_pool,
+                    source_iteration_chains,
+                    span,
+                    iteration_one_engine,
+                    variable_pool,
+                    callbacks,
+                    event_log_trace,
+                )
+                canonical_keys.update(res.outputs.keys())
+                self._append_batch_outputs(batch_result_dict, res.outputs)
+            except Exception as err:
+                self._handle_serial_batch_error(
+                    err, error_strategy, batch_result_dict, canonical_keys
+                )
+
+        return batch_result_dict
+
+    def _handle_serial_batch_error(
+        self,
+        err: Exception,
+        error_strategy: ErrorStrategy,
+        batch_result_dict: dict[str, list[Any]],
+        canonical_keys: set[str],
+    ) -> None:
+        """
+        Handle a single batch error in serial execution mode.
+        """
+        if error_strategy == ErrorStrategy.FAIL_FAST:
+            raise err
+        elif error_strategy == ErrorStrategy.CONTINUE:
+            for key in canonical_keys:
+                if key not in batch_result_dict:
+                    batch_result_dict[key] = []
+                batch_result_dict[key].append(None)
+        # IGNORE_ERROR_OUTPUT: skip this batch entirely (no action needed)
+
+    def _should_run_parallel(self, batch_datas: list[Any]) -> bool:
+        """
+        Determine whether the current iteration should run in parallel.
+        """
+        return (
+            self.isParallel
+            and len(batch_datas) > 1
+            and not self._contains_question_answer
+        )
+
+    def _iteration_chain_has_question_answer(
+        self, iteration_chains: Chains | None = None
+    ) -> bool:
+        """
+        Determine whether the iteration subgraph contains question-answer nodes.
+        """
+        if iteration_chains is None:
+            return False
+
+        for simple_path in iteration_chains.master_chains:
+            if any(
+                node_id.split("::")[0] == NodeType.QUESTION_ANSWER.value
+                for node_id in simple_path.node_id_list
+            ):
+                return True
+
+        return False
+
+    async def _execute_batches_in_parallel(
+        self,
+        batch_datas: list[Any],
+        span: Span,
+        iteration_one_engine: Any,
+        variable_pool: VariablePool,
+        callbacks: ChatCallBacks,
+        event_log_trace: WorkflowLog,
+    ) -> dict[str, list[Any]]:
+        """
+        Execute iteration batches with independent engines and ordered event relay.
+        """
+        error_strategy = self._get_error_strategy()
+        queue_end = object()
+        fail_fast_queue: asyncio.Queue[Exception] = asyncio.Queue()
+        sub_dsl = iteration_one_engine.workflow_dsl.extract_iteration_sub_dsl(
+            self.node_id
+        )
+        semaphore = asyncio.Semaphore(max(1, self.maxConcurrency))
+        history, history_v2 = self._build_iteration_history(variable_pool)
+
+        child_queues, collector_tasks, runner_tasks = self._create_parallel_tasks(
+            batch_datas=batch_datas,
+            queue_end=queue_end,
+            semaphore=semaphore,
+            span=span,
+            iteration_one_engine=iteration_one_engine,
+            variable_pool=variable_pool,
+            callbacks=callbacks,
+            event_log_trace=event_log_trace,
+            fail_fast_queue=fail_fast_queue,
+            error_strategy=error_strategy,
+            sub_dsl=sub_dsl,
+            history=history,
+            history_v2=history_v2,
+        )
+        fail_fast_monitor = self._create_fail_fast_monitor(
+            error_strategy, fail_fast_queue, runner_tasks
+        )
+        outcomes = await self._gather_parallel_outcomes(
+            child_queues=child_queues,
+            runner_tasks=runner_tasks,
+            collector_tasks=collector_tasks,
+            fail_fast_monitor=fail_fast_monitor,
+            callbacks=callbacks,
+            queue_end=queue_end,
+        )
+
+        ordered_outcomes = sorted(outcomes, key=lambda outcome: outcome.index)
+        self._aggregate_parallel_usage(callbacks, ordered_outcomes)
+        first_error = self._get_first_parallel_error(ordered_outcomes)
+
+        if error_strategy == ErrorStrategy.FAIL_FAST and first_error is not None:
+            raise first_error
+
+        return self._build_parallel_batch_result(ordered_outcomes, error_strategy)
+
+    def _create_parallel_tasks(
+        self,
+        batch_datas: list[Any],
+        queue_end: object,
+        semaphore: asyncio.Semaphore,
+        span: Span,
+        iteration_one_engine: Any,
+        variable_pool: VariablePool,
+        callbacks: ChatCallBacks,
+        event_log_trace: WorkflowLog,
+        fail_fast_queue: asyncio.Queue[Exception],
+        error_strategy: ErrorStrategy,
+        sub_dsl: Any,
+        history: list[Any],
+        history_v2: list[Any],
+    ) -> tuple[
+        list[IterationChildQueues],
+        list[asyncio.Task[None]],
+        list[asyncio.Task[IterationBatchOutcome]],
+    ]:
+        """
+        Create per-batch queues, collector tasks, and runner tasks.
+        """
+        child_queues: list[IterationChildQueues] = []
+        collector_tasks: list[asyncio.Task[None]] = []
+        runner_tasks: list[asyncio.Task[IterationBatchOutcome]] = []
+
+        for index, batch_data in enumerate(batch_datas):
+            queues = self._create_iteration_child_queues()
+            child_queues.append(queues)
+            collector_tasks.append(
+                asyncio.create_task(
+                    self._collect_child_events(
+                        child_stream_queue=queues.stream_queue,
+                        child_order_queue=queues.order_queue,
+                        relay_queue=queues.relay_queue,
+                        queue_end=queue_end,
+                    )
+                )
+            )
+            runner_tasks.append(
+                asyncio.create_task(
+                    self._run_parallel_batch(
+                        index=index,
+                        batch_data=batch_data,
+                        queues=queues,
+                        queue_end=queue_end,
+                        semaphore=semaphore,
+                        span=span,
+                        iteration_one_engine=iteration_one_engine,
+                        variable_pool=variable_pool,
+                        callbacks=callbacks,
+                        event_log_trace=event_log_trace,
+                        fail_fast_queue=fail_fast_queue,
+                        error_strategy=error_strategy,
+                        sub_dsl=sub_dsl,
+                        history=history,
+                        history_v2=history_v2,
+                    )
+                )
+            )
+
+        return child_queues, collector_tasks, runner_tasks
+
+    def _create_iteration_child_queues(self) -> IterationChildQueues:
+        """
+        Create the queue bundle used by one parallel iteration.
+        """
+        return IterationChildQueues(
+            stream_queue=asyncio.Queue(),
+            order_queue=asyncio.Queue(),
+            relay_queue=asyncio.Queue(),
+        )
+
+    async def _run_parallel_batch(
+        self,
+        index: int,
+        batch_data: Any,
+        queues: IterationChildQueues,
+        queue_end: object,
+        semaphore: asyncio.Semaphore,
+        span: Span,
+        iteration_one_engine: Any,
+        variable_pool: VariablePool,
+        callbacks: ChatCallBacks,
+        event_log_trace: WorkflowLog,
+        fail_fast_queue: asyncio.Queue[Exception],
+        error_strategy: ErrorStrategy,
+        sub_dsl: Any,
+        history: list[Any],
+        history_v2: list[Any],
+    ) -> IterationBatchOutcome:
+        """
+        Run one batch item in its own child engine.
+        """
+        child_engine = None
+        try:
+            async with semaphore:
+                child_engine, child_span = self._create_iteration_child_engine(
+                    parent_span=span,
+                    iteration_one_engine=iteration_one_engine,
+                    variable_pool=variable_pool,
+                    iteration_index=index,
+                    callbacks=callbacks,
+                    sub_dsl=sub_dsl,
+                )
+                child_callbacks = self._create_child_callbacks(
+                    parent_callbacks=callbacks,
+                    child_engine=child_engine,
+                    stream_queue=queues.stream_queue,
+                    order_queue=queues.order_queue,
+                    iteration_index=index,
+                )
+                run_coro = child_engine.async_run(
+                    inputs=self._build_iteration_start_inputs(child_engine, batch_data),
+                    span=child_span,
+                    callback=child_callbacks,
+                    history=history,
+                    history_v2=history_v2,
+                    event_log_trace=event_log_trace,
+                )
+                result = await asyncio.wait_for(run_coro, timeout=self.timeout)
+                return IterationBatchOutcome(
+                    index=index,
+                    result=result,
+                    usage=child_callbacks.generate_usage.model_copy(deep=True),
+                )
+        except asyncio.CancelledError:
+            return IterationBatchOutcome(index=index, cancelled=True)
+        except Exception as err:
+            if error_strategy == ErrorStrategy.FAIL_FAST:
+                await fail_fast_queue.put(err)
+            return IterationBatchOutcome(index=index, error=err)
+        finally:
+            await self._cleanup_child_engine(child_engine)
+            await queues.stream_queue.put(queue_end)
+            await queues.order_queue.put(queue_end)
+
+    def _create_iteration_child_engine(
+        self,
+        parent_span: Span,
+        iteration_one_engine: Any,
+        variable_pool: VariablePool,
+        iteration_index: int,
+        callbacks: ChatCallBacks,
+        sub_dsl: Any,
+    ) -> tuple[Any, Span]:
+        """
+        Create and configure the child engine for one parallel batch.
+        """
+        from workflow.engine.dsl_engine import WorkflowEngineFactory
+        from workflow.extensions.otlp.trace.span import Span
+
+        child_span = Span(
+            app_id=parent_span.app_id,
+            uid=parent_span.uid,
+            chat_id=parent_span.chat_id,
+        )
+        child_engine = WorkflowEngineFactory.create_iteration_engine(
+            iteration_one_engine.workflow_dsl,
+            self.node_id,
+            child_span,
+            sub_dsl=sub_dsl,
+        )
+        child_engine.engine_ctx.qa_node_lock = (
+            iteration_one_engine.engine_ctx.qa_node_lock or asyncio.Lock()
+        )
+        child_engine.engine_ctx.variable_pool = copy.deepcopy(variable_pool)
+        self._annotate_iteration_child_logs(
+            child_engine=child_engine,
+            iteration_index=iteration_index,
+            parent_event_id=getattr(callbacks, "event_id", ""),
+            parent_flow_id=getattr(callbacks, "flow_id", ""),
+        )
+        return child_engine, child_span
+
+    def _create_fail_fast_monitor(
+        self,
+        error_strategy: ErrorStrategy,
+        fail_fast_queue: asyncio.Queue[Exception],
+        runner_tasks: list[asyncio.Task[IterationBatchOutcome]],
+    ) -> asyncio.Task[None] | None:
+        """
+        Create the fail-fast monitor when that mode is enabled.
+        """
+        if error_strategy != ErrorStrategy.FAIL_FAST:
+            return None
+        return asyncio.create_task(
+            self._monitor_fail_fast(fail_fast_queue, runner_tasks)
+        )
+
+    async def _gather_parallel_outcomes(
+        self,
+        child_queues: list[IterationChildQueues],
+        runner_tasks: list[asyncio.Task[IterationBatchOutcome]],
+        collector_tasks: list[asyncio.Task[None]],
+        fail_fast_monitor: asyncio.Task[None] | None,
+        callbacks: ChatCallBacks,
+        queue_end: object,
+    ) -> list[IterationBatchOutcome]:
+        """
+        Relay child events, wait for outcomes, and ensure background tasks are cleaned up.
+        """
+        try:
+            for queues in child_queues:
+                await self._emit_child_events(
+                    relay_queue=queues.relay_queue,
+                    callbacks=callbacks,
+                    queue_end=queue_end,
+                )
+            return list(await asyncio.gather(*runner_tasks))
+        except BaseException:
+            await self._cancel_parallel_background_tasks(
+                runner_tasks=runner_tasks,
+                collector_tasks=collector_tasks,
+                fail_fast_monitor=fail_fast_monitor,
+            )
+            raise
+        finally:
+            await self._finalize_parallel_background_tasks(
+                collector_tasks=collector_tasks,
+                fail_fast_monitor=fail_fast_monitor,
+            )
+
+    async def _cancel_parallel_background_tasks(
+        self,
+        runner_tasks: list[asyncio.Task[IterationBatchOutcome]],
+        collector_tasks: list[asyncio.Task[None]],
+        fail_fast_monitor: asyncio.Task[None] | None,
+    ) -> None:
+        """
+        Cancel all unfinished background tasks used by parallel iteration.
+        """
+        for task in [*runner_tasks, *collector_tasks]:
+            if not task.done():
+                task.cancel()
+        if fail_fast_monitor and not fail_fast_monitor.done():
+            fail_fast_monitor.cancel()
+
+        remaining = [
+            task
+            for task in [*runner_tasks, *collector_tasks, fail_fast_monitor]
+            if task is not None and not task.done()
+        ]
+        if remaining:
+            await asyncio.gather(*remaining, return_exceptions=True)
+
+    async def _finalize_parallel_background_tasks(
+        self,
+        collector_tasks: list[asyncio.Task[None]],
+        fail_fast_monitor: asyncio.Task[None] | None,
+    ) -> None:
+        """
+        Await background tasks so no orphaned tasks remain after parallel execution.
+        """
+        if fail_fast_monitor:
+            fail_fast_monitor.cancel()
+            await asyncio.gather(fail_fast_monitor, return_exceptions=True)
+        await asyncio.gather(*collector_tasks, return_exceptions=True)
+
+    def _get_first_parallel_error(
+        self, ordered_outcomes: list[IterationBatchOutcome]
+    ) -> Exception | None:
+        """
+        Return the first non-cancelled error from parallel outcomes.
+        """
+        return next(
+            (
+                outcome.error
+                for outcome in ordered_outcomes
+                if outcome.error is not None and not outcome.cancelled
+            ),
+            None,
+        )
+
+    def _build_parallel_batch_result(
+        self,
+        ordered_outcomes: list[IterationBatchOutcome],
+        error_strategy: ErrorStrategy,
+    ) -> dict[str, list[Any]]:
+        """
+        Build aligned batch outputs from ordered parallel outcomes.
+        """
+        canonical_keys = set(self.output_identifier)
+        batch_result_dict: dict[str, list[Any]] = {}
+
+        for outcome in ordered_outcomes:
+            if outcome.result is not None:
+                self._append_parallel_outcome_values(
+                    batch_result_dict=batch_result_dict,
+                    canonical_keys=canonical_keys,
+                    outputs=outcome.result.outputs,
+                )
+            elif error_strategy == ErrorStrategy.CONTINUE:
+                # Append None placeholders for failed batch
+                self._append_parallel_outcome_values(
+                    batch_result_dict=batch_result_dict,
+                    canonical_keys=canonical_keys,
+                    outputs=None,
+                )
+            elif error_strategy == ErrorStrategy.IGNORE_ERROR_OUTPUT:
+                # Skip failed batch entirely (no placeholder)
+                pass
+
+        return batch_result_dict
+
+    def _append_parallel_outcome_values(
+        self,
+        batch_result_dict: dict[str, list[Any]],
+        canonical_keys: set[str],
+        outputs: dict[str, Any] | None,
+    ) -> None:
+        """
+        Append one outcome's values, preserving output alignment across batches.
+        """
+        for key in canonical_keys:
+            if key not in batch_result_dict:
+                batch_result_dict[key] = []
+            batch_result_dict[key].append(None if outputs is None else outputs.get(key))
+
+    async def _monitor_fail_fast(
+        self,
+        fail_fast_queue: asyncio.Queue[Exception],
+        runner_tasks: list[asyncio.Task[IterationBatchOutcome]],
+    ) -> None:
+        """
+        Cancel remaining iteration tasks as soon as the first error is observed.
+        """
+        try:
+            await fail_fast_queue.get()
+            for task in runner_tasks:
+                if not task.done():
+                    task.cancel()
+        except asyncio.CancelledError:
+            return
+
+    async def _collect_child_events(
+        self,
+        child_stream_queue: asyncio.Queue,
+        child_order_queue: asyncio.Queue,
+        relay_queue: asyncio.Queue,
+        queue_end: object,
+    ) -> None:
+        """
+        Drain child queues concurrently and preserve each child's event order.
+        """
+        queue_done_state = {"stream": False, "order": False}
+
+        while not all(queue_done_state.values()):
+            wait_tasks = self._build_child_queue_wait_tasks(
+                child_stream_queue=child_stream_queue,
+                child_order_queue=child_order_queue,
+                queue_done_state=queue_done_state,
+            )
+
+            done, pending = await asyncio.wait(
+                wait_tasks.keys(), return_when=asyncio.FIRST_COMPLETED
+            )
+            await self._cancel_pending_wait_tasks(pending)
+
+            for done_task in done:
+                queue_type = wait_tasks[done_task]
+                await self._consume_child_event_task_result(
+                    done_task=done_task,
+                    queue_type=queue_type,
+                    relay_queue=relay_queue,
+                    queue_end=queue_end,
+                    queue_done_state=queue_done_state,
+                )
+
+        await relay_queue.put(queue_end)
+
+    def _build_child_queue_wait_tasks(
+        self,
+        child_stream_queue: asyncio.Queue,
+        child_order_queue: asyncio.Queue,
+        queue_done_state: dict[str, bool],
+    ) -> dict[asyncio.Task, str]:
+        """
+        Build the set of queue read tasks that are still active.
+        """
+        wait_tasks: dict[asyncio.Task, str] = {}
+        if not queue_done_state["stream"]:
+            wait_tasks[asyncio.create_task(child_stream_queue.get())] = "stream"
+        if not queue_done_state["order"]:
+            wait_tasks[asyncio.create_task(child_order_queue.get())] = "order"
+        return wait_tasks
+
+    async def _cancel_pending_wait_tasks(
+        self, pending_tasks: set[asyncio.Task]
+    ) -> None:
+        """
+        Cancel and await queue read tasks that lost the race.
+        """
+        for pending_task in pending_tasks:
+            pending_task.cancel()
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    async def _consume_child_event_task_result(
+        self,
+        done_task: asyncio.Task,
+        queue_type: str,
+        relay_queue: asyncio.Queue,
+        queue_end: object,
+        queue_done_state: dict[str, bool],
+    ) -> None:
+        """
+        Consume one completed queue read task and update queue completion state.
+        """
+        try:
+            payload = done_task.result()
+        except (asyncio.CancelledError, Exception):
+            self._mark_child_queue_done(queue_done_state, queue_type)
+            return
+
+        if payload is queue_end:
+            self._mark_child_queue_done(queue_done_state, queue_type)
+            return
+
+        await relay_queue.put((queue_type, payload))
+
+    def _mark_child_queue_done(
+        self, queue_done_state: dict[str, bool], queue_type: str
+    ) -> None:
+        """
+        Mark one child queue as finished.
+        """
+        queue_done_state[queue_type] = True
+
+    async def _emit_child_events(
+        self,
+        relay_queue: asyncio.Queue,
+        callbacks: ChatCallBacks,
+        queue_end: object,
+    ) -> None:
+        """
+        Emit one child's buffered events to the parent queues in strict order.
+        """
+        while True:
+            payload = await relay_queue.get()
+            if payload is queue_end:
+                return
+
+            queue_type, event_payload = payload
+            if queue_type == "stream":
+                await callbacks.stream_queue.put(event_payload)
+            else:
+                await callbacks.order_stream_result_q.put(event_payload)
+
+    def _create_child_callbacks(
+        self,
+        parent_callbacks: ChatCallBacks,
+        child_engine: Any,
+        stream_queue: asyncio.Queue,
+        order_queue: asyncio.Queue,
+        iteration_index: int,
+    ) -> ChatCallBacks:
+        """
+        Create an isolated callback handler for a child iteration engine.
+        """
+        return ChatCallBacks(
+            sid=parent_callbacks.sid,
+            stream_queue=stream_queue,
+            end_node_output_mode=child_engine.end_node_output_mode,
+            support_stream_node_ids=child_engine.support_stream_node_ids,
+            need_order_stream_result_q=order_queue,
+            chains=child_engine.engine_ctx.chains,
+            event_id=parent_callbacks.event_id,
+            flow_id=parent_callbacks.flow_id,
+            ordered_stream_namespace=f"{self.node_id}::{iteration_index}",
+        )
+
+    def _annotate_iteration_child_logs(
+        self,
+        child_engine: Any,
+        iteration_index: int,
+        parent_event_id: str,
+        parent_flow_id: str,
+    ) -> None:
+        """
+        Annotate child engine node logs with iteration runtime metadata.
+        """
+        built_nodes = getattr(
+            getattr(child_engine, "engine_ctx", None), "built_nodes", {}
+        )
+        for built_node in built_nodes.values():
+            node_log = getattr(built_node, "node_log", None)
+            if node_log is None:
+                continue
+            node_log.append_config_data(
+                {
+                    "iteration_index": iteration_index,
+                    "parent_event_id": parent_event_id,
+                    "parent_flow_id": parent_flow_id,
+                    "parent_iteration_node_id": self.node_id,
+                }
+            )
+            node_log.add_info_log("iteration child runtime metadata attached")
+
+    def _aggregate_parallel_usage(
+        self,
+        callbacks: ChatCallBacks,
+        ordered_outcomes: list[IterationBatchOutcome],
+    ) -> None:
+        """
+        Aggregate child callback usage into the parent callback usage.
+        """
+        parent_usage = getattr(callbacks, "generate_usage", None)
+        if parent_usage is None:
+            return
+
+        for outcome in ordered_outcomes:
+            if outcome.usage is not None:
+                parent_usage.add(outcome.usage)
+
+    async def _cleanup_child_engine(self, child_engine: Any) -> None:
+        """
+        Best-effort cleanup for per-batch child engines.
+        """
+        if child_engine is None:
+            return
+
+        for method_name in ("aclose", "close", "cleanup"):
+            method = getattr(child_engine, method_name, None)
+            if method is None:
+                continue
+            result = method()
+            if asyncio.iscoroutine(result):
+                await result
+            break
+
+    def _build_iteration_history(
+        self, variable_pool: VariablePool
+    ) -> tuple[list[Any], list[Any]]:
+        """
+        Build history payloads shared by iteration executions.
+        """
+        history = []
+        history_ai_msg = variable_pool.get_history(node_id=self.node_id)
+        for history_item in history_ai_msg:
+            history.append(history_item.dict())
+
+        history_v2 = []
+        if variable_pool.history_v2:
+            # Keep master-stash semantics by passing origin_history only,
+            # but deep copy it so parallel iterations never share mutable items.
+            history_v2 = copy.deepcopy(variable_pool.history_v2.origin_history)
+        return history, history_v2
+
+    def _append_batch_outputs(
+        self, batch_result_dict: dict[str, list[Any]], outputs: dict[str, Any]
+    ) -> None:
+        """
+        Append one successful batch result into the aggregated result dictionary.
+        """
+        for result_key, result_value in outputs.items():
+            if result_key not in batch_result_dict:
+                batch_result_dict[result_key] = []
+            batch_result_dict[result_key].append(result_value)
+
+    def _get_error_strategy(self) -> ErrorStrategy:
+        """
+        Normalize the configured error strategy.
+        """
+        try:
+            return ErrorStrategy(self.errorStrategy)
+        except ValueError:
+            return ErrorStrategy.FAIL_FAST
+
+    def _build_iteration_start_inputs(
+        self, iteration_engine: Any, batch_data: Any
+    ) -> dict[str, Any]:
+        """
+        Build iteration start inputs from the child start node declaration.
+        """
+        start_node_id = iteration_engine.sparkflow_engine_node.node_id
+        output_variable_mapping = getattr(
+            iteration_engine.engine_ctx.variable_pool,
+            "output_variable_mapping",
+            {},
+        )
+        available_start_keys = [
+            mapping_key.split(f"{start_node_id}-", 1)[1]
+            for mapping_key in output_variable_mapping.keys()
+            if mapping_key.startswith(f"{start_node_id}-")
+        ]
+        start_output_identifier = getattr(
+            iteration_engine.sparkflow_engine_node.node_instance,
+            "output_identifier",
+            [],
+        )
+
+        if start_output_identifier and all(
+            key in available_start_keys for key in start_output_identifier
+        ):
+            resolved_start_keys = start_output_identifier
+        elif available_start_keys:
+            resolved_start_keys = available_start_keys
+        else:
+            resolved_start_keys = []
+
+        if not resolved_start_keys:
+            return {self.input_identifier[0]: batch_data}
+
+        if len(resolved_start_keys) == 1:
+            return {resolved_start_keys[0]: batch_data}
+
+        if isinstance(batch_data, dict):
+            return {
+                key: batch_data.get(key)
+                for key in resolved_start_keys
+                if key in batch_data
+            }
+
+        return {resolved_start_keys[0]: batch_data}
+
     async def _process_single_batch(
         self,
         batch_data: Any,
@@ -176,7 +1002,9 @@ class IterationNode(BaseNode):
         :param event_log_trace: Event logging trace for the workflow
         :return: NodeRunResult containing the execution results for this batch item
         """
-        cur_batch_data_dict = {self.input_identifier[0]: batch_data}
+        cur_batch_data_dict = self._build_iteration_start_inputs(
+            iteration_one_engine, batch_data
+        )
 
         # Prepare execution environment for this iteration
         new_variable_pool = copy.deepcopy(temp_variable_pool)
@@ -185,33 +1013,53 @@ class IterationNode(BaseNode):
         iteration_one_engine.engine_ctx.variable_pool = new_variable_pool
         iteration_one_engine.engine_ctx.chains = iteration_chains
 
-        # Convert legacy history format for compatibility
-        history = []
-        history_ai_msg = variable_pool.get_history(node_id=self.node_id)
-        for h in history_ai_msg:
-            history.append(h.dict())
+        try:
+            # Convert legacy history format for compatibility
+            history, history_v2 = self._build_iteration_history(variable_pool)
+            return await iteration_one_engine.async_run(
+                inputs=cur_batch_data_dict,
+                span=span,
+                callback=callbacks,
+                history=history,
+                history_v2=history_v2,
+                event_log_trace=event_log_trace,
+            )
+        finally:
+            await self._reset_iteration_engine_state(
+                iteration_one_engine=iteration_one_engine,
+                iteration_chains=iteration_chains,
+                variable_pool=new_variable_pool,
+            )
 
-        # Use original history for iteration nodes without rounds and token processing
-        history_v2 = []
-        if variable_pool.history_v2:
-            history_v2 = variable_pool.history_v2.origin_history
-        res = await iteration_one_engine.async_run(
-            inputs=cur_batch_data_dict,
-            span=span,
-            callback=callbacks,
-            history=history,
-            history_v2=history_v2,
-            event_log_trace=event_log_trace,
-        )
+    async def _reset_iteration_engine_state(
+        self,
+        iteration_one_engine: Any,
+        iteration_chains: Chains,
+        variable_pool: VariablePool,
+    ) -> None:
+        """
+        Reset the shared serial iteration engine after each batch attempt.
+        """
+        pending_tasks: list[asyncio.Task[Any]] = []
+        for task in iteration_one_engine.engine_ctx.dfs_tasks:
+            if not isinstance(task, asyncio.Task):
+                continue
+            if task.done():
+                continue
+            task.cancel()
+            pending_tasks.append(task)
 
-        # Reset node running status after each iteration execution
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
         self._init_iteration_node(
             iteration_one_engine.engine_ctx.node_run_status,
             iteration_chains,
             variable_pool,
         )
+        iteration_one_engine.engine_ctx.responses.clear()
+        iteration_one_engine.engine_ctx.dfs_tasks.clear()
         iteration_one_engine.engine_ctx.end_complete = asyncio.Event()
-        return res
 
     def _init_iteration_node(
         self,


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->

- Add parallel execution support for iteration nodes with configurable concurrency, timeout, and error handling strategies
- Isolate child iteration execution context, including callback queues, variable pools, and history state, to prevent cross-batch interference
- Improve workflow engine task handling and cleanup to better support iteration subgraph execution and cancellation scenarios
- Add iteration sub-DSL extraction and chain resolution enhancements for standalone child workflow execution
- Update ordered streaming callback handling to keep parallel iteration outputs isolated and correctly sequenced

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
