### PR TITLE
fix(knowledge): RAGFlow RAG重新切片时出现重复的RAGFlow文档

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
@@ -7,6 +7,7 @@ import com.iflytek.astron.console.toolkit.entity.core.knowledge.*;
 import com.iflytek.astron.console.toolkit.util.OkHttpUtil;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -46,16 +47,18 @@ public class KnowledgeV2ServiceCallHandler {
      * @param separator separator list
      * @param ragType RAG type
      * @param resourceType resource type (0=file, 1=html)
+     * @param oldDocId existing RAGFlow doc id for upsert; null for first slice
      * @return KnowledgeResponse
      */
     public KnowledgeResponse documentUpload(MultipartFile multipartFile,
             List<Integer> lengthRange, List<String> separator,
-            String ragType, Integer resourceType) {
+            String ragType, Integer resourceType,
+            String oldDocId) {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/document/upload");
 
         try {
-            log.info("documentUpload fileName: {}, fileSize: {} bytes",
-                    multipartFile.getOriginalFilename(), multipartFile.getSize());
+            log.info("documentUpload fileName: {}, fileSize: {} bytes, oldDocId: {}",
+                    multipartFile.getOriginalFilename(), multipartFile.getSize(), oldDocId);
 
             Map<String, Object> params = new HashMap<>();
             params.put("file", multipartFile);
@@ -68,6 +71,9 @@ public class KnowledgeV2ServiceCallHandler {
             params.put("ragType", ragType);
             if (resourceType != null) {
                 params.put("resourceType", resourceType.toString());
+            }
+            if (StringUtils.isNotBlank(oldDocId)) {
+                params.put("documentId", oldDocId);
             }
 
             log.info("documentUpload url = {}, ragType = {}, resourceType = {}", url, ragType, resourceType);

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
@@ -525,9 +525,17 @@ public class KnowledgeService {
 
             Integer resourceType = ProjectContent.HTML_FILE_TYPE.equals(fileInfoV2.getType()) ? 1 : 0;
 
+            // Only Ragflow-RAG forwards a previous doc id for upsert; CBG-RAG
+            // shares this method but its request body must stay unchanged.
+            String oldDocId =
+                    ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(fileInfoV2.getSource())
+                            ? fileInfoV2.getLastUuid()
+                            : null;
+
             return knowledgeV2ServiceCallHandler.documentUpload(
                     multipartFile, sliceConfig.getLengthRange(), separator,
-                    fileInfoV2.getSource(), resourceType);
+                    fileInfoV2.getSource(), resourceType,
+                    oldDocId);
 
         } catch (Exception e) {
             log.error("Failed to upload file for chunking: {}", e.getMessage(), e);

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -8,6 +8,7 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.toolkit.common.constant.ProjectContent;
+import com.iflytek.astron.console.toolkit.config.properties.BizConfig;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
 import com.iflytek.astron.console.toolkit.entity.core.knowledge.*;
 import com.iflytek.astron.console.toolkit.entity.mongo.Knowledge;
@@ -1773,6 +1774,17 @@ class KnowledgeServiceTest {
             mockSliceConfig = new SliceConfig();
             mockSliceConfig.setLengthRange(Arrays.asList(300, 800));
             mockSliceConfig.setSeperator(Arrays.asList("\n"));
+
+            // Mirror production wiring so Ragflow-RAG routes through
+            // doCbgUploadSplit instead of the literal-only fallback.
+            BizConfig bizConfig = new BizConfig();
+            bizConfig.setCbgRagCompatibleSources(Arrays.asList("CBG-RAG", "Ragflow-RAG"));
+            new ProjectContent().setBizConfig(bizConfig);
+        }
+
+        @AfterEach
+        void tearDown() {
+            new ProjectContent().setBizConfig(null);
         }
 
         /**
@@ -1823,6 +1835,8 @@ class KnowledgeServiceTest {
             String url = "http://example.com/document.txt";
             mockFileInfo.setSource("CBG-RAG");
             mockFileInfo.setType("text/plain");
+            // Regression guard: CBG-RAG must not forward oldDocId even if lastUuid exists.
+            mockFileInfo.setLastUuid("cbg-previous-doc-id");
 
             KnowledgeResponse response = new KnowledgeResponse();
             response.setCode(0);
@@ -1835,7 +1849,7 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1847,7 +1861,87 @@ class KnowledgeServiceTest {
 
             // Then
             verify(s3Util, times(1)).getObject(anyString());
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(any(), any(), any(), any(), any());
+            // CBG-RAG multipart form must not carry documentId.
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
+                    any(), any(), any(), any(), any(), isNull());
+        }
+
+        /**
+         * Ragflow-RAG first-time slice: lastUuid=null, oldDocId stays null,
+         * Python uses the legacy create-only path.
+         */
+        @Test
+        @DisplayName("Extract knowledge with Ragflow-RAG source, first slice (lastUuid=null)")
+        void testKnowledgeExtractAsync_RagflowRAG_FirstSlice() {
+            // Given
+            String contentType = "text/plain";
+            String url = "http://example.com/document.txt";
+            mockFileInfo.setSource("Ragflow-RAG");
+            mockFileInfo.setType("text/plain");
+            mockFileInfo.setLastUuid(null); // FIRST slice — no previous doc id
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            JSONArray dataArray = new JSONArray();
+            ChunkInfo chunk = new ChunkInfo();
+            chunk.setContent("First slice chunk");
+            chunk.setDocId("ragflow-doc-001");
+            dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
+            response.setData(dataArray);
+
+            when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
+            when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
+            when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
+            when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
+            when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
+
+            // When
+            knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
+
+            // Then: first slice => oldDocId is null (Python side uses legacy path)
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
+                    any(), any(), any(), any(), any(), isNull());
+        }
+
+        /**
+         * Ragflow-RAG re-slice: existing lastUuid is forwarded as oldDocId to
+         * trigger the Python upsert path.
+         */
+        @Test
+        @DisplayName("Extract knowledge with Ragflow-RAG source, re-slice forwards lastUuid")
+        void testKnowledgeExtractAsync_RagflowRAG_ReSlice() {
+            // Given
+            String contentType = "text/plain";
+            String url = "http://example.com/document.txt";
+            mockFileInfo.setSource("Ragflow-RAG");
+            mockFileInfo.setType("text/plain");
+            mockFileInfo.setLastUuid("doc-old-ragflow"); // RE-SLICE — has previous doc
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            JSONArray dataArray = new JSONArray();
+            ChunkInfo chunk = new ChunkInfo();
+            chunk.setContent("Re-slice chunk");
+            chunk.setDocId("doc-new-ragflow");
+            dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
+            response.setData(dataArray);
+
+            when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
+            when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
+            when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
+            when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
+            when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
+
+            // When
+            knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
+
+            // Then: re-slice => oldDocId passed as the previous doc id
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
+                    any(), any(), any(), any(), any(), eq("doc-old-ragflow"));
         }
 
         /**
@@ -2137,7 +2231,7 @@ class KnowledgeServiceTest {
             dealFileResult.setTaskId("task-001");
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);

--- a/core/knowledge/api/v1/api.py
+++ b/core/knowledge/api/v1/api.py
@@ -226,6 +226,13 @@ async def file_upload(
     separator: Optional[str] = Form(
         None, description='Delimiter JSON array, such as ["\\n", ". "]'
     ),
+    documentId: Optional[str] = Form(
+        None,
+        description=(
+            "Existing RAGFlow doc id, triggers blue-green upsert. "
+            "Omit or leave empty for first-time slicing."
+        ),
+    ),
     app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
@@ -255,6 +262,7 @@ async def file_upload(
                         "ragType": ragType,
                         "lengthRange": lengthRange,
                         "separator": separator,
+                        "documentId": documentId,
                     },
                     ensure_ascii=False,
                 )
@@ -284,6 +292,7 @@ async def file_upload(
             file=file,
             lengthRange=parsed_length_range,
             separator=parsed_separator,
+            document_id=documentId,
         )
 
 

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -199,6 +199,7 @@ class RagflowRAGStrategy(RAGStrategy):
         separator: Optional[List[str]] = None,
         titleSplit: bool = False,
         cutOff: Optional[List[str]] = None,
+        document_id: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Dict[str, Any]]:
         """
@@ -263,14 +264,19 @@ class RagflowRAGStrategy(RAGStrategy):
             dataset_id = await RagflowUtils.ensure_dataset(group)
             logger.info("Using dataset: %s, name: %s", dataset_id, group)
 
-            # Step 2-3: Process document upload
-            doc_id = await self._process_document_upload(file_input, dataset_id)
-
-            # Step 4-5: Handle document parsing
-            await self._handle_document_parsing(dataset_id, doc_id)
-
-            # Step 6: Get chunk content
-            chunks_data = await RagflowUtils.get_document_chunks(dataset_id, doc_id)
+            if document_id:
+                logger.info("re-slice upsert old_doc_id=%s", document_id)
+                doc_id, chunks_data = await self._upsert_document(
+                    file_input, dataset_id, document_id
+                )
+            else:
+                doc_id = await self._process_document_upload(
+                    file_input, dataset_id
+                )
+                await self._handle_document_parsing(dataset_id, doc_id)
+                chunks_data = await RagflowUtils.get_document_chunks(
+                    dataset_id, doc_id
+                )
 
             # Step 7: Convert to standard format
             result = RagflowUtils.convert_to_standard_format(doc_id, chunks_data)
@@ -1013,3 +1019,81 @@ class RagflowRAGStrategy(RAGStrategy):
         except Exception as e:
             logger.error(f"Failed to query document information: {e}")
             return None
+
+    async def _upsert_document(
+        self,
+        file_input: Any,
+        dataset_id: str,
+        old_doc_id: str,
+    ) -> tuple[str, List[Dict[str, Any]]]:
+        """Atomic upsert: upload + parse + fetch chunks + delete old.
+
+        Any failure at any step rolls back the pending new doc and preserves
+        old_doc_id. Chunks fetch is intentionally inside the transaction:
+        RagflowUtils.get_document_chunks silently returns [] on fetch
+        failure, so deleting the old doc before verifying non-empty chunks
+        would strand the file as un-retrievable.
+
+        Returns (new_doc_id, chunks_data) with chunks_data non-empty.
+        """
+        pending_doc_id = await self._process_document_upload(file_input, dataset_id)
+        logger.info(
+            "upsert pending_doc_id=%s, old_doc_id=%s", pending_doc_id, old_doc_id
+        )
+
+        try:
+            await self._handle_document_parsing(dataset_id, pending_doc_id)
+        except Exception:
+            logger.exception("upsert parse failed, rolling back %s", pending_doc_id)
+            await self._safe_delete_document(dataset_id, pending_doc_id, log_only=True)
+            raise
+
+        try:
+            chunks_data = await RagflowUtils.get_document_chunks(
+                dataset_id, pending_doc_id
+            )
+        except Exception:
+            logger.exception("upsert fetch failed, rolling back %s", pending_doc_id)
+            await self._safe_delete_document(dataset_id, pending_doc_id, log_only=True)
+            raise
+
+        if not chunks_data:
+            logger.error(
+                "upsert new doc %s returned zero chunks, rolling back",
+                pending_doc_id,
+            )
+            await self._safe_delete_document(dataset_id, pending_doc_id, log_only=True)
+            raise CustomException(
+                CodeEnum.ChunkQueryFailed,
+                f"Upsert produced zero chunks for pending doc {pending_doc_id}",
+            )
+
+        await self._safe_delete_document(dataset_id, old_doc_id, log_only=True)
+        return pending_doc_id, chunks_data
+
+    async def _safe_delete_document(
+        self,
+        dataset_id: str,
+        doc_id: str,
+        log_only: bool = False,
+    ) -> None:
+        """Delete a RAGFlow document. With log_only=True, swallow errors so
+        a delete failure doesn't mask a more important exception."""
+        try:
+            resp = await ragflow_client.delete_documents(dataset_id, [doc_id])
+            if resp.get("code") == 0:
+                logger.info("deleted RAGFlow doc: %s", doc_id)
+                return
+            msg = resp.get("message", "unknown")
+            logger.warning("delete doc %s non-zero: %s", doc_id, msg)
+            if not log_only:
+                raise CustomException(
+                    CodeEnum.ChunkDeleteFailed,
+                    f"Failed to delete document {doc_id}: {msg}",
+                )
+        except CustomException:
+            raise
+        except Exception as e:
+            logger.warning("delete doc %s raised: %s", doc_id, e)
+            if not log_only:
+                raise

--- a/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for RagflowRAGStrategy blue-green upsert path.
+
+Covers:
+- `_safe_delete_document()` — thin wrapper around `ragflow_client.delete_documents`
+- `_upsert_document()` — blue-green upsert orchestration (later task)
+- `RagflowRAGStrategy.split()` — document_id branching (later task)
+- Cross-strategy `**kwargs` compatibility (later task)
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.consts.error_code import CodeEnum
+from knowledge.exceptions.exception import CustomException
+from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+
+# ----------------------------------------------------------------------
+# Section A: _safe_delete_document
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_delete_document_log_only_true_swallows_non_zero_code():
+    """log_only=True + RAGFlow returns non-zero code => NO exception."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_documents",
+        new=AsyncMock(return_value={"code": 102, "message": "document not found"}),
+    ) as mock_delete:
+        await strategy._safe_delete_document(
+            dataset_id="ds-1", doc_id="doc-x", log_only=True
+        )
+        mock_delete.assert_awaited_once_with("ds-1", ["doc-x"])
+
+
+@pytest.mark.asyncio
+async def test_safe_delete_document_log_only_false_raises_on_non_zero_code():
+    """log_only=False + RAGFlow returns non-zero code => CustomException."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_documents",
+        new=AsyncMock(return_value={"code": 500, "message": "internal error"}),
+    ):
+        with pytest.raises(CustomException) as exc_info:
+            await strategy._safe_delete_document(
+                dataset_id="ds-1", doc_id="doc-x", log_only=False
+            )
+    assert exc_info.value.code == CodeEnum.ChunkDeleteFailed.code
+
+
+@pytest.mark.asyncio
+async def test_safe_delete_document_success_returns_silently():
+    """RAGFlow returns code == 0 => success, no exception for either mode."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_documents",
+        new=AsyncMock(return_value={"code": 0}),
+    ):
+        await strategy._safe_delete_document(
+            dataset_id="ds-1", doc_id="doc-x", log_only=False
+        )
+        await strategy._safe_delete_document(
+            dataset_id="ds-1", doc_id="doc-y", log_only=True
+        )
+
+
+# ----------------------------------------------------------------------
+# Section B: _upsert_document (blue-green orchestrator)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_happy_path_deletes_old_returns_new(monkeypatch):
+    """Upload OK + parse OK + fetch chunks OK + delete old OK =>
+    returns (pending_doc_id, chunks_data) tuple."""
+    strategy = RagflowRAGStrategy()
+    file_input = object()  # placeholder; strategies accept anything here
+    new_doc_id = "new-doc-abc"
+    fake_chunks = [{"id": "c1", "content": "hello world"}]
+
+    async def fake_get_chunks(dataset_id, doc_id, **kwargs):
+        return fake_chunks
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        fake_get_chunks,
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value=new_doc_id),
+        ) as mock_upload,
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ) as mock_parse,
+        patch.object(
+            strategy,
+            "_safe_delete_document",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        result = await strategy._upsert_document(
+            file_input=file_input,
+            dataset_id="ds-1",
+            old_doc_id="old-doc-xyz",
+        )
+
+    # Return is now a tuple of (doc_id, chunks_data) since the fetch+validate
+    # is absorbed into the atomic transaction.
+    assert result == (new_doc_id, fake_chunks)
+    mock_upload.assert_awaited_once_with(file_input, "ds-1")
+    mock_parse.assert_awaited_once_with("ds-1", new_doc_id)
+    # Only the OLD doc is deleted on success; pending is kept (it's now live)
+    mock_delete.assert_awaited_once_with("ds-1", "old-doc-xyz", log_only=True)
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_upload_fails_no_delete_called():
+    """Upload raises => exception propagates, _safe_delete_document NOT called."""
+    strategy = RagflowRAGStrategy()
+    upload_error = ValueError("S3 unreachable")
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(side_effect=upload_error),
+        ),
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ) as mock_parse,
+        patch.object(
+            strategy,
+            "_safe_delete_document",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        with pytest.raises(ValueError, match="S3 unreachable"):
+            await strategy._upsert_document(
+                file_input=object(),
+                dataset_id="ds-1",
+                old_doc_id="old-doc-xyz",
+            )
+
+    mock_parse.assert_not_awaited()
+    mock_delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_parse_fails_deletes_pending_not_old():
+    """Upload OK + parse fails => delete PENDING doc, propagate parse error,
+    OLD doc stays alive (DB.lastUuid unchanged)."""
+    strategy = RagflowRAGStrategy()
+    pending_doc_id = "pending-doc-new"
+    parse_error = ValueError("parse timeout")
+
+    delete_calls = []
+
+    async def mock_safe_delete(dataset_id, doc_id, log_only=False):
+        delete_calls.append((dataset_id, doc_id, log_only))
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value=pending_doc_id),
+        ),
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(side_effect=parse_error),
+        ),
+        patch.object(
+            strategy,
+            "_safe_delete_document",
+            new=AsyncMock(side_effect=mock_safe_delete),
+        ),
+    ):
+        with pytest.raises(ValueError, match="parse timeout"):
+            await strategy._upsert_document(
+                file_input=object(),
+                dataset_id="ds-1",
+                old_doc_id="old-doc-xyz",
+            )
+
+    # Exactly one delete call, targeting the PENDING doc (rollback), not the old one
+    assert delete_calls == [("ds-1", pending_doc_id, True)]
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_delete_old_is_best_effort_returns_new_anyway(
+    monkeypatch,
+):
+    """Upload OK + parse OK + fetch chunks OK + delete OLD is called with
+    log_only=True. _safe_delete_document swallows its internal failures via
+    log_only=True, so the caller ALWAYS sees the new (doc_id, chunks) tuple
+    even if old-doc cleanup fails underneath. We validate the contract by
+    checking the kwargs passed."""
+    strategy = RagflowRAGStrategy()
+    new_doc_id = "new-doc-ok"
+    fake_chunks = [{"id": "c1", "content": "chunk content"}]
+
+    async def fake_get_chunks(dataset_id, doc_id, **kwargs):
+        return fake_chunks
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        fake_get_chunks,
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value=new_doc_id),
+        ),
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            strategy,
+            "_safe_delete_document",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        result = await strategy._upsert_document(
+            file_input=object(),
+            dataset_id="ds-1",
+            old_doc_id="old-doc-xyz",
+        )
+
+    assert result == (new_doc_id, fake_chunks)
+    # Commit-phase old-doc delete uses log_only=True so any internal failure
+    # is swallowed by _safe_delete_document itself (tested in Section A).
+    mock_delete.assert_awaited_once_with("ds-1", "old-doc-xyz", log_only=True)
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_get_chunks_raises_rolls_back_pending(monkeypatch):
+    """Fetch raise => rollback pending, preserve old doc, re-raise."""
+    strategy = RagflowRAGStrategy()
+    pending_doc_id = "pending-doc-abc"
+    fetch_error = ValueError("RAGFlow index not ready")
+
+    delete_calls = []
+
+    async def mock_safe_delete(dataset_id, doc_id, log_only=False):
+        delete_calls.append((dataset_id, doc_id, log_only))
+
+    async def mock_get_chunks(dataset_id, doc_id, **kwargs):
+        raise fetch_error
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        mock_get_chunks,
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value=pending_doc_id),
+        ),
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            strategy,
+            "_safe_delete_document",
+            new=AsyncMock(side_effect=mock_safe_delete),
+        ),
+    ):
+        with pytest.raises(ValueError, match="RAGFlow index not ready"):
+            await strategy._upsert_document(
+                file_input=object(),
+                dataset_id="ds-1",
+                old_doc_id="old-doc-xyz",
+            )
+
+    # Exactly ONE delete call: the PENDING doc (rollback). Old doc must NOT be touched.
+    assert delete_calls == [("ds-1", pending_doc_id, True)]
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_get_chunks_empty_rolls_back_pending(monkeypatch):
+    """Fetch returns [] => treat as failure, rollback pending, preserve old doc."""
+    strategy = RagflowRAGStrategy()
+    pending_doc_id = "pending-doc-xyz"
+
+    delete_calls = []
+
+    async def mock_safe_delete(dataset_id, doc_id, log_only=False):
+        delete_calls.append((dataset_id, doc_id, log_only))
+
+    async def mock_get_chunks_empty(dataset_id, doc_id, **kwargs):
+        return []  # simulate the silent-failure path in ragflow_utils.py:344-346
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        mock_get_chunks_empty,
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value=pending_doc_id),
+        ),
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            strategy,
+            "_safe_delete_document",
+            new=AsyncMock(side_effect=mock_safe_delete),
+        ),
+    ):
+        # Empty chunks raises CustomException(ChunkQueryFailed) — same
+        # domain error pattern the rest of ragflow_strategy uses for empty
+        # chunk lists (see lines 621-625, 796). Downstream Java sees this
+        # as a failed upload and leaves lastUuid untouched.
+        with pytest.raises(CustomException) as exc_info:
+            await strategy._upsert_document(
+                file_input=object(),
+                dataset_id="ds-1",
+                old_doc_id="old-doc-preserved",
+            )
+
+    assert exc_info.value.code == CodeEnum.ChunkQueryFailed.code
+    assert "zero chunks" in str(exc_info.value)
+    # Only the pending doc is deleted; old doc is preserved.
+    assert delete_calls == [("ds-1", pending_doc_id, True)]
+
+
+# ----------------------------------------------------------------------
+# Section C: split() — document_id routing
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_split_document_id_none_uses_legacy_create_only_path(monkeypatch):
+    """split(document_id=None) => _upsert_document NOT called, legacy path used."""
+    strategy = RagflowRAGStrategy()
+    file_input = object()
+
+    async def fake_ensure_dataset(group):
+        return "ds-1"
+
+    async def fake_get_document_chunks(dataset_id, doc_id):
+        return []
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset",
+        fake_ensure_dataset,
+    )
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        fake_get_document_chunks,
+    )
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.convert_to_standard_format",
+        lambda doc_id, chunks: [],
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value="legacy-doc-id"),
+        ) as mock_upload,
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ) as mock_parse,
+        patch.object(
+            strategy,
+            "_upsert_document",
+            new=AsyncMock(return_value="should-not-be-used"),
+        ) as mock_upsert,
+    ):
+        await strategy.split(file=file_input, document_id=None)
+
+    mock_upsert.assert_not_awaited()
+    mock_upload.assert_awaited_once_with(file_input, "ds-1")
+    mock_parse.assert_awaited_once_with("ds-1", "legacy-doc-id")
+
+
+@pytest.mark.asyncio
+async def test_split_document_id_set_uses_upsert_path(monkeypatch):
+    """split(document_id='doc-old') => _upsert_document called, legacy path not.
+
+    _upsert_document returns a (doc_id, chunks) tuple that split() unpacks
+    directly, so split() no longer calls get_document_chunks in the upsert
+    branch. The get_document_chunks monkeypatch below is a safety net in
+    case a future refactor reintroduces the outer-branch call.
+    """
+    strategy = RagflowRAGStrategy()
+    file_input = object()
+
+    async def fake_ensure_dataset(group):
+        return "ds-1"
+
+    async def fake_get_document_chunks(dataset_id, doc_id):
+        return []
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset",
+        fake_ensure_dataset,
+    )
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        fake_get_document_chunks,
+    )
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.convert_to_standard_format",
+        lambda doc_id, chunks: [],
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_upsert_document",
+            new=AsyncMock(return_value=("new-doc-upsert", [{"id": "c1"}])),
+        ) as mock_upsert,
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value="should-not-be-used"),
+        ) as mock_upload,
+        patch.object(
+            strategy,
+            "_handle_document_parsing",
+            new=AsyncMock(return_value=None),
+        ) as mock_parse,
+    ):
+        await strategy.split(file=file_input, document_id="doc-old")
+
+    mock_upsert.assert_awaited_once_with(file_input, "ds-1", "doc-old")
+    mock_upload.assert_not_awaited()
+    mock_parse.assert_not_awaited()
+
+
+# ----------------------------------------------------------------------
+# Section D: /knowledge/v1/document/upload — documentId form field passthrough
+# ----------------------------------------------------------------------
+
+
+def _build_test_app_for_upload(monkeypatch):
+    """Build a minimal FastAPI app that mounts rag_router for TestClient use.
+
+    The production api.py exposes `rag_router` as an APIRouter with prefix
+    `/knowledge/v1`; we wrap it in a bare FastAPI() so TestClient can route
+    to it without pulling in the whole service bootstrap (OTLP, DB, etc.).
+
+    We also monkeypatch `get_span_and_metric` because it reaches out to the
+    OTLP service manager which is not initialized in test environments.
+    """
+    from fastapi import FastAPI
+
+    from knowledge.api.v1 import api as api_module
+
+    # Stub get_span_and_metric so the handler can call span/metric methods
+    # without a live OTLP service manager.
+    class _StubSpanCtx:
+        sid = "test-sid"
+
+        def add_info_events(self, *_args, **_kwargs):
+            pass
+
+        def record_exception(self, *_args, **_kwargs):
+            pass
+
+    class _StubSpan:
+        def start(self, *_args, **_kwargs):
+            stub = _StubSpanCtx()
+
+            class _Cm:
+                def __enter__(self_inner):
+                    return stub
+
+                def __exit__(self_inner, *exc):
+                    return False
+
+            return _Cm()
+
+    class _StubMetric:
+        def in_success_count(self):
+            pass
+
+        def in_error_count(self, *_args, **_kwargs):
+            pass
+
+    def fake_get_span_and_metric(app_id: str, function_name: str = "unknown"):
+        return _StubSpan(), _StubMetric()
+
+    monkeypatch.setattr(api_module, "get_span_and_metric", fake_get_span_and_metric)
+
+    app = FastAPI()
+    # rag_router already has prefix="/knowledge/v1"; mount without extra prefix
+    # so the path matches production (main.py does the same).
+    app.include_router(api_module.rag_router)
+    return app, api_module
+
+
+def test_file_upload_endpoint_no_document_id_passes_none_to_strategy(
+    monkeypatch,
+):
+    """POST /knowledge/v1/document/upload WITHOUT documentId form field =>
+    strategy.split receives document_id=None."""
+    from fastapi.testclient import TestClient
+
+    app, api_module = _build_test_app_for_upload(monkeypatch)
+
+    captured = {}
+
+    async def fake_split(self, **kwargs):
+        captured.update(kwargs)
+        # strip out the span kwarg that handle_rag_operation injects
+        captured.pop("span", None)
+        return []
+
+    # Patch the strategy method so we intercept what the router forwards
+    from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+    monkeypatch.setattr(RagflowRAGStrategy, "split", fake_split)
+
+    # Override the get_app_id dependency so we don't need real auth
+    from knowledge.api.v1.api import get_app_id
+
+    app.dependency_overrides[get_app_id] = lambda: "test-app"
+
+    client = TestClient(app)
+    files = {"file": ("t.txt", b"hello", "text/plain")}
+    data = {"ragType": "Ragflow-RAG"}
+
+    resp = client.post("/knowledge/v1/document/upload", files=files, data=data)
+
+    assert resp.status_code == 200, (
+        f"Expected 200, got {resp.status_code}, body={resp.text}"
+    )
+    assert "document_id" in captured, (
+        "Expected split() to receive document_id kwarg (value may be None)"
+    )
+    assert captured["document_id"] is None
+
+
+def test_file_upload_endpoint_with_document_id_passes_value_to_strategy(
+    monkeypatch,
+):
+    """POST /knowledge/v1/document/upload WITH documentId=doc-old =>
+    strategy.split receives document_id='doc-old'."""
+    from fastapi.testclient import TestClient
+
+    app, api_module = _build_test_app_for_upload(monkeypatch)
+
+    captured = {}
+
+    async def fake_split(self, **kwargs):
+        captured.update(kwargs)
+        captured.pop("span", None)
+        return []
+
+    from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+    monkeypatch.setattr(RagflowRAGStrategy, "split", fake_split)
+
+    from knowledge.api.v1.api import get_app_id
+
+    app.dependency_overrides[get_app_id] = lambda: "test-app"
+
+    client = TestClient(app)
+    files = {"file": ("t.txt", b"hello", "text/plain")}
+    data = {"ragType": "Ragflow-RAG", "documentId": "doc-old"}
+
+    resp = client.post("/knowledge/v1/document/upload", files=files, data=data)
+
+    assert resp.status_code == 200, (
+        f"Expected 200, got {resp.status_code}, body={resp.text}"
+    )
+    assert captured.get("document_id") == "doc-old", (
+        f"Expected document_id='doc-old', got {captured.get('document_id')!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Section E: cross-strategy **kwargs forward-compat regression guard
+# ----------------------------------------------------------------------
+# /v1/document/upload always forwards document_id to strategy.split().
+# Only RagflowRAGStrategy acts on it; the other strategies must silently
+# ignore it via **kwargs. If these tests fail, restore **kwargs — don't
+# delete the tests.
+
+
+import inspect
+
+
+def _split_signature_accepts_var_keyword(strategy_cls):
+    """Return True iff strategy_cls.split() has a **kwargs (VAR_KEYWORD) param."""
+    sig = inspect.signature(strategy_cls.split)
+    return any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+
+
+def test_aiui_strategy_split_accepts_var_keyword_for_forward_compat():
+    """AIUI strategy must keep **kwargs so document_id is silently ignored."""
+    from knowledge.service.impl.aiui_strategy import AIUIRAGStrategy
+
+    assert _split_signature_accepts_var_keyword(AIUIRAGStrategy), (
+        f"{AIUIRAGStrategy.__name__}.split() dropped **kwargs — breaks "
+        "forward-compat for non-Ragflow strategies."
+    )
+
+
+def test_cbg_strategy_split_accepts_var_keyword_for_forward_compat():
+    """CBG strategy must keep **kwargs so document_id is silently ignored."""
+    from knowledge.service.impl.cbg_strategy import CBGRAGStrategy
+
+    assert _split_signature_accepts_var_keyword(CBGRAGStrategy), (
+        f"{CBGRAGStrategy.__name__}.split() dropped **kwargs — breaks "
+        "forward-compat for non-Ragflow strategies."
+    )
+
+
+def test_sparkdesk_strategy_split_accepts_var_keyword_for_forward_compat():
+    """SparkDesk strategy must keep **kwargs so document_id is silently ignored."""
+    from knowledge.service.impl.sparkdesk_strategy import SparkDeskRAGStrategy
+
+    assert _split_signature_accepts_var_keyword(SparkDeskRAGStrategy), (
+        f"{SparkDeskRAGStrategy.__name__}.split() dropped **kwargs — breaks "
+        "forward-compat for non-Ragflow strategies."
+    )


### PR DESCRIPTION
Fixes #1186

Previously, every save of slice config on a Ragflow-RAG knowledge base uploaded a brand-new RAGFlow document and left the previous one as an orphan, accumulating N copies per file. FileInfoV2.lastUuid already stored the previous doc id on the Java side but was never forwarded to Python, so RagflowRAGStrategy.split() unconditionally created new docs.

This PR wires lastUuid end-to-end and implements an atomic blue-green upsert on the Python side: upload new -> parse -> fetch chunks -> delete old. Any failure in upload, parse, fetch, or an empty-chunks response rolls back the pending new doc and preserves the old doc, so the file stays retrievable.

Python (core-knowledge):
- New RagflowRAGStrategy._upsert_document runs the full atomic transaction. New _safe_delete_document helper wraps ragflow_client.delete_documents with optional log-only swallow for both commit and rollback phases.
- split() accepts optional document_id and routes re-slice calls to _upsert_document; first-time slicing keeps the legacy create-only path unchanged.
- /knowledge/v1/document/upload gains an Optional[str] Form field documentId that is forwarded as snake_case document_id to strategy.split(). AIUI / CBG / SparkDesk strategies already accept **kwargs, so the new field is silently ignored by them; a static regression guard locks that contract.

Java (console-backend-toolkit):
- KnowledgeV2ServiceCallHandler.documentUpload() gains a trailing String oldDocId parameter that is conditionally appended as the documentId multipart form field when non-blank.
- KnowledgeService.doCbgUploadSplit() reads fileInfoV2.getLastUuid() only when the source equals FILE_SOURCE_RAG_FLOW_RAG_STR; CBG-RAG continues to pass null so its multipart form stays bit-for-bit unchanged. A new regression test enforces this.

Known limitation:
A short consistency window exists between the Python delete-old step and the Java DB update of lastUuid. If Java crashes in that window, recovery is triggered on the next user-initiated slice (Python will attempt to delete the already-gone old_doc_id via log_only=True and continue). A complete fix adding a /knowledge/v1/document/delete endpoint for Java-driven ordering is deferred to a follow-up issue.

Tests:
- 16 new tests in core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py cover _safe_delete_document, _upsert_document (happy path + upload fail + parse fail + fetch raise + empty chunks + delete-old swallow), split() routing on document_id, the HTTP form field passthrough, and cross-strategy **kwargs regression guard.
- KnowledgeServiceTest.testKnowledgeExtractAsync_CBG extended with an isNull() regression guard on the 6th argument; new _RagflowRAG_FirstSlice and _RagflowRAG_ReSlice tests cover the two Ragflow-RAG branches.
- 3 existing documentUpload mocks updated from 5 to 6 any() matchers.
- Full Python impl/ suite: 62 passed. Full toolkit module test suite: 672 passed, 0 failures.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
