### PR TITLE
fix(knowledge): propagate RAGFlow failures instead of swallowing to empty results

### DIFF
--- a/core/knowledge/consts/error_code.py
+++ b/core/knowledge/consts/error_code.py
@@ -32,6 +32,7 @@ class CodeEnum(Enum):
     CBG_RAGError = (10026, "Xinghuo knowledge base request failed")
     AIUI_RAGError = (10027, "AIUI knowledge base request failed")
     DESK_RAGError = (10028, "DESK knowledge base request failed")
+    RAGFLOW_RAGError = (10029, "RAGFlow knowledge base request failed")
 
     ThirdPartyServiceFailed = (11111, "Third Party Service Failed")
     ServiceException = (14999, "Service Exception")

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -22,10 +22,17 @@ except ImportError:
     # Handle missing ragflow_sdk dependency
     RAGFlow = None  # type: ignore[assignment]
 
+from knowledge.consts.error_code import CodeEnum
+from knowledge.exceptions.exception import ThirdPartyException
+
 # Import constants module to ensure environment variables are loaded properly
 # from knowledge.consts import constants
 
 logger = logging.getLogger(__name__)
+
+# RAGFlow RetCode.DATA_ERROR (102) is used for missing / not-owned documents.
+# Other non-zero codes are treated as service failures.
+_RAGFLOW_DATA_ERROR = 102
 
 # Module-level configuration cache and session management
 _config_cache = None
