### PR TITLE
feat(knowledge): route RAGFlow ops by per-repo datasets

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/SplitRequest.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/SplitRequest.java
@@ -50,6 +50,18 @@ public class SplitRequest {
      */
     Integer resourceType;
 
+    /**
+     * RAGFlow dataset group (coreRepoId for Ragflow-RAG). Optional; null falls back to the default
+     * group.
+     */
+    private String group;
+
+    /**
+     * Human-readable label written into the RAGFlow dataset description on first creation. Helps
+     * operators identify the dataset in the RAGFlow UI without resolving UUIDs.
+     */
+    private String groupDescription;
+
     // Default to AIUI value
     public SplitRequest() {
         this.ragType = ProjectContent.FILE_SOURCE_AIUI_RAG2_STR;

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/SplitRequest.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/SplitRequest.java
@@ -54,13 +54,13 @@ public class SplitRequest {
      * RAGFlow dataset group (coreRepoId for Ragflow-RAG). Optional; null falls back to the default
      * group.
      */
-    private String group;
+    String group;
 
     /**
      * Human-readable label written into the RAGFlow dataset description on first creation. Helps
      * operators identify the dataset in the RAGFlow UI without resolving UUIDs.
      */
-    private String groupDescription;
+    String groupDescription;
 
     // Default to AIUI value
     public SplitRequest() {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
@@ -31,7 +31,7 @@ public class KnowledgeV2ServiceCallHandler {
      * @param request the split request describing the document
      * @param coreRepoId Ragflow-RAG dataset name/group; forwarded as {@code group} so the upstream
      *        service can resolve the matching dataset. Ignored for non-Ragflow-RAG sources to keep
-     *        CBG/AIUI/Spark behaviour intact.
+     *        CBG/AIUI/Spark behavior intact.
      * @param repoName human-readable repo display name; written into RAGFlow dataset description on
      *        first lazy creation. Pass {@code null} to skip.
      * @return knowledge response from the upstream split API
@@ -59,7 +59,7 @@ public class KnowledgeV2ServiceCallHandler {
      * @param oldDocId existing RAGFlow doc id for upsert; null for first slice
      * @param coreRepoId Ragflow-RAG dataset name/group; forwarded as {@code group} so the upstream
      *        service can resolve the matching dataset. Ignored for non-Ragflow-RAG sources to keep
-     *        CBG/AIUI/Spark behaviour intact.
+     *        CBG/AIUI/Spark behavior intact.
      * @param repoName human-readable repo display name; written into RAGFlow dataset description on
      *        first lazy creation. Pass {@code null} to skip.
      * @return KnowledgeResponse

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.toolkit.handler;
 
 import com.alibaba.fastjson2.JSON;
+import com.iflytek.astron.console.toolkit.common.constant.ProjectContent;
 import com.iflytek.astron.console.toolkit.config.properties.RepoAuthorizedConfig;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
 import com.iflytek.astron.console.toolkit.entity.core.knowledge.*;
@@ -27,10 +28,18 @@ public class KnowledgeV2ServiceCallHandler {
     /**
      * Document parsing and chunking
      *
-     * @param request
-     * @return
+     * @param request the split request describing the document
+     * @param coreRepoId Ragflow-RAG dataset name/group; forwarded as {@code group} so the upstream
+     *        service can resolve the matching dataset. Ignored for non-Ragflow-RAG sources to keep
+     *        CBG/AIUI/Spark behaviour intact.
+     * @param repoName human-readable repo display name; written into RAGFlow dataset description on
+     *        first lazy creation. Pass {@code null} to skip.
+     * @return knowledge response from the upstream split API
      */
-    public KnowledgeResponse documentSplit(SplitRequest request) {
+    public KnowledgeResponse documentSplit(
+            SplitRequest request, String coreRepoId, String repoName) {
+        applyGroupToSplitRequest(request, coreRepoId);
+        applyGroupDescriptionToSplitRequest(request, repoName);
         String url = apiUrl.getKnowledgeUrl().concat("/v1/document/split");
         String reqBody = JSON.toJSONString(request);
         log.info("documentSplit url = {}, request = {}", url, reqBody);
@@ -48,12 +57,19 @@ public class KnowledgeV2ServiceCallHandler {
      * @param ragType RAG type
      * @param resourceType resource type (0=file, 1=html)
      * @param oldDocId existing RAGFlow doc id for upsert; null for first slice
+     * @param coreRepoId Ragflow-RAG dataset name/group; forwarded as {@code group} so the upstream
+     *        service can resolve the matching dataset. Ignored for non-Ragflow-RAG sources to keep
+     *        CBG/AIUI/Spark behaviour intact.
+     * @param repoName human-readable repo display name; written into RAGFlow dataset description on
+     *        first lazy creation. Pass {@code null} to skip.
      * @return KnowledgeResponse
      */
     public KnowledgeResponse documentUpload(MultipartFile multipartFile,
             List<Integer> lengthRange, List<String> separator,
             String ragType, Integer resourceType,
-            String oldDocId) {
+            String oldDocId,
+            String coreRepoId,
+            String repoName) {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/document/upload");
 
         try {
@@ -75,6 +91,8 @@ public class KnowledgeV2ServiceCallHandler {
             if (StringUtils.isNotBlank(oldDocId)) {
                 params.put("documentId", oldDocId);
             }
+            applyGroupToUploadParams(params, ragType, coreRepoId);
+            applyGroupDescriptionToUploadParams(params, ragType, repoName);
 
             log.info("documentUpload url = {}, ragType = {}, resourceType = {}", url, ragType, resourceType);
             String post = OkHttpUtil.postMultipart(url, new HashMap<>(), null, params, null);
@@ -86,6 +104,63 @@ public class KnowledgeV2ServiceCallHandler {
             errorResponse.setCode(-1);
             errorResponse.setMessage("Upload failed: " + e.getMessage());
             return errorResponse;
+        }
+    }
+
+    /**
+     * Set {@code group} on the split request for Ragflow-RAG when {@code coreRepoId} is non-blank.
+     * No-op otherwise so other RAG strategies stay untouched.
+     */
+    void applyGroupToSplitRequest(SplitRequest request, String coreRepoId) {
+        if (request == null) {
+            return;
+        }
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(request.getRagType())
+                && StringUtils.isNotBlank(coreRepoId)) {
+            request.setGroup(coreRepoId);
+        }
+    }
+
+    /**
+     * Add {@code group} to the upload params map for Ragflow-RAG when {@code coreRepoId} is non-blank.
+     * No-op otherwise.
+     */
+    void applyGroupToUploadParams(Map<String, Object> params, String ragType, String coreRepoId) {
+        if (params == null) {
+            return;
+        }
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(ragType)
+                && StringUtils.isNotBlank(coreRepoId)) {
+            params.put("group", coreRepoId);
+        }
+    }
+
+    /**
+     * Set {@code groupDescription} on the split request for Ragflow-RAG when {@code repoName} is
+     * non-blank. No-op otherwise.
+     */
+    void applyGroupDescriptionToSplitRequest(SplitRequest request, String repoName) {
+        if (request == null) {
+            return;
+        }
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(request.getRagType())
+                && StringUtils.isNotBlank(repoName)) {
+            request.setGroupDescription(repoName);
+        }
+    }
+
+    /**
+     * Add {@code groupDescription} to the upload params map for Ragflow-RAG when {@code repoName} is
+     * non-blank. No-op otherwise.
+     */
+    void applyGroupDescriptionToUploadParams(
+            Map<String, Object> params, String ragType, String repoName) {
+        if (params == null) {
+            return;
+        }
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(ragType)
+                && StringUtils.isNotBlank(repoName)) {
+            params.put("groupDescription", repoName);
         }
     }
 

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
@@ -575,6 +575,20 @@ public class KnowledgeService {
         return (repo != null) ? repo.getCoreRepoId() : null;
     }
 
+    private boolean applyRagflowGroupForDelete(KnowledgeRequest request, FileInfoV2 fileInfoV2) {
+        try {
+            String coreRepoId = resolveCoreRepoIdForRagflow(fileInfoV2);
+            if (coreRepoId != null) {
+                request.setGroup(coreRepoId);
+            }
+            return true;
+        } catch (IllegalStateException e) {
+            log.warn("Skip Ragflow-RAG delete because repo metadata is invalid. fileId={}, uuid={}, reason={}",
+                    fileInfoV2.getId(), fileInfoV2.getUuid(), e.getMessage());
+            return false;
+        }
+    }
+
     /**
      * Loads the {@link Repo} for a Ragflow-RAG document; returns {@code null} for other sources.
      * Callers read both {@code coreRepoId} and {@code name} from the result with one DB query.
@@ -1478,9 +1492,8 @@ public class KnowledgeService {
                         needDelete = false;
                     }
                 }
-                String coreRepoId = resolveCoreRepoIdForRagflow(fileInfoV2);
-                if (coreRepoId != null) {
-                    request.setGroup(coreRepoId);
+                if (!applyRagflowGroupForDelete(request, fileInfoV2)) {
+                    continue;
                 }
                 if (needDelete) {
                     KnowledgeResponse response = knowledgeV2ServiceCallHandler.deleteDocOrChunk(request);
@@ -1510,9 +1523,8 @@ public class KnowledgeService {
                 throw new BusinessException(ResponseEnum.REPO_FILE_NOT_EXIST);
             }
             request.setRagType(fileInfoV2.getSource());
-            String coreRepoId = resolveCoreRepoIdForRagflow(fileInfoV2);
-            if (coreRepoId != null) {
-                request.setGroup(coreRepoId);
+            if (!applyRagflowGroupForDelete(request, fileInfoV2)) {
+                return;
             }
             KnowledgeResponse response = knowledgeV2ServiceCallHandler.deleteDocOrChunk(request);
             if (response.getCode() != 0) {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
@@ -568,7 +568,7 @@ public class KnowledgeService {
     /**
      * Returns the {@code coreRepoId} for Ragflow-RAG, or {@code null} for other sources.
      *
-     * @throws IllegalStateException if Ragflow-RAG and {@code repoId} or {@code coreRepoId} is missing.
+     * @throws BusinessException if Ragflow-RAG and {@code repoId} or {@code coreRepoId} is missing.
      */
     private String resolveCoreRepoIdForRagflow(FileInfoV2 fileInfoV2) {
         Repo repo = loadRagflowRepoOrNull(fileInfoV2);
@@ -582,7 +582,7 @@ public class KnowledgeService {
                 request.setGroup(coreRepoId);
             }
             return true;
-        } catch (IllegalStateException e) {
+        } catch (BusinessException e) {
             log.warn("Skip Ragflow-RAG delete because repo metadata is invalid. fileId={}, uuid={}, reason={}",
                     fileInfoV2.getId(), fileInfoV2.getUuid(), e.getMessage());
             return false;
@@ -593,8 +593,8 @@ public class KnowledgeService {
      * Loads the {@link Repo} for a Ragflow-RAG document; returns {@code null} for other sources.
      * Callers read both {@code coreRepoId} and {@code name} from the result with one DB query.
      *
-     * @throws IllegalStateException if Ragflow-RAG and {@code repoId} / {@link Repo} /
-     *         {@code coreRepoId} is missing.
+     * @throws BusinessException if Ragflow-RAG and {@code repoId} / {@link Repo} / {@code coreRepoId}
+     *         is missing.
      */
     private Repo loadRagflowRepoOrNull(FileInfoV2 fileInfoV2) {
         if (!ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(fileInfoV2.getSource())) {
@@ -602,16 +602,18 @@ public class KnowledgeService {
         }
         Long repoId = fileInfoV2.getRepoId();
         if (repoId == null) {
-            throw new IllegalStateException(
-                    "Ragflow-RAG upload/split requires repoId on FileInfoV2 id="
-                            + fileInfoV2.getId());
+            log.error("Ragflow-RAG upload/split requires repoId on FileInfoV2 id={}",
+                    fileInfoV2.getId());
+            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
         Repo repo = repoService.getById(repoId);
         if (repo == null) {
-            throw new IllegalStateException("Repo not found for repoId=" + repoId);
+            log.error("Repo not found for repoId={}", repoId);
+            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
         if (!StringUtils.isNotBlank(repo.getCoreRepoId())) {
-            throw new IllegalStateException("Repo " + repoId + " has no coreRepoId");
+            log.error("Repo {} has no coreRepoId", repoId);
+            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
         return repo;
     }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
@@ -532,10 +532,14 @@ public class KnowledgeService {
                             ? fileInfoV2.getLastUuid()
                             : null;
 
+            Repo ragflowRepo = loadRagflowRepoOrNull(fileInfoV2);
+            String coreRepoId = (ragflowRepo != null) ? ragflowRepo.getCoreRepoId() : null;
+            String repoName = (ragflowRepo != null) ? ragflowRepo.getName() : null;
+
             return knowledgeV2ServiceCallHandler.documentUpload(
                     multipartFile, sliceConfig.getLengthRange(), separator,
                     fileInfoV2.getSource(), resourceType,
-                    oldDocId);
+                    oldDocId, coreRepoId, repoName);
 
         } catch (Exception e) {
             log.error("Failed to upload file for chunking: {}", e.getMessage(), e);
@@ -555,7 +559,47 @@ public class KnowledgeService {
             request.setResourceType(1);
         }
         request.setRagType(fileInfoV2.getSource());
-        return knowledgeV2ServiceCallHandler.documentSplit(request);
+        Repo ragflowRepo = loadRagflowRepoOrNull(fileInfoV2);
+        String coreRepoId = (ragflowRepo != null) ? ragflowRepo.getCoreRepoId() : null;
+        String repoName = (ragflowRepo != null) ? ragflowRepo.getName() : null;
+        return knowledgeV2ServiceCallHandler.documentSplit(request, coreRepoId, repoName);
+    }
+
+    /**
+     * Returns the {@code coreRepoId} for Ragflow-RAG, or {@code null} for other sources.
+     *
+     * @throws IllegalStateException if Ragflow-RAG and {@code repoId} or {@code coreRepoId} is missing.
+     */
+    private String resolveCoreRepoIdForRagflow(FileInfoV2 fileInfoV2) {
+        Repo repo = loadRagflowRepoOrNull(fileInfoV2);
+        return (repo != null) ? repo.getCoreRepoId() : null;
+    }
+
+    /**
+     * Loads the {@link Repo} for a Ragflow-RAG document; returns {@code null} for other sources.
+     * Callers read both {@code coreRepoId} and {@code name} from the result with one DB query.
+     *
+     * @throws IllegalStateException if Ragflow-RAG and {@code repoId} / {@link Repo} /
+     *         {@code coreRepoId} is missing.
+     */
+    private Repo loadRagflowRepoOrNull(FileInfoV2 fileInfoV2) {
+        if (!ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(fileInfoV2.getSource())) {
+            return null;
+        }
+        Long repoId = fileInfoV2.getRepoId();
+        if (repoId == null) {
+            throw new IllegalStateException(
+                    "Ragflow-RAG upload/split requires repoId on FileInfoV2 id="
+                            + fileInfoV2.getId());
+        }
+        Repo repo = repoService.getById(repoId);
+        if (repo == null) {
+            throw new IllegalStateException("Repo not found for repoId=" + repoId);
+        }
+        if (!StringUtils.isNotBlank(repo.getCoreRepoId())) {
+            throw new IllegalStateException("Repo " + repoId + " has no coreRepoId");
+        }
+        return repo;
     }
 
     /** When code==11111 extract inner parentheses text, keep original message otherwise. */
@@ -1434,6 +1478,10 @@ public class KnowledgeService {
                         needDelete = false;
                     }
                 }
+                String coreRepoId = resolveCoreRepoIdForRagflow(fileInfoV2);
+                if (coreRepoId != null) {
+                    request.setGroup(coreRepoId);
+                }
                 if (needDelete) {
                     KnowledgeResponse response = knowledgeV2ServiceCallHandler.deleteDocOrChunk(request);
                     if (response.getCode() != 0) {
@@ -1462,6 +1510,10 @@ public class KnowledgeService {
                 throw new BusinessException(ResponseEnum.REPO_FILE_NOT_EXIST);
             }
             request.setRagType(fileInfoV2.getSource());
+            String coreRepoId = resolveCoreRepoIdForRagflow(fileInfoV2);
+            if (coreRepoId != null) {
+                request.setGroup(coreRepoId);
+            }
             KnowledgeResponse response = knowledgeV2ServiceCallHandler.deleteDocOrChunk(request);
             if (response.getCode() != 0) {
                 log.error("Failed to delete knowledge chunk, message:{}", response.getMessage());

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandlerTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandlerTest.java
@@ -1,0 +1,105 @@
+package com.iflytek.astron.console.toolkit.handler;
+
+import com.iflytek.astron.console.toolkit.entity.core.knowledge.SplitRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link KnowledgeV2ServiceCallHandler} {@code group} and {@code groupDescription}
+ * forwarding (Ragflow-RAG only).
+ */
+class KnowledgeV2ServiceCallHandlerTest {
+
+    // The package-private helpers below are decorators on request/params; we
+    // exercise them directly to avoid mocking OkHttpUtil static methods.
+
+    @Test
+    void documentSplit_RagflowRAG_withCoreRepoId_setsGroupOnRequest() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        SplitRequest req = new SplitRequest();
+        req.setRagType("Ragflow-RAG");
+        handler.applyGroupToSplitRequest(req, "abc-uuid");
+        assertEquals("abc-uuid", req.getGroup());
+    }
+
+    @Test
+    void documentSplit_NonRagflowRAG_doesNotSetGroup() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        SplitRequest req = new SplitRequest();
+        req.setRagType("CBG-RAG");
+        handler.applyGroupToSplitRequest(req, "abc-uuid");
+        assertNull(req.getGroup());
+    }
+
+    @Test
+    void documentSplit_RagflowRAG_withNullCoreRepoId_doesNotSetGroup() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        SplitRequest req = new SplitRequest();
+        req.setRagType("Ragflow-RAG");
+        handler.applyGroupToSplitRequest(req, null);
+        assertNull(req.getGroup());
+    }
+
+    @Test
+    void applyGroupToUploadParams_RagflowRAG_withCoreRepoId_addsGroup() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        Map<String, Object> params = new HashMap<>();
+        handler.applyGroupToUploadParams(params, "Ragflow-RAG", "abc-uuid");
+        assertEquals("abc-uuid", params.get("group"));
+    }
+
+    @Test
+    void applyGroupToUploadParams_NonRagflowRAG_doesNotAddGroup() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        Map<String, Object> params = new HashMap<>();
+        handler.applyGroupToUploadParams(params, "CBG-RAG", "abc-uuid");
+        assertNull(params.get("group"));
+    }
+
+    @Test
+    void applyGroupToUploadParams_RagflowRAG_withBlankCoreRepoId_doesNotAddGroup() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        Map<String, Object> params = new HashMap<>();
+        handler.applyGroupToUploadParams(params, "Ragflow-RAG", "");
+        assertNull(params.get("group"));
+    }
+
+    @Test
+    void applyGroupDescriptionToSplitRequest_RagflowRAG_withRepoName_setsDescription() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        SplitRequest req = new SplitRequest();
+        req.setRagType("Ragflow-RAG");
+        handler.applyGroupDescriptionToSplitRequest(req, "客服知识库");
+        assertEquals("客服知识库", req.getGroupDescription());
+    }
+
+    @Test
+    void applyGroupDescriptionToSplitRequest_NonRagflowRAG_doesNotSetDescription() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        SplitRequest req = new SplitRequest();
+        req.setRagType("CBG-RAG");
+        handler.applyGroupDescriptionToSplitRequest(req, "客服知识库");
+        assertNull(req.getGroupDescription());
+    }
+
+    @Test
+    void applyGroupDescriptionToUploadParams_RagflowRAG_withRepoName_addsDescription() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        Map<String, Object> params = new HashMap<>();
+        handler.applyGroupDescriptionToUploadParams(params, "Ragflow-RAG", "客服知识库");
+        assertEquals("客服知识库", params.get("groupDescription"));
+    }
+
+    @Test
+    void applyGroupDescriptionToUploadParams_RagflowRAG_withBlankRepoName_doesNotAdd() {
+        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+        Map<String, Object> params = new HashMap<>();
+        handler.applyGroupDescriptionToUploadParams(params, "Ragflow-RAG", "");
+        assertNull(params.get("groupDescription"));
+    }
+}

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -30,15 +30,18 @@ import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
 import com.iflytek.astron.console.toolkit.util.S3Util;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -1808,7 +1811,7 @@ class KnowledgeServiceTest {
             dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
             response.setData(dataArray);
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1819,7 +1822,7 @@ class KnowledgeServiceTest {
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
             // Then
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any());
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any(), any());
             verify(previewKnowledgeMapper, times(1)).insertBatch(anyList());
             verify(fileInfoV2Service, times(1)).updateById(any(FileInfoV2.class));
         }
@@ -1849,7 +1852,7 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1861,15 +1864,13 @@ class KnowledgeServiceTest {
 
             // Then
             verify(s3Util, times(1)).getObject(anyString());
-            // CBG-RAG multipart form must not carry documentId.
+            // CBG-RAG multipart form must not carry documentId; coreRepoId is
+            // null because CBG-RAG keeps the legacy single-dataset behaviour.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
-                    any(), any(), any(), any(), any(), isNull());
+                    any(), any(), any(), any(), any(), isNull(), isNull(), isNull());
         }
 
-        /**
-         * Ragflow-RAG first-time slice: lastUuid=null, oldDocId stays null, Python uses the legacy
-         * create-only path.
-         */
+        /** Ragflow-RAG first slice: lastUuid=null forwards as oldDocId=null. */
         @Test
         @DisplayName("Extract knowledge with Ragflow-RAG source, first slice (lastUuid=null)")
         void testKnowledgeExtractAsync_RagflowRAG_FirstSlice() {
@@ -1878,7 +1879,7 @@ class KnowledgeServiceTest {
             String url = "http://example.com/document.txt";
             mockFileInfo.setSource("Ragflow-RAG");
             mockFileInfo.setType("text/plain");
-            mockFileInfo.setLastUuid(null); // FIRST slice — no previous doc id
+            mockFileInfo.setLastUuid(null);
 
             KnowledgeResponse response = new KnowledgeResponse();
             response.setCode(0);
@@ -1890,25 +1891,23 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
+            when(repoService.getById(mockFileInfo.getRepoId())).thenReturn(mockRepo);
 
             // When
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
-            // Then: first slice => oldDocId is null (Python side uses legacy path)
+            // Then: oldDocId=null; coreRepoId and repoName forwarded.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
-                    any(), any(), any(), any(), any(), isNull());
+                    any(), any(), any(), any(), any(), isNull(), eq("core-repo-001"), eq("Test Repository"));
         }
 
-        /**
-         * Ragflow-RAG re-slice: existing lastUuid is forwarded as oldDocId to trigger the Python upsert
-         * path.
-         */
+        /** Ragflow-RAG re-slice: existing lastUuid forwards as oldDocId. */
         @Test
         @DisplayName("Extract knowledge with Ragflow-RAG source, re-slice forwards lastUuid")
         void testKnowledgeExtractAsync_RagflowRAG_ReSlice() {
@@ -1917,7 +1916,7 @@ class KnowledgeServiceTest {
             String url = "http://example.com/document.txt";
             mockFileInfo.setSource("Ragflow-RAG");
             mockFileInfo.setType("text/plain");
-            mockFileInfo.setLastUuid("doc-old-ragflow"); // RE-SLICE — has previous doc
+            mockFileInfo.setLastUuid("doc-old-ragflow");
 
             KnowledgeResponse response = new KnowledgeResponse();
             response.setCode(0);
@@ -1929,19 +1928,20 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
+            when(repoService.getById(mockFileInfo.getRepoId())).thenReturn(mockRepo);
 
             // When
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
-            // Then: re-slice => oldDocId passed as the previous doc id
+            // Then: oldDocId carries previous; coreRepoId and repoName forwarded.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
-                    any(), any(), any(), any(), any(), eq("doc-old-ragflow"));
+                    any(), any(), any(), any(), any(), eq("doc-old-ragflow"), eq("core-repo-001"), eq("Test Repository"));
         }
 
         /**
@@ -1959,7 +1959,7 @@ class KnowledgeServiceTest {
             response.setCode(1);
             response.setMessage("Extraction failed");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -1986,7 +1986,7 @@ class KnowledgeServiceTest {
             response.setCode(11111);
             response.setMessage("Error (inner error message)");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2012,7 +2012,7 @@ class KnowledgeServiceTest {
             response.setCode(0);
             response.setData(new JSONArray());
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2039,7 +2039,7 @@ class KnowledgeServiceTest {
             response.setCode(0);
             response.setData(new JSONArray());
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2096,7 +2096,7 @@ class KnowledgeServiceTest {
             dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
             response.setData(dataArray);
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -2107,7 +2107,7 @@ class KnowledgeServiceTest {
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
             // Then
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any());
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any(), any());
         }
     }
 
@@ -2156,7 +2156,7 @@ class KnowledgeServiceTest {
             dealFileResult.setParseSuccess(true);
             dealFileResult.setTaskId("task-001");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -2170,7 +2170,7 @@ class KnowledgeServiceTest {
                     mockFileInfo, mockExtractTask, mockFileService);
 
             // Then
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any());
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any(), any());
             verify(mockFileService, times(1)).saveTaskAndUpdateFileStatus(mockFileInfo.getId());
             verify(mockFileService, times(1)).embeddingFile(mockFileInfo.getId(), mockFileInfo.getSpaceId());
         }
@@ -2190,7 +2190,7 @@ class KnowledgeServiceTest {
             response.setCode(1);
             response.setMessage("Extraction failed");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2231,7 +2231,7 @@ class KnowledgeServiceTest {
             dealFileResult.setTaskId("task-001");
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -2265,7 +2265,7 @@ class KnowledgeServiceTest {
             response.setCode(0);
             response.setData(new JSONArray());
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2276,6 +2276,188 @@ class KnowledgeServiceTest {
             // Then
             verify(mockFileService, never()).saveTaskAndUpdateFileStatus(anyLong());
             verify(mockFileService, never()).embeddingFile(anyLong(), anyLong());
+        }
+    }
+
+    /**
+     * coreRepoId routing tests.
+     *
+     * <p>
+     * Tests for {@code coreRepoId} resolution and forwarding through delete paths.
+     */
+    @Nested
+    @DisplayName("coreRepoId routing tests")
+    class CoreRepoIdRoutingTests {
+
+        @Test
+        @DisplayName("resolveCoreRepoIdForRagflow returns null for non-Ragflow-RAG sources")
+        void resolveCoreRepoIdForRagflow_NonRagflowRAG_returnsNull() {
+            FileInfoV2 file = new FileInfoV2();
+            file.setSource("CBG-RAG");
+            file.setRepoId(42L);
+            String result = ReflectionTestUtils.invokeMethod(
+                    knowledgeService, "resolveCoreRepoIdForRagflow", file);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("resolveCoreRepoIdForRagflow throws when Ragflow-RAG file lacks repoId")
+        void resolveCoreRepoIdForRagflow_RagflowRAG_nullRepoId_throws() {
+            FileInfoV2 file = new FileInfoV2();
+            file.setSource("Ragflow-RAG");
+            file.setRepoId(null);
+            file.setId(99L);
+            IllegalStateException ex = assertThrows(IllegalStateException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            knowledgeService, "resolveCoreRepoIdForRagflow", file));
+            assertThat(ex.getMessage()).contains("requires repoId");
+        }
+
+        @Test
+        @DisplayName("resolveCoreRepoIdForRagflow throws when Repo missing")
+        void resolveCoreRepoIdForRagflow_RagflowRAG_repoNotFound_throws() {
+            FileInfoV2 file = new FileInfoV2();
+            file.setSource("Ragflow-RAG");
+            file.setRepoId(42L);
+            when(repoService.getById(42L)).thenReturn(null);
+            IllegalStateException ex = assertThrows(IllegalStateException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            knowledgeService, "resolveCoreRepoIdForRagflow", file));
+            assertThat(ex.getMessage()).contains("Repo not found");
+        }
+
+        @Test
+        @DisplayName("resolveCoreRepoIdForRagflow throws when coreRepoId blank")
+        void resolveCoreRepoIdForRagflow_RagflowRAG_emptyCoreRepoId_throws() {
+            FileInfoV2 file = new FileInfoV2();
+            file.setSource("Ragflow-RAG");
+            file.setRepoId(42L);
+            Repo repo = new Repo();
+            repo.setCoreRepoId(null);
+            when(repoService.getById(42L)).thenReturn(repo);
+            IllegalStateException ex = assertThrows(IllegalStateException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            knowledgeService, "resolveCoreRepoIdForRagflow", file));
+            assertThat(ex.getMessage()).contains("no coreRepoId");
+        }
+
+        @Test
+        @DisplayName("resolveCoreRepoIdForRagflow returns coreRepoId on happy path")
+        void resolveCoreRepoIdForRagflow_happyPath_returnsCoreRepoId() {
+            FileInfoV2 file = new FileInfoV2();
+            file.setSource("Ragflow-RAG");
+            file.setRepoId(42L);
+            Repo repo = new Repo();
+            repo.setCoreRepoId("abc-uuid");
+            when(repoService.getById(42L)).thenReturn(repo);
+            String result = ReflectionTestUtils.invokeMethod(
+                    knowledgeService, "resolveCoreRepoIdForRagflow", file);
+            assertThat(result).isEqualTo("abc-uuid");
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeDoc sets group on Ragflow-RAG request")
+        void deleteKnowledgeDoc_RagflowRAG_setsGroupOnRequest() {
+            JSONArray deleteDocIds = new JSONArray();
+            deleteDocIds.add("doc-rf-001");
+
+            FileInfoV2 rfFile = new FileInfoV2();
+            rfFile.setSource("Ragflow-RAG");
+            rfFile.setRepoId(100L);
+            rfFile.setId(1L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(rfFile);
+
+            Repo rfRepo = new Repo();
+            rfRepo.setId(100L);
+            rfRepo.setCoreRepoId("rf-core-uuid");
+            when(repoService.getById(100L)).thenReturn(rfRepo);
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            when(knowledgeV2ServiceCallHandler.deleteDocOrChunk(any())).thenReturn(response);
+
+            knowledgeService.deleteKnowledgeDoc(deleteDocIds, null);
+
+            ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
+            assertThat(captor.getValue().getGroup()).isEqualTo("rf-core-uuid");
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeDoc leaves group null for non-Ragflow-RAG (AIUI/CBG)")
+        void deleteKnowledgeDoc_NonRagflowRAG_doesNotSetGroup() {
+            JSONArray deleteDocIds = new JSONArray();
+            deleteDocIds.add("doc-aiui-001");
+
+            FileInfoV2 aiuiFile = new FileInfoV2();
+            aiuiFile.setSource("AIUI-RAG2");
+            aiuiFile.setRepoId(100L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(aiuiFile);
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            when(knowledgeV2ServiceCallHandler.deleteDocOrChunk(any())).thenReturn(response);
+
+            knowledgeService.deleteKnowledgeDoc(deleteDocIds, null);
+
+            ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
+            assertThat(captor.getValue().getGroup()).isNull();
+            // Repo should not be loaded for non-Ragflow-RAG sources.
+            verify(repoService, never()).getById(anyLong());
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeChunks sets group on Ragflow-RAG request")
+        void deleteKnowledgeChunks_RagflowRAG_setsGroupOnRequest() {
+            String docId = "doc-rf-001";
+            JSONArray chunkIds = new JSONArray();
+            chunkIds.add("chunk-001");
+
+            FileInfoV2 rfFile = new FileInfoV2();
+            rfFile.setSource("Ragflow-RAG");
+            rfFile.setRepoId(100L);
+            rfFile.setId(1L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(rfFile);
+
+            Repo rfRepo = new Repo();
+            rfRepo.setId(100L);
+            rfRepo.setCoreRepoId("rf-core-uuid");
+            when(repoService.getById(100L)).thenReturn(rfRepo);
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            when(knowledgeV2ServiceCallHandler.deleteDocOrChunk(any())).thenReturn(response);
+
+            knowledgeService.deleteKnowledgeChunks(docId, chunkIds);
+
+            ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
+            assertThat(captor.getValue().getGroup()).isEqualTo("rf-core-uuid");
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeChunks leaves group null for non-Ragflow-RAG (AIUI/CBG)")
+        void deleteKnowledgeChunks_NonRagflowRAG_doesNotSetGroup() {
+            String docId = "doc-aiui-001";
+            JSONArray chunkIds = new JSONArray();
+            chunkIds.add("chunk-001");
+
+            FileInfoV2 aiuiFile = new FileInfoV2();
+            aiuiFile.setSource("AIUI-RAG2");
+            aiuiFile.setRepoId(100L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(aiuiFile);
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            when(knowledgeV2ServiceCallHandler.deleteDocOrChunk(any())).thenReturn(response);
+
+            knowledgeService.deleteKnowledgeChunks(docId, chunkIds);
+
+            ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
+            assertThat(captor.getValue().getGroup()).isNull();
+            verify(repoService, never()).getById(anyLong());
         }
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -2408,6 +2408,46 @@ class KnowledgeServiceTest {
         }
 
         @Test
+        @DisplayName("deleteKnowledgeDoc skips invalid Ragflow-RAG metadata and continues")
+        void deleteKnowledgeDoc_RagflowRAG_invalidMetadata_skipsAndContinues() {
+            JSONArray deleteDocIds = new JSONArray();
+            deleteDocIds.add("doc-rf-invalid");
+            deleteDocIds.add("doc-rf-valid");
+
+            FileInfoV2 invalidFile = new FileInfoV2();
+            invalidFile.setSource("Ragflow-RAG");
+            invalidFile.setRepoId(404L);
+            invalidFile.setId(1L);
+            invalidFile.setUuid("doc-rf-invalid");
+
+            FileInfoV2 validFile = new FileInfoV2();
+            validFile.setSource("Ragflow-RAG");
+            validFile.setRepoId(100L);
+            validFile.setId(2L);
+            validFile.setUuid("doc-rf-valid");
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(invalidFile, validFile);
+
+            Repo rfRepo = new Repo();
+            rfRepo.setId(100L);
+            rfRepo.setCoreRepoId("rf-core-uuid");
+            when(repoService.getById(anyLong())).thenAnswer(invocation -> {
+                Long repoId = invocation.getArgument(0);
+                return Long.valueOf(100L).equals(repoId) ? rfRepo : null;
+            });
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            when(knowledgeV2ServiceCallHandler.deleteDocOrChunk(any())).thenReturn(response);
+
+            knowledgeService.deleteKnowledgeDoc(deleteDocIds, null);
+
+            ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
+            assertThat(captor.getValue().getDocId()).isEqualTo("doc-rf-valid");
+            assertThat(captor.getValue().getGroup()).isEqualTo("rf-core-uuid");
+        }
+
+        @Test
         @DisplayName("deleteKnowledgeChunks sets group on Ragflow-RAG request")
         void deleteKnowledgeChunks_RagflowRAG_setsGroupOnRequest() {
             String docId = "doc-rf-001";
@@ -2458,6 +2498,25 @@ class KnowledgeServiceTest {
             verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
             assertThat(captor.getValue().getGroup()).isNull();
             verify(repoService, never()).getById(anyLong());
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeChunks skips invalid Ragflow-RAG metadata")
+        void deleteKnowledgeChunks_RagflowRAG_invalidMetadata_skipsDelete() {
+            String docId = "doc-rf-invalid";
+            JSONArray chunkIds = new JSONArray();
+            chunkIds.add("chunk-001");
+
+            FileInfoV2 invalidFile = new FileInfoV2();
+            invalidFile.setSource("Ragflow-RAG");
+            invalidFile.setRepoId(404L);
+            invalidFile.setId(1L);
+            invalidFile.setUuid(docId);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(invalidFile);
+
+            knowledgeService.deleteKnowledgeChunks(docId, chunkIds);
+
+            verify(knowledgeV2ServiceCallHandler, never()).deleteDocOrChunk(any());
         }
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -1865,7 +1865,7 @@ class KnowledgeServiceTest {
             // Then
             verify(s3Util, times(1)).getObject(anyString());
             // CBG-RAG multipart form must not carry documentId; coreRepoId is
-            // null because CBG-RAG keeps the legacy single-dataset behaviour.
+            // null because CBG-RAG keeps the legacy single-dataset behavior.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
                     any(), any(), any(), any(), any(), isNull(), isNull(), isNull());
         }
@@ -2307,10 +2307,10 @@ class KnowledgeServiceTest {
             file.setSource("Ragflow-RAG");
             file.setRepoId(null);
             file.setId(99L);
-            IllegalStateException ex = assertThrows(IllegalStateException.class,
+            BusinessException ex = assertThrows(BusinessException.class,
                     () -> ReflectionTestUtils.invokeMethod(
                             knowledgeService, "resolveCoreRepoIdForRagflow", file));
-            assertThat(ex.getMessage()).contains("requires repoId");
+            assertThat(ex.getResponseEnum()).isEqualTo(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
 
         @Test
@@ -2320,10 +2320,10 @@ class KnowledgeServiceTest {
             file.setSource("Ragflow-RAG");
             file.setRepoId(42L);
             when(repoService.getById(42L)).thenReturn(null);
-            IllegalStateException ex = assertThrows(IllegalStateException.class,
+            BusinessException ex = assertThrows(BusinessException.class,
                     () -> ReflectionTestUtils.invokeMethod(
                             knowledgeService, "resolveCoreRepoIdForRagflow", file));
-            assertThat(ex.getMessage()).contains("Repo not found");
+            assertThat(ex.getResponseEnum()).isEqualTo(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
 
         @Test
@@ -2335,10 +2335,10 @@ class KnowledgeServiceTest {
             Repo repo = new Repo();
             repo.setCoreRepoId(null);
             when(repoService.getById(42L)).thenReturn(repo);
-            IllegalStateException ex = assertThrows(IllegalStateException.class,
+            BusinessException ex = assertThrows(BusinessException.class,
                     () -> ReflectionTestUtils.invokeMethod(
                             knowledgeService, "resolveCoreRepoIdForRagflow", file));
-            assertThat(ex.getMessage()).contains("no coreRepoId");
+            assertThat(ex.getResponseEnum()).isEqualTo(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
 
         @Test

--- a/core/knowledge/api/v1/api.py
+++ b/core/knowledge/api/v1/api.py
@@ -180,6 +180,8 @@ async def file_split(
             titleSplit=split_request.titleSplit,
             cutOff=split_request.cutOff,
             document_id=split_request.documentId,
+            group=split_request.group,
+            groupDescription=split_request.groupDescription,
         )
 
 
@@ -234,6 +236,21 @@ async def file_upload(
             "Omit or leave empty for first-time slicing."
         ),
     ),
+    group: Optional[str] = Form(
+        None,
+        description=(
+            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
+            "When omitted, falls back to the default dataset."
+        ),
+    ),
+    groupDescription: Optional[str] = Form(
+        None,
+        description=(
+            "Human-readable label written into RAGFlow dataset description "
+            "on first creation; helps operators identify the dataset in the "
+            "RAGFlow UI without resolving UUIDs."
+        ),
+    ),
     app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
@@ -246,6 +263,10 @@ async def file_upload(
         ragType: RAG type (form-data mode)
         lengthRange: Split length range as JSON string (form-data mode)
         separator: Separator list as JSON string (form-data mode)
+        documentId: Existing RAGFlow doc id for re-slice upsert (form-data mode)
+        group: RAGFlow dataset group (form-data mode)
+        groupDescription: Human-readable label written into the RAGFlow dataset
+            description on first creation (form-data mode)
         app_id: Application identifier
 
     Returns:
@@ -264,6 +285,8 @@ async def file_upload(
                         "lengthRange": lengthRange,
                         "separator": separator,
                         "documentId": documentId,
+                        "group": group,
+                        "groupDescription": groupDescription,
                     },
                     ensure_ascii=False,
                 )
@@ -294,6 +317,8 @@ async def file_upload(
             lengthRange=parsed_length_range,
             separator=parsed_separator,
             document_id=documentId,
+            group=group,
+            groupDescription=groupDescription,
         )
 
 
@@ -394,6 +419,7 @@ async def chunk_delete(
             operation_callable=strategy.chunks_delete,
             docId=delete_request.docId,
             chunkIds=delete_request.chunkIds,
+            group=delete_request.group,
         )
 
 
@@ -476,6 +502,7 @@ async def query_doc(
             metric=metric,
             operation_callable=strategy.query_doc,
             docId=query_request.docId,
+            group=query_request.group,
         )
 
 
@@ -504,4 +531,5 @@ async def query_doc_name(
             metric=metric,
             operation_callable=strategy.query_doc_name,
             docId=query_request.docId,
+            group=query_request.group,
         )

--- a/core/knowledge/domain/entity/chunk_dto.py
+++ b/core/knowledge/domain/entity/chunk_dto.py
@@ -34,6 +34,7 @@ class FileSplitReq(BaseModel):
         cutOff: Cutoff marker list, optional
         titleSplit: Whether to split by title, default is False
         documentId: Existing RAGFlow doc id for re-slice upsert, optional
+        group: RAGFlow dataset group, optional
     """
 
     file: str = Field(..., min_length=1, description="Required, minimum length 1")
@@ -55,6 +56,21 @@ class FileSplitReq(BaseModel):
         description=(
             "Existing RAGFlow doc id, triggers blue-green upsert. "
             "Omit or leave empty for first-time slicing."
+        ),
+    )
+    group: Optional[str] = Field(
+        default=None,
+        description=(
+            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
+            "When omitted, falls back to the default dataset."
+        ),
+    )
+    groupDescription: Optional[str] = Field(
+        default=None,
+        description=(
+            "Human-readable label written into RAGFlow dataset description "
+            "on first creation; helps operators identify the dataset in the "
+            "RAGFlow UI without resolving UUIDs."
         ),
     )
 
@@ -111,11 +127,19 @@ class ChunkDeleteReq(BaseModel):
         docId: Document ID, required
         chunkIds: Chunk ID list, optional
         ragType: RAG type
+        group: RAGFlow dataset group, optional
     """
 
     docId: str = Field(..., min_length=1, description="Required, minimum length 1")
     chunkIds: Optional[List[str]] = Field(default=None, description="Chunk ID list")
     ragType: RAGType = Field(..., description="RAG type")
+    group: Optional[str] = Field(
+        default=None,
+        description=(
+            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
+            "When omitted, falls back to the default dataset."
+        ),
+    )
 
 
 class QueryMatch(BaseModel):
@@ -237,7 +261,15 @@ class QueryDocReq(BaseModel):
     Attributes:
         docId: Document ID, required
         ragType: RAG type
+        group: RAGFlow dataset group, optional
     """
 
     docId: str = Field(..., min_length=1, description="Required, minimum length 1")
     ragType: RAGType = Field(..., description="RAG type")
+    group: Optional[str] = Field(
+        default=None,
+        description=(
+            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
+            "When omitted, falls back to the default dataset."
+        ),
+    )

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -456,6 +456,19 @@ async def create_dataset(name: str, **kwargs: Any) -> Dict[str, Any]:
     return await _make_request("POST", "/api/v1/datasets", data=data)
 
 
+async def update_dataset(dataset_id: str, **kwargs: Any) -> Dict[str, Any]:
+    """Update dataset metadata via RAGFlow PUT /api/v1/datasets/{id}.
+
+    Args:
+        dataset_id: Dataset ID to update.
+        **kwargs: Fields to patch (description, name, embedding_model, ...).
+
+    Returns:
+        Update response from RAGFlow.
+    """
+    return await _make_request("PUT", f"/api/v1/datasets/{dataset_id}", data=kwargs)
+
+
 # ==================== Document Management APIs ====================
 
 

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -48,9 +48,14 @@ class RagflowUtils:
     async def get_dataset_id_by_name(dataset_name: str) -> Optional[str]:
         """Look up a dataset ID by name.
 
-        Returns ``None`` only when RAGFlow successfully returns no matching
-        dataset (``code == 0`` with empty data). Raises
-        ``ThirdPartyException`` for non-zero RAGFlow codes; transport
+        Returns ``None`` for not-found cases:
+        * ``code == 0`` with empty / non-matching data
+        * ``code == 108`` with a "lacks permission" message — RAGFlow
+          collapses "dataset does not exist" and "no access" into the same
+          response, so callers cannot distinguish them. Treating this as
+          not-found preserves fail-closed semantics for query routing.
+
+        Other non-zero codes raise ``ThirdPartyException``; transport
         exceptions propagate.
         """
         from knowledge.infra.ragflow import ragflow_client
@@ -64,6 +69,14 @@ class RagflowUtils:
                     return dataset.get("id")
             return None
         msg = datasets_response.get("message", "Unknown error")
+        if code == 108 and "lacks permission" in msg.lower():
+            logger.info(
+                "Dataset %r not found on RAGFlow (code=108: %s); "
+                "treating as not-found",
+                dataset_name,
+                msg,
+            )
+            return None
         raise ThirdPartyException(
             msg=f"RAGFlow list_datasets name={dataset_name}: code={code} message={msg}",
             e=CodeEnum.RAGFLOW_RAGError,

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -23,6 +23,7 @@ from knowledge.infra.ragflow.ragflow_client import (
     list_datasets,
     list_document_chunks,
     list_documents_in_dataset,
+    update_dataset,
 )
 
 logger = logging.getLogger(__name__)
@@ -106,28 +107,19 @@ class RagflowUtils:
         return results
 
     @staticmethod
-    async def ensure_dataset(group: str) -> str:
+    async def ensure_dataset(group: str, description: Optional[str] = None) -> str:
+        """Ensure dataset exists, create if missing; return dataset_id.
+
+        ``description`` is written at creation time and best-effort synced when
+        an existing dataset's description differs. Sync failures are swallowed
+        — a friendly label must never block document writes.
         """
-        Ensure dataset exists, create if it doesn't exist
-
-        Uses per-dataset locks to prevent race conditions when multiple concurrent
-        requests try to create the same dataset.
-
-        Args:
-            group: Dataset name
-
-        Returns:
-            Dataset ID
-        """
-        # Get or create a lock for this specific dataset name
         async with _locks_lock:
             if group not in _dataset_locks:
                 _dataset_locks[group] = asyncio.Lock()
 
-        # Acquire the lock for this dataset to ensure serial execution
         async with _dataset_locks[group]:
             try:
-                # 1. Check if dataset exists (Double-Check Locking pattern)
                 logger.info(f"Checking if dataset exists: {group}")
                 datasets_response = await list_datasets(name=group)
 
@@ -139,13 +131,18 @@ class RagflowUtils:
                             logger.info(
                                 f"Found existing dataset: {group}, ID: {dataset_id}"
                             )
+                            await RagflowUtils._sync_description_if_stale(
+                                dataset_id,
+                                current=dataset.get("description"),
+                                desired=description,
+                            )
                             return dataset_id
 
-                # 2. Dataset doesn't exist, create new dataset
                 logger.info(f"Dataset doesn't exist, creating new dataset: {group}")
                 create_response = await create_dataset(
                     name=group,
-                    description=f"Automatically created dataset: {group}",
+                    description=description
+                    or f"Automatically created dataset: {group}",
                     chunk_method="naive",
                 )
 
@@ -161,6 +158,42 @@ class RagflowUtils:
             except Exception as e:
                 logger.error(f"Dataset management failed: {e}")
                 raise Exception(f"Unable to ensure dataset exists: {str(e)}")
+
+    @staticmethod
+    async def _sync_description_if_stale(
+        dataset_id: str, current: Optional[str], desired: Optional[str]
+    ) -> None:
+        """Best-effort lazy sync of a dataset's description.
+
+        Skips when ``desired`` is empty (caller did not supply a label) or
+        when ``current`` already matches. Exceptions are swallowed and logged
+        — a UI-friendly description must never block document writes.
+        """
+        if not desired or current == desired:
+            return
+        try:
+            resp = await update_dataset(dataset_id, description=desired)
+            if resp.get("code") != 0:
+                logger.warning(
+                    "Best-effort description sync rejected by RAGFlow for "
+                    "dataset %s: code=%s message=%s",
+                    dataset_id,
+                    resp.get("code"),
+                    resp.get("message", "Unknown error"),
+                )
+                return
+            logger.info(
+                "Updated dataset %s description: %r -> %r",
+                dataset_id,
+                current,
+                desired,
+            )
+        except Exception as e:
+            logger.warning(
+                "Best-effort description sync failed for dataset %s: %s",
+                dataset_id,
+                e,
+            )
 
     @staticmethod
     async def _download_url_file(file: str) -> tuple[bytes, str]:

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -323,7 +323,12 @@ class RagflowRAGStrategy(RAGStrategy):
                 }
             ]
         """
+        # ``group`` falls back to the default dataset (legacy callers may omit it);
+        # ``group_description`` deliberately has no fallback — when the upstream
+        # caller does not supply a human-readable label, ensure_dataset uses its
+        # own "Automatically created dataset: {group}" placeholder on first create.
         group = kwargs.get("group") or RagflowUtils.get_default_dataset_name()
+        group_description = kwargs.get("groupDescription")
         file = kwargs.get("file")
 
         # Parameter validation
@@ -347,7 +352,9 @@ class RagflowRAGStrategy(RAGStrategy):
 
         try:
             # Step 1: Dataset management
-            dataset_id = await RagflowUtils.ensure_dataset(group)
+            dataset_id = await RagflowUtils.ensure_dataset(
+                group, description=group_description
+            )
             logger.info("Using dataset: %s, name: %s", dataset_id, group)
 
             if document_id:
@@ -391,16 +398,23 @@ class RagflowRAGStrategy(RAGStrategy):
             "copiedFrom": None,
         }
 
-    async def _validate_chunks_save_config(self, doc_id: str) -> str:
-        """Validate chunks_save configuration and dataset"""
-        default_group = RagflowUtils.get_default_dataset_name()
+    async def _validate_chunks_save_config(
+        self,
+        doc_id: str,
+        group: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> str:
+        """Resolve dataset for chunks_save; lazy-creates if missing."""
+        group_name = group or RagflowUtils.get_default_dataset_name()
 
-        dataset_id = await RagflowUtils.ensure_dataset(default_group)
+        dataset_id = await RagflowUtils.ensure_dataset(
+            group_name, description=description
+        )
         if not dataset_id:
-            logger.error(f"Unable to find or create dataset: {default_group}")
+            logger.error(f"Unable to find or create dataset: {group_name}")
             raise CustomException(
                 CodeEnum.ChunkSaveFailed,
-                f"Unable to find or create dataset: {default_group}",
+                f"Unable to find or create dataset: {group_name}",
             )
 
         return dataset_id
@@ -708,17 +722,15 @@ class RagflowRAGStrategy(RAGStrategy):
         )
 
         try:
-            # 1. Validate configuration and dataset
-            dataset_id = await self._validate_chunks_save_config(docId)
+            dataset_id = await self._validate_chunks_save_config(
+                docId, group, description=kwargs.get("groupDescription")
+            )
             logger.info(f"Using dataset: {dataset_id}")
 
-            # 2. Validate if document exists
             await self._validate_document_exists(dataset_id, docId)
 
-            # 3. Get existing chunks
             existing_chunks = await self._get_existing_chunks(dataset_id, docId)
 
-            # 4. Process each chunk
             current_time = time.strftime("%Y-%m-%d %H:%M:%S")
             chunks_typed = [
                 chunk if isinstance(chunk, dict) else chunk.__dict__ for chunk in chunks
@@ -738,17 +750,19 @@ class RagflowRAGStrategy(RAGStrategy):
             logger.error(f"Chunk save operation failed: {e}")
             raise CustomException(CodeEnum.ChunkSaveFailed, str(e))
 
-    async def _validate_chunks_update_config(self) -> str:
-        """Validate chunks_update configuration and dataset"""
-        default_group = RagflowUtils.get_default_dataset_name()
+    async def _validate_chunks_update_config(self, group: Optional[str] = None) -> str:
+        """Resolve dataset for chunks_update; never lazy-creates.
 
-        dataset_id = await RagflowUtils.ensure_dataset(default_group)
+        Update against a non-existent dataset is a logic error and surfaces
+        as ``ChunkUpdateFailed``.
+        """
+        group_name = group or RagflowUtils.get_default_dataset_name()
+
+        dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
         if not dataset_id:
-            logger.error(f"Unable to find or create dataset: {default_group}")
-            raise CustomException(
-                CodeEnum.ChunkUpdateFailed,
-                f"Unable to find or create dataset: {default_group}",
-            )
+            err = f"Dataset {group_name!r} not found in RAGFlow, cannot update chunk"
+            logger.error(err)
+            raise CustomException(CodeEnum.ChunkUpdateFailed, err)
 
         return dataset_id
 
@@ -877,11 +891,9 @@ class RagflowRAGStrategy(RAGStrategy):
         )
 
         try:
-            # 1. Validate configuration and dataset
-            dataset_id = await self._validate_chunks_update_config()
+            dataset_id = await self._validate_chunks_update_config(group)
             logger.info(f"Using dataset: {dataset_id}")
 
-            # 2. Process each chunk update
             failed_chunks: Dict[str, str] = {}
             successful_count = 0
 
@@ -909,7 +921,11 @@ class RagflowRAGStrategy(RAGStrategy):
             raise CustomException(CodeEnum.ChunkUpdateFailed, str(e))
 
     async def chunks_delete(
-        self, docId: str, chunkIds: List[str], **kwargs: Any
+        self,
+        docId: str,
+        chunkIds: List[str],
+        group: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         """
         Delete knowledge chunks using RAGFlow.
@@ -917,6 +933,10 @@ class RagflowRAGStrategy(RAGStrategy):
         Args:
             docId: Document ID
             chunkIds: List of chunk IDs to delete
+            group: Optional RAGFlow dataset name. ``None`` falls back to the
+                configured default group. Resolution does NOT lazy-create —
+                if the dataset does not exist the delete is a no-op
+                (idempotent).
             **kwargs: Additional parameters
 
         Returns:
@@ -933,22 +953,21 @@ class RagflowRAGStrategy(RAGStrategy):
             )
 
         logger.info(
-            f"Processing chunk deletion request: docId={docId}, chunks_count={len(chunkIds)}"
+            f"Processing chunk deletion request: docId={docId}, "
+            f"group={group}, chunks_count={len(chunkIds)}"
         )
 
         try:
-            # 1. Get dataset name from config, then find dataset ID
-            default_group = RagflowUtils.get_default_dataset_name()
-
-            dataset_id = await RagflowUtils.ensure_dataset(default_group)
-            if not dataset_id:
-                logger.error(f"Unable to find or create dataset: {default_group}")
-                raise CustomException(
-                    CodeEnum.ChunkDeleteFailed,
-                    f"Unable to find or create dataset: {default_group}",
+            group_name = group or RagflowUtils.get_default_dataset_name()
+            dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
+            if dataset_id is None:
+                logger.info(
+                    f"Dataset {group_name!r} not found in RAGFlow, "
+                    f"treating delete as no-op (idempotent)"
                 )
+                return None
 
-            logger.info(f"Using dataset: {default_group} (ID: {dataset_id})")
+            logger.info(f"Using dataset: {group_name} (ID: {dataset_id})")
 
             # 2. Call RAGFlow deletion API directly
             delete_response = await ragflow_client.delete_chunks(

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -6,10 +6,11 @@ RAGFlow Strategy Implementation Module
 Provides document processing and knowledge management strategy based on RAGFlow
 """
 
+import asyncio
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from knowledge.consts.error_code import CodeEnum
 from knowledge.domain.entity.chunk_dto import RagflowQueryExt
@@ -39,96 +40,43 @@ class RagflowRAGStrategy(RAGStrategy):
         threshold: Optional[float] = 0,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """
-        Execute query using RAGFlow and return results.
-
-        Args:
-            query: Query string
-            doc_ids: List of specified document IDs
-            repo_ids: Ignore this parameter, use default dataset name from config
-            top_k: Default result limit; overridden by ``ragflow_ext.top_k``.
-            threshold: Similarity threshold
-            **kwargs: Optional ``ragflow_ext: RagflowQueryExt`` from the API
-                layer; other keys are ignored.
-
-        Returns:
-            Query result dictionary (abstract interface format)
-        """
+        """Query RAGFlow with repo-aware dataset routing."""
         try:
-            logger.info("Starting RAGFlow query: query=%s, doc_ids=%s", query, doc_ids)
-
+            logger.info(
+                "Starting RAGFlow query: query=%s, doc_ids=%s, repo_ids=%s",
+                query,
+                doc_ids,
+                repo_ids,
+            )
             ext: Optional[RagflowQueryExt] = kwargs.get("ragflow_ext")
 
-            # Get dataset name from configuration
-            dataset_name = RagflowUtils.get_default_dataset_name()
-            dataset_id = await RagflowUtils.get_dataset_id_by_name(dataset_name)
+            dataset_ids, missing = await self._resolve_query_datasets(repo_ids)
+            if missing:
+                logger.warning(
+                    "RAGFlow datasets missing for repos: %s "
+                    "(fail-closed: skipping these repos)",
+                    missing,
+                )
+            if not dataset_ids:
+                return self._empty_query_result(query)
 
-            if not dataset_id:
-                logger.warning("Dataset not found: %s", dataset_name)
-                return {"query": query, "count": 0, "results": []}
-
-            logger.info("Using dataset: %s (ID: %s)", dataset_name, dataset_id)
-
-            # ragflow_ext.top_k overrides topN as the retrieval/result limit.
             effective_top_k = (
                 ext.top_k if ext and ext.top_k is not None else (top_k or 6)
             )
-
-            # Preserve the existing vector/keyword blend weight default.
-            vsw = (
-                ext.vector_similarity_weight
-                if ext and ext.vector_similarity_weight is not None
-                else 0.2
+            payload = self._build_retrieval_payload(
+                query=query,
+                dataset_ids=dataset_ids,
+                doc_ids=doc_ids,
+                top_k=effective_top_k,
+                threshold=threshold or 0,
+                ext=ext,
             )
-
-            ragflow_request: Dict[str, Any] = {
-                "question": query,
-                "dataset_ids": [dataset_id],
-                "top_k": effective_top_k,
-                "similarity_threshold": threshold,
-                "vector_similarity_weight": vsw,
-            }
-
-            if doc_ids:
-                ragflow_request["document_ids"] = doc_ids
-
-            if ext is not None:
-                if ext.keyword is not None:
-                    ragflow_request["keyword"] = ext.keyword
-                if ext.rerank_id is not None:
-                    ragflow_request["rerank_id"] = ext.rerank_id
-                if ext.use_kg is not None:
-                    ragflow_request["use_kg"] = ext.use_kg
-                if ext.highlight is not None:
-                    # RAGFlow v0.20.5 compares `highlight` as a string;
-                    # passing a Python bool leaves it enabled. v0.24.0 accepts
-                    # bool directly — drop str() once the pinned image is >=
-                    # v0.24.0.
-                    ragflow_request["highlight"] = str(ext.highlight)
-
-            # Call RAGFlow retrieval API
-            ragflow_response = await ragflow_client.retrieval_with_dataset(
-                dataset_id=dataset_id, request_data=ragflow_request
+            return await self._execute_retrieval(
+                payload=payload,
+                query=query,
+                threshold=threshold or 0,
+                effective_top_k=effective_top_k,
             )
-
-            if ragflow_response.get("code") != 0:
-                msg = ragflow_response.get("message", "Unknown error")
-                logger.error("RAGFlow query failed: %s", ragflow_response)
-                raise ThirdPartyException(
-                    msg=f"RAGFlow retrieval failed: {msg}",
-                    e=CodeEnum.RAGFLOW_RAGError,
-                )
-
-            # Parse response and convert format
-            results = RagflowUtils.convert_ragflow_query_response(
-                ragflow_response, threshold or 0
-            )
-
-            if effective_top_k and effective_top_k > 0:
-                results = results[:effective_top_k]
-
-            logger.info("Query completed, returning %d results", len(results))
-            return {"query": query, "count": len(results), "results": results}
 
         except CustomException:
             raise
@@ -140,6 +88,107 @@ class RagflowRAGStrategy(RAGStrategy):
                 msg=f"RAGFlow retrieval failed: {e}",
                 e=CodeEnum.RAGFLOW_RAGError,
             ) from e
+
+    async def _resolve_query_datasets(
+        self, repo_ids: Optional[List[str]]
+    ) -> Tuple[List[str], List[str]]:
+        """Resolve RAGFlow dataset_ids from repo_ids; return (found, missing)."""
+        if not repo_ids:
+            default_name = RagflowUtils.get_default_dataset_name()
+            ds_id = await RagflowUtils.get_dataset_id_by_name(default_name)
+            return ([ds_id] if ds_id else [], [])
+
+        # Concurrent lookup: multi-repo query latency = 1 × RTT, not N × RTT.
+        results = await asyncio.gather(
+            *(RagflowUtils.get_dataset_id_by_name(rid) for rid in repo_ids)
+        )
+        dataset_ids: List[str] = []
+        missing: List[str] = []
+        for repo_id, ds_id in zip(repo_ids, results):
+            if ds_id:
+                dataset_ids.append(ds_id)
+            else:
+                missing.append(repo_id)
+        return (dataset_ids, missing)
+
+    def _build_retrieval_payload(
+        self,
+        query: str,
+        dataset_ids: List[str],
+        doc_ids: Optional[List[str]],
+        top_k: int,
+        threshold: float,
+        ext: Optional[RagflowQueryExt],
+    ) -> Dict[str, Any]:
+        """Build the RAGFlow ``/retrieval`` request body."""
+        payload: Dict[str, Any] = {
+            "question": query,
+            "dataset_ids": dataset_ids,
+            "top_k": top_k,
+            "similarity_threshold": threshold,
+            "vector_similarity_weight": 0.2,
+        }
+        if doc_ids:
+            payload["document_ids"] = doc_ids
+        if ext is not None:
+            self._apply_ragflow_ext(payload, ext)
+        return payload
+
+    def _apply_ragflow_ext(self, payload: Dict[str, Any], ext: RagflowQueryExt) -> None:
+        """Apply optional ``RagflowQueryExt`` fields onto the payload."""
+        # NB: top_k is intentionally not applied here. query() resolves
+        # effective_top_k upstream and writes it into the payload first.
+        if ext.vector_similarity_weight is not None:
+            payload["vector_similarity_weight"] = ext.vector_similarity_weight
+        if ext.keyword is not None:
+            payload["keyword"] = ext.keyword
+        if ext.rerank_id is not None:
+            payload["rerank_id"] = ext.rerank_id
+        if ext.use_kg is not None:
+            payload["use_kg"] = ext.use_kg
+        if ext.highlight is not None:
+            # RAGFlow v0.20.5 compares ``highlight`` as a string; passing a
+            # Python bool leaves it enabled. v0.24.0 accepts bool directly —
+            # drop ``str()`` once the pinned image is >= v0.24.0.
+            payload["highlight"] = str(ext.highlight)
+
+    async def _execute_retrieval(
+        self,
+        payload: Dict[str, Any],
+        query: str,
+        threshold: float,
+        effective_top_k: int,
+    ) -> Dict[str, Any]:
+        """Call RAGFlow ``/retrieval`` and convert response."""
+        # ``ragflow_client.retrieval_with_dataset`` ignores ``dataset_id``
+        # (the underlying RAGFlow body uses ``request_data['dataset_ids']``
+        # for the actual filter). The first id is passed only to satisfy the
+        # current client signature; remove this arg once the client drops it.
+        primary_dataset_id = payload["dataset_ids"][0]
+        ragflow_response = await ragflow_client.retrieval_with_dataset(
+            dataset_id=primary_dataset_id, request_data=payload
+        )
+
+        if ragflow_response.get("code") != 0:
+            msg = ragflow_response.get("message", "Unknown error")
+            logger.error("RAGFlow query failed: %s", ragflow_response)
+            raise ThirdPartyException(
+                msg=f"RAGFlow retrieval failed: {msg}",
+                e=CodeEnum.RAGFLOW_RAGError,
+            )
+
+        results = RagflowUtils.convert_ragflow_query_response(
+            ragflow_response, threshold
+        )
+        if effective_top_k and effective_top_k > 0:
+            results = results[:effective_top_k]
+
+        logger.info("Query completed, returning %d results", len(results))
+        return {"query": query, "count": len(results), "results": results}
+
+    def _empty_query_result(self, query: str) -> Dict[str, Any]:
+        """Unified empty-result format for fail-closed query paths."""
+        return {"query": query, "count": 0, "results": []}
 
     def _validate_split_parameters(
         self, fileUrl: Optional[str], file: Optional[Any]
@@ -928,18 +977,21 @@ class RagflowRAGStrategy(RAGStrategy):
                 CodeEnum.ChunkDeleteFailed, f"Deletion operation failed: {str(e)}"
             )
 
-    async def query_doc(self, docId: str, **kwargs: Any) -> List[Dict[str, Any]]:
-        """
-        Query all chunk information for a document using RAGFlow.
-        """
+    async def query_doc(
+        self, docId: str, group: Optional[str] = None, **kwargs: Any
+    ) -> List[Dict[str, Any]]:
+        """Query all chunk information for a document using RAGFlow."""
         try:
             logger.info(f"Starting document chunk query: docId={docId}")
 
-            # Get dataset ID
-            dataset_name = RagflowUtils.get_default_dataset_name()
-            dataset_id = await RagflowUtils.get_dataset_id_by_name(dataset_name)
+            group_name = group or RagflowUtils.get_default_dataset_name()
+            dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
             if not dataset_id:
-                logger.warning(f"Dataset not found: {dataset_name}")
+                logger.warning(
+                    "RAGFlow dataset missing for group %r "
+                    "(fail-closed: returning empty)",
+                    group_name,
+                )
                 return []
 
             # Step 1: Get total count
@@ -1011,19 +1063,20 @@ class RagflowRAGStrategy(RAGStrategy):
             ) from e
 
     async def query_doc_name(
-        self, docId: str, **kwargs: Any
+        self, docId: str, group: Optional[str] = None, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
-        """
-        Query document name and information using RAGFlow.
-        """
+        """Query document name and information using RAGFlow."""
         try:
             logger.info(f"Starting document info query: docId={docId}")
 
-            # Get dataset ID
-            dataset_name = RagflowUtils.get_default_dataset_name()
-            dataset_id = await RagflowUtils.get_dataset_id_by_name(dataset_name)
+            group_name = group or RagflowUtils.get_default_dataset_name()
+            dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
             if not dataset_id:
-                logger.warning(f"Dataset not found: {dataset_name}")
+                logger.warning(
+                    "RAGFlow dataset missing for group %r "
+                    "(fail-closed: returning None)",
+                    group_name,
+                )
                 return None
 
             # Get document information

--- a/core/knowledge/tests/domain/entity/chunk_dto_test.py
+++ b/core/knowledge/tests/domain/entity/chunk_dto_test.py
@@ -90,6 +90,34 @@ class TestFileSplitReq:
         )
         assert req.documentId == "doc-abc-123"
 
+    def test_group_default_none(self) -> None:
+        """FileSplitReq.group is Optional, default None for backward compat."""
+        req = FileSplitReq(file="test content", ragType=RAGType.RagFlow_RAG)
+        assert req.group is None
+
+    def test_group_accepts_string(self) -> None:
+        """FileSplitReq.group accepts explicit RAGFlow dataset group/name."""
+        req = FileSplitReq(
+            file="test content",
+            ragType=RAGType.RagFlow_RAG,
+            group="abc-uuid",
+        )
+        assert req.group == "abc-uuid"
+
+    def test_group_description_default_none(self) -> None:
+        """FileSplitReq.groupDescription is Optional, default None."""
+        req = FileSplitReq(file="test content", ragType=RAGType.RagFlow_RAG)
+        assert req.groupDescription is None
+
+    def test_group_description_accepts_string(self) -> None:
+        """FileSplitReq.groupDescription accepts a human-readable label."""
+        req = FileSplitReq(
+            file="test content",
+            ragType=RAGType.RagFlow_RAG,
+            groupDescription="客服知识库",
+        )
+        assert req.groupDescription == "客服知识库"
+
 
 class TestChunkSaveReq:
     """Test ChunkSaveReq model."""
@@ -210,6 +238,21 @@ class TestChunkDeleteReq:
         """Test with empty chunk IDs list."""
         req = ChunkDeleteReq(docId="doc123", chunkIds=[], ragType=RAGType.AIUI_RAG2)
         assert req.chunkIds == []
+
+    def test_group_default_none(self) -> None:
+        """ChunkDeleteReq.group is Optional, default None for backward compat."""
+        req = ChunkDeleteReq(docId="doc123", ragType=RAGType.RagFlow_RAG)
+        assert req.group is None
+
+    def test_group_accepts_string(self) -> None:
+        """ChunkDeleteReq.group accepts explicit RAGFlow dataset group/name."""
+        req = ChunkDeleteReq(
+            docId="doc123",
+            chunkIds=["c1"],
+            ragType=RAGType.RagFlow_RAG,
+            group="abc-uuid",
+        )
+        assert req.group == "abc-uuid"
 
 
 class TestQueryMatch:
@@ -373,6 +416,16 @@ class TestQueryDocReq:
         field_names = [error["loc"][0] for error in errors]
         assert "docId" in field_names
         assert "ragType" in field_names
+
+    def test_group_default_none(self) -> None:
+        """group is Optional, default None for backward compat."""
+        req = QueryDocReq(docId="doc123", ragType=RAGType.RagFlow_RAG)
+        assert req.group is None
+
+    def test_group_accepts_string(self) -> None:
+        """group accepts explicit string value."""
+        req = QueryDocReq(docId="doc123", ragType=RAGType.RagFlow_RAG, group="abc-uuid")
+        assert req.group == "abc-uuid"
 
 
 class TestIntegrationCases:

--- a/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
@@ -91,3 +91,112 @@ class TestGetDatasetIdByName:
             with pytest.raises(ThirdPartyException) as exc_info:
                 await RagflowUtils.get_dataset_id_by_name("AnyKB")
         assert "Authentication failed" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# ensure_dataset description sync (lazy + best-effort)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_skips_update_when_description_matches() -> None:
+    """No update_dataset call when existing description == desired."""
+    list_resp = {
+        "code": 0,
+        "data": [{"name": "g", "id": "ds-1", "description": "客服库"}],
+    }
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.list_datasets",
+        new=AsyncMock(return_value=list_resp),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.update_dataset", new=AsyncMock()
+    ) as mock_update:
+        result = await RagflowUtils.ensure_dataset("g", description="客服库")
+        assert result == "ds-1"
+        mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_updates_when_description_stale() -> None:
+    """Best-effort update when existing description differs from desired."""
+    list_resp = {
+        "code": 0,
+        "data": [{"name": "g", "id": "ds-1", "description": "Old name"}],
+    }
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.list_datasets",
+        new=AsyncMock(return_value=list_resp),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.update_dataset",
+        new=AsyncMock(return_value={"code": 0}),
+    ) as mock_update:
+        result = await RagflowUtils.ensure_dataset("g", description="新名字")
+        assert result == "ds-1"
+        mock_update.assert_awaited_once_with("ds-1", description="新名字")
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_skips_update_when_description_none() -> None:
+    """No update when caller passes description=None (no label to sync)."""
+    list_resp = {
+        "code": 0,
+        "data": [{"name": "g", "id": "ds-1", "description": "Old name"}],
+    }
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.list_datasets",
+        new=AsyncMock(return_value=list_resp),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.update_dataset", new=AsyncMock()
+    ) as mock_update:
+        await RagflowUtils.ensure_dataset("g", description=None)
+        mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_swallows_update_failures(caplog) -> None:
+    """update_dataset failure logs warning + returns dataset_id (does not raise)."""
+    import logging
+
+    list_resp = {
+        "code": 0,
+        "data": [{"name": "g", "id": "ds-1", "description": "stale"}],
+    }
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.list_datasets",
+        new=AsyncMock(return_value=list_resp),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.update_dataset",
+        new=AsyncMock(side_effect=RuntimeError("RAGFlow 5xx")),
+    ):
+        with caplog.at_level(logging.WARNING):
+            result = await RagflowUtils.ensure_dataset("g", description="new")
+        assert result == "ds-1"
+        assert any(
+            "Best-effort description sync failed" in r.message for r in caplog.records
+        )
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_warns_on_non_zero_update_code(caplog) -> None:
+    """update_dataset HTTP 200 with non-zero RAGFlow code logs warning, no raise."""
+    import logging
+
+    list_resp = {
+        "code": 0,
+        "data": [{"name": "g", "id": "ds-1", "description": "stale"}],
+    }
+    update_resp = {"code": 102, "message": "permission denied"}
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.list_datasets",
+        new=AsyncMock(return_value=list_resp),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.update_dataset",
+        new=AsyncMock(return_value=update_resp),
+    ):
+        with caplog.at_level(logging.WARNING):
+            result = await RagflowUtils.ensure_dataset("g", description="new")
+        assert result == "ds-1"
+        assert any(
+            "rejected by RAGFlow" in r.message and "permission denied" in r.message
+            for r in caplog.records
+        )

--- a/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
@@ -84,13 +84,38 @@ class TestGetDatasetIdByName:
     @pytest.mark.asyncio
     async def test_raises_on_non_zero_code(self) -> None:
         """Non-zero code (auth / argument / operating error) => ThirdPartyException.
-        RAGFlow's ``/datasets`` endpoint returns ``code=0, data=[]`` for
-        genuine no-match, so any non-zero code is a real protocol failure."""
+        Genuine protocol failures still surface; only the not-found shapes
+        below are folded into ``None``."""
         resp = {"code": 109, "message": "Authentication failed"}
         with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
             with pytest.raises(ThirdPartyException) as exc_info:
                 await RagflowUtils.get_dataset_id_by_name("AnyKB")
         assert "Authentication failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_code_108_lacks_permission(self) -> None:
+        """code=108 with 'lacks permission' message => not-found => ``None``.
+
+        RAGFlow returns this shape for both nonexistent and inaccessible
+        datasets; callers cannot tell them apart, so the safe fail-closed
+        behavior is to treat it as not-found rather than raising.
+        """
+        resp = {
+            "code": 108,
+            "message": "User 'u-1' lacks permission for dataset 'MissingKB'",
+        }
+        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
+            result = await RagflowUtils.get_dataset_id_by_name("MissingKB")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_on_code_108_unrelated_message(self) -> None:
+        """code=108 without 'lacks permission' marker still raises so we don't
+        silently swallow other 108-class errors."""
+        resp = {"code": 108, "message": "Some other 108 error"}
+        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
+            with pytest.raises(ThirdPartyException):
+                await RagflowUtils.get_dataset_id_by_name("AnyKB")
 
 
 # ---------------------------------------------------------------------------

--- a/core/knowledge/tests/service/impl/ragflow_strategy_chunks_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_chunks_test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for RagflowRAGStrategy chunks_save / chunks_update / chunks_delete
+group routing behavior."""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.exceptions.exception import CustomException
+from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+_ENSURE_DATASET = "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset"
+_GET_DATASET_NAME = (
+    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
+)
+_GET_DATASET_ID = (
+    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
+)
+
+
+# ----------------------------------------------------------------------
+# chunks_save (lazy create via ensure_dataset)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunks_save_routes_to_group_dataset_with_lazy_create() -> None:
+    """chunks_save with explicit group calls ensure_dataset(group)."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _ENSURE_DATASET,
+        new=AsyncMock(return_value="ds-abc"),
+    ) as mock_ensure, patch.object(
+        strategy,
+        "_validate_document_exists",
+        new=AsyncMock(return_value=None),
+    ), patch.object(
+        strategy,
+        "_get_existing_chunks",
+        new=AsyncMock(return_value={}),
+    ), patch.object(
+        strategy,
+        "_process_chunks_batch",
+        new=AsyncMock(return_value=([{"id": "c1"}], [])),
+    ), patch.object(
+        strategy,
+        "_handle_chunk_results",
+        new=AsyncMock(return_value=[{"id": "c1"}]),
+    ):
+        await strategy.chunks_save(
+            docId="doc-1",
+            group="abc-uuid",
+            uid="user-1",
+            chunks=[{"content": "hello"}],
+        )
+        mock_ensure.assert_awaited_once_with("abc-uuid", description=None)
+
+
+@pytest.mark.asyncio
+async def test_chunks_save_with_null_group_falls_back_to_default() -> None:
+    """chunks_save with group=None falls back to RAGFLOW_DEFAULT_GROUP."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_NAME,
+        return_value="default-group",
+    ), patch(
+        _ENSURE_DATASET,
+        new=AsyncMock(return_value="ds-default"),
+    ) as mock_ensure, patch.object(
+        strategy,
+        "_validate_document_exists",
+        new=AsyncMock(return_value=None),
+    ), patch.object(
+        strategy,
+        "_get_existing_chunks",
+        new=AsyncMock(return_value={}),
+    ), patch.object(
+        strategy,
+        "_process_chunks_batch",
+        new=AsyncMock(return_value=([{"id": "c1"}], [])),
+    ), patch.object(
+        strategy,
+        "_handle_chunk_results",
+        new=AsyncMock(return_value=[{"id": "c1"}]),
+    ):
+        await strategy.chunks_save(
+            docId="doc-1",
+            group=None,
+            uid="user-1",
+            chunks=[{"content": "hello"}],
+        )
+        mock_ensure.assert_awaited_once_with("default-group", description=None)
+
+
+@pytest.mark.asyncio
+async def test_chunks_save_lazy_creates_when_group_dataset_missing() -> None:
+    """chunks_save uses ensure_dataset which lazy creates if missing."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _ENSURE_DATASET,
+        new=AsyncMock(return_value="ds-newly-created"),
+    ) as mock_ensure, patch.object(
+        strategy,
+        "_validate_document_exists",
+        new=AsyncMock(return_value=None),
+    ), patch.object(
+        strategy,
+        "_get_existing_chunks",
+        new=AsyncMock(return_value={}),
+    ), patch.object(
+        strategy,
+        "_process_chunks_batch",
+        new=AsyncMock(return_value=([{"id": "c1"}], [])),
+    ), patch.object(
+        strategy,
+        "_handle_chunk_results",
+        new=AsyncMock(return_value=[{"id": "c1"}]),
+    ):
+        await strategy.chunks_save(
+            docId="doc-1",
+            group="brand-new-repo",
+            uid="user-1",
+            chunks=[{"content": "hello"}],
+        )
+        mock_ensure.assert_awaited_once_with("brand-new-repo", description=None)
+
+
+# ----------------------------------------------------------------------
+# chunks_update (no-create, raise on missing)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunks_update_routes_to_group_dataset() -> None:
+    """chunks_update with explicit group resolves dataset by group."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_ID,
+        new=AsyncMock(return_value="ds-abc"),
+    ) as mock_lookup, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_chunk",
+        new=AsyncMock(return_value={"code": 0}),
+    ):
+        await strategy.chunks_update(
+            docId="doc-1",
+            group="abc-uuid",
+            uid="user-1",
+            chunks=[{"chunkId": "c1", "content": "new"}],
+        )
+        mock_lookup.assert_awaited_once_with("abc-uuid")
+
+
+@pytest.mark.asyncio
+async def test_chunks_update_with_null_group_falls_back_to_default() -> None:
+    """chunks_update with group=None falls back to default."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_NAME,
+        return_value="default-group",
+    ), patch(
+        _GET_DATASET_ID,
+        new=AsyncMock(return_value="ds-default"),
+    ) as mock_lookup, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_chunk",
+        new=AsyncMock(return_value={"code": 0}),
+    ):
+        await strategy.chunks_update(
+            docId="doc-1",
+            group=None,
+            uid="user-1",
+            chunks=[{"chunkId": "c1", "content": "new"}],
+        )
+        mock_lookup.assert_awaited_once_with("default-group")
+
+
+@pytest.mark.asyncio
+async def test_chunks_update_raises_when_dataset_missing() -> None:
+    """chunks_update raises when dataset not found in RAGFlow."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_ID,
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(CustomException) as exc_info:
+            await strategy.chunks_update(
+                docId="doc-1",
+                group="ghost-uuid",
+                uid="user-1",
+                chunks=[{"chunkId": "c1", "content": "x"}],
+            )
+        # Strong assertion: error message must mention all three signals
+        msg = str(exc_info.value).lower()
+        assert "not found" in msg
+        assert "update" in msg
+        assert "ghost-uuid" in msg
+
+
+# ----------------------------------------------------------------------
+# chunks_delete (signature add group + silent skip)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunks_delete_routes_to_group_dataset() -> None:
+    """chunks_delete with explicit group resolves dataset by group."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_ID,
+        new=AsyncMock(return_value="ds-abc"),
+    ) as mock_lookup, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_chunks",
+        new=AsyncMock(return_value={"code": 0}),
+    ):
+        await strategy.chunks_delete(
+            docId="doc-1",
+            chunkIds=["c1", "c2"],
+            group="abc-uuid",
+        )
+        mock_lookup.assert_awaited_once_with("abc-uuid")
+
+
+@pytest.mark.asyncio
+async def test_chunks_delete_with_null_group_falls_back_to_default() -> None:
+    """chunks_delete with group=None falls back to default."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_NAME,
+        return_value="default-group",
+    ), patch(
+        _GET_DATASET_ID,
+        new=AsyncMock(return_value="ds-default"),
+    ) as mock_lookup, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_chunks",
+        new=AsyncMock(return_value={"code": 0}),
+    ):
+        await strategy.chunks_delete(
+            docId="doc-1",
+            chunkIds=["c1"],
+            group=None,
+        )
+        mock_lookup.assert_awaited_once_with("default-group")
+
+
+@pytest.mark.asyncio
+async def test_chunks_delete_silent_skip_when_dataset_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """chunks_delete returns no-op + logs info when dataset missing."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_ID,
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_chunks",
+        new=AsyncMock(),
+    ) as mock_delete:
+        with caplog.at_level(
+            logging.INFO,
+            logger="knowledge.service.impl.ragflow_strategy",
+        ):
+            await strategy.chunks_delete(
+                docId="doc-1",
+                chunkIds=["c1"],
+                group="ghost-uuid",
+            )
+        mock_delete.assert_not_called()
+        assert any(
+            "no-op" in r.message.lower() for r in caplog.records
+        ), f"Expected 'no-op' in logs, got: {[r.message for r in caplog.records]}"

--- a/core/knowledge/tests/service/impl/ragflow_strategy_query_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_query_test.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for RagflowRAGStrategy.query() multi-repo dataset routing."""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.domain.entity.chunk_dto import RagflowQueryExt
+from knowledge.exceptions.exception import ThirdPartyException
+from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+_GET_DATASET_NAME = (
+    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
+)
+_GET_DATASET_ID = (
+    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
+)
+_RETRIEVAL = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.retrieval_with_dataset"
+)
+_CONVERT = (
+    "knowledge.service.impl.ragflow_strategy."
+    "RagflowUtils.convert_ragflow_query_response"
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_query_datasets helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_no_repo_ids_uses_default() -> None:
+    """repo_ids=None falls back to default group dataset."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
+    ):
+        dataset_ids, missing = await strategy._resolve_query_datasets(None)
+        assert dataset_ids == ["ds-default"]
+        assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_no_repo_ids_default_missing() -> None:
+    """Default dataset missing returns ([], [])."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value=None)
+    ):
+        dataset_ids, missing = await strategy._resolve_query_datasets(None)
+        assert dataset_ids == []
+        assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_empty_list_uses_default() -> None:
+    """Empty repo_ids list also falls to default."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
+    ):
+        dataset_ids, missing = await strategy._resolve_query_datasets([])
+        assert dataset_ids == ["ds-default"]
+        assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_single_repo_present() -> None:
+    """Single repo_ids, dataset exists."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")):
+        dataset_ids, missing = await strategy._resolve_query_datasets(["abc-uuid"])
+        assert dataset_ids == ["ds-abc"]
+        assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_multi_repo_partial_missing() -> None:
+    """Multiple repo_ids, some datasets missing."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(side_effect=["ds-abc", None])):
+        dataset_ids, missing = await strategy._resolve_query_datasets(
+            ["abc-uuid", "def-not-exist"]
+        )
+        assert dataset_ids == ["ds-abc"]
+        assert missing == ["def-not-exist"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_all_missing() -> None:
+    """All repo_ids datasets missing returns ([], [...all])."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(side_effect=[None, None])):
+        dataset_ids, missing = await strategy._resolve_query_datasets(["xxx", "yyy"])
+        assert dataset_ids == []
+        assert missing == ["xxx", "yyy"]
+
+
+# ---------------------------------------------------------------------------
+# _build_retrieval_payload + _apply_ragflow_ext helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_retrieval_payload_basic() -> None:
+    """Payload contains dataset_ids, question, top_k, similarity_threshold."""
+    strategy = RagflowRAGStrategy()
+    payload = strategy._build_retrieval_payload(
+        query="hello",
+        dataset_ids=["ds-1", "ds-2"],
+        doc_ids=None,
+        top_k=5,
+        threshold=0.3,
+        ext=None,
+    )
+    assert payload["dataset_ids"] == ["ds-1", "ds-2"]
+    assert payload["question"] == "hello"
+    assert payload["top_k"] == 5
+    assert payload["similarity_threshold"] == 0.3
+    assert payload["vector_similarity_weight"] == 0.2
+
+
+def test_build_retrieval_payload_with_doc_ids_double_filter() -> None:
+    """Payload includes both dataset_ids and document_ids when doc_ids given."""
+    strategy = RagflowRAGStrategy()
+    payload = strategy._build_retrieval_payload(
+        query="hello",
+        dataset_ids=["ds-1"],
+        doc_ids=["doc1", "doc2"],
+        top_k=5,
+        threshold=0.0,
+        ext=None,
+    )
+    assert payload["dataset_ids"] == ["ds-1"]
+    assert payload["document_ids"] == ["doc1", "doc2"]
+
+
+def test_apply_ragflow_ext_sets_keyword_and_other_fields() -> None:
+    """_apply_ragflow_ext sets non-top_k fields on payload."""
+    strategy = RagflowRAGStrategy()
+    payload = {"top_k": 5, "question": "x"}
+    ext = RagflowQueryExt(top_k=20, keyword=True)
+    strategy._apply_ragflow_ext(payload, ext)
+    assert payload["top_k"] == 5  # unchanged: helper does NOT touch top_k
+    assert payload["keyword"] is True
+
+
+def test_apply_ragflow_ext_highlight_str_workaround() -> None:
+    """v0.20.5 workaround: highlight is converted to str(bool)."""
+    strategy = RagflowRAGStrategy()
+    payload: dict = {}
+    ext = RagflowQueryExt(highlight=False)
+    strategy._apply_ragflow_ext(payload, ext)
+    # v0.20.5 highlight string-comparison bug: must pass str(False) = "False".
+    assert payload["highlight"] == "False"
+
+
+# ---------------------------------------------------------------------------
+# _execute_retrieval + _empty_query_result helpers
+# ---------------------------------------------------------------------------
+
+
+def test_empty_query_result_format() -> None:
+    """Empty result has unified shape: query/count/results."""
+    strategy = RagflowRAGStrategy()
+    result = strategy._empty_query_result("hello")
+    assert result == {"query": "hello", "count": 0, "results": []}
+
+
+@pytest.mark.asyncio
+async def test_execute_retrieval_returns_converted_results() -> None:
+    """_execute_retrieval calls retrieval API + converts response."""
+    strategy = RagflowRAGStrategy()
+    fake_resp = {
+        "code": 0,
+        "data": {"chunks": [{"similarity": 0.9, "document_id": "d1", "content": "c1"}]},
+    }
+    converted = [{"docId": "d1", "content": "c1", "score": 0.9}]
+    with patch(
+        _RETRIEVAL, new=AsyncMock(return_value=fake_resp)
+    ) as mock_retrieval, patch(_CONVERT, return_value=converted):
+        result = await strategy._execute_retrieval(
+            payload={
+                "question": "x",
+                "dataset_ids": ["ds-1"],
+                "top_k": 5,
+                "similarity_threshold": 0.0,
+                "vector_similarity_weight": 0.2,
+            },
+            query="x",
+            threshold=0.0,
+            effective_top_k=5,
+        )
+    assert result["count"] == 1
+    assert result["query"] == "x"
+    assert result["results"][0]["docId"] == "d1"
+    # The retrieval client takes request_data via keyword.
+    assert mock_retrieval.await_args.kwargs["request_data"]["dataset_ids"] == ["ds-1"]
+
+
+# ---------------------------------------------------------------------------
+# query() integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_single_repo_routes_to_repo_dataset() -> None:
+    """Single repo_ids runs full query pipeline and returns hits.
+
+    Discriminates repo-routing vs default-routing: default name maps to a
+    different dataset id, so a query() that ignores repo_ids would fail
+    this assertion.
+    """
+    strategy = RagflowRAGStrategy()
+    fake_resp = {
+        "code": 0,
+        "data": {
+            "chunks": [{"similarity": 0.9, "document_id": "d1", "content": "hit"}]
+        },
+    }
+    converted = [{"docId": "d1", "content": "hit", "score": 0.9}]
+
+    async def _resolve(name: str) -> str:
+        # Distinct ids per name — proves we routed via repo_ids, not default.
+        return "ds-abc" if name == "abc-uuid" else "ds-DEFAULT"
+
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(side_effect=_resolve)
+    ), patch(
+        _RETRIEVAL, new=AsyncMock(return_value=fake_resp)
+    ) as mock_retrieval, patch(
+        _CONVERT, return_value=converted
+    ):
+        result = await strategy.query(
+            query="hello",
+            repo_ids=["abc-uuid"],
+            doc_ids=None,
+            top_k=5,
+        )
+        sent_payload = mock_retrieval.await_args.kwargs["request_data"]
+        # Routes to the repo's dataset, not the default one.
+        assert sent_payload["dataset_ids"] == ["ds-abc"]
+        assert result["count"] == 1
+        assert result["results"][0]["docId"] == "d1"
+
+
+@pytest.mark.asyncio
+async def test_query_all_missing_datasets_returns_empty(caplog) -> None:
+    """All repo datasets missing returns empty + warning, no RAGFlow call."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(return_value=None)), patch(
+        _RETRIEVAL, new=AsyncMock()
+    ) as mock_retrieval:
+        with caplog.at_level(
+            logging.WARNING, logger="knowledge.service.impl.ragflow_strategy"
+        ):
+            result = await strategy.query(
+                query="hello",
+                repo_ids=["xxx", "yyy"],
+                doc_ids=None,
+                top_k=5,
+            )
+        mock_retrieval.assert_not_called()
+        assert result == {"query": "hello", "count": 0, "results": []}
+        assert any("missing" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_query_repo_and_doc_ids_double_filter() -> None:
+    """repo_ids + doc_ids: payload has both repo dataset and docs."""
+    strategy = RagflowRAGStrategy()
+    fake_resp = {"code": 0, "data": {"chunks": []}}
+
+    async def _resolve(name: str) -> str:
+        return "ds-abc" if name == "abc-uuid" else "ds-DEFAULT"
+
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(side_effect=_resolve)
+    ), patch(
+        _RETRIEVAL, new=AsyncMock(return_value=fake_resp)
+    ) as mock_retrieval, patch(
+        _CONVERT, return_value=[]
+    ):
+        await strategy.query(
+            query="hello",
+            repo_ids=["abc-uuid"],
+            doc_ids=["doc1", "doc2"],
+            top_k=5,
+        )
+        sent_payload = mock_retrieval.await_args.kwargs["request_data"]
+        assert sent_payload["dataset_ids"] == ["ds-abc"]
+        assert sent_payload["document_ids"] == ["doc1", "doc2"]
+
+
+@pytest.mark.asyncio
+async def test_query_propagates_ragflow_errors() -> None:
+    """RAGFlow exception bubbles as ThirdPartyException, NOT empty."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")), patch(
+        _RETRIEVAL, new=AsyncMock(side_effect=RuntimeError("RAGFlow 5xx"))
+    ):
+        with pytest.raises(ThirdPartyException):
+            await strategy.query(
+                query="hello",
+                repo_ids=["abc-uuid"],
+                doc_ids=None,
+                top_k=5,
+            )
+
+
+# ---------------------------------------------------------------------------
+# query_doc / query_doc_name (read paths) — group routing
+# ---------------------------------------------------------------------------
+
+_LIST_CHUNKS = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.list_document_chunks"
+)
+_GET_DOC_INFO = (
+    "knowledge.service.impl.ragflow_strategy.ragflow_client.get_document_info"
+)
+
+
+@pytest.mark.asyncio
+async def test_query_doc_routes_to_group_dataset() -> None:
+    """query_doc with explicit group resolves dataset by group, not default."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")
+    ) as mock_lookup, patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(return_value={"code": 0, "data": {"total": 0, "chunks": []}}),
+    ):
+        await strategy.query_doc(docId="doc-1", group="abc-uuid")
+        mock_lookup.assert_awaited_once_with("abc-uuid")
+
+
+@pytest.mark.asyncio
+async def test_query_doc_with_null_group_falls_back_to_default() -> None:
+    """query_doc with group=None falls back to default group."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
+    ) as mock_lookup, patch(
+        _LIST_CHUNKS,
+        new=AsyncMock(return_value={"code": 0, "data": {"total": 0, "chunks": []}}),
+    ):
+        await strategy.query_doc(docId="doc-1", group=None)
+        mock_lookup.assert_awaited_once_with("default-group")
+
+
+@pytest.mark.asyncio
+async def test_query_doc_returns_empty_when_dataset_missing() -> None:
+    """query_doc returns [] when dataset for group not found."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(return_value=None)), patch(
+        _LIST_CHUNKS, new=AsyncMock()
+    ) as mock_list:
+        result = await strategy.query_doc(docId="doc-1", group="ghost-uuid")
+        assert result == []
+        mock_list.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_doc_name_routes_to_group_dataset() -> None:
+    """query_doc_name with explicit group resolves dataset by group."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")
+    ) as mock_lookup, patch(
+        _GET_DOC_INFO, new=AsyncMock(return_value={"name": "f.pdf", "run": "DONE"})
+    ):
+        await strategy.query_doc_name(docId="doc-1", group="abc-uuid")
+        mock_lookup.assert_awaited_once_with("abc-uuid")
+
+
+@pytest.mark.asyncio
+async def test_query_doc_name_with_null_group_falls_back_to_default() -> None:
+    """query_doc_name with group=None falls back to default group."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
+    ) as mock_lookup, patch(
+        _GET_DOC_INFO, new=AsyncMock(return_value={"name": "f.pdf", "run": "DONE"})
+    ):
+        await strategy.query_doc_name(docId="doc-1", group=None)
+        mock_lookup.assert_awaited_once_with("default-group")
+
+
+@pytest.mark.asyncio
+async def test_query_doc_name_returns_none_when_dataset_missing() -> None:
+    """query_doc_name returns None when dataset for group not found."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_ID, new=AsyncMock(return_value=None)), patch(
+        _GET_DOC_INFO, new=AsyncMock()
+    ) as mock_info:
+        result = await strategy.query_doc_name(docId="doc-1", group="ghost-uuid")
+        assert result is None
+        mock_info.assert_not_called()

--- a/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
@@ -384,7 +384,7 @@ async def test_split_document_id_none_uses_legacy_create_only_path(
     strategy = RagflowRAGStrategy()
     file_input = object()
 
-    async def fake_ensure_dataset(group: str) -> str:
+    async def fake_ensure_dataset(group: str, description=None) -> str:
         return "ds-1"
 
     async def fake_get_document_chunks(dataset_id: str, doc_id: str) -> list[Any]:
@@ -441,7 +441,7 @@ async def test_split_document_id_set_uses_upsert_path(
     strategy = RagflowRAGStrategy()
     file_input = object()
 
-    async def fake_ensure_dataset(group: str) -> str:
+    async def fake_ensure_dataset(group: str, description=None) -> str:
         return "ds-1"
 
     async def fake_get_document_chunks(dataset_id: str, doc_id: str) -> list[Any]:
@@ -491,7 +491,7 @@ async def test_split_preserves_custom_exception_from_upsert(
     """split() must preserve domain errors so API returns the right code."""
     strategy = RagflowRAGStrategy()
 
-    async def fake_ensure_dataset(group: str) -> str:
+    async def fake_ensure_dataset(group: str, description=None) -> str:
         return "ds-1"
 
     monkeypatch.setattr(
@@ -520,7 +520,7 @@ async def test_split_prefers_kwargs_group_over_default(
     strategy = RagflowRAGStrategy()
     captured: dict[str, Any] = {}
 
-    async def fake_ensure_dataset(group: str) -> str:
+    async def fake_ensure_dataset(group: str, description=None) -> str:
         captured["group"] = group
         return "ds-1"
 


### PR DESCRIPTION
## Summary

本 PR 修复 Ragflow-RAG 多知识库隔离问题：RAGFlow 操作不再默认落到共享 dataset，而是按照 Astron 知识库对应的 `coreRepoId` 路由到独立的 RAGFlow dataset。

修复后，上传、切片、查询、文档读取、chunk 更新和 chunk 删除都会使用对应知识库的 dataset，避免不同 Astron 知识库之间发生检索或写入污染。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

Refs #1214（本 PR 覆盖该 issue 中前 3 项 follow-up：`repo_id` 透传 / 上传 `dataset_id` / 查询按 dataset 路由；级联删除策略另起 PR）

## Changes

- 使用 `coreRepoId` 作为 Ragflow-RAG 对应的 RAGFlow dataset group/name。
- 传递 Astron 知识库名称作为 `groupDescription`，写入 RAGFlow dataset description，方便在 RAGFlow UI 中识别。
- 写路径按需 lazy create RAGFlow dataset，并对已存在 dataset 的 description 做 best-effort 同步。
- 查询/读取路径按知识库 dataset 路由，包括：
  - `/chunk/query`
  - `/document/chunk`
  - `/document/name`
- 写入/变更路径按知识库 dataset 路由，包括：
  - upload
  - split / re-split
  - chunk update
  - chunk delete
- 将 RAGFlow dataset lookup 的 `code=108` 视为 not found，使缺失 dataset 走 fail-closed，而不是回退到默认 dataset。
- 保持非 Ragflow-RAG 策略行为不变。

## Backward Compatibility

- 未传 `group` 的 legacy Ragflow-RAG 调用仍会回退到配置的默认 dataset。
- 本 PR 只改变 Astron 管理的 Ragflow-RAG 知识库路径：这些路径会显式传递 `coreRepoId`，用于实现 dataset 隔离。
- 本 PR 不迁移已经存在于默认 RAGFlow dataset 中的历史数据。

## Testing

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing completed

已执行：

```bash
cd core/knowledge
./.venv/bin/python -m pytest -q
# 360 passed, 32 warnings
```

```bash
cd console/backend
mvn -pl toolkit -Dspotless.check.skip=true test
# Tests run: 694, Failures: 0, Errors: 0, Skipped: 0
```

```bash
cd core/knowledge
./.venv/bin/python -m flake8 --max-line-length 88 --ignore=E203,W503,E501 --max-complexity 10 infra/ragflow/ragflow_utils.py tests/infra/ragflow/ragflow_utils_test.py
./.venv/bin/python -m isort --check-only --profile black infra/ragflow/ragflow_utils.py tests/infra/ragflow/ragflow_utils_test.py
./.venv/bin/python -m black --check infra/ragflow/ragflow_utils.py tests/infra/ragflow/ragflow_utils_test.py
```

真实 RAGFlow 冒烟覆盖：

- `ensure_dataset(repo-A)` 会按 group/name 创建 dataset。
- 重复执行 `ensure_dataset(repo-A)` 返回同一个 dataset id。
- dataset description 可以写入并同步更新。
- `ensure_dataset(repo-B)` 会创建独立 dataset。
- 查询缺失 dataset 时返回空结果/fail-closed，不回退默认 dataset。

注意：完整 Spotless 检查当前会在 `WorkflowService.java` 报格式问题；该文件不在本 PR diff 中，且该问题已存在于 `origin/main`。

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (not needed; behavior is covered by tests)
- [x] Breaking changes documented (not applicable)
