### PR TITLE
Keep traceback in send

### DIFF
--- a/core/common/service/kafka/kafka_service.py
+++ b/core/common/service/kafka/kafka_service.py
@@ -50,7 +50,7 @@ class KafkaProducerService(Service):
             self.producer.poll(timeout)
         except Exception as e:
             logger.error(f"Kafka message send failed: {e}")
-            raise e
+            raise
 
     def _delivery_report(self, err: Any, msg: Any) -> None:
         """


### PR DESCRIPTION
Not sure how often send hits the edge case, but It re-raises the caught exception object and loses the cleaner traceback shape. this patch changes that to a plain raise so the original stack stays intact. Close this if it’s not worth the noise.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.