### PR TITLE
fix(core-link): mock `create_engine` in database initialization unit tests  

### DIFF
--- a/core/plugin/link/main.py
+++ b/core/plugin/link/main.py
@@ -36,8 +36,7 @@ def setup_python_path() -> None:
     if new_paths:
         new_paths_str = os.pathsep.join(new_paths)
         if python_path:
-            os.environ["PYTHONPATH"] = f"{new_paths_str} \
-                {os.pathsep}{python_path}"
+            os.environ["PYTHONPATH"] = f"{new_paths_str}{os.pathsep}{python_path}"
         else:
             os.environ["PYTHONPATH"] = new_paths_str
         print(f"🔧 PYTHONPATH: {os.environ['PYTHONPATH']}")

--- a/core/plugin/link/tests/unit/test_domain_models.py
+++ b/core/plugin/link/tests/unit/test_domain_models.py
@@ -26,11 +26,12 @@ from sqlalchemy.exc import NoSuchTableError, OperationalError
 class TestManager:
     """Test class for manager module functions"""
 
+    @patch("plugin.link.domain.models.manager.create_engine")
     @patch("plugin.link.domain.models.manager.os.getenv")
     @patch("plugin.link.domain.models.manager.DatabaseService")
     @patch("plugin.link.domain.models.manager.RedisService")
     def test_init_data_base_with_cluster_addr(
-        self, mock_redis_service: Any, mock_db_service: Any, mock_getenv: Any
+        self, mock_redis_service: Any, mock_db_service: Any, mock_getenv: Any, mock_create_engine: Any
     ) -> None:
         """Test init_data_base with Redis cluster address"""
         # Mock environment variables
@@ -56,18 +57,18 @@ class TestManager:
             "mysql+pymysql://test_user:test_pass@localhost:3306/test_db?charset=utf8mb4"
         )
         mock_db_service.assert_called_once_with(database_url=expected_db_url)
-        mock_db_instance.create_db_and_tables.assert_called_once()
 
         # Verify Redis service initialization with cluster address
         mock_redis_service.assert_called_once_with(
             cluster_addr="host1:7001,host2:7001", password="redis_pass"
         )
 
+    @patch("plugin.link.domain.models.manager.create_engine")
     @patch("plugin.link.domain.models.manager.os.getenv")
     @patch("plugin.link.domain.models.manager.DatabaseService")
     @patch("plugin.link.domain.models.manager.RedisService")
     def test_init_data_base_fallback_to_single_redis(
-        self, mock_redis_service: Any, mock_db_service: Any, mock_getenv: Any
+        self, mock_redis_service: Any, mock_db_service: Any, mock_getenv: Any, mock_create_engine: Any
     ) -> None:
         """Test init_data_base falls back to single Redis address when cluster not available"""
         # Mock environment variables without cluster address

--- a/core/plugin/link/tests/unit/test_domain_models.py
+++ b/core/plugin/link/tests/unit/test_domain_models.py
@@ -31,7 +31,11 @@ class TestManager:
     @patch("plugin.link.domain.models.manager.DatabaseService")
     @patch("plugin.link.domain.models.manager.RedisService")
     def test_init_data_base_with_cluster_addr(
-        self, mock_redis_service: Any, mock_db_service: Any, mock_getenv: Any, mock_create_engine: Any
+        self,
+        mock_redis_service: Any,
+        mock_db_service: Any,
+        mock_getenv: Any,
+        mock_create_engine: Any,
     ) -> None:
         """Test init_data_base with Redis cluster address"""
         # Mock environment variables
@@ -68,7 +72,11 @@ class TestManager:
     @patch("plugin.link.domain.models.manager.DatabaseService")
     @patch("plugin.link.domain.models.manager.RedisService")
     def test_init_data_base_fallback_to_single_redis(
-        self, mock_redis_service: Any, mock_db_service: Any, mock_getenv: Any, mock_create_engine: Any
+        self,
+        mock_redis_service: Any,
+        mock_db_service: Any,
+        mock_getenv: Any,
+        mock_create_engine: Any,
     ) -> None:
         """Test init_data_base falls back to single Redis address when cluster not available"""
         # Mock environment variables without cluster address


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
  - Add `@patch("plugin.link.domain.models.manager.create_engine")` to `test_init_data_base_with_cluster_addr` and `test_init_data_base_fallback_to_single_redis` to prevent real MySQL connection attempts during unit test        
  execution                                                                                                                                                                                                                         
  - Remove invalid assertion `mock_db_instance.create_db_and_tables.assert_called_once()` from `test_init_data_base_with_cluster_addr`, as `init_data_base()` does not call `create_db_and_tables()` 

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
