### PR TITLE
fix: pass bot template when creating bot

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -1377,6 +1377,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     // 人设相关字段
                     enablePersonality: personalityData.enablePersonality,
                     personalityConfig: personalityData.personalityConfig,
+                    botTemplate: botTemplateInfoValue?.botTemplate || '',
                   };
 
                   insertBot(obj)
@@ -1426,6 +1427,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     // 人设相关字段
                     enablePersonality: personalityData.enablePersonality,
                     personalityConfig: personalityData.personalityConfig,
+                    botTemplate: botTemplateInfoValue?.botTemplate || '',
                   };
 
                   insertBot(obj)


### PR DESCRIPTION
## Summary
- include `botTemplate` in the create-bot payload built from the config page flow
- fix both create branches so template-based agent creation persists the selected template id
- keep the change scoped to the frontend request assembly because backend DTOs and mapper fields already support `botTemplate`

## Testing
- `git diff --check`

## Notes
- I traced the issue through the existing frontend type, backend DTO, and mapper support for `botTemplate`.
- The missing field was in the config-page `insertBot(obj)` payload assembly, so this PR only patches that final request-building step.
