### PR TITLE
fix(ragflow): honor explicit dataset id during upload

### DIFF
--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -469,12 +469,12 @@ async def upload_document_to_dataset(
     - When ``dataset_id`` is non-empty, resolve the dataset via SDK id lookup
       and upload to it. If the SDK returns no matching dataset, raise
       ``ValueError`` instead of redirecting to the env default group.
-    - When ``dataset_id`` is empty, fall back to the legacy
-      ``RAGFLOW_DEFAULT_GROUP``-based lookup to preserve single-dataset
-      behavior for callers that don't yet pass explicit ids.
+    - When ``dataset_id`` is empty, use the configured
+      ``RAGFLOW_DEFAULT_GROUP`` lookup. Missing or empty default groups fail
+      before any dataset lookup.
 
     Args:
-        dataset_id: Dataset ID; empty string triggers legacy default-group path.
+        dataset_id: Dataset ID; empty string triggers configured fallback.
         file_content: File content bytes.
         filename: File name.
 
@@ -483,11 +483,10 @@ async def upload_document_to_dataset(
 
     Raises:
         ValueError: If ``dataset_id`` is provided but not resolvable via SDK,
-            or if the legacy path cannot find the configured default group.
+            or if the configured fallback cannot resolve a dataset.
     """
-    rag = get_rag_object()
-
     if dataset_id:
+        rag = get_rag_object()
         sdk_datasets: List[Any] = rag.list_datasets(id=dataset_id)
         if not sdk_datasets:
             raise ValueError(
@@ -523,15 +522,14 @@ async def _resolve_dataset_via_rest(group_name: str, rag: Any) -> Any:
 
 
 async def _upload_via_default_group(file_content: bytes, filename: str) -> List[Any]:
-    """Legacy upload path: resolve dataset via ``RAGFLOW_DEFAULT_GROUP`` env.
+    """Legacy upload path using configured ``RAGFLOW_DEFAULT_GROUP``.
 
     Kept separate to avoid increasing ``upload_document_to_dataset`` complexity.
     """
     group_name = os.getenv("RAGFLOW_DEFAULT_GROUP", "")
     if not group_name:
         raise ValueError(
-            "RAGFLOW_DEFAULT_GROUP is not set; cannot upload via legacy "
-            "default-group path — refusing to route to an arbitrary dataset"
+            "RAGFLOW_DEFAULT_GROUP is not set; cannot upload without dataset_id"
         )
     rag = get_rag_object()
 

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -463,49 +463,87 @@ async def upload_document_to_dataset(
     dataset_id: str, file_content: bytes, filename: str
 ) -> List[Any]:
     """
-    Upload document to specified dataset API
+    Upload document to the specified dataset.
+
+    Resolution strategy:
+    - When ``dataset_id`` is non-empty, resolve the dataset via SDK id lookup
+      and upload to it. If the SDK returns no matching dataset, raise
+      ``ValueError`` instead of redirecting to the env default group.
+    - When ``dataset_id`` is empty, fall back to the legacy
+      ``RAGFLOW_DEFAULT_GROUP``-based lookup to preserve single-dataset
+      behavior for callers that don't yet pass explicit ids.
 
     Args:
-        dataset_id: Dataset ID
-        file_content: File content
-        filename: File name
+        dataset_id: Dataset ID; empty string triggers legacy default-group path.
+        file_content: File content bytes.
+        filename: File name.
 
     Returns:
-        Upload response containing document ID
-    """
+        Upload response containing document ID(s).
 
-    group_name = os.getenv("RAGFLOW_DEFAULT_GROUP", "")
+    Raises:
+        ValueError: If ``dataset_id`` is provided but not resolvable via SDK,
+            or if the legacy path cannot find the configured default group.
+    """
     rag = get_rag_object()
 
-    def _pick_first_dataset(datasets: List[Any]) -> Any:
-        if datasets:
-            return datasets[0]
-        raise ValueError(f"Dataset '{group_name}' not found when uploading document")
+    if dataset_id:
+        sdk_datasets: List[Any] = rag.list_datasets(id=dataset_id)
+        if not sdk_datasets:
+            raise ValueError(
+                f"Dataset id={dataset_id} not visible to RAGFlow SDK; "
+                "refusing to silently fall back to RAGFLOW_DEFAULT_GROUP "
+                "to avoid cross-repo upload contamination"
+            )
+        return sdk_datasets[0].upload_documents(
+            [{"displayed_name": filename, "blob": file_content}]
+        )
 
-    dataset_obj: Any
+    return await _upload_via_default_group(file_content=file_content, filename=filename)
 
-    try:
-        # Preferred path: SDK finds the dataset directly by name
-        dataset_obj = _pick_first_dataset(rag.list_datasets(name=group_name))
-    except ValueError:
+
+async def _resolve_dataset_via_rest(group_name: str, rag: Any) -> Any:
+    """Fallback: locate default-group dataset via REST when SDK name lookup fails.
+
+    Kept separate to avoid increasing default-group path complexity.
+    """
+    rest_response = await list_datasets(name=group_name)
+    datasets = rest_response.get("data", []) if rest_response else []
+    if not datasets:
+        raise ValueError(f"Dataset '{group_name}' does not exist in RAGFlow")
+    actual_id = datasets[0].get("id")
+    if not actual_id:
+        raise ValueError(f"Dataset '{group_name}' REST response missing id field")
+    sdk_datasets: List[Any] = rag.list_datasets(id=actual_id)
+    if not sdk_datasets:
+        raise ValueError(
+            f"Dataset '{group_name}' (id={actual_id}) not visible to ragflow_sdk"
+        )
+    return sdk_datasets[0]
+
+
+async def _upload_via_default_group(file_content: bytes, filename: str) -> List[Any]:
+    """Legacy upload path: resolve dataset via ``RAGFLOW_DEFAULT_GROUP`` env.
+
+    Kept separate to avoid increasing ``upload_document_to_dataset`` complexity.
+    """
+    group_name = os.getenv("RAGFLOW_DEFAULT_GROUP", "")
+    if not group_name:
+        raise ValueError(
+            "RAGFLOW_DEFAULT_GROUP is not set; cannot upload via legacy "
+            "default-group path — refusing to route to an arbitrary dataset"
+        )
+    rag = get_rag_object()
+
+    sdk_hit: List[Any] = rag.list_datasets(name=group_name)
+    if sdk_hit:
+        dataset_obj = sdk_hit[0]
+    else:
         logger.warning(
             "Dataset '%s' not visible via SDK lookup, refreshing via REST API",
             group_name,
         )
-
-        rest_response = await list_datasets(name=group_name)
-        datasets = rest_response.get("data", []) if rest_response else []
-        if not datasets:
-            raise ValueError(f"Dataset '{group_name}' does not exist in RAGFlow")
-
-        # Fall back to locating dataset via ID if REST returned it
-        actual_id = datasets[0].get("id") or dataset_id
-        sdk_datasets: List[Any] = rag.list_datasets(id=actual_id)
-        if not sdk_datasets:
-            raise ValueError(
-                f"Dataset '{group_name}' (id={actual_id}) not visible to ragflow_sdk"
-            )
-        dataset_obj = sdk_datasets[0]
+        dataset_obj = await _resolve_dataset_via_rest(group_name, rag)
 
     return dataset_obj.upload_documents(
         [{"displayed_name": filename, "blob": file_content}]

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_upload_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_upload_test.py
@@ -105,7 +105,7 @@ async def test_upload_uses_env_default_group_when_dataset_id_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_upload_raises_when_dataset_id_empty_and_env_group_missing() -> None:
-    """dataset_id='' with a missing env group raises ValueError."""
+    """Configured env group absent from RAGFlow raises ValueError."""
     mock_rag = MagicMock()
     mock_rag.list_datasets = MagicMock(return_value=[])
 
@@ -145,26 +145,27 @@ async def test_upload_payload_contains_displayed_name_and_blob() -> None:
     )
 
 
+@pytest.mark.parametrize("env_value", [None, ""])
 @pytest.mark.asyncio
-async def test_upload_raises_when_dataset_id_empty_and_env_group_unset() -> None:
-    """dataset_id='' + RAGFLOW_DEFAULT_GROUP unset → ValueError.
-
-    Guards the legacy path against routing to an arbitrary dataset when the
-    env variable is missing or empty: an empty ``name=`` SDK lookup could
-    otherwise return all datasets and pick any first one (same family of
-    cross-repo contamination as the RF-22 bug on the explicit-id path).
-    """
+async def test_upload_raises_when_dataset_id_empty_and_default_group_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, env_value: str | None
+) -> None:
+    """Empty default group fails before SDK dataset lookup."""
     mock_rag = MagicMock()
+    if env_value is None:
+        monkeypatch.delenv("RAGFLOW_DEFAULT_GROUP", raising=False)
+    else:
+        monkeypatch.setenv("RAGFLOW_DEFAULT_GROUP", env_value)
 
     with patch.object(
         ragflow_client, "get_rag_object", return_value=mock_rag
-    ), patch.dict("os.environ", {"RAGFLOW_DEFAULT_GROUP": ""}, clear=False):
+    ) as get_rag_object_mock:
         with pytest.raises(ValueError, match="RAGFLOW_DEFAULT_GROUP is not set"):
             await ragflow_client.upload_document_to_dataset(
                 dataset_id="",
-                file_content=b"should not land anywhere",
-                filename="rf22_unset_env.txt",
+                file_content=b"hello",
+                filename="t.pdf",
             )
 
-    # SDK must NEVER be queried — validation kicks in before any lookup
+    get_rag_object_mock.assert_not_called()
     mock_rag.list_datasets.assert_not_called()

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_upload_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_upload_test.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for explicit dataset upload and legacy fallback."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge.infra.ragflow import ragflow_client
+
+
+def _make_dataset_mock(ds_id: str) -> MagicMock:
+    """Build a mock dataset object with recordable upload_documents."""
+    ds = MagicMock()
+    ds.id = ds_id
+    ds.upload_documents = MagicMock(return_value=[{"id": f"doc-of-{ds_id}"}])
+    return ds
+
+
+@pytest.mark.asyncio
+async def test_upload_honors_dataset_id_when_provided_and_resolvable() -> None:
+    """When dataset_id resolves via SDK, upload to that dataset (not default group)."""
+    target_ds = _make_dataset_mock("ds-A")
+    mock_rag = MagicMock()
+    mock_rag.list_datasets = MagicMock(return_value=[target_ds])
+
+    with patch.object(
+        ragflow_client, "get_rag_object", return_value=mock_rag
+    ), patch.dict("os.environ", {"RAGFLOW_DEFAULT_GROUP": "wrong-group"}, clear=False):
+        result = await ragflow_client.upload_document_to_dataset(
+            dataset_id="ds-A",
+            file_content=b"hello",
+            filename="t.pdf",
+        )
+
+    mock_rag.list_datasets.assert_called_once_with(id="ds-A")
+    target_ds.upload_documents.assert_called_once_with(
+        [{"displayed_name": "t.pdf", "blob": b"hello"}]
+    )
+    assert result == [{"id": "doc-of-ds-A"}]
+
+
+@pytest.mark.asyncio
+async def test_upload_raises_when_dataset_id_provided_but_sdk_returns_empty() -> None:
+    """Explicit dataset_id misses fail without falling back to the env group."""
+    mock_rag = MagicMock()
+    mock_rag.list_datasets = MagicMock(return_value=[])
+    rest_mock = AsyncMock()
+
+    with patch.object(
+        ragflow_client, "get_rag_object", return_value=mock_rag
+    ), patch.object(ragflow_client, "list_datasets", new=rest_mock), patch.dict(
+        "os.environ", {"RAGFLOW_DEFAULT_GROUP": "default-group"}, clear=False
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"not visible to RAGFlow SDK"
+                r".*refusing to silently fall back"
+                r".*cross-repo upload contamination"
+            ),
+        ):
+            await ragflow_client.upload_document_to_dataset(
+                dataset_id="ds-missing",
+                file_content=b"hello",
+                filename="t.pdf",
+            )
+
+    name_based_calls = [
+        call
+        for call in mock_rag.list_datasets.call_args_list
+        if call.kwargs.get("name") is not None
+    ]
+    assert not name_based_calls, (
+        f"Fail-closed violated: SDK name-based lookup attempted after id miss: "
+        f"{name_based_calls}"
+    )
+    rest_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_uses_env_default_group_when_dataset_id_empty() -> None:
+    """dataset_id='' uses the legacy env-based path."""
+    default_ds = _make_dataset_mock("ds-default")
+    mock_rag = MagicMock()
+    mock_rag.list_datasets = MagicMock(return_value=[default_ds])
+
+    with patch.object(
+        ragflow_client, "get_rag_object", return_value=mock_rag
+    ), patch.dict(
+        "os.environ", {"RAGFLOW_DEFAULT_GROUP": "default-group"}, clear=False
+    ):
+        result = await ragflow_client.upload_document_to_dataset(
+            dataset_id="",
+            file_content=b"hello",
+            filename="t.pdf",
+        )
+
+    mock_rag.list_datasets.assert_called_once_with(name="default-group")
+    default_ds.upload_documents.assert_called_once_with(
+        [{"displayed_name": "t.pdf", "blob": b"hello"}]
+    )
+    assert result == [{"id": "doc-of-ds-default"}]
+
+
+@pytest.mark.asyncio
+async def test_upload_raises_when_dataset_id_empty_and_env_group_missing() -> None:
+    """dataset_id='' with a missing env group raises ValueError."""
+    mock_rag = MagicMock()
+    mock_rag.list_datasets = MagicMock(return_value=[])
+
+    with patch.object(
+        ragflow_client, "get_rag_object", return_value=mock_rag
+    ), patch.dict(
+        "os.environ", {"RAGFLOW_DEFAULT_GROUP": "missing-group"}, clear=False
+    ), patch.object(
+        ragflow_client,
+        "list_datasets",
+        new=AsyncMock(return_value={"data": []}),
+    ):
+        with pytest.raises(ValueError, match="does not exist"):
+            await ragflow_client.upload_document_to_dataset(
+                dataset_id="",
+                file_content=b"hello",
+                filename="t.pdf",
+            )
+
+
+@pytest.mark.asyncio
+async def test_upload_payload_contains_displayed_name_and_blob() -> None:
+    """Verify the exact payload shape passed to SDK upload_documents."""
+    target_ds = _make_dataset_mock("ds-A")
+    mock_rag = MagicMock()
+    mock_rag.list_datasets = MagicMock(return_value=[target_ds])
+
+    with patch.object(ragflow_client, "get_rag_object", return_value=mock_rag):
+        await ragflow_client.upload_document_to_dataset(
+            dataset_id="ds-A",
+            file_content=b"content-bytes",
+            filename="doc.txt",
+        )
+
+    target_ds.upload_documents.assert_called_once_with(
+        [{"displayed_name": "doc.txt", "blob": b"content-bytes"}]
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_raises_when_dataset_id_empty_and_env_group_unset() -> None:
+    """dataset_id='' + RAGFLOW_DEFAULT_GROUP unset → ValueError.
+
+    Guards the legacy path against routing to an arbitrary dataset when the
+    env variable is missing or empty: an empty ``name=`` SDK lookup could
+    otherwise return all datasets and pick any first one (same family of
+    cross-repo contamination as the RF-22 bug on the explicit-id path).
+    """
+    mock_rag = MagicMock()
+
+    with patch.object(
+        ragflow_client, "get_rag_object", return_value=mock_rag
+    ), patch.dict("os.environ", {"RAGFLOW_DEFAULT_GROUP": ""}, clear=False):
+        with pytest.raises(ValueError, match="RAGFLOW_DEFAULT_GROUP is not set"):
+            await ragflow_client.upload_document_to_dataset(
+                dataset_id="",
+                file_content=b"should not land anywhere",
+                filename="rf22_unset_env.txt",
+            )
+
+    # SDK must NEVER be queried — validation kicks in before any lookup
+    mock_rag.list_datasets.assert_not_called()


### PR DESCRIPTION
## Summary

修复 RAGFlow 文档上传时显式 `dataset_id` 被忽略的问题。

当调用方传入非空 `dataset_id` 时，上传逻辑现在会通过 RAGFlow SDK 按 id 查找目标 dataset，并上传到该 dataset。如果 SDK 无法看到该 dataset，则直接失败，避免静默回退到 `RAGFLOW_DEFAULT_GROUP` 导致文档上传到错误知识库。

当 `dataset_id` 为空时，保留原有基于 `RAGFLOW_DEFAULT_GROUP` 的 legacy 行为，避免影响旧调用路径。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

N/A

## Changes

- 非空 `dataset_id` 场景下，按 SDK dataset id lookup 后上传。
- 显式 `dataset_id` 查找失败时 fail closed，不再静默回退到默认 group。
- 保留空 `dataset_id` 时的 `RAGFLOW_DEFAULT_GROUP` legacy fallback 行为。
- 新增回归测试，覆盖显式 id 上传、id miss 失败、legacy fallback、上传 payload shape。

## Testing

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing completed

Commands run:

```bash
cd core/knowledge

pytest tests/infra/ragflow/ragflow_client_upload_test.py -q

.venv/bin/black --check \
  infra/ragflow/ragflow_client.py \
  tests/infra/ragflow/ragflow_client_upload_test.py

.venv/bin/isort --check-only --profile black \
  infra/ragflow/ragflow_client.py \
  tests/infra/ragflow/ragflow_client_upload_test.py

.venv/bin/python -m flake8 \
  --max-line-length 88 --ignore=E203,W503,E501 --max-complexity 10 \
  infra/ragflow/ragflow_client.py \
  tests/infra/ragflow/ragflow_client_upload_test.py
```
