### PR TITLE
fix(knowledge): paginate RAGFlow chunks and use id filter for lookups

### DIFF
--- a/core/knowledge/infra/ragflow/__init__.py
+++ b/core/knowledge/infra/ragflow/__init__.py
@@ -9,6 +9,7 @@ from .ragflow_client import (  # Query related APIs; Dataset management APIs; Do
     create_dataset,
     delete_chunks,
     delete_documents,
+    fetch_all_document_chunks,
     get_document_info,
     list_datasets,
     list_document_chunks,
@@ -41,6 +42,7 @@ __all__ = [
     "add_chunk",
     # Helper functions
     "wait_for_parsing",
+    "fetch_all_document_chunks",
     "get_document_info",
     # Resource management
     "cleanup_session",

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -692,6 +692,11 @@ async def get_document_info(dataset_id: str, doc_id: str) -> Optional[Dict[str, 
     Returns:
         Document information dict, or ``None`` if not found / on error.
     """
+    # Defense-in-depth: RAGFlow server truthy-checks ``id``, so ``id=`` on the
+    # wire scans the whole dataset (see docstring above for version refs).
+    if not doc_id:
+        logger.warning(f"empty doc_id for dataset={dataset_id}")
+        return None
     try:
         response = await list_documents_in_dataset(
             dataset_id, doc_id=doc_id, page=1, page_size=1

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -633,6 +633,8 @@ async def fetch_all_document_chunks(
             ``max_pages`` is exceeded without ``total`` being reached.
     """
     chunks: List[Dict[str, Any]] = []
+    # Optional so a page that drops ``total`` can't downgrade the stop condition.
+    total: Optional[int] = None
     page = 1
     while page <= max_pages:
         resp = await list_document_chunks(
@@ -647,18 +649,20 @@ async def fetch_all_document_chunks(
         data = resp.get("data") or {}
         batch = data.get("chunks") or []
         chunks.extend(batch)
-        total = data.get("total") or 0
-        if len(chunks) >= total:
+        # Missing/None/non-int => keep last-known good value.
+        raw_total = data.get("total")
+        if isinstance(raw_total, int) and raw_total >= 0:
+            total = raw_total
+        if total is not None and len(chunks) >= total:
             return chunks
         if not batch:
-            # Server returned an empty page but ``total`` still exceeds what
-            # we've collected. Treat as a protocol anomaly (stale pagination,
-            # mid-request deletion, or server mis-report) and fail closed —
-            # returning the partial list would let the caller re-insert the
+            # Protocol anomaly (stale pagination, mid-request deletion, or
+            # server mis-report): fail closed to avoid re-inserting the
             # missing chunks as if they didn't exist.
             raise RuntimeError(
                 f"fetch_all_document_chunks: empty page {page} but only "
-                f"{len(chunks)}/{total} chunks fetched for doc={document_id}"
+                f"{len(chunks)}/{total if total is not None else '?'} "
+                f"chunks fetched for doc={document_id}"
             )
         page += 1
     raise RuntimeError(

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -597,6 +597,76 @@ async def list_document_chunks(
     return await _make_request("GET", endpoint)
 
 
+async def fetch_all_document_chunks(
+    dataset_id: str,
+    document_id: str,
+    page_size: int = 1024,
+    max_pages: int = 1000,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch all chunks for a single document by paginating through the RAGFlow API.
+
+    Uses the server-reported ``total`` field in each response envelope to decide
+    when to stop. **Fail-closed semantics**: any non-zero response ``code``
+    raises ``RuntimeError`` rather than returning partial results. The caller
+    (``RagflowRAGStrategy._get_existing_chunks``) is the reconciliation source
+    of truth for chunk-upsert deduplication, so a partial mapping would cause
+    the reconciler to re-add existing chunks, corrupting the dataset.
+
+    Args:
+        dataset_id: Dataset ID.
+        document_id: Document ID.
+        page_size: Items per page. Default 1024 to match
+            ``list_document_chunks``'s own default — almost every realistic
+            document fits in a single page, so pagination only kicks in for
+            truly large documents.
+        max_pages: Safety cap to prevent runaway loops if the server mis-reports
+            ``total``. Default 1000 => up to ~1M chunks per document with
+            default ``page_size``, well above any realistic single-document
+            chunk count.
+
+    Returns:
+        All chunks flattened into a single list (possibly empty).
+
+    Raises:
+        RuntimeError: on non-zero ``code`` from any paginated call, or when
+            ``max_pages`` is exceeded without ``total`` being reached.
+    """
+    chunks: List[Dict[str, Any]] = []
+    page = 1
+    while page <= max_pages:
+        resp = await list_document_chunks(
+            dataset_id, document_id, page=page, page_size=page_size
+        )
+        if resp.get("code") != 0:
+            raise RuntimeError(
+                f"fetch_all_document_chunks failed on page {page} for "
+                f"doc={document_id}: code={resp.get('code')}, "
+                f"message={resp.get('message')}"
+            )
+        data = resp.get("data") or {}
+        batch = data.get("chunks") or []
+        chunks.extend(batch)
+        total = data.get("total") or 0
+        if len(chunks) >= total:
+            return chunks
+        if not batch:
+            # Server returned an empty page but ``total`` still exceeds what
+            # we've collected. Treat as a protocol anomaly (stale pagination,
+            # mid-request deletion, or server mis-report) and fail closed —
+            # returning the partial list would let the caller re-insert the
+            # missing chunks as if they didn't exist.
+            raise RuntimeError(
+                f"fetch_all_document_chunks: empty page {page} but only "
+                f"{len(chunks)}/{total} chunks fetched for doc={document_id}"
+            )
+        page += 1
+    raise RuntimeError(
+        f"fetch_all_document_chunks exceeded max_pages={max_pages} for "
+        f"doc={document_id}; server may be mis-reporting total"
+    )
+
+
 async def get_document_info(dataset_id: str, doc_id: str) -> Optional[Dict[str, Any]]:
     """
     Get detailed information for a single document

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -669,30 +669,42 @@ async def fetch_all_document_chunks(
 
 async def get_document_info(dataset_id: str, doc_id: str) -> Optional[Dict[str, Any]]:
     """
-    Get detailed information for a single document
+    Get detailed information for a single document via RAGFlow's id filter.
+
+    Uses the ``id`` query parameter on ``/api/v1/datasets/{dataset_id}/documents``,
+    which performs exact-match filtering server-side (verified against RAGFlow
+    v0.20.5 ~ v0.24.0: ``DocumentService.get_list`` applies
+    ``.where(cls.model.id == id)`` — peewee equality, not ``LIKE``).
+
+    A non-existent ``doc_id`` causes the server handler to return a non-zero
+    ``code`` with a "You don't own the document" message; we treat that as
+    "not found" and return ``None``. Transport-level exceptions are logged
+    and also surface as ``None`` to preserve the original caller contract.
 
     Args:
-        dataset_id: Dataset ID
-        doc_id: Document ID
+        dataset_id: Dataset ID.
+        doc_id: Document ID.
 
     Returns:
-        Document information, returns None if not found
+        Document information dict, or ``None`` if not found / on error.
     """
     try:
-        # Do not pass doc_id parameter, get all documents then iterate to find
         response = await list_documents_in_dataset(
-            dataset_id, doc_id="", page=1, page_size=1000
+            dataset_id, doc_id=doc_id, page=1, page_size=1
         )
-
         if response.get("code") == 0:
-            docs = response.get("data", {}).get("docs", [])
-            for doc in docs:
-                if doc.get("id") == doc_id:
-                    return doc
+            data = response.get("data") or {}
+            docs = data.get("docs") or []
+            # page_size=1 + server-side exact-match filter => at most one doc;
+            # the id re-check is defensive in case a future RAGFlow release
+            # relaxes the filter to LIKE.
+            if docs and docs[0].get("id") == doc_id:
+                return docs[0]
         return None
-
     except Exception as e:
-        logger.error(f"Failed to get document info: {e}")
+        logger.error(
+            f"Failed to get document info for doc={doc_id} in dataset={dataset_id}: {e}"
+        )
         return None
 
 

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -369,39 +369,48 @@ class RagflowRAGStrategy(RAGStrategy):
     async def _get_existing_chunks(
         self, dataset_id: str, doc_id: str
     ) -> Dict[str, Dict]:
-        """Get mapping of existing chunks"""
-        existing_chunks = {}
+        """Get mapping of existing chunks for a document.
+
+        Uses ``ragflow_client.fetch_all_document_chunks`` to paginate through
+        all chunks via the server-reported ``total`` field, so documents with
+        large chunk counts are fully covered.
+
+        **Fail-closed**: errors propagate rather than being swallowed into an
+        empty dict — a partial or empty mapping would cause
+        ``_process_single_chunk`` to treat existing chunks as missing and
+        re-insert them, corrupting the dataset with duplicates. The caller
+        ``chunks_save`` converts any ``Exception`` to
+        ``CustomException(ChunkSaveFailed)``, so transient RAGFlow failures
+        during reconciliation abort the upsert cleanly.
+        """
+        existing_chunks: Dict[str, Dict] = {}
         try:
-            chunks_response = await ragflow_client.list_document_chunks(
-                dataset_id, doc_id, page=1, page_size=1000
+            all_chunks = await ragflow_client.fetch_all_document_chunks(
+                dataset_id, doc_id
             )
-            if chunks_response.get("code") == 0:
-                chunks_data = chunks_response.get("data", {})
-                existing_chunk_list = chunks_data.get("chunks", [])
+        except Exception:
+            # Log doc/dataset context before re-raising — the upstream
+            # chunks_save catch-all only sees the exception message, so
+            # without this line the doc_id is lost in production triage.
+            logger.error(
+                f"fetch_all_document_chunks failed for doc={doc_id} "
+                f"in dataset={dataset_id}"
+            )
+            raise
 
-                for chunk in existing_chunk_list:
-                    # Get various identifiers of chunk
-                    data_index = str(chunk.get("dataIndex", ""))
-                    chunk_id = chunk.get("id") or chunk.get("chunk_id")
+        for chunk in all_chunks:
+            data_index = str(chunk.get("dataIndex", ""))
+            chunk_id = chunk.get("id") or chunk.get("chunk_id")
 
-                    if chunk_id:
-                        # Use chunk_id as primary key (corresponding to dataIndex in split results)
-                        existing_chunks[str(chunk_id)] = chunk
+            if chunk_id:
+                existing_chunks[str(chunk_id)] = chunk
+                if data_index:
+                    existing_chunks[data_index] = chunk
 
-                        # If dataIndex exists, also use as backup key
-                        if data_index:
-                            existing_chunks[data_index] = chunk
-
-                logger.info(
-                    f"Document {doc_id} already has {len(existing_chunk_list)} chunks, established {len(existing_chunks)} mappings"
-                )
-            else:
-                logger.info(
-                    f"Unable to get existing chunks or document does not exist: {chunks_response}"
-                )
-        except Exception as e:
-            logger.warning(f"Error checking existing chunks: {e}")
-
+        logger.info(
+            f"Document {doc_id} already has {len(all_chunks)} chunks, "
+            f"established {len(existing_chunks)} mappings"
+        )
         return existing_chunks
 
     async def _process_single_chunk(

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -325,34 +325,41 @@ class RagflowRAGStrategy(RAGStrategy):
         return dataset_id
 
     async def _validate_document_exists(self, dataset_id: str, doc_id: str) -> None:
-        """Validate if document exists, raise exception if error occurs"""
+        """Validate that the document exists in RAGFlow.
+
+        Delegates to ``ragflow_client.get_document_info`` which uses RAGFlow's
+        server-side ``id`` filter for an O(1) exact lookup (verified against
+        v0.20.5 ~ v0.24.0). Raises ``CustomException(ChunkSaveFailed)`` on
+        not-found or on any underlying error.
+
+        Note on error attribution: ``get_document_info`` swallows transport-level
+        exceptions and returns ``None`` (preserving its null-safe contract).
+        That means a ``None`` here can mean either "document genuinely absent"
+        or "RAGFlow unreachable". The caller's infra-layer logs (from
+        ``get_document_info``'s ``logger.error``) carry the underlying cause;
+        our message below stays neutral rather than asserting the doc is gone.
+        """
         try:
-            docs_response = await ragflow_client.list_documents_in_dataset(
-                dataset_id, doc_id, page=1, page_size=1000
-            )
-
-            if docs_response.get("code") == 0:
-                docs_data = docs_response.get("data", {})
-                docs = docs_data.get("docs", [])
-
-                for doc in docs:
-                    if doc.get("id") == doc_id:
-                        logger.info(f"Document {doc_id} exists in RAGFlow")
-                        return  # Document exists, validation passed
-
-                logger.error(f"Document {doc_id} does not exist in RAGFlow")
-                raise CustomException(
-                    CodeEnum.ChunkSaveFailed, f"Document {doc_id} does not exist"
+            doc = await ragflow_client.get_document_info(dataset_id, doc_id)
+            if doc is None:
+                logger.error(
+                    f"Document {doc_id} not found in RAGFlow "
+                    f"(either absent or RAGFlow unreachable — see infra logs)"
                 )
-            else:
-                logger.error(f"Unable to get document list: {docs_response}")
                 raise CustomException(
-                    CodeEnum.ChunkSaveFailed, "Unable to get document list"
+                    CodeEnum.ChunkSaveFailed,
+                    f"Document {doc_id} not found or RAGFlow unreachable",
                 )
-
+            logger.info(f"Document {doc_id} exists in RAGFlow")
         except CustomException:
-            raise  # Re-raise custom exceptions
+            # Re-raise without re-wrapping; the catch-all below would otherwise
+            # swallow the already-correct code/message from the None branch.
+            raise
         except Exception as e:
+            # Defensive: get_document_info's contract is to swallow all
+            # exceptions and return None, so this branch is normally
+            # unreachable. It covers contract violations (e.g. import-level
+            # failure) and future relaxations of that contract.
             logger.error(f"Error checking document existence: {e}")
             raise CustomException(
                 CodeEnum.ChunkSaveFailed,

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
@@ -18,6 +18,7 @@ from knowledge.infra.ragflow import ragflow_client
 # Mock paths — extracted so a future rename of the client module doesn't
 # require chasing string literals across tests.
 _LIST_CHUNKS = "knowledge.infra.ragflow.ragflow_client.list_document_chunks"
+_LIST_DOCS = "knowledge.infra.ragflow.ragflow_client.list_documents_in_dataset"
 
 
 # ----------------------------------------------------------------------
@@ -138,3 +139,73 @@ async def test_fetch_all_document_chunks_honors_max_pages_safeguard() -> None:
     assert "max_pages" in str(exc_info.value)
     assert "doc-x" in str(exc_info.value)
     assert mock_list.await_count == 3
+
+
+# ----------------------------------------------------------------------
+# Section B: get_document_info
+# ----------------------------------------------------------------------
+
+
+def _docs_page(docs: List[Dict[str, Any]], total: int) -> Dict[str, Any]:
+    """Build a well-formed RAGFlow documents-API response envelope."""
+    return {"code": 0, "data": {"docs": docs, "total": total}}
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_passes_doc_id_as_filter_with_page_size_one() -> None:
+    """Happy path: server-side id filter, single-row page, returns the match."""
+    doc = {"id": "doc-x", "name": "test.pdf", "chunk_count": 3}
+    with patch(
+        _LIST_DOCS,
+        new=AsyncMock(return_value=_docs_page(docs=[doc], total=1)),
+    ) as mock_list:
+        result = await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert result == doc
+    mock_list.assert_awaited_once_with("ds-1", doc_id="doc-x", page=1, page_size=1)
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_non_matching_id_returns_none() -> None:
+    """Server returns docs list without the requested id => None (defensive)."""
+    other = {"id": "doc-y", "name": "other.pdf"}
+    with patch(
+        _LIST_DOCS,
+        new=AsyncMock(return_value=_docs_page(docs=[other], total=1)),
+    ):
+        result = await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_empty_docs_returns_none() -> None:
+    """code=0 but docs=[] (id unknown to server, some versions of RAGFlow
+    filter to empty list rather than returning a non-zero code) => None."""
+    with patch(
+        _LIST_DOCS,
+        new=AsyncMock(return_value=_docs_page(docs=[], total=0)),
+    ):
+        result = await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_server_error_returns_none() -> None:
+    """Non-zero code (e.g. 'You don't own the document') => None."""
+    error_resp = {"code": 102, "message": "You don't own the document doc-x."}
+    with patch(
+        _LIST_DOCS,
+        new=AsyncMock(return_value=error_resp),
+    ):
+        result = await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_exception_returns_none() -> None:
+    """Transport-level exception => None, no propagation."""
+    with patch(
+        _LIST_DOCS,
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert result is None

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
@@ -251,3 +251,14 @@ async def test_get_document_info_exception_returns_none() -> None:
     ):
         result = await ragflow_client.get_document_info("ds-1", "doc-x")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_empty_doc_id_returns_none_without_network_call() -> (
+    None
+):
+    """Empty ``doc_id`` short-circuits without hitting RAGFlow."""
+    with patch(_LIST_DOCS, new=AsyncMock()) as mock_list:
+        result = await ragflow_client.get_document_info("ds-1", "")
+    assert result is None
+    mock_list.assert_not_called()

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
@@ -121,6 +121,48 @@ async def test_fetch_all_document_chunks_empty_mid_page_raises_fail_closed() -> 
 
 
 @pytest.mark.asyncio
+async def test_fetch_all_document_chunks_missing_total_mid_page_does_not_return_partial() -> (
+    None
+):
+    """Mid-iteration page drops ``total`` while still returning a real batch =>
+    paginator must keep paginating using the last-known total, not hand back a
+    partial list that would let _get_existing_chunks re-insert missing chunks.
+    """
+    page1 = _chunk_page(chunks=[{"id": "c1"}, {"id": "c2"}], total=10)
+    page2_no_total = {"code": 0, "data": {"chunks": [{"id": "c3"}]}}
+    page3_rest = _chunk_page(chunks=[{"id": f"c{i}"} for i in range(4, 11)], total=10)
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(side_effect=[page1, page2_no_total, page3_rest]),
+    ) as mock_list:
+        result = await ragflow_client.fetch_all_document_chunks(
+            "ds-1", "doc-x", page_size=2
+        )
+    assert [c["id"] for c in result] == [f"c{i}" for i in range(1, 11)]
+    assert mock_list.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_empty_data_envelope_mid_page_raises_fail_closed() -> (
+    None
+):
+    """Mid-iteration page with ``code=0`` but an empty ``data`` envelope
+    (chunks missing AND total missing) must raise, not silently return the
+    so-far list.
+    """
+    page1 = _chunk_page(chunks=[{"id": "c1"}, {"id": "c2"}], total=10)
+    page2_empty_envelope = {"code": 0, "data": {}}
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(side_effect=[page1, page2_empty_envelope]),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            await ragflow_client.fetch_all_document_chunks("ds-1", "doc-x", page_size=2)
+    assert "doc-x" in str(exc_info.value)
+    assert "empty page 2" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_fetch_all_document_chunks_honors_max_pages_safeguard() -> None:
     """Pathological `total` larger than max_pages*page_size => raise after
     max_pages (fail-closed: we cannot distinguish a real huge document from

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for RAGFlow client pagination helpers and id-filter lookups.
+
+Covers:
+- `fetch_all_document_chunks()` — paginator for per-document chunks, follows
+  the server-reported `total` field across pages.
+- `get_document_info()` — single-document lookup via RAGFlow `id` query param.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.infra.ragflow import ragflow_client
+
+# Mock paths — extracted so a future rename of the client module doesn't
+# require chasing string literals across tests.
+_LIST_CHUNKS = "knowledge.infra.ragflow.ragflow_client.list_document_chunks"
+
+
+# ----------------------------------------------------------------------
+# Section A: fetch_all_document_chunks
+# ----------------------------------------------------------------------
+
+
+def _chunk_page(chunks: List[Dict[str, Any]], total: int) -> Dict[str, Any]:
+    """Build a well-formed RAGFlow chunks-API response envelope."""
+    return {"code": 0, "data": {"chunks": chunks, "total": total}}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_single_page_returns_all_items() -> None:
+    """total <= page_size => one API call, all items returned."""
+    page1 = _chunk_page(
+        chunks=[{"id": "c1"}, {"id": "c2"}, {"id": "c3"}],
+        total=3,
+    )
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(return_value=page1),
+    ) as mock_list:
+        result = await ragflow_client.fetch_all_document_chunks(
+            "ds-1", "doc-x", page_size=100
+        )
+    assert [c["id"] for c in result] == ["c1", "c2", "c3"]
+    mock_list.assert_awaited_once_with("ds-1", "doc-x", page=1, page_size=100)
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_multi_page_iterates_until_complete() -> None:
+    """total > page_size => multiple API calls, results concatenated in order."""
+    page1 = _chunk_page(chunks=[{"id": f"c{i}"} for i in range(1, 3)], total=5)
+    page2 = _chunk_page(chunks=[{"id": f"c{i}"} for i in range(3, 5)], total=5)
+    page3 = _chunk_page(chunks=[{"id": "c5"}], total=5)
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(side_effect=[page1, page2, page3]),
+    ) as mock_list:
+        result = await ragflow_client.fetch_all_document_chunks(
+            "ds-1", "doc-x", page_size=2
+        )
+    assert [c["id"] for c in result] == ["c1", "c2", "c3", "c4", "c5"]
+    assert mock_list.await_count == 3
+    mock_list.assert_any_await("ds-1", "doc-x", page=1, page_size=2)
+    mock_list.assert_any_await("ds-1", "doc-x", page=2, page_size=2)
+    mock_list.assert_any_await("ds-1", "doc-x", page=3, page_size=2)
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_empty_document_returns_empty_list() -> None:
+    """Document with zero chunks => empty list, one API call."""
+    empty = _chunk_page(chunks=[], total=0)
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(return_value=empty),
+    ) as mock_list:
+        result = await ragflow_client.fetch_all_document_chunks("ds-1", "doc-x")
+    assert result == []
+    mock_list.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_non_zero_code_raises_fail_closed() -> None:
+    """API error mid-iteration => raise, do NOT return partial results.
+
+    Returning a partial mapping would make the caller treat missing chunks as
+    'not yet ingested' and re-add them, corrupting the dataset with
+    duplicates (see fail-closed invariant in the plan header).
+    """
+    page1 = _chunk_page(chunks=[{"id": "c1"}, {"id": "c2"}], total=10)
+    page2_error = {"code": 102, "message": "internal error"}
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(side_effect=[page1, page2_error]),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            await ragflow_client.fetch_all_document_chunks("ds-1", "doc-x", page_size=2)
+    assert "doc-x" in str(exc_info.value)
+    assert "102" in str(exc_info.value) or "internal error" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_empty_mid_page_raises_fail_closed() -> None:
+    """Server declares total=N but a mid-iteration page returns an empty batch
+    => raise. Returning the partial list would let _process_single_chunk treat
+    the missing chunks as new and re-insert them (duplicate corruption).
+    """
+    page1 = _chunk_page(chunks=[{"id": "c1"}, {"id": "c2"}], total=10)
+    page2_empty = _chunk_page(chunks=[], total=10)  # anomaly: total unmet
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(side_effect=[page1, page2_empty]),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            await ragflow_client.fetch_all_document_chunks("ds-1", "doc-x", page_size=2)
+    assert "doc-x" in str(exc_info.value)
+    assert "2/10" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_document_chunks_honors_max_pages_safeguard() -> None:
+    """Pathological `total` larger than max_pages*page_size => raise after
+    max_pages (fail-closed: we cannot distinguish a real huge document from
+    a server mis-reporting ``total``, so surface it to the caller)."""
+    # Server always claims total=999_999 but returns one chunk per page.
+    # Without the safeguard this would loop ~500k times.
+    page_with_one = _chunk_page(chunks=[{"id": "c"}], total=999_999)
+    with patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(return_value=page_with_one),
+    ) as mock_list:
+        with pytest.raises(RuntimeError) as exc_info:
+            await ragflow_client.fetch_all_document_chunks(
+                "ds-1", "doc-x", page_size=1, max_pages=3
+            )
+    assert "max_pages" in str(exc_info.value)
+    assert "doc-x" in str(exc_info.value)
+    assert mock_list.await_count == 3

--- a/core/knowledge/tests/service/impl/ragflow_strategy_pagination_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_pagination_test.py
@@ -17,12 +17,18 @@ from knowledge.exceptions.exception import CustomException
 from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 
 # Mock paths — extracted so a future rename of the strategy module doesn't
-# require chasing string literals across tests.
+# require chasing 6+ string literals.
 _GET_DOC_INFO = (
     "knowledge.service.impl.ragflow_strategy.ragflow_client.get_document_info"
 )
 _LIST_DOCS = (
     "knowledge.service.impl.ragflow_strategy.ragflow_client.list_documents_in_dataset"
+)
+_FETCH_ALL_CHUNKS = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.fetch_all_document_chunks"
+)
+_LIST_CHUNKS = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.list_document_chunks"
 )
 
 
@@ -122,3 +128,175 @@ async def test_validate_document_exists_raises_on_unexpected_exception() -> None
     assert exc_info.value.code == CodeEnum.ChunkSaveFailed.code
     mock_get.assert_awaited_once_with("ds-1", "doc-x")
     mock_list.assert_not_awaited()
+
+
+# ----------------------------------------------------------------------
+# Section B: _get_existing_chunks
+# ----------------------------------------------------------------------
+
+
+def _make_chunk(chunk_id: str, data_index: str = "") -> Dict[str, Any]:
+    return {"id": chunk_id, "dataIndex": data_index, "content": f"body-{chunk_id}"}
+
+
+# Every test below pins BOTH the new helper (`fetch_all_document_chunks`)
+# AND the underlying `list_document_chunks`. The second patch is a regression
+# guard: it asserts (via `mock_list.assert_not_awaited()`) that the
+# implementation never falls back to the old direct-client path. Also keeps
+# test failures local/deterministic — no real HTTP regardless of wiring.
+
+
+@pytest.mark.asyncio
+async def test_get_existing_chunks_maps_by_chunk_id_and_data_index() -> None:
+    """Each chunk produces an entry keyed by chunk id, plus an extra entry
+    keyed by dataIndex when dataIndex is non-empty."""
+    strategy = RagflowRAGStrategy()
+    chunks = [
+        _make_chunk("c1", data_index="0.0"),
+        _make_chunk("c2", data_index=""),
+        _make_chunk("c3", data_index="1.0"),
+    ]
+    with (
+        patch(
+            _FETCH_ALL_CHUNKS,
+            new=AsyncMock(return_value=chunks),
+        ) as mock_fetch,
+        patch(
+            _LIST_CHUNKS,
+            new=AsyncMock(
+                return_value={
+                    "code": 0,
+                    "data": {"chunks": chunks, "total": len(chunks)},
+                }
+            ),
+        ) as mock_list,
+    ):
+        mapping = await strategy._get_existing_chunks("ds-1", "doc-x")
+
+    assert mapping["c1"]["id"] == "c1"
+    assert mapping["c2"]["id"] == "c2"
+    assert mapping["c3"]["id"] == "c3"
+    assert mapping["0.0"]["id"] == "c1"
+    assert mapping["1.0"]["id"] == "c3"
+    mock_fetch.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_existing_chunks_empty_document_returns_empty_mapping() -> None:
+    """Fresh document with no chunks => paginator returns [], mapping is {}.
+
+    Guards the for-loop body from being replaced with an early-return
+    optimization that might accidentally skip the logger.info or otherwise
+    change observable behavior on the empty-doc branch.
+    """
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(
+            _FETCH_ALL_CHUNKS,
+            new=AsyncMock(return_value=[]),
+        ) as mock_fetch,
+        patch(
+            _LIST_CHUNKS,
+            new=AsyncMock(return_value={"code": 0, "data": {"chunks": [], "total": 0}}),
+        ) as mock_list,
+    ):
+        mapping = await strategy._get_existing_chunks("ds-1", "doc-x")
+    assert mapping == {}
+    mock_fetch.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_existing_chunks_returns_all_chunks_across_pages() -> None:
+    """Regression test for the data-loss bug: a document with 2500 chunks
+    must produce 2500 chunk-id entries (previously only page 1 / 1000 were
+    returned)."""
+    strategy = RagflowRAGStrategy()
+    many_chunks = [_make_chunk(f"c{i}") for i in range(2500)]
+    with (
+        patch(
+            _FETCH_ALL_CHUNKS,
+            new=AsyncMock(return_value=many_chunks),
+        ) as mock_fetch,
+        patch(
+            _LIST_CHUNKS,
+            new=AsyncMock(
+                return_value={
+                    "code": 0,
+                    "data": {"chunks": many_chunks[:1000], "total": 2500},
+                }
+            ),
+        ) as mock_list,
+    ):
+        mapping = await strategy._get_existing_chunks("ds-1", "doc-x")
+    assert len(mapping) == 2500
+    assert "c0" in mapping
+    assert "c2499" in mapping
+    mock_fetch.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_existing_chunks_skips_chunks_without_id() -> None:
+    """Chunks with neither `id` nor `chunk_id` are ignored (no KeyError).
+
+    Red-light stability: without the `mock_fetch.assert_awaited_once` check
+    at the end, the old implementation would ALSO pass this test — it would
+    iterate the mocked `list_document_chunks` chunks list (identical content)
+    and produce the same mapping. The awaited-once assertion is what makes
+    the red light deterministic.
+    """
+    strategy = RagflowRAGStrategy()
+    chunks: List[Dict[str, Any]] = [
+        {"id": "c1", "dataIndex": "0.0"},
+        {"dataIndex": "1.0"},  # no id at all
+        {"chunk_id": "c3", "dataIndex": "2.0"},  # legacy chunk_id key
+    ]
+    with (
+        patch(
+            _FETCH_ALL_CHUNKS,
+            new=AsyncMock(return_value=chunks),
+        ) as mock_fetch,
+        patch(
+            _LIST_CHUNKS,
+            new=AsyncMock(
+                return_value={
+                    "code": 0,
+                    "data": {"chunks": chunks, "total": len(chunks)},
+                }
+            ),
+        ) as mock_list,
+    ):
+        mapping = await strategy._get_existing_chunks("ds-1", "doc-x")
+    assert "c1" in mapping
+    assert "c3" in mapping
+    assert "1.0" not in mapping
+    mock_fetch.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_existing_chunks_propagates_fetch_error_fail_closed() -> None:
+    """Underlying fetch raises => exception propagates (fail-closed).
+
+    Behavioral change: the previous implementation swallowed errors and
+    returned {}, which combined with the downstream dedup logic in
+    `_process_single_chunk` silently re-added every chunk on transient
+    RAGFlow failures. The new behavior surfaces the error so that
+    `chunks_save` aborts (via its `except Exception` -> CustomException
+    conversion) rather than corrupt the dataset with duplicates."""
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(
+            _FETCH_ALL_CHUNKS,
+            new=AsyncMock(side_effect=RuntimeError("network down")),
+        ),
+        patch(
+            _LIST_CHUNKS,
+            new=AsyncMock(side_effect=RuntimeError("network down")),
+        ),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            await strategy._get_existing_chunks("ds-1", "doc-x")
+    assert "network down" in str(exc_info.value)

--- a/core/knowledge/tests/service/impl/ragflow_strategy_pagination_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_pagination_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for RagflowRAGStrategy pagination / existence-check fixes (RF-19).
+
+Covers:
+- `_validate_document_exists()` — delegates to `ragflow_client.get_document_info`.
+- `_get_existing_chunks()` — uses `ragflow_client.fetch_all_document_chunks`.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.consts.error_code import CodeEnum
+from knowledge.exceptions.exception import CustomException
+from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+# Mock paths — extracted so a future rename of the strategy module doesn't
+# require chasing string literals across tests.
+_GET_DOC_INFO = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.get_document_info"
+)
+_LIST_DOCS = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.list_documents_in_dataset"
+)
+
+
+# ----------------------------------------------------------------------
+# Section A: _validate_document_exists
+# ----------------------------------------------------------------------
+
+
+# Every test below pins BOTH the new helper (`get_document_info`) AND the
+# underlying `list_documents_in_dataset`. The second patch is a regression
+# guard: it asserts (via `mock_list.assert_not_awaited()`) that the
+# implementation never falls back to the old direct-client path. Also keeps
+# test failures local/deterministic — no real HTTP regardless of wiring.
+
+
+@pytest.mark.asyncio
+async def test_validate_document_exists_success_when_get_document_info_returns_doc() -> (
+    None
+):
+    """`get_document_info` returns a dict => validation passes silently.
+
+    Also asserts the new helper is the code path actually taken; if the old
+    implementation is still in place it will instead call
+    `list_documents_in_dataset` and `mock_get` will stay un-awaited.
+    """
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(
+            _GET_DOC_INFO,
+            new=AsyncMock(return_value={"id": "doc-x", "name": "t.pdf"}),
+        ) as mock_get,
+        patch(
+            _LIST_DOCS,
+            new=AsyncMock(
+                return_value={"code": 0, "data": {"docs": [{"id": "doc-x"}]}}
+            ),
+        ) as mock_list,
+    ):
+        await strategy._validate_document_exists("ds-1", "doc-x")
+    mock_get.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_validate_document_exists_raises_when_get_document_info_returns_none() -> (
+    None
+):
+    """`get_document_info` returns None => CustomException(ChunkSaveFailed)."""
+    strategy = RagflowRAGStrategy()
+    # `list_documents_in_dataset` is mocked as "doc exists" so the old implementation
+    # would mistakenly PASS validation — that way the red-light failure is stable
+    # (CustomException not raised) instead of a network error.
+    with (
+        patch(
+            _GET_DOC_INFO,
+            new=AsyncMock(return_value=None),
+        ) as mock_get,
+        patch(
+            _LIST_DOCS,
+            new=AsyncMock(
+                return_value={"code": 0, "data": {"docs": [{"id": "doc-x"}]}}
+            ),
+        ) as mock_list,
+    ):
+        with pytest.raises(CustomException) as exc_info:
+            await strategy._validate_document_exists("ds-1", "doc-x")
+    assert exc_info.value.code == CodeEnum.ChunkSaveFailed.code
+    assert "doc-x" in str(exc_info.value)
+    mock_get.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_validate_document_exists_raises_on_unexpected_exception() -> None:
+    """Underlying transport error => CustomException, not bare RuntimeError.
+
+    Red-light stability: without the `mock_get.assert_awaited_once` check at
+    the end, the old implementation would ALSO pass this test — its own
+    try/except converts the RuntimeError raised by the mocked
+    list_documents_in_dataset into CustomException(ChunkSaveFailed). The
+    assertion that the new helper was called is what distinguishes the
+    two implementations.
+    """
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(
+            _GET_DOC_INFO,
+            new=AsyncMock(side_effect=RuntimeError("network down")),
+        ) as mock_get,
+        patch(
+            _LIST_DOCS,
+            new=AsyncMock(side_effect=RuntimeError("network down")),
+        ) as mock_list,
+    ):
+        with pytest.raises(CustomException) as exc_info:
+            await strategy._validate_document_exists("ds-1", "doc-x")
+    assert exc_info.value.code == CodeEnum.ChunkSaveFailed.code
+    mock_get.assert_awaited_once_with("ds-1", "doc-x")
+    mock_list.assert_not_awaited()


### PR DESCRIPTION
## Summary
修复 `core/knowledge` 中 RAGFlow 文档与 chunk 查询的分页问题：

- 避免文档超过 1000 个 chunks 时只读取第一页，导致已有 chunks 被误判为不存在
- 避免 RAGFlow 抖动时 `_get_existing_chunks` 吞异常返回 `{}`，导致下游重复插入 chunks
- 将文档存在性检查从 `page_size=1000` 本地扫描改为 RAGFlow `id` 精确查询，降低资源浪费和 OOM 风险

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Closes #1210

## Changes
1. 新增 `fetch_all_document_chunks`
   - 按 RAGFlow 返回的 `total` 分页拉取文档 chunks
   - 遇到非零 code、空页但 total 未达成、超过 `max_pages` 时 fail-closed，抛出 `RuntimeError`
   - 默认 `page_size=1024`，与现有 `list_document_chunks` 保持一致

2. 优化文档查询路径
   - `get_document_info` 改用 RAGFlow `id` query 参数 + `page_size=1`
   - `_validate_document_exists` 委托给 `get_document_info`
   - 避免一次拉 1000 条文档后本地扫描

3. 修复 chunk 保存前的已有 chunk 查询
   - `_get_existing_chunks` 改用 `fetch_all_document_chunks`
   - 错误不再被吞掉，异常向上抛给 `chunks_save`
   - 避免在 RAGFlow 异常时把所有 chunks 当作新数据重复插入

## Behavior Change
`_get_existing_chunks` 不再在 RAGFlow 错误时返回空字典，而是抛出异常。

因此 `chunks_save` 在 RAGFlow 抖动或分页异常时会返回 `CustomException(ChunkSaveFailed)`。这会暴露原本被掩盖的失败，但可以避免静默重复写入数据。

## Testing
- [x] `uv run pytest tests/ -v` → 239 passed
- [x] 新增 19 个针对本次改动的单元测试
  - `tests/infra/ragflow/ragflow_client_pagination_test.py`
  - `tests/service/impl/ragflow_strategy_pagination_test.py`
- [x] `black --check` 通过
- [x] CI 参数版 `flake8` 通过
- [x] CI 参数版 `mypy` 通过
- [x] 真实 RAGFlow v0.20.5 只读冒烟验证通过
  - `get_document_info` 验证真实 / 虚假 / 近似 doc_id
  - `fetch_all_document_chunks` 验证单页 / 多页拉取
  - 虚假 doc_id 时 paginator 正确抛错

## Screenshots
N/A，服务端逻辑修复。

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated（docstring 已覆盖 fail-closed 不变量和 id filter 验证依据）
- [x] Behavior changes documented（见 Behavior Change 段）