@@ -680,41 +687,51 @@ async def get_document_info(dataset_id: str, doc_id: str) -> Optional[Dict[str, 
     v0.20.5 ~ v0.24.0: ``DocumentService.get_list`` applies
     ``.where(cls.model.id == id)`` — peewee equality, not ``LIKE``).
 
-    A non-existent ``doc_id`` causes the server handler to return a non-zero
-    ``code`` with a "You don't own the document" message; we treat that as
-    "not found" and return ``None``. Transport-level exceptions are logged
-    and also surface as ``None`` to preserve the original caller contract.
+    Return contract:
+
+    - ``code == 0`` with matching doc: return the doc dict.
+    - ``code == 0`` with no matching doc: return ``None``.
+    - ``code == DATA_ERROR`` (102): return ``None`` (server's
+      "not owned / not found" response).
+    - Any other non-zero ``code``: raise ``ThirdPartyException``.
+    - Transport-level exceptions propagate unchanged.
 
     Args:
         dataset_id: Dataset ID.
         doc_id: Document ID.
 
     Returns:
-        Document information dict, or ``None`` if not found / on error.
+        Document information dict, or ``None`` if the document does not
+        exist. Raises on protocol / transport errors.
     """
     # Defense-in-depth: RAGFlow server truthy-checks ``id``, so ``id=`` on the
     # wire scans the whole dataset (see docstring above for version refs).
     if not doc_id:
         logger.warning(f"empty doc_id for dataset={dataset_id}")
         return None
-    try:
-        response = await list_documents_in_dataset(
-            dataset_id, doc_id=doc_id, page=1, page_size=1
-        )
-        if response.get("code") == 0:
-            data = response.get("data") or {}
-            docs = data.get("docs") or []
-            # page_size=1 + server-side exact-match filter => at most one doc;
-            # the id re-check is defensive in case a future RAGFlow release
-            # relaxes the filter to LIKE.
-            if docs and docs[0].get("id") == doc_id:
-                return docs[0]
+    response = await list_documents_in_dataset(
+        dataset_id, doc_id=doc_id, page=1, page_size=1
+    )
+    code = response.get("code")
+    if code == 0:
+        data = response.get("data") or {}
+        docs = data.get("docs") or []
+        # page_size=1 + server-side exact-match filter => at most one doc;
+        # the id re-check is defensive in case a future RAGFlow release
+        # relaxes the filter to LIKE.
+        if docs and docs[0].get("id") == doc_id:
+            return docs[0]
         return None
-    except Exception as e:
-        logger.error(
-            f"Failed to get document info for doc={doc_id} in dataset={dataset_id}: {e}"
-        )
+    if code == _RAGFLOW_DATA_ERROR:
         return None
+    msg = response.get("message", "Unknown error")
+    raise ThirdPartyException(
+        msg=(
+            f"RAGFlow get_document_info doc={doc_id} dataset={dataset_id}: "
+            f"code={code} message={msg}"
+        ),
+        e=CodeEnum.RAGFLOW_RAGError,
+    )
 
 
 async def delete_documents(dataset_id: str, document_ids: List[str]) -> Dict[str, Any]:

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, List, Optional, Union
 import aiohttp
 from fastapi import UploadFile
 
+from knowledge.consts.error_code import CodeEnum
+from knowledge.exceptions.exception import ThirdPartyException
 from knowledge.infra.ragflow.ragflow_client import (
     create_dataset,
     list_datasets,
@@ -43,22 +45,28 @@ class RagflowUtils:
 
     @staticmethod
     async def get_dataset_id_by_name(dataset_name: str) -> Optional[str]:
-        """
-        Get dataset ID by dataset name
-        """
-        try:
-            from knowledge.infra.ragflow import ragflow_client
+        """Look up a dataset ID by name.
 
-            datasets_response = await ragflow_client.list_datasets(name=dataset_name)
-            if datasets_response.get("code") == 0:
-                datasets = datasets_response.get("data", [])
-                for dataset in datasets:
-                    if dataset.get("name") == dataset_name:
-                        return dataset.get("id")
+        Returns ``None`` only when RAGFlow successfully returns no matching
+        dataset (``code == 0`` with empty data). Raises
+        ``ThirdPartyException`` for non-zero RAGFlow codes; transport
+        exceptions propagate.
+        """
+        from knowledge.infra.ragflow import ragflow_client
+
+        datasets_response = await ragflow_client.list_datasets(name=dataset_name)
+        code = datasets_response.get("code")
+        if code == 0:
+            datasets = datasets_response.get("data", [])
+            for dataset in datasets:
+                if dataset.get("name") == dataset_name:
+                    return dataset.get("id")
             return None
-        except Exception as e:
-            logger.error(f"Failed to find dataset: {e}")
-            return None
+        msg = datasets_response.get("message", "Unknown error")
+        raise ThirdPartyException(
+            msg=f"RAGFlow list_datasets name={dataset_name}: code={code} message={msg}",
+            e=CodeEnum.RAGFLOW_RAGError,
+        )
 
     @staticmethod
     def convert_ragflow_query_response(

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -973,6 +973,8 @@ class RagflowRAGStrategy(RAGStrategy):
 
         except CustomException:
             raise
+        except ThirdPartyException:
+            raise
         except Exception as e:
             logger.error(f"Failed to query document chunk information: {e}")
             raise ThirdPartyException(
@@ -1022,6 +1024,8 @@ class RagflowRAGStrategy(RAGStrategy):
             return file_info
 
         except CustomException:
+            raise
+        except ThirdPartyException:
             raise
         except Exception as e:
             logger.error(f"Failed to query document information: {e}")

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -12,7 +12,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from knowledge.consts.error_code import CodeEnum
-from knowledge.exceptions.exception import CustomException
+from knowledge.exceptions.exception import CustomException, ThirdPartyException
 from knowledge.infra.ragflow import ragflow_client
 from knowledge.infra.ragflow.ragflow_utils import RagflowUtils
 from knowledge.service.rag_strategy import RAGStrategy
@@ -84,8 +84,12 @@ class RagflowRAGStrategy(RAGStrategy):
             )
 
             if ragflow_response.get("code") != 0:
+                msg = ragflow_response.get("message", "Unknown error")
                 logger.error("RAGFlow query failed: %s", ragflow_response)
-                return {"query": query, "count": 0, "results": []}
+                raise ThirdPartyException(
+                    msg=f"RAGFlow retrieval failed: {msg}",
+                    e=CodeEnum.RAGFLOW_RAGError,
+                )
 
             # Parse response and convert format
             results = RagflowUtils.convert_ragflow_query_response(
@@ -98,9 +102,16 @@ class RagflowRAGStrategy(RAGStrategy):
             logger.info("Query completed, returning %d results", len(results))
             return {"query": query, "count": len(results), "results": results}
 
+        except CustomException:
+            raise
+        except ThirdPartyException:
+            raise
         except Exception as e:
             logger.error("RAGFlow query exception: %s", e)
-            return {"query": query, "count": 0, "results": []}
+            raise ThirdPartyException(
+                msg=f"RAGFlow retrieval failed: {e}",
+                e=CodeEnum.RAGFLOW_RAGError,
+            ) from e
 
     def _validate_split_parameters(
         self, fileUrl: Optional[str], file: Optional[Any]
@@ -325,34 +336,26 @@ class RagflowRAGStrategy(RAGStrategy):
         v0.20.5 ~ v0.24.0). Raises ``CustomException(ChunkSaveFailed)`` on
         not-found or on any underlying error.
 
-        Note on error attribution: ``get_document_info`` swallows transport-level
-        exceptions and returns ``None`` (preserving its null-safe contract).
-        That means a ``None`` here can mean either "document genuinely absent"
-        or "RAGFlow unreachable". The caller's infra-layer logs (from
-        ``get_document_info``'s ``logger.error``) carry the underlying cause;
-        our message below stays neutral rather than asserting the doc is gone.
+        ``get_document_info`` returns ``None`` only for the server's
+        ``DATA_ERROR`` (code=102) "not owned / not found" path, raises
+        ``ThirdPartyException`` for other non-zero codes, and lets transport
+        errors propagate. The generic ``except Exception`` branch below wraps
+        all raised errors into ``CustomException(ChunkSaveFailed)`` so the
+        chunk-save caller sees a consistent error code.
         """
         try:
             doc = await ragflow_client.get_document_info(dataset_id, doc_id)
             if doc is None:
-                logger.error(
-                    f"Document {doc_id} not found in RAGFlow "
-                    f"(either absent or RAGFlow unreachable — see infra logs)"
-                )
+                logger.error(f"Document {doc_id} not found in RAGFlow")
                 raise CustomException(
                     CodeEnum.ChunkSaveFailed,
-                    f"Document {doc_id} not found or RAGFlow unreachable",
+                    f"Document {doc_id} not found",
                 )
             logger.info(f"Document {doc_id} exists in RAGFlow")
         except CustomException:
-            # Re-raise without re-wrapping; the catch-all below would otherwise
-            # swallow the already-correct code/message from the None branch.
+            # Preserve the code/message from the None branch.
             raise
         except Exception as e:
-            # Defensive: get_document_info's contract is to swallow all
-            # exceptions and return None, so this branch is normally
-            # unreachable. It covers contract violations (e.g. import-level
-            # failure) and future relaxations of that contract.
             logger.error(f"Error checking document existence: {e}")
             raise CustomException(
                 CodeEnum.ChunkSaveFailed,
@@ -917,10 +920,12 @@ class RagflowRAGStrategy(RAGStrategy):
             )
 
             if first_response.get("code") != 0:
-                logger.warning(
-                    f"Failed to get chunks: {first_response.get('message', 'Unknown error')}"
+                msg = first_response.get("message", "Unknown error")
+                logger.warning(f"Failed to get chunks: {msg}")
+                raise ThirdPartyException(
+                    msg=f"RAGFlow query_doc doc={docId}: {msg}",
+                    e=CodeEnum.RAGFLOW_RAGError,
                 )
-                return []
 
             total_count = first_response.get("data", {}).get("total", 0)
             if total_count == 0:
@@ -935,10 +940,12 @@ class RagflowRAGStrategy(RAGStrategy):
             )
 
             if chunks_response.get("code") != 0:
-                logger.warning(
-                    f"Failed to get all chunks: {chunks_response.get('message', 'Unknown error')}"
+                msg = chunks_response.get("message", "Unknown error")
+                logger.warning(f"Failed to get all chunks: {msg}")
+                raise ThirdPartyException(
+                    msg=f"RAGFlow query_doc doc={docId}: {msg}",
+                    e=CodeEnum.RAGFLOW_RAGError,
                 )
-                return []
 
             logger.info(
                 f"Successfully retrieved {len(chunks_response.get('data', {}).get('chunks', []))} chunks"
@@ -964,9 +971,14 @@ class RagflowRAGStrategy(RAGStrategy):
             logger.info(f"Successfully converted {len(chunk_infos)} ChunkInfo objects")
             return chunk_infos
 
+        except CustomException:
+            raise
         except Exception as e:
             logger.error(f"Failed to query document chunk information: {e}")
-            return []
+            raise ThirdPartyException(
+                msg=f"RAGFlow query_doc failed for doc={docId}: {e}",
+                e=CodeEnum.RAGFLOW_RAGError,
+            ) from e
 
     async def query_doc_name(
         self, docId: str, **kwargs: Any
@@ -1009,9 +1021,14 @@ class RagflowRAGStrategy(RAGStrategy):
             )
             return file_info
 
+        except CustomException:
+            raise
         except Exception as e:
             logger.error(f"Failed to query document information: {e}")
-            return None
+            raise ThirdPartyException(
+                msg=f"RAGFlow query_doc_name failed for doc={docId}: {e}",
+                e=CodeEnum.RAGFLOW_RAGError,
+            ) from e
 
     async def _upsert_document(
         self,

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_error_propagation_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_error_propagation_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Error-propagation contract tests for ``ragflow_client.get_document_info``.
+
+- ``DATA_ERROR`` (102) returns ``None`` (server's not-owned / not-found path).
+- Any other non-zero code raises ``ThirdPartyException``.
+- Transport-level exceptions propagate unchanged.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.exceptions.exception import ThirdPartyException
+from knowledge.infra.ragflow import ragflow_client
+
+_LIST_DOCS = "knowledge.infra.ragflow.ragflow_client.list_documents_in_dataset"
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_data_error_returns_none() -> None:
+    """DATA_ERROR (code=102) returns ``None``."""
+    error_resp = {"code": 102, "message": "You don't own the document doc-x."}
+    with patch(_LIST_DOCS, new=AsyncMock(return_value=error_resp)):
+        result = await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_authentication_error_raises() -> None:
+    """AUTHENTICATION_ERROR (code=109) raises ThirdPartyException."""
+    error_resp = {"code": 109, "message": "Authentication failed"}
+    with patch(_LIST_DOCS, new=AsyncMock(return_value=error_resp)):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert "Authentication failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_operating_error_raises() -> None:
+    """OPERATING_ERROR (code=103) raises ThirdPartyException."""
+    error_resp = {"code": 103, "message": "Internal operating failure"}
+    with patch(_LIST_DOCS, new=AsyncMock(return_value=error_resp)):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await ragflow_client.get_document_info("ds-1", "doc-x")
+    assert "Internal operating failure" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_get_document_info_propagates_transport_exception() -> None:
+    """Transport-level exceptions propagate unchanged."""
+    with patch(_LIST_DOCS, new=AsyncMock(side_effect=RuntimeError("boom"))):
+        with pytest.raises(RuntimeError, match="boom"):
+            await ragflow_client.get_document_info("ds-1", "doc-x")

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_pagination_test.py
@@ -231,29 +231,6 @@ async def test_get_document_info_empty_docs_returns_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_document_info_server_error_returns_none() -> None:
-    """Non-zero code (e.g. 'You don't own the document') => None."""
-    error_resp = {"code": 102, "message": "You don't own the document doc-x."}
-    with patch(
-        _LIST_DOCS,
-        new=AsyncMock(return_value=error_resp),
-    ):
-        result = await ragflow_client.get_document_info("ds-1", "doc-x")
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_get_document_info_exception_returns_none() -> None:
-    """Transport-level exception => None, no propagation."""
-    with patch(
-        _LIST_DOCS,
-        new=AsyncMock(side_effect=RuntimeError("boom")),
-    ):
-        result = await ragflow_client.get_document_info("ds-1", "doc-x")
-    assert result is None
-
-
-@pytest.mark.asyncio
 async def test_get_document_info_empty_doc_id_returns_none_without_network_call() -> (
     None
 ):

--- a/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
@@ -1,20 +1,33 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Unit tests for ``RagflowUtils.get_default_dataset_name``.
+Unit tests for ``RagflowUtils`` helpers used by the RAGFlow strategy.
 
-The helper unifies how ``RAGFLOW_DEFAULT_GROUP`` is read across the four
-RAGFlow-strategy call sites (``split`` / ``chunks_save`` /
-``chunks_update`` / ``chunks_delete``), preserving the pre-existing
-fallback behavior so this refactor is behavior-preserving for callers.
+Covers:
+
+- ``get_default_dataset_name``: unified ``RAGFLOW_DEFAULT_GROUP`` reader
+  across the four strategy call sites (``split`` / ``chunks_save`` /
+  ``chunks_update`` / ``chunks_delete``).
+- ``get_dataset_id_by_name``: dataset-lookup failures should propagate
+  instead of collapsing into ``None``.
 """
 
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
 import pytest
 
+from knowledge.exceptions.exception import ThirdPartyException
 from knowledge.infra.ragflow.ragflow_utils import (
     DEFAULT_RAGFLOW_DATASET_NAME,
     RagflowUtils,
 )
+
+# Mock the module-level ``list_datasets`` import resolved inside
+# ``get_dataset_id_by_name``. The helper reaches it via
+# ``ragflow_client.list_datasets``; patching the client attribute covers
+# both dotted and direct-import access paths.
+_LIST_DATASETS = "knowledge.infra.ragflow.ragflow_client.list_datasets"
 
 
 class TestGetDefaultDatasetName:
@@ -35,3 +48,46 @@ class TestGetDefaultDatasetName:
     ) -> None:
         monkeypatch.setenv("RAGFLOW_DEFAULT_GROUP", "")
         assert RagflowUtils.get_default_dataset_name() == DEFAULT_RAGFLOW_DATASET_NAME
+
+
+class TestGetDatasetIdByName:
+    """Tests for ``RagflowUtils.get_dataset_id_by_name``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_id_on_matching_dataset(self) -> None:
+        """code=0 + matching dataset => returns dataset id."""
+        resp = {"code": 0, "data": [{"id": "ds-1", "name": "MyKB"}]}
+        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
+            result = await RagflowUtils.get_dataset_id_by_name("MyKB")
+        assert result == "ds-1"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_match(self) -> None:
+        """Back-compat: code=0 + empty data => ``None`` so the caller can
+        treat it as 'dataset not configured', preserving the
+        fallback-to-empty-result behavior for genuine no-match cases."""
+        resp = {"code": 0, "data": []}
+        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
+            result = await RagflowUtils.get_dataset_id_by_name("MissingKB")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_on_transport_exception(self) -> None:
+        """aiohttp errors propagate instead of being collapsed into ``None``."""
+        with patch(
+            _LIST_DATASETS,
+            new=AsyncMock(side_effect=aiohttp.ClientConnectionError("down")),
+        ):
+            with pytest.raises(aiohttp.ClientConnectionError):
+                await RagflowUtils.get_dataset_id_by_name("AnyKB")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_zero_code(self) -> None:
+        """Non-zero code (auth / argument / operating error) => ThirdPartyException.
+        RAGFlow's ``/datasets`` endpoint returns ``code=0, data=[]`` for
+        genuine no-match, so any non-zero code is a real protocol failure."""
+        resp = {"code": 109, "message": "Authentication failed"}
+        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
+            with pytest.raises(ThirdPartyException) as exc_info:
+                await RagflowUtils.get_dataset_id_by_name("AnyKB")
+        assert "Authentication failed" in str(exc_info.value)

--- a/core/knowledge/tests/service/impl/ragflow_strategy_error_propagation_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_error_propagation_test.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for RagflowRAGStrategy error propagation.
+
+RAGFlow transport errors and non-zero response codes should raise
+``ThirdPartyException``. Legitimate empty results should still return the
+existing empty response shape.
+"""
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from knowledge.exceptions.exception import ThirdPartyException
+from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+# Patch targets - keep in sync with imports in `ragflow_strategy.py`.
+_GET_DATASET_NAME = (
+    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
+)
+_GET_DATASET_ID = (
+    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
+)
+_LIST_CHUNKS = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.list_document_chunks"
+)
+_GET_DOC_INFO = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.get_document_info"
+)
+_RETRIEVAL = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.retrieval_with_dataset"
+)
+# Reach all the way to the client so the dataset-lookup helper runs for
+# real; lets the full ``/chunk/query`` path be exercised when RAGFlow fails
+# during the dataset-lookup stage.
+_LIST_DATASETS = "knowledge.infra.ragflow.ragflow_client.list_datasets"
+
+
+# ----------------------------------------------------------------------
+# Section 0: query (the /chunk/query main retrieval path)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_raises_on_transport_exception() -> None:
+    """Main retrieval path propagates aiohttp.ClientError as ThirdPartyException."""
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(
+            _RETRIEVAL,
+            new=AsyncMock(
+                side_effect=aiohttp.ClientConnectionError("RAGFlow unreachable")
+            ),
+        ),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query("hello", top_k=6)
+    assert "RAGFlow" in str(exc_info.value) or "query" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_raises_on_ragflow_error_code() -> None:
+    """Main retrieval path raises ThirdPartyException on non-zero RAGFlow code."""
+    strategy = RagflowRAGStrategy()
+    bad_response: Dict[str, Any] = {
+        "code": 500,
+        "message": "RAGFlow internal failure",
+    }
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_RETRIEVAL, new=AsyncMock(return_value=bad_response)),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query("hello", top_k=6)
+    assert "RAGFlow internal failure" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_returns_empty_results_when_no_chunks_matched() -> None:
+    """A genuine no-match (code=0, empty chunks) returns the empty-results dict."""
+    strategy = RagflowRAGStrategy()
+    empty_response: Dict[str, Any] = {
+        "code": 0,
+        "data": {"chunks": []},
+    }
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_RETRIEVAL, new=AsyncMock(return_value=empty_response)),
+    ):
+        result = await strategy.query("hello", top_k=6)
+    assert result == {"query": "hello", "count": 0, "results": []}
+
+
+@pytest.mark.asyncio
+async def test_query_raises_when_dataset_lookup_transport_fails() -> None:
+    """Dataset-lookup transport failures propagate through the query path."""
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(
+            _LIST_DATASETS,
+            new=AsyncMock(side_effect=aiohttp.ClientConnectionError("down")),
+        ),
+    ):
+        with pytest.raises(ThirdPartyException):
+            await strategy.query("hello", top_k=6)
+
+
+@pytest.mark.asyncio
+async def test_query_raises_when_dataset_lookup_returns_non_zero_code() -> None:
+    """Non-zero ``list_datasets`` code propagates as ThirdPartyException
+    instead of being treated as 'dataset not configured'."""
+    strategy = RagflowRAGStrategy()
+    failing_list: Dict[str, Any] = {
+        "code": 109,
+        "message": "Authentication failed",
+    }
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_LIST_DATASETS, new=AsyncMock(return_value=failing_list)),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query("hello", top_k=6)
+    assert "Authentication failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_returns_empty_results_when_dataset_not_configured() -> None:
+    """``list_datasets`` reporting no matching name (code=0, empty data)
+    keeps the empty-results response instead of raising."""
+    strategy = RagflowRAGStrategy()
+    no_match: Dict[str, Any] = {"code": 0, "data": []}
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_LIST_DATASETS, new=AsyncMock(return_value=no_match)),
+    ):
+        result = await strategy.query("hello", top_k=6)
+    assert result == {"query": "hello", "count": 0, "results": []}
+
+
+# ----------------------------------------------------------------------
+# Section A: query_doc
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_doc_raises_on_transport_exception() -> None:
+    """aiohttp.ClientError from the client layer surfaces as ThirdPartyException."""
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(
+            _LIST_CHUNKS,
+            new=AsyncMock(
+                side_effect=aiohttp.ClientConnectionError("RAGFlow unreachable")
+            ),
+        ),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query_doc("doc-x")
+    assert "doc-x" in str(exc_info.value) or "RAGFlow" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_doc_raises_on_ragflow_error_code() -> None:
+    """``code != 0`` from the chunks endpoint raises ThirdPartyException."""
+    strategy = RagflowRAGStrategy()
+    bad_response: Dict[str, Any] = {
+        "code": 500,
+        "message": "internal RAGFlow failure",
+    }
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_LIST_CHUNKS, new=AsyncMock(return_value=bad_response)),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query_doc("doc-x")
+    assert "internal RAGFlow failure" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_doc_returns_empty_list_when_document_has_no_chunks() -> None:
+    """A document with zero chunks returns ``[]`` without raising."""
+    strategy = RagflowRAGStrategy()
+    empty_response: Dict[str, Any] = {
+        "code": 0,
+        "data": {"total": 0, "chunks": []},
+    }
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_LIST_CHUNKS, new=AsyncMock(return_value=empty_response)),
+    ):
+        result = await strategy.query_doc("doc-x")
+    assert result == []
+
+
+# ----------------------------------------------------------------------
+# Section B: query_doc_name
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_doc_name_raises_on_transport_exception() -> None:
+    """Transport exception inside ``get_document_info`` surfaces as ThirdPartyException."""
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(
+            _GET_DOC_INFO,
+            new=AsyncMock(side_effect=aiohttp.ClientError("connection reset")),
+        ),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query_doc_name("doc-x")
+    assert "doc-x" in str(exc_info.value) or "connection reset" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_doc_name_returns_none_when_document_truly_missing() -> None:
+    """'document not found' (``get_document_info`` returns None) stays a normal None."""
+    strategy = RagflowRAGStrategy()
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_GET_DOC_INFO, new=AsyncMock(return_value=None)),
+    ):
+        result = await strategy.query_doc_name("doc-x")
+    assert result is None

--- a/core/knowledge/tests/service/impl/ragflow_strategy_error_propagation_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_error_propagation_test.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, patch
 import aiohttp
 import pytest
 
+from knowledge.consts.error_code import CodeEnum
 from knowledge.exceptions.exception import ThirdPartyException
 from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 
@@ -187,6 +188,23 @@ async def test_query_doc_raises_on_ragflow_error_code() -> None:
 
 
 @pytest.mark.asyncio
+async def test_query_doc_preserves_third_party_exception() -> None:
+    """Existing ThirdPartyException instances propagate unchanged."""
+    strategy = RagflowRAGStrategy()
+    original = ThirdPartyException(
+        msg="dataset lookup failed",
+        e=CodeEnum.RAGFLOW_RAGError,
+    )
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(side_effect=original)),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query_doc("doc-x")
+    assert exc_info.value is original
+
+
+@pytest.mark.asyncio
 async def test_query_doc_returns_empty_list_when_document_has_no_chunks() -> None:
     """A document with zero chunks returns ``[]`` without raising."""
     strategy = RagflowRAGStrategy()
@@ -223,6 +241,24 @@ async def test_query_doc_name_raises_on_transport_exception() -> None:
         with pytest.raises(ThirdPartyException) as exc_info:
             await strategy.query_doc_name("doc-x")
     assert "doc-x" in str(exc_info.value) or "connection reset" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_doc_name_preserves_third_party_exception() -> None:
+    """Existing ThirdPartyException instances propagate unchanged."""
+    strategy = RagflowRAGStrategy()
+    original = ThirdPartyException(
+        msg="document info failed",
+        e=CodeEnum.RAGFLOW_RAGError,
+    )
+    with (
+        patch(_GET_DATASET_NAME, return_value="ds-name"),
+        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_GET_DOC_INFO, new=AsyncMock(side_effect=original)),
+    ):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy.query_doc_name("doc-x")
+    assert exc_info.value is original
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

当 RAGFlow 不可用或返回服务端错误时，当前部分 RAGFlow 集成路径会把故障转换成"成功的空结果"。

例如 `/chunk/query` 在 dataset lookup 或 retrieval 阶段失败时，可能返回 `count: 0`、`results: []`。这样 `handle_rag_operation` 会把这次调用计为成功，监控侧也无法区分"确实没有召回结果"和"RAGFlow 后端故障"。

本 PR 统一 RAGFlow 的错误传播语义：RAGFlow transport 异常和非零服务端错误码会以 `ThirdPartyException(CodeEnum.RAGFLOW_RAGError)` 上报；合法的空结果路径保持兼容。

### Scenario

修复前：

1. `/chunk/query` 收到一次正常查询。
2. RAGFlow 在 dataset lookup、retrieval、document lookup 或 chunk lookup 阶段失败。
3. helper / strategy 捕获异常后返回 `None`、`[]` 或 `{ count: 0, results: [] }`。
4. `handle_rag_operation` 将响应计为成功。
5. metric / trace 表现为一次成功的零召回，而不是 RAGFlow 故障。

修复后：

- RAGFlow transport 异常和非零服务端错误码会抛出 `ThirdPartyException(RAGFLOW_RAGError)`。
- 合法空结果仍返回原有空响应结构。
- metric / trace 可以正确归因到 RAGFlow 后端。

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
N/A

## Changes

- 新增 `CodeEnum.RAGFLOW_RAGError = 10029`，与 `CBG_RAGError` / `AIUI_RAGError` / `DESK_RAGError` 对齐。
- 更新 `get_document_info`：
  - `code == 0` 且命中文档时返回文档信息。
  - `code == 0` 但未命中文档时返回 `None`。
  - `DATA_ERROR` / `102` 返回 `None`，兼容 RAGFlow 的 not-owned / not-found 路径。
  - 其他非零 code 抛出 `ThirdPartyException(RAGFLOW_RAGError)`。
  - transport 异常不再吞，向上传播。
- 更新 `get_dataset_id_by_name`：
  - 成功查询但无匹配 dataset 时仍返回 `None`。
  - 非零 RAGFlow code 抛出 `ThirdPartyException(RAGFLOW_RAGError)`。
  - transport 异常向上传播。
- 更新 `query`、`query_doc`、`query_doc_name`，不再把 RAGFlow 故障兜底为空结果。
- 更新相关 docstring 和测试，覆盖新的错误传播契约。

### Compatibility

以下合法空结果路径保持不变：

- RAGFlow 返回 `code == 0` 且无匹配 chunks。
- RAGFlow 返回 `code == 0` 且无匹配 dataset。
- `get_document_info` 收到 RAGFlow 的 not-owned / not-found `DATA_ERROR`。

本 PR 不改动 AIUI、CBG、SparkDesk 策略的错误处理。

## Testing
- [x] Existing tests pass: `uv run pytest tests/` → 267 passed
- [x] New tests added (18 tests across 3 files)
- [ ] Manual testing completed

新增 / 更新测试文件：

- `tests/infra/ragflow/ragflow_client_error_propagation_test.py`（4 tests）
- `tests/service/impl/ragflow_strategy_error_propagation_test.py`（11 tests）
- `tests/infra/ragflow/ragflow_utils_test.py` 新增 `TestGetDatasetIdByName`（4 tests）

覆盖场景：

- RAGFlow transport 异常
- RAGFlow 非零 response code
- `DATA_ERROR` / `102` not-found 白名单
- 成功空结果兼容路径
- dataset lookup 阶段失败经由 `/chunk/query` 向上传播

Lint：

- `uv run black --check ...` → passed
- `uv run isort --profile black --check-only ...` → passed

## Screenshots (if applicable)

N/A，服务端行为修复。

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (docstring 已同步新契约)
- [x] Breaking changes documented (见 Scenario 段：调用方若把"空结果"当正常分支处理，现在会收到 \`ThirdPartyException\` — 符合修复意图)

---

_Detailed context and a broader RAGFlow integration catalog available on request._