### PR TITLE
fix(knowledge): forward documentId in /document/split for Ragflow upsert

### DIFF
--- a/core/knowledge/api/v1/api.py
+++ b/core/knowledge/api/v1/api.py
@@ -179,6 +179,7 @@ async def file_split(
             separator=split_request.separator,
             titleSplit=split_request.titleSplit,
             cutOff=split_request.cutOff,
+            document_id=split_request.documentId,
         )
 
 

--- a/core/knowledge/domain/entity/chunk_dto.py
+++ b/core/knowledge/domain/entity/chunk_dto.py
@@ -33,6 +33,7 @@ class FileSplitReq(BaseModel):
         separator: Separator list, optional
         cutOff: Cutoff marker list, optional
         titleSplit: Whether to split by title, default is False
+        documentId: Existing RAGFlow doc id for re-slice upsert, optional
     """
 
     file: str = Field(..., min_length=1, description="Required, minimum length 1")
@@ -48,6 +49,13 @@ class FileSplitReq(BaseModel):
     cutOff: Optional[List[str]] = Field(default=None, description="Cutoff marker list")
     titleSplit: Optional[bool] = Field(
         default=False, description="Whether to split by title"
+    )
+    documentId: Optional[str] = Field(
+        default=None,
+        description=(
+            "Existing RAGFlow doc id, triggers blue-green upsert. "
+            "Omit or leave empty for first-time slicing."
+        ),
     )
 
 

--- a/core/knowledge/tests/domain/entity/chunk_dto_test.py
+++ b/core/knowledge/tests/domain/entity/chunk_dto_test.py
@@ -75,6 +75,20 @@ class TestFileSplitReq:
         assert "file" in field_names
         assert "ragType" in field_names
 
+    def test_document_id_default_none(self) -> None:
+        """Test documentId defaults to None for first-time slicing."""
+        req = FileSplitReq(file="test content", ragType=RAGType.RagFlow_RAG)
+        assert req.documentId is None
+
+    def test_document_id_accepts_string(self) -> None:
+        """Test documentId accepts existing RAGFlow doc id for re-slice upsert."""
+        req = FileSplitReq(
+            file="test content",
+            ragType=RAGType.RagFlow_RAG,
+            documentId="doc-abc-123",
+        )
+        assert req.documentId == "doc-abc-123"
+
 
 class TestChunkSaveReq:
     """Test ChunkSaveReq model."""

--- a/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
@@ -658,6 +658,88 @@ def test_file_upload_endpoint_with_document_id_passes_value_to_strategy(
     ), f"Expected document_id='doc-old', got {captured.get('document_id')!r}"
 
 
+def test_file_split_endpoint_no_document_id_passes_none_to_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /knowledge/v1/document/split WITHOUT documentId JSON field =>
+    strategy.split receives document_id=None."""
+    from fastapi.testclient import TestClient
+
+    app, _api_module = _build_test_app_for_upload(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_split(self: Any, **kwargs: Any) -> list[Any]:
+        captured.update(kwargs)
+        captured.pop("span", None)
+        return []
+
+    from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+    monkeypatch.setattr(RagflowRAGStrategy, "split", fake_split)
+
+    from knowledge.api.v1.api import get_app_id
+
+    app.dependency_overrides[get_app_id] = lambda: "test-app"
+
+    client = TestClient(app)
+    resp = client.post(
+        "/knowledge/v1/document/split",
+        json={"file": "https://example.com/a.txt", "ragType": "Ragflow-RAG"},
+    )
+
+    assert (
+        resp.status_code == 200
+    ), f"Expected 200, got {resp.status_code}, body={resp.text}"
+    assert (
+        "document_id" in captured
+    ), "Expected split() to receive document_id kwarg (value may be None)"
+    assert captured["document_id"] is None
+
+
+def test_file_split_endpoint_with_document_id_passes_value_to_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /knowledge/v1/document/split WITH documentId=doc-old =>
+    strategy.split receives document_id='doc-old' so the upsert path
+    deduplicates the re-slice instead of creating a new RAGFlow doc."""
+    from fastapi.testclient import TestClient
+
+    app, _api_module = _build_test_app_for_upload(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_split(self: Any, **kwargs: Any) -> list[Any]:
+        captured.update(kwargs)
+        captured.pop("span", None)
+        return []
+
+    from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+    monkeypatch.setattr(RagflowRAGStrategy, "split", fake_split)
+
+    from knowledge.api.v1.api import get_app_id
+
+    app.dependency_overrides[get_app_id] = lambda: "test-app"
+
+    client = TestClient(app)
+    resp = client.post(
+        "/knowledge/v1/document/split",
+        json={
+            "file": "https://example.com/a.txt",
+            "ragType": "Ragflow-RAG",
+            "documentId": "doc-old",
+        },
+    )
+
+    assert (
+        resp.status_code == 200
+    ), f"Expected 200, got {resp.status_code}, body={resp.text}"
+    assert (
+        captured.get("document_id") == "doc-old"
+    ), f"Expected document_id='doc-old', got {captured.get('document_id')!r}"
+
+
 # ----------------------------------------------------------------------
 # Section E: cross-strategy **kwargs forward-compat regression guard
 # ----------------------------------------------------------------------


### PR DESCRIPTION
在评估第三方客户端直接调用 `/document/split` 的接入方式时，发现该入口无法携带旧 RAGFlow document id 进入 upsert 路径。

进一步检查后确认：#1181 已覆盖 `/document/upload` 的 `documentId` 透传，但平行的 JSON 入口 `/document/split` 仍未把 `documentId` 传给 `strategy.split()`。如果调用方直接走 `/document/split`，该入口无法与 `/document/upload` 保持一致的 Ragflow upsert 语义。

Python 侧补齐对应字段和透传，与 `/document/upload` 行为对齐：

- `FileSplitReq`（`core/knowledge/domain/entity/chunk_dto.py`）新增 `Optional[str] documentId`，description 与 `/document/upload` 的 `documentId` form 字段保持一致
- `file_split` handler（`core/knowledge/api/v1/api.py`）在 `handle_rag_operation(...)` 透传 `document_id=split_request.documentId`，与 `/document/upload` 第 295 行处理方式一致
- `RagflowRAGStrategy.split()`、`_upsert_document()` 无需改动（#1181 已支持 `document_id` 参数）

Scope（仅涉及 Python 侧，刻意不触及）：

- Java `SplitRequest.java` 和 `KnowledgeService.doUrlSplit()`——默认配置下 `cbg-rag-compatible-sources` 把 `Ragflow-RAG` 路由到 `/document/upload`（#1181 路径），Java backend 实际不会经由 `/document/split` 下发 Ragflow 重切请求；如后续需打通 Java 侧入口，可独立 PR 补齐 `setDocumentId(...)`
- 其他 RAG 类型（AIUI / CBG / SparkDesk）的 strategy 实现

向后兼容：

- `documentId` 为 `Optional[str]` 且默认 `None`，旧调用方 JSON 中不带该字段时与修复前行为一致
- 非 Ragflow 三家 strategy 的 `split()` 方法均保留 `**kwargs`，`document_id` 参数会被静默吞掉；#1181 已加入的 `test_{aiui,cbg,sparkdesk}_strategy_split_accepts_var_keyword_for_forward_compat` regression guard 持续守护该契约
- 默认部署下 Ragflow-RAG / CBG-RAG / AIUI-RAG2 / SparkDesk-RAG 的用户可见行为字节级不变

测试：

- `FileSplitReq` 新增 2 个 DTO 单元测试（默认 `None` + 接受字符串）
- `/document/split` 新增 2 个 FastAPI TestClient 端点测试，覆盖"不传 documentId"和"传 documentId"两个分支，模式与 #1181 的 `/document/upload` 端点测试对齐
- 既有 3 个 `**kwargs` forward-compat regression guard 通过
- 完整 knowledge 测试套件：`224 passed`（原 220 + 4 新增）
- `black` / `isort --profile black` / `flake8` / `mypy`：clean

## Summary
<!-- Brief description of what this PR does -->
Python 侧补齐 `/document/split` JSON 入口的 `documentId` 字段与透传，使其与 #1181 已在 `/document/upload`（form-data）打通的 Ragflow 蓝绿 upsert 契约保持对称，便于第三方客户端直接调用 `/document/split` 时触发 upsert 路径。

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->
No related issue. Discovered during evaluation of third-party direct `/document/split` integration (follow-up to #1181).

## Changes
<!-- Key changes made in this PR -->
- `core/knowledge/domain/entity/chunk_dto.py`：`FileSplitReq` 新增 `Optional[str] documentId`
- `core/knowledge/api/v1/api.py`：`file_split` handler 透传 `document_id=split_request.documentId` 给 `strategy.split()`
- `core/knowledge/tests/domain/entity/chunk_dto_test.py`：新增 2 个 DTO 单元测试
- `core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py`：新增 2 个 `/document/split` endpoint 测试

## Testing
<!-- How these changes were tested -->
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
N/A

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Breaking changes documented (no breaking changes — fully backward compatible)
