### PR TITLE
feat: persist ragflow dataset id and route by id

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/constant/ResponseEnum.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/constant/ResponseEnum.java
@@ -395,6 +395,7 @@ public enum ResponseEnum {
     REPO_KNOWLEDGE_QUERY_FAILED(8737, "repo.knowledge.query.failed"),
     REPO_DELETE_FAILED_BOT_USED(8738, "repo.delete.failed.bot.used"),
     REPO_FILE_UPLOAD_TYPE_NOT_EXIST(8739, "repo.file.upload.type.not.exist"),
+    REPO_CREATE_RAGFLOW_FAILED(8740, "repo.create.ragflow.failed"),
 
     // 8900 - 9000 (Model related)
     MODEL_NOT_COMPATIBLE_OPENAI(8900, "model.not.compatible.openai"),

--- a/console/backend/commons/src/main/resources/messages_en.properties
+++ b/console/backend/commons/src/main/resources/messages_en.properties
@@ -376,6 +376,7 @@ repo.file.disabled=Document disabled
 repo.knowledge.query.failed=Knowledge retrieval failed
 repo.delete.failed.bot.used=Knowledge base has bot association usage, cannot delete
 repo.file.upload.type.not.exist=Upload failed: File type not supported
+repo.create.ragflow.failed=Failed to create RAGFlow dataset: {0}
 
 # Model 8900+
 model.not.compatible.openai=Interface return format not compatible with OpenAI protocol

--- a/console/backend/commons/src/main/resources/messages_zh.properties
+++ b/console/backend/commons/src/main/resources/messages_zh.properties
@@ -388,6 +388,7 @@ repo.file.disabled=文档已停用
 repo.knowledge.query.failed=知识检索失败
 repo.delete.failed.bot.used=知识库存在bot关联使用，不能删除
 repo.file.upload.type.not.exist=上传失败：文件类型不支持
+repo.create.ragflow.failed=RAGFlow 知识库创建失败：{0}
 
 # 模型 8900+
 model.not.compatible.openai=接口返回格式不兼容 OpenAI 协议

--- a/console/backend/hub/src/main/resources/db/migration/V1.28__add_ragflow_dataset_id_to_repo.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.28__add_ragflow_dataset_id_to_repo.sql
@@ -1,0 +1,5 @@
+ALTER TABLE repo
+    ADD COLUMN ragflow_dataset_id VARCHAR(64) NULL
+    COMMENT 'RAGFlow dataset.id for Ragflow-RAG repos; NULL uses the default dataset';
+
+CREATE INDEX idx_repo_ragflow_dataset_id ON repo (ragflow_dataset_id);

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/DatasetCreateRequest.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/DatasetCreateRequest.java
@@ -1,0 +1,16 @@
+package com.iflytek.astron.console.toolkit.entity.core.knowledge;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Request body for POST /v1/dataset/create. */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DatasetCreateRequest {
+
+    String name;
+
+    String description;
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/KnowledgeRequest.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/KnowledgeRequest.java
@@ -17,6 +17,9 @@ public class KnowledgeRequest {
      */
     String group;
 
+    /** RAGFlow dataset.id for Ragflow-RAG routing; blank uses the default dataset. */
+    String datasetId;
+
     /**
      * Required: No. User ID to which the document belongs, users can specify themselves
      */

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/QueryMatchObj.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/QueryMatchObj.java
@@ -16,6 +16,9 @@ public class QueryMatchObj {
      */
     List<String> repoId;
 
+    /** RAGFlow dataset.id values for Ragflow-RAG routing. */
+    List<String> datasetId;
+
     /**
      * Required: No. Knowledge base score threshold, default 0
      */

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/SplitRequest.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/core/knowledge/SplitRequest.java
@@ -50,17 +50,8 @@ public class SplitRequest {
      */
     Integer resourceType;
 
-    /**
-     * RAGFlow dataset group (coreRepoId for Ragflow-RAG). Optional; null falls back to the default
-     * group.
-     */
-    String group;
-
-    /**
-     * Human-readable label written into the RAGFlow dataset description on first creation. Helps
-     * operators identify the dataset in the RAGFlow UI without resolving UUIDs.
-     */
-    String groupDescription;
+    /** RAGFlow dataset.id for Ragflow-RAG routing; blank uses the default dataset. */
+    String datasetId;
 
     // Default to AIUI value
     public SplitRequest() {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/table/repo/Repo.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/table/repo/Repo.java
@@ -121,6 +121,9 @@ public class Repo implements Serializable {
     // Knowledge base type, CBG-RAG / AIUI-RAG2
     private String tag;
 
+    /** RAGFlow dataset.id for Ragflow-RAG repos; null uses the default dataset. */
+    private String ragflowDatasetId;
+
     private Long spaceId;
 
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
@@ -48,22 +48,28 @@ public class KnowledgeV2ServiceCallHandler {
             String msg = (parsed == null) ? "blank response" : parsed.getMessage();
             throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED, msg);
         }
-        Object data = parsed.getData();
-        JSONObject dataObj;
-        if (data instanceof JSONObject) {
-            dataObj = (JSONObject) data;
-        } else if (data instanceof String) {
-            dataObj = JSON.parseObject((String) data);
-        } else {
-            throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED,
-                    "RAGFlow returned non-object data");
-        }
+        return extractDatasetId(parsed.getData());
+    }
+
+    private String extractDatasetId(Object data) {
+        JSONObject dataObj = toJsonObject(data);
         String datasetId = dataObj == null ? null : dataObj.getString(DATASET_ID_FIELD);
         if (StringUtils.isBlank(datasetId)) {
             throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED,
                     "RAGFlow returned blank datasetId");
         }
         return datasetId;
+    }
+
+    private JSONObject toJsonObject(Object data) {
+        if (data instanceof JSONObject) {
+            return (JSONObject) data;
+        }
+        if (data instanceof String) {
+            return JSON.parseObject((String) data);
+        }
+        throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED,
+                "RAGFlow returned non-object data");
     }
 
     /**

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandler.java
@@ -1,6 +1,9 @@
 package com.iflytek.astron.console.toolkit.handler;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.toolkit.common.constant.ProjectContent;
 import com.iflytek.astron.console.toolkit.config.properties.RepoAuthorizedConfig;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
@@ -25,25 +28,57 @@ public class KnowledgeV2ServiceCallHandler {
     @Resource
     private RepoAuthorizedConfig repoAuthorizedConfig;
 
+    private static final String DATASET_ID_FIELD = "datasetId";
+
+    /**
+     * Create or reuse a RAGFlow dataset and return its id.
+     *
+     * @param name RAGFlow dataset.name
+     * @param description RAGFlow dataset.description; nullable
+     */
+    public String createRagflowDataset(String name, String description) {
+        String url = apiUrl.getKnowledgeUrl().concat("/v1/dataset/create");
+        DatasetCreateRequest req = new DatasetCreateRequest(name, description);
+        String reqBody = JSON.toJSONString(req);
+        log.info("createRagflowDataset url = {}, name = {}", url, name);
+        String resp = postJson(url, reqBody);
+        log.info("createRagflowDataset response = {}", resp);
+        KnowledgeResponse parsed = JSON.parseObject(resp, KnowledgeResponse.class);
+        if (parsed == null || parsed.getCode() == null || parsed.getCode() != 0) {
+            String msg = (parsed == null) ? "blank response" : parsed.getMessage();
+            throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED, msg);
+        }
+        Object data = parsed.getData();
+        JSONObject dataObj;
+        if (data instanceof JSONObject) {
+            dataObj = (JSONObject) data;
+        } else if (data instanceof String) {
+            dataObj = JSON.parseObject((String) data);
+        } else {
+            throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED,
+                    "RAGFlow returned non-object data");
+        }
+        String datasetId = dataObj == null ? null : dataObj.getString(DATASET_ID_FIELD);
+        if (StringUtils.isBlank(datasetId)) {
+            throw new BusinessException(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED,
+                    "RAGFlow returned blank datasetId");
+        }
+        return datasetId;
+    }
+
     /**
      * Document parsing and chunking
      *
      * @param request the split request describing the document
-     * @param coreRepoId Ragflow-RAG dataset name/group; forwarded as {@code group} so the upstream
-     *        service can resolve the matching dataset. Ignored for non-Ragflow-RAG sources to keep
-     *        CBG/AIUI/Spark behavior intact.
-     * @param repoName human-readable repo display name; written into RAGFlow dataset description on
-     *        first lazy creation. Pass {@code null} to skip.
+     * @param datasetId RAGFlow dataset.id; ignored when blank or non-Ragflow
      * @return knowledge response from the upstream split API
      */
-    public KnowledgeResponse documentSplit(
-            SplitRequest request, String coreRepoId, String repoName) {
-        applyGroupToSplitRequest(request, coreRepoId);
-        applyGroupDescriptionToSplitRequest(request, repoName);
+    public KnowledgeResponse documentSplit(SplitRequest request, String datasetId) {
+        applyDatasetIdToSplitRequest(request, datasetId);
         String url = apiUrl.getKnowledgeUrl().concat("/v1/document/split");
         String reqBody = JSON.toJSONString(request);
         log.info("documentSplit url = {}, request = {}", url, reqBody);
-        String post = OkHttpUtil.post(url, reqBody);
+        String post = postJson(url, reqBody);
         log.info("documentSplit response = {}", post);
         return JSON.parseObject(post, KnowledgeResponse.class);
     }
@@ -57,19 +92,14 @@ public class KnowledgeV2ServiceCallHandler {
      * @param ragType RAG type
      * @param resourceType resource type (0=file, 1=html)
      * @param oldDocId existing RAGFlow doc id for upsert; null for first slice
-     * @param coreRepoId Ragflow-RAG dataset name/group; forwarded as {@code group} so the upstream
-     *        service can resolve the matching dataset. Ignored for non-Ragflow-RAG sources to keep
-     *        CBG/AIUI/Spark behavior intact.
-     * @param repoName human-readable repo display name; written into RAGFlow dataset description on
-     *        first lazy creation. Pass {@code null} to skip.
+     * @param datasetId RAGFlow dataset.id; ignored when blank or non-Ragflow
      * @return KnowledgeResponse
      */
     public KnowledgeResponse documentUpload(MultipartFile multipartFile,
             List<Integer> lengthRange, List<String> separator,
             String ragType, Integer resourceType,
             String oldDocId,
-            String coreRepoId,
-            String repoName) {
+            String datasetId) {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/document/upload");
 
         try {
@@ -91,11 +121,10 @@ public class KnowledgeV2ServiceCallHandler {
             if (StringUtils.isNotBlank(oldDocId)) {
                 params.put("documentId", oldDocId);
             }
-            applyGroupToUploadParams(params, ragType, coreRepoId);
-            applyGroupDescriptionToUploadParams(params, ragType, repoName);
+            applyDatasetIdToUploadParams(params, ragType, datasetId);
 
             log.info("documentUpload url = {}, ragType = {}, resourceType = {}", url, ragType, resourceType);
-            String post = OkHttpUtil.postMultipart(url, new HashMap<>(), null, params, null);
+            String post = OkHttpUtil.postMultipart(url, null, null, params, null);
             log.info("documentUpload response = {}", post);
             return JSON.parseObject(post, KnowledgeResponse.class);
         } catch (Exception e) {
@@ -107,60 +136,24 @@ public class KnowledgeV2ServiceCallHandler {
         }
     }
 
-    /**
-     * Set {@code group} on the split request for Ragflow-RAG when {@code coreRepoId} is non-blank.
-     * No-op otherwise so other RAG strategies stay untouched.
-     */
-    void applyGroupToSplitRequest(SplitRequest request, String coreRepoId) {
+    void applyDatasetIdToSplitRequest(SplitRequest request, String datasetId) {
         if (request == null) {
             return;
         }
         if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(request.getRagType())
-                && StringUtils.isNotBlank(coreRepoId)) {
-            request.setGroup(coreRepoId);
+                && StringUtils.isNotBlank(datasetId)) {
+            request.setDatasetId(datasetId);
         }
     }
 
-    /**
-     * Add {@code group} to the upload params map for Ragflow-RAG when {@code coreRepoId} is non-blank.
-     * No-op otherwise.
-     */
-    void applyGroupToUploadParams(Map<String, Object> params, String ragType, String coreRepoId) {
+    void applyDatasetIdToUploadParams(
+            Map<String, Object> params, String ragType, String datasetId) {
         if (params == null) {
             return;
         }
         if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(ragType)
-                && StringUtils.isNotBlank(coreRepoId)) {
-            params.put("group", coreRepoId);
-        }
-    }
-
-    /**
-     * Set {@code groupDescription} on the split request for Ragflow-RAG when {@code repoName} is
-     * non-blank. No-op otherwise.
-     */
-    void applyGroupDescriptionToSplitRequest(SplitRequest request, String repoName) {
-        if (request == null) {
-            return;
-        }
-        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(request.getRagType())
-                && StringUtils.isNotBlank(repoName)) {
-            request.setGroupDescription(repoName);
-        }
-    }
-
-    /**
-     * Add {@code groupDescription} to the upload params map for Ragflow-RAG when {@code repoName} is
-     * non-blank. No-op otherwise.
-     */
-    void applyGroupDescriptionToUploadParams(
-            Map<String, Object> params, String ragType, String repoName) {
-        if (params == null) {
-            return;
-        }
-        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(ragType)
-                && StringUtils.isNotBlank(repoName)) {
-            params.put("groupDescription", repoName);
+                && StringUtils.isNotBlank(datasetId)) {
+            params.put(DATASET_ID_FIELD, datasetId);
         }
     }
 
@@ -168,7 +161,7 @@ public class KnowledgeV2ServiceCallHandler {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/chunks/save");
         String reqBody = JSON.toJSONString(request);
         log.info("saveChunk url = {}, request = {}", url, reqBody);
-        String post = OkHttpUtil.post(url, reqBody);
+        String post = postJson(url, reqBody);
         log.info("saveChunk response = {}", post);
         return JSON.parseObject(post, KnowledgeResponse.class);
     }
@@ -177,7 +170,7 @@ public class KnowledgeV2ServiceCallHandler {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/chunk/update");
         String reqBody = JSON.toJSONString(request);
         log.info("updateChunk url = {}, request = {}", url, reqBody);
-        String post = OkHttpUtil.post(url, reqBody);
+        String post = postJson(url, reqBody);
         log.info("updateChunk response = {}", post);
         return JSON.parseObject(post, KnowledgeResponse.class);
     }
@@ -186,7 +179,7 @@ public class KnowledgeV2ServiceCallHandler {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/chunk/delete");
         String reqBody = JSON.toJSONString(request);
         log.info("deleteDocOrChunk url = {}, request = {}", url, reqBody);
-        String post = OkHttpUtil.post(url, reqBody);
+        String post = postJson(url, reqBody);
         log.info("deleteDocOrChunk response = {}", post);
         return JSON.parseObject(post, KnowledgeResponse.class);
     }
@@ -195,8 +188,12 @@ public class KnowledgeV2ServiceCallHandler {
         String url = apiUrl.getKnowledgeUrl().concat("/v1/chunk/query");
         String reqBody = JSON.toJSONString(request);
         log.info("knowledgeQuery request url:{}\ndata:{}", url, reqBody);
-        String respData = OkHttpUtil.post(url, reqBody);
+        String respData = postJson(url, reqBody);
         log.info("knowledgeQuery response data:{}", respData);
         return JSON.parseObject(respData, KnowledgeResponse.class);
+    }
+
+    private String postJson(String url, String reqBody) {
+        return OkHttpUtil.post(url, reqBody);
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
@@ -91,11 +91,11 @@ public class KnowledgeService {
      */
     @Transactional
     public Knowledge createKnowledge(KnowledgeVO knowledgeVO) {
-        List<String> uuids = preCheck(knowledgeVO.getFileId());
-        Repo repo = repoService.getOnly(Wrappers.lambdaQuery(Repo.class).eq(Repo::getCoreRepoId, uuids.get(1)));
+        RepoContext repoContext = getRepoContext(knowledgeVO.getFileId());
+        Repo repo = repoService.getOnly(Wrappers.lambdaQuery(Repo.class).eq(Repo::getCoreRepoId, repoContext.coreRepoId));
         dataPermissionCheckTool.checkRepoBelong(repo);
         // Create knowledge
-        Knowledge knowledge = this.getKnowledgePojo(knowledgeVO, uuids.getFirst());
+        Knowledge knowledge = this.getKnowledgePojo(knowledgeVO, repoContext.fileUuid);
 
         String auditSuggest = null;
         // Query current document enabled status
@@ -127,9 +127,11 @@ public class KnowledgeService {
             // 3. Determine type, override chunk_id
             String source = fileInfoV2.getSource();
             if (ProjectContent.isAiuiRagCompatible(source)) {
-                this.addKnowledge4AIUI(uuids.get(0), uuids.get(1), jsonArray, source);
+                this.addKnowledge4AIUI(repoContext.fileUuid, repoContext.coreRepoId,
+                        repoContext.ragflowDatasetId, jsonArray, source);
             } else if (ProjectContent.isCbgRagCompatible(source)) {
-                Map<String, String> cbgKnowledgeMap = this.addKnowledge4CBG(uuids.get(0), uuids.get(1), jsonArray, source);
+                Map<String, String> cbgKnowledgeMap = this.addKnowledge4CBG(repoContext.fileUuid,
+                        repoContext.coreRepoId, repoContext.ragflowDatasetId, jsonArray, source);
                 if (!cbgKnowledgeMap.isEmpty()) {
                     for (String key : cbgKnowledgeMap.keySet()) {
                         knowledge.setId(cbgKnowledgeMap.get(key));
@@ -167,7 +169,7 @@ public class KnowledgeService {
         }
         Knowledge knowledge = new Knowledge();
         BeanUtils.copyProperties(mysqlKnowledge, knowledge);
-        List<String> uuids = preCheck(knowledgeVO.getFileId());
+        RepoContext repoContext = getRepoContext(knowledgeVO.getFileId());
 
         String originKnowledge = knowledge.getContent().getString("content");
         boolean notNeedUpdate = originKnowledge.equals(knowledgeVO.getContent());
@@ -177,7 +179,7 @@ public class KnowledgeService {
 
         knowledge.getContent().put("content", knowledgeVO.getContent());
         knowledge.setUpdatedAt(LocalDateTime.now());
-        Repo repo = repoService.getOnly(Wrappers.lambdaQuery(Repo.class).eq(Repo::getCoreRepoId, uuids.get(1)));
+        Repo repo = repoService.getOnly(Wrappers.lambdaQuery(Repo.class).eq(Repo::getCoreRepoId, repoContext.coreRepoId));
         dataPermissionCheckTool.checkRepoBelong(repo);
 
         String auditSuggest = null;
@@ -205,7 +207,8 @@ public class KnowledgeService {
             // 1. Modify knowledge point - using MySQL
             BeanUtils.copyProperties(knowledge, mysqlKnowledge);
             knowledgeMapper.updateById(mysqlKnowledge);
-            this.updateKnowledge(uuids.get(0), uuids.get(1), updateKnowledgeArray);
+            this.updateKnowledge(repoContext.fileUuid, repoContext.coreRepoId,
+                    repoContext.ragflowDatasetId, updateKnowledgeArray);
         } catch (Exception e) {
             log.error("Failed to modify knowledge point", e);
             throw e;
@@ -240,7 +243,7 @@ public class KnowledgeService {
             throw new BusinessException(ResponseEnum.REPO_FILE_NOT_EXIST);
         }
 
-        List<String> uuids = this.preCheck(fileInfoV2.getId());
+        RepoContext repoContext = this.getRepoContext(fileInfoV2.getId());
 
         JSONObject content = knowledge.getContent();
         String auditSuggest = content.getString("auditSuggest");
@@ -258,11 +261,13 @@ public class KnowledgeService {
 
                 jsonArray.add(this.convertKnowledge2Object(knowledge, knowledge.getFileId()));
                 if (ProjectContent.isAiuiRagCompatible(source)) {
-                    this.addKnowledge4AIUI(uuids.get(0), uuids.get(1), jsonArray, source);
+                    this.addKnowledge4AIUI(repoContext.fileUuid, repoContext.coreRepoId,
+                            repoContext.ragflowDatasetId, jsonArray, source);
                 } else if (ProjectContent.isCbgRagCompatible(source)) {
                     // Delete first then add
                     knowledgeMapper.deleteById(id);
-                    Map<String, String> cbgKnowledgeMap = this.addKnowledge4CBG(uuids.get(0), uuids.get(1), jsonArray, source);
+                    Map<String, String> cbgKnowledgeMap = this.addKnowledge4CBG(repoContext.fileUuid,
+                            repoContext.coreRepoId, repoContext.ragflowDatasetId, jsonArray, source);
                     if (!cbgKnowledgeMap.isEmpty()) {
                         for (String key : cbgKnowledgeMap.keySet()) {
                             knowledge.setId(cbgKnowledgeMap.get(key));
@@ -273,7 +278,7 @@ public class KnowledgeService {
             } else {// Disable - corresponding logic is to delete knowledge
                 JSONArray delKbList = new JSONArray();
                 delKbList.add(knowledge.getId());
-                this.deleteKnowledgeChunks(uuids.getFirst(), delKbList);
+                this.deleteKnowledgeChunks(repoContext.fileUuid, delKbList);
             }
             // Save using MySQL
             BeanUtils.copyProperties(knowledge, mysqlKnowledge);
@@ -295,11 +300,11 @@ public class KnowledgeService {
      * @throws BusinessException if file not found or operation fails
      */
     public void enableDoc(Long id, Integer enabled) {
-        List<String> uuids = this.preCheck(id);
+        RepoContext repoContext = this.getRepoContext(id);
         // ClientSession session = mongoClient.startSession();
         // try {
         // session.startTransaction();
-        FileInfoV2 fileInfoV2 = fileInfoV2Service.getOnly(new QueryWrapper<FileInfoV2>().eq("uuid", uuids.get(0)));
+        FileInfoV2 fileInfoV2 = fileInfoV2Service.getOnly(new QueryWrapper<FileInfoV2>().eq("uuid", repoContext.fileUuid));
         if (fileInfoV2 == null) {
             throw new BusinessException(ResponseEnum.REPO_FILE_NOT_EXIST);
         }
@@ -309,7 +314,7 @@ public class KnowledgeService {
             // List<Knowledge> knowledges = mongoTemplate.find(new Query(newCriteria), Knowledge.class);
 
             // Use MySQL query to replace MongoDB query
-            List<MysqlKnowledge> mysqlKnowledges = knowledgeMapper.findByFileIdAndEnabled(uuids.getFirst(), 0);
+            List<MysqlKnowledge> mysqlKnowledges = knowledgeMapper.findByFileIdAndEnabled(repoContext.fileUuid, 0);
             List<Knowledge> knowledges = new ArrayList<>();
             for (MysqlKnowledge mysql : mysqlKnowledges) {
                 Knowledge knowledge = new Knowledge();
@@ -317,12 +322,13 @@ public class KnowledgeService {
                 knowledges.add(knowledge);
             }
             // 2. Convert knowledge points to the structure required by the knowledge base
-            JSONArray waitAddKnowledge = this.getWaitAddKnowledge(knowledges, uuids.get(0));
+            JSONArray waitAddKnowledge = this.getWaitAddKnowledge(knowledges, repoContext.fileUuid);
             // 3. Add new (CBG knowledge base does not delete knowledge base slice information when
             // enabling/disabling doc)
             String source = fileInfoV2.getSource();
             if (ProjectContent.isAiuiRagCompatible(source)) {
-                List<String> failedKnowledge = this.addKnowledge4AIUI(uuids.get(0), uuids.get(1), waitAddKnowledge, source);
+                List<String> failedKnowledge = this.addKnowledge4AIUI(repoContext.fileUuid,
+                        repoContext.coreRepoId, repoContext.ragflowDatasetId, waitAddKnowledge, source);
                 // 4. Check if there are failed knowledge points
                 if (!CollectionUtils.isEmpty(failedKnowledge)) {
                     List<Knowledge> updateKnowledgeList = new ArrayList<>();
@@ -353,10 +359,10 @@ public class KnowledgeService {
             // mongoTemplate.updateMulti(query, update, Knowledge.class);
 
             // Use MySQL update
-            knowledgeMapper.updateEnabledByFileIdAndOldEnabled(uuids.getFirst(), 0, 1);
+            knowledgeMapper.updateEnabledByFileIdAndOldEnabled(repoContext.fileUuid, 0, 1);
         } else {// Disable - corresponding logic is to delete document
             JSONArray delDocList = new JSONArray();
-            delDocList.add(uuids.getFirst());
+            delDocList.add(repoContext.fileUuid);
             if (ProjectContent.isAiuiRagCompatible(fileInfoV2.getSource())) {
                 this.deleteKnowledgeDoc(delDocList, null);
             }
@@ -369,7 +375,7 @@ public class KnowledgeService {
             // mongoTemplate.updateMulti(query, update, Knowledge.class);
 
             // Use MySQL update
-            knowledgeMapper.updateEnabledByFileIdAndOldEnabled(uuids.getFirst(), 1, 0);
+            knowledgeMapper.updateEnabledByFileIdAndOldEnabled(repoContext.fileUuid, 1, 0);
         }
         // session.commitTransaction();
         // } catch (Exception e) {
@@ -532,14 +538,12 @@ public class KnowledgeService {
                             ? fileInfoV2.getLastUuid()
                             : null;
 
-            Repo ragflowRepo = loadRagflowRepoOrNull(fileInfoV2);
-            String coreRepoId = (ragflowRepo != null) ? ragflowRepo.getCoreRepoId() : null;
-            String repoName = (ragflowRepo != null) ? ragflowRepo.getName() : null;
+            String datasetId = resolveRagflowDatasetIdOrNull(fileInfoV2);
 
             return knowledgeV2ServiceCallHandler.documentUpload(
                     multipartFile, sliceConfig.getLengthRange(), separator,
                     fileInfoV2.getSource(), resourceType,
-                    oldDocId, coreRepoId, repoName);
+                    oldDocId, datasetId);
 
         } catch (Exception e) {
             log.error("Failed to upload file for chunking: {}", e.getMessage(), e);
@@ -559,27 +563,53 @@ public class KnowledgeService {
             request.setResourceType(1);
         }
         request.setRagType(fileInfoV2.getSource());
-        Repo ragflowRepo = loadRagflowRepoOrNull(fileInfoV2);
-        String coreRepoId = (ragflowRepo != null) ? ragflowRepo.getCoreRepoId() : null;
-        String repoName = (ragflowRepo != null) ? ragflowRepo.getName() : null;
-        return knowledgeV2ServiceCallHandler.documentSplit(request, coreRepoId, repoName);
+        String datasetId = resolveRagflowDatasetIdOrNull(fileInfoV2);
+        return knowledgeV2ServiceCallHandler.documentSplit(request, datasetId);
     }
 
-    /**
-     * Returns the {@code coreRepoId} for Ragflow-RAG, or {@code null} for other sources.
-     *
-     * @throws BusinessException if Ragflow-RAG and {@code repoId} or {@code coreRepoId} is missing.
-     */
-    private String resolveCoreRepoIdForRagflow(FileInfoV2 fileInfoV2) {
-        Repo repo = loadRagflowRepoOrNull(fileInfoV2);
-        return (repo != null) ? repo.getCoreRepoId() : null;
+    /** Return ragflow_dataset_id for Ragflow-RAG; null keeps default dataset routing. */
+    private String resolveRagflowDatasetIdOrNull(FileInfoV2 fileInfoV2) {
+        return resolveRagflowDatasetIdOrNull(fileInfoV2, null);
     }
 
-    private boolean applyRagflowGroupForDelete(KnowledgeRequest request, FileInfoV2 fileInfoV2) {
+    /** Same resolver with an optional repoId -> datasetId cache. */
+    private String resolveRagflowDatasetIdOrNull(FileInfoV2 fileInfoV2,
+            Map<Long, String> repoIdToDatasetId) {
+        if (!ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(fileInfoV2.getSource())) {
+            return null;
+        }
+        Long repoId = fileInfoV2.getRepoId();
+        if (repoId == null) {
+            log.error("Ragflow-RAG file requires repoId on FileInfoV2 id={}",
+                    fileInfoV2.getId());
+            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
+        }
+        if (repoIdToDatasetId != null && repoIdToDatasetId.containsKey(repoId)) {
+            // Preserve cached null values for repos without ragflowDatasetId.
+            return repoIdToDatasetId.get(repoId);
+        }
+        Repo repo = repoService.getById(repoId);
+        if (repo == null) {
+            log.error("Repo not found for repoId={}", repoId);
+            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
+        }
+        String datasetId = repo.getRagflowDatasetId();
+        if (repoIdToDatasetId != null) {
+            repoIdToDatasetId.put(repoId, datasetId);
+        }
+        return datasetId;
+    }
+
+    private boolean applyRagflowDatasetIdForDelete(KnowledgeRequest request, FileInfoV2 fileInfoV2) {
+        return applyRagflowDatasetIdForDelete(request, fileInfoV2, null);
+    }
+
+    private boolean applyRagflowDatasetIdForDelete(KnowledgeRequest request,
+            FileInfoV2 fileInfoV2, Map<Long, String> repoIdToDatasetId) {
         try {
-            String coreRepoId = resolveCoreRepoIdForRagflow(fileInfoV2);
-            if (coreRepoId != null) {
-                request.setGroup(coreRepoId);
+            String datasetId = resolveRagflowDatasetIdOrNull(fileInfoV2, repoIdToDatasetId);
+            if (datasetId != null) {
+                request.setDatasetId(datasetId);
             }
             return true;
         } catch (BusinessException e) {
@@ -587,35 +617,6 @@ public class KnowledgeService {
                     fileInfoV2.getId(), fileInfoV2.getUuid(), e.getMessage());
             return false;
         }
-    }
-
-    /**
-     * Loads the {@link Repo} for a Ragflow-RAG document; returns {@code null} for other sources.
-     * Callers read both {@code coreRepoId} and {@code name} from the result with one DB query.
-     *
-     * @throws BusinessException if Ragflow-RAG and {@code repoId} / {@link Repo} / {@code coreRepoId}
-     *         is missing.
-     */
-    private Repo loadRagflowRepoOrNull(FileInfoV2 fileInfoV2) {
-        if (!ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(fileInfoV2.getSource())) {
-            return null;
-        }
-        Long repoId = fileInfoV2.getRepoId();
-        if (repoId == null) {
-            log.error("Ragflow-RAG upload/split requires repoId on FileInfoV2 id={}",
-                    fileInfoV2.getId());
-            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
-        }
-        Repo repo = repoService.getById(repoId);
-        if (repo == null) {
-            log.error("Repo not found for repoId={}", repoId);
-            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
-        }
-        if (!StringUtils.isNotBlank(repo.getCoreRepoId())) {
-            log.error("Repo {} has no coreRepoId", repoId);
-            throw new BusinessException(ResponseEnum.REPO_STATUS_ILLEGAL);
-        }
-        return repo;
     }
 
     /** When code==11111 extract inner parentheses text, keep original message otherwise. */
@@ -1022,6 +1023,7 @@ public class KnowledgeService {
         PushResult r = new PushResult();
         FileInfoV2 fileInfoV2 = fileInfoV2Service.getById(fileId);
         r.source = fileInfoV2.getSource();
+        String datasetId = resolveRagflowDatasetIdOrNull(fileInfoV2);
 
         final int maxSaveCount = 200;
         final int maxThreadCount = 3;
@@ -1038,7 +1040,8 @@ public class KnowledgeService {
                     presetFail.add(obj.getString("chunkId"));
                 }
                 try {
-                    List<String> childFailed = this.addKnowledge4AIUI(uuid.get(0), uuid.get(1), batch, r.source);
+                    List<String> childFailed = this.addKnowledge4AIUI(uuid.get(0), uuid.get(1),
+                            datasetId, batch, r.source);
                     if (!CollectionUtils.isEmpty(childFailed)) {
                         r.failedKnowledge.addAll(childFailed);
                     }
@@ -1064,7 +1067,8 @@ public class KnowledgeService {
                     for (Object o : jsonArray.subList(i, end)) {
                         batch.add((JSONObject) o);
                     }
-                    futures.add(pool.submit(() -> this.addKnowledge4CBG(uuid.get(0), uuid.get(1), batch, r.source)));
+                    futures.add(pool.submit(() -> this.addKnowledge4CBG(uuid.get(0), uuid.get(1),
+                            datasetId, batch, r.source)));
                 }
                 for (Future<Map<String, String>> f : futures) {
                     try {
@@ -1313,15 +1317,22 @@ public class KnowledgeService {
         }
     }
 
-    /**
-     * Perform pre-check validation and return file and repository information
-     *
-     * @param fileId the database ID of the file to be checked
-     * @return list containing: uuid[0] = file uuid, uuid[1] = core system side repoId, uuid[2] = last
-     *         uuid
-     * @throws BusinessException if file not found or repository not found
-     */
-    private List<String> preCheck(Long fileId) {
+    private static class RepoContext {
+        private final String fileUuid;
+        private final String coreRepoId;
+        private final String lastUuid;
+        private final String ragflowDatasetId;
+
+        private RepoContext(String fileUuid, String coreRepoId, String lastUuid,
+                String ragflowDatasetId) {
+            this.fileUuid = fileUuid;
+            this.coreRepoId = coreRepoId;
+            this.lastUuid = lastUuid;
+            this.ragflowDatasetId = ragflowDatasetId;
+        }
+    }
+
+    private RepoContext getRepoContext(Long fileId) {
         FileInfoV2 fileInfoV2 = fileInfoV2Service.getById(fileId);
         if (fileInfoV2 == null) {
             throw new BusinessException(ResponseEnum.REPO_FILE_NOT_EXIST);
@@ -1330,12 +1341,27 @@ public class KnowledgeService {
         if (repo == null) {
             throw new BusinessException(ResponseEnum.REPO_NOT_EXIST);
         }
+        String datasetId = ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(fileInfoV2.getSource())
+                ? repo.getRagflowDatasetId()
+                : null;
+        return new RepoContext(fileInfoV2.getUuid(), repo.getCoreRepoId(),
+                fileInfoV2.getLastUuid(), datasetId);
+    }
 
+    private List<String> preCheck(Long fileId) {
+        RepoContext context = getRepoContext(fileId);
         List<String> uuids = new ArrayList<>();
-        uuids.add(fileInfoV2.getUuid());
-        uuids.add(repo.getCoreRepoId());
-        uuids.add(fileInfoV2.getLastUuid());
+        uuids.add(context.fileUuid);
+        uuids.add(context.coreRepoId);
+        uuids.add(context.lastUuid);
         return uuids;
+    }
+
+    private void applyRagflowDatasetId(KnowledgeRequest request, String source, String datasetId) {
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(source)
+                && StringUtils.isNotBlank(datasetId)) {
+            request.setDatasetId(datasetId);
+        }
     }
 
     /**
@@ -1348,12 +1374,14 @@ public class KnowledgeService {
      * @return KnowledgeResponse containing the operation result
      * @throws BusinessException if knowledge addition fails
      */
-    private KnowledgeResponse addKnowledge(String docId, String group, JSONArray addChunkArray, String source) {
+    private KnowledgeResponse addKnowledge(String docId, String group, String datasetId,
+            JSONArray addChunkArray, String source) {
         KnowledgeResponse response = new KnowledgeResponse();
         if (!addChunkArray.isEmpty()) { // Embedding
             KnowledgeRequest request = new KnowledgeRequest();
             request.setDocId(docId);
             request.setGroup(group);
+            applyRagflowDatasetId(request, source, datasetId);
             request.setChunks(addChunkArray.toArray());
             request.setRagType(source);
             response = knowledgeV2ServiceCallHandler.saveChunk(request);
@@ -1376,7 +1404,12 @@ public class KnowledgeService {
      * @throws BusinessException if CBG knowledge base operations fail
      */
     public Map<String, String> addKnowledge4CBG(String docId, String group, JSONArray addChunkArray, String source) {
-        KnowledgeResponse knowledge = this.addKnowledge(docId, group, addChunkArray, source);
+        return addKnowledge4CBG(docId, group, null, addChunkArray, source);
+    }
+
+    public Map<String, String> addKnowledge4CBG(String docId, String group, String datasetId,
+            JSONArray addChunkArray, String source) {
+        KnowledgeResponse knowledge = this.addKnowledge(docId, group, datasetId, addChunkArray, source);
         List<CbgKnowledgeData> cbgKnowledgeDataList;
         Map<String, String> resultMap = new HashMap<>();
         try {
@@ -1405,7 +1438,12 @@ public class KnowledgeService {
      * @throws BusinessException if AIUI knowledge base operations fail
      */
     public List<String> addKnowledge4AIUI(String docId, String group, JSONArray addChunkArray, String source) {
-        KnowledgeResponse knowledge = this.addKnowledge(docId, group, addChunkArray, source);
+        return addKnowledge4AIUI(docId, group, null, addChunkArray, source);
+    }
+
+    public List<String> addKnowledge4AIUI(String docId, String group, String datasetId,
+            JSONArray addChunkArray, String source) {
+        KnowledgeResponse knowledge = this.addKnowledge(docId, group, datasetId, addChunkArray, source);
         List<String> resultList = new ArrayList<>();
         JSONObject data = (JSONObject) knowledge.getData();
         if (data != null) {
@@ -1433,6 +1471,11 @@ public class KnowledgeService {
      * @throws BusinessException if file not found or update operations fail
      */
     public List<String> updateKnowledge(String docId, String group, JSONArray updateChunkArray) {
+        return updateKnowledge(docId, group, null, updateChunkArray);
+    }
+
+    public List<String> updateKnowledge(String docId, String group, String datasetId,
+            JSONArray updateChunkArray) {
         List<String> resultList = new ArrayList<>();
         if (!updateChunkArray.isEmpty()) { // Delete document
             KnowledgeRequest request = new KnowledgeRequest();
@@ -1445,6 +1488,7 @@ public class KnowledgeService {
             }
 
             request.setRagType(fileInfoV2.getSource());
+            applyRagflowDatasetId(request, fileInfoV2.getSource(), datasetId);
 
             KnowledgeResponse response = knowledgeV2ServiceCallHandler.updateChunk(request);
             if (response.getCode() != 0) {
@@ -1477,6 +1521,8 @@ public class KnowledgeService {
     public void deleteKnowledgeDoc(JSONArray deleteDocIds, Map<String, List<String>> chunkIdsMap) {
         boolean needDelete = true;
         if (!deleteDocIds.isEmpty()) { // Delete documents
+            // Avoid repeated repo lookups in one batch.
+            Map<Long, String> repoIdToDatasetId = new HashMap<>();
             for (int i = 0; i < deleteDocIds.size(); i++) {
                 KnowledgeRequest request = new KnowledgeRequest();
                 String docId = deleteDocIds.getString(i);
@@ -1494,7 +1540,7 @@ public class KnowledgeService {
                         needDelete = false;
                     }
                 }
-                if (!applyRagflowGroupForDelete(request, fileInfoV2)) {
+                if (!applyRagflowDatasetIdForDelete(request, fileInfoV2, repoIdToDatasetId)) {
                     continue;
                 }
                 if (needDelete) {
@@ -1525,7 +1571,7 @@ public class KnowledgeService {
                 throw new BusinessException(ResponseEnum.REPO_FILE_NOT_EXIST);
             }
             request.setRagType(fileInfoV2.getSource());
-            if (!applyRagflowGroupForDelete(request, fileInfoV2)) {
+            if (!applyRagflowDatasetIdForDelete(request, fileInfoV2)) {
                 return;
             }
             KnowledgeResponse response = knowledgeV2ServiceCallHandler.deleteDocOrChunk(request);

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/RepoService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/RepoService.java
@@ -69,6 +69,8 @@ import java.util.stream.Collectors;
 @Service
 @Slf4j
 public class RepoService extends ServiceImpl<RepoMapper, Repo> {
+    private static final int RAGFLOW_DATASET_NAME_MAX_LENGTH = 255;
+
     /**
      * Get single record by query wrapper
      *
@@ -135,17 +137,29 @@ public class RepoService extends ServiceImpl<RepoMapper, Repo> {
     @Resource
     private ApiUrl apiUrl;
 
-    /**
-     * Create a new repository with the provided repository information. Validates repository name
-     * uniqueness, tag validity, and creates the repository record.
-     *
-     * @param repoVO repository value object containing repository creation information
-     * @return created Repo object with generated IDs and default settings
-     * @throws BusinessException if repository name is duplicate or tag is invalid
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    /** Spring proxy used for internal transactional calls. */
+    @Resource
+    @Lazy
+    private RepoService self;
+
+    /** Create a repo and persist the RAGFlow dataset id for Ragflow-RAG. */
     public Repo createRepo(RepoVO repoVO) {
         Long spaceId = SpaceInfoUtil.getSpaceId();
+        validateRepoNameUnique(repoVO, spaceId);
+        validateTag(repoVO.getTag());
+
+        String coreRepoId = resolveCoreRepoId(repoVO);
+        String ragflowDatasetId = null;
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(repoVO.getTag())) {
+            String datasetName = buildRagflowDatasetName(repoVO.getName(), coreRepoId);
+            ragflowDatasetId = knowledgeV2ServiceCallHandler.createRagflowDataset(datasetName, repoVO.getName());
+        }
+
+        return self.persistRepo(repoVO, spaceId, coreRepoId, ragflowDatasetId);
+    }
+
+    /** Reject duplicate repo names in the current personal or space scope. */
+    private void validateRepoNameUnique(RepoVO repoVO, Long spaceId) {
         Repo existRepo;
         if (spaceId == null) {
             existRepo = this.getOnly(Wrappers.lambdaQuery(Repo.class).eq(Repo::getUserId, UserInfoManagerHandler.getUserId()).eq(Repo::getName, repoVO.getName()).eq(Repo::getDeleted, 0));
@@ -155,27 +169,48 @@ public class RepoService extends ServiceImpl<RepoMapper, Repo> {
         if (existRepo != null) {
             throw new BusinessException(ResponseEnum.REPO_NAME_DUPLICATE);
         }
+    }
 
-        // Check tag
-        if (!ProjectContent.isCbgRagCompatible(repoVO.getTag()) && !ProjectContent.isAiuiRagCompatible(repoVO.getTag())) {
+    /** Reject unsupported RAG tags. */
+    private void validateTag(String tag) {
+        if (!ProjectContent.isCbgRagCompatible(tag) && !ProjectContent.isAiuiRagCompatible(tag)) {
             throw new BusinessException(ResponseEnum.REPO_TYPE_NOT_MATCH);
         }
-        // 1. Create knowledge base
+    }
+
+    /** Ragflow-RAG always uses a server-generated core repo id. */
+    private String resolveCoreRepoId(RepoVO repoVO) {
+        if (ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR.equals(repoVO.getTag())) {
+            return UUID.randomUUID().toString().replace("-", "");
+        }
+        if (StringUtils.isEmpty(repoVO.getOuterRepoId())) {
+            return UUID.randomUUID().toString().replace("-", "");
+        }
+        return repoVO.getOuterRepoId();
+    }
+
+    /** Build {@code repoName-coreRepoId}, trimming only the readable prefix. */
+    private String buildRagflowDatasetName(String repoName, String coreRepoId) {
+        String suffix = coreRepoId;
+        String readableName = StringUtils.defaultIfBlank(repoName, "repo").trim();
+        int maxReadableLength = RAGFLOW_DATASET_NAME_MAX_LENGTH - suffix.length() - 1;
+        if (readableName.length() > maxReadableLength) {
+            readableName = readableName.substring(0, maxReadableLength);
+        }
+        return readableName + "-" + suffix;
+    }
+
+    /** Persist a new repo row and apply visibility settings in one transaction. */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Repo persistRepo(RepoVO repoVO, Long spaceId, String coreRepoId, String ragflowDatasetId) {
         Repo repo = new Repo();
         repo.setAppId(repoVO.getAppId());
         repo.setSource(repoVO.getSource() == null ? 0 : repoVO.getSource());
         repo.setName(repoVO.getName());
         repo.setUserId(UserInfoManagerHandler.getUserId());
-        if (StringUtils.isEmpty(repoVO.getOuterRepoId())) {
-            String uuid = UUID.randomUUID().toString().replace("-", "");
-            repo.setCoreRepoId(uuid);
-            repo.setOuterRepoId(uuid);
-        } else {
-            repo.setCoreRepoId(repoVO.getOuterRepoId());
-            repo.setOuterRepoId(repoVO.getOuterRepoId());
-        }
-        // Boolean enableAudit = repoVO.getEnableAudit();
-        // repo.setEnableAudit(enableAudit == null || enableAudit);
+        repo.setCoreRepoId(coreRepoId);
+        repo.setOuterRepoId(coreRepoId);
+        repo.setRagflowDatasetId(ragflowDatasetId);
         repo.setEnableAudit(false);
         repo.setIcon(repoVO.getAvatarIcon());
         repo.setDescription(repoVO.getDesc());
@@ -194,19 +229,6 @@ public class RepoService extends ServiceImpl<RepoMapper, Repo> {
         this.save(repo);
 
         groupVisibilityService.setRepoVisibility(repo.getId(), 1, visibility, repoVO.getUids());
-
-        // 3. Core system knowledge base creation - removed knowledge base creation
-        /*
-         * JSONObject repoRequestObject = this.getRepoRequestObject();
-         * repoRequestObject.getJSONObject("header").put("businessId",repoAuthorizedConfig.getBusinessId());
-         * repoRequestObject.getJSONObject("parameter").put("type", ProjectContent.REPO_OPERATE_CREATED);
-         * repoRequestObject.getJSONObject("parameter").put("repoId", repo.getCoreRepoId()); JSONObject
-         * jsonObject = knowledgeServiceCallHandler.repoManage(repoRequestObject); if
-         * (jsonObject.getJSONObject("header").getInteger("code") !=0) {
-         * log.error("Knowledge base creation failed, message:{}",
-         * jsonObject.getJSONObject("header").getString("message")); throw new
-         * CustomException("Knowledge base creation failed"); }
-         */
         return repo;
     }
 
@@ -963,6 +985,11 @@ public class RepoService extends ServiceImpl<RepoMapper, Repo> {
         String coreRepoId = repo.getCoreRepoId();
         QueryMatchObj matchObj = new QueryMatchObj();
         matchObj.setRepoId(Collections.singletonList(coreRepoId));
+
+        String ragflowDatasetId = repo.getRagflowDatasetId();
+        if (StringUtils.isNotBlank(ragflowDatasetId)) {
+            matchObj.setDatasetId(Collections.singletonList(ragflowDatasetId));
+        }
 
         List<String> docIds = new ArrayList<>();
         List<FileInfoV2> fileInfos = fileInfoV2Mapper.getFileInfoV2ByRepoId(repo.getId());

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -67,6 +67,7 @@ import com.iflytek.astron.console.toolkit.entity.table.relation.FlowDbRel;
 import com.iflytek.astron.console.toolkit.entity.table.relation.FlowRepoRel;
 import com.iflytek.astron.console.toolkit.entity.table.relation.FlowToolRel;
 import com.iflytek.astron.console.toolkit.entity.table.repo.FileInfoV2;
+import com.iflytek.astron.console.toolkit.entity.table.repo.Repo;
 import com.iflytek.astron.console.toolkit.entity.dto.skill.SkillImportDto;
 import com.iflytek.astron.console.toolkit.entity.table.tool.*;
 import com.iflytek.astron.console.toolkit.entity.table.workflow.*;
@@ -83,6 +84,7 @@ import com.iflytek.astron.console.toolkit.mapper.relation.FlowDbRelMapper;
 import com.iflytek.astron.console.toolkit.mapper.relation.FlowRepoRelMapper;
 import com.iflytek.astron.console.toolkit.mapper.relation.FlowToolRelMapper;
 import com.iflytek.astron.console.toolkit.mapper.repo.FileInfoV2Mapper;
+import com.iflytek.astron.console.toolkit.mapper.repo.RepoMapper;
 import com.iflytek.astron.console.toolkit.mapper.tool.*;
 import com.iflytek.astron.console.toolkit.mapper.trace.ChatInfoMapper;
 import com.iflytek.astron.console.toolkit.mapper.trace.NodeInfoMapper;
@@ -240,6 +242,8 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
     McpServerHandler mcpServerHandler;
     @Resource
     FileInfoV2Mapper fileInfoV2Mapper;
+    @Resource
+    RepoMapper repoMapper;
     @Autowired
     private UserLangChainInfoMapper userLangChainInfoDao;
     @Autowired
@@ -2311,9 +2315,9 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
 
     private void setDocIds(BizNodeData bizNodeData, JSONArray repoIds) {
         if (!CollUtil.isEmpty(repoIds)) {
+            List<String> coreRepoIds = extractRepoIds(repoIds);
             JSONArray docIds = new JSONArray();
-            for (int i = 0; i < repoIds.size(); i++) {
-                String repoId = repoIds.getString(i);
+            for (String repoId : coreRepoIds) {
                 List<FileInfoV2> fileInfoList = fileInfoV2Mapper.getFileInfoV2ByCoreRepoId(repoId);
                 if (CollUtil.isNotEmpty(fileInfoList)) {
                     log.info("get file info list ,{}", fileInfoList);
@@ -2322,6 +2326,12 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
                 }
             }
             bizNodeData.getNodeParam().put("docIds", docIds);
+            JSONArray datasetIds = getDatasetIdsForRepos(coreRepoIds);
+            if (!datasetIds.isEmpty()) {
+                bizNodeData.getNodeParam().put("datasetIds", datasetIds);
+            } else {
+                bizNodeData.getNodeParam().remove("datasetIds");
+            }
         }
     }
 
@@ -2489,6 +2499,12 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             if (!allDocIds.isEmpty()) {
                 match.put("docIds", allDocIds);
             }
+            JSONArray datasetIds = getDatasetIdsForRepos(repoIds);
+            if (!datasetIds.isEmpty()) {
+                match.put("datasetIds", datasetIds);
+            } else {
+                match.remove("datasetIds");
+            }
         }
     }
 
@@ -2522,6 +2538,28 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             }
         }
         return allDocIds;
+    }
+
+    private JSONArray getDatasetIdsForRepos(List<String> repoIds) {
+        JSONArray datasetIds = new JSONArray();
+        if (CollUtil.isEmpty(repoIds)) {
+            return datasetIds;
+        }
+        List<Repo> repos = repoMapper.listInRepoCoreIds(repoIds);
+        if (CollUtil.isEmpty(repos)) {
+            return datasetIds;
+        }
+        Map<String, String> datasetIdMap = repos.stream()
+                .filter(repo -> StringUtils.isNotBlank(repo.getCoreRepoId()))
+                .filter(repo -> StringUtils.isNotBlank(repo.getRagflowDatasetId()))
+                .collect(Collectors.toMap(Repo::getCoreRepoId, Repo::getRagflowDatasetId, (a, b) -> a));
+        for (String repoId : repoIds) {
+            String datasetId = datasetIdMap.get(repoId);
+            if (StringUtils.isNotBlank(datasetId)) {
+                datasetIds.add(datasetId);
+            }
+        }
+        return datasetIds;
     }
 
     private void dealWithUrl(JSONObject modelConfig, String serviceId) {

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandlerTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/handler/KnowledgeV2ServiceCallHandlerTest.java
@@ -1,105 +1,174 @@
 package com.iflytek.astron.console.toolkit.handler;
 
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
+import com.iflytek.astron.console.toolkit.entity.core.knowledge.QueryMatchObj;
+import com.iflytek.astron.console.toolkit.entity.core.knowledge.QueryRequest;
 import com.iflytek.astron.console.toolkit.entity.core.knowledge.SplitRequest;
+import com.iflytek.astron.console.toolkit.util.OkHttpUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
-/**
- * Unit tests for {@link KnowledgeV2ServiceCallHandler} {@code group} and {@code groupDescription}
- * forwarding (Ragflow-RAG only).
- */
+/** Unit tests for {@link KnowledgeV2ServiceCallHandler}. */
 class KnowledgeV2ServiceCallHandlerTest {
 
-    // The package-private helpers below are decorators on request/params; we
-    // exercise them directly to avoid mocking OkHttpUtil static methods.
+    private KnowledgeV2ServiceCallHandler handler;
 
-    @Test
-    void documentSplit_RagflowRAG_withCoreRepoId_setsGroupOnRequest() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
-        SplitRequest req = new SplitRequest();
-        req.setRagType("Ragflow-RAG");
-        handler.applyGroupToSplitRequest(req, "abc-uuid");
-        assertEquals("abc-uuid", req.getGroup());
+    @BeforeEach
+    void setUp() {
+        handler = new KnowledgeV2ServiceCallHandler();
+        ApiUrl apiUrl = mock(ApiUrl.class);
+        when(apiUrl.getKnowledgeUrl()).thenReturn("http://core-knowledge.local");
+        ReflectionTestUtils.setField(handler, "apiUrl", apiUrl);
     }
 
     @Test
-    void documentSplit_NonRagflowRAG_doesNotSetGroup() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+    void applyDatasetIdToSplitRequest_setsForRagflowOnly() {
+        SplitRequest req = new SplitRequest();
+        req.setRagType("Ragflow-RAG");
+        handler.applyDatasetIdToSplitRequest(req, "ds-1");
+        assertThat(req.getDatasetId()).isEqualTo("ds-1");
+    }
+
+    @Test
+    void applyDatasetIdToSplitRequest_noOpForNonRagflow() {
         SplitRequest req = new SplitRequest();
         req.setRagType("CBG-RAG");
-        handler.applyGroupToSplitRequest(req, "abc-uuid");
-        assertNull(req.getGroup());
+        handler.applyDatasetIdToSplitRequest(req, "ds-1");
+        assertThat(req.getDatasetId()).isNull();
     }
 
     @Test
-    void documentSplit_RagflowRAG_withNullCoreRepoId_doesNotSetGroup() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+    void applyDatasetIdToSplitRequest_noOpForBlankDatasetId() {
         SplitRequest req = new SplitRequest();
         req.setRagType("Ragflow-RAG");
-        handler.applyGroupToSplitRequest(req, null);
-        assertNull(req.getGroup());
+        handler.applyDatasetIdToSplitRequest(req, "");
+        assertThat(req.getDatasetId()).isNull();
+        handler.applyDatasetIdToSplitRequest(req, null);
+        assertThat(req.getDatasetId()).isNull();
     }
 
     @Test
-    void applyGroupToUploadParams_RagflowRAG_withCoreRepoId_addsGroup() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+    void applyDatasetIdToSplitRequest_nullRequestIsNoOp() {
+        handler.applyDatasetIdToSplitRequest(null, "ds-1");
+    }
+
+    @Test
+    void applyDatasetIdToUploadParams_setsForRagflowOnly() {
         Map<String, Object> params = new HashMap<>();
-        handler.applyGroupToUploadParams(params, "Ragflow-RAG", "abc-uuid");
-        assertEquals("abc-uuid", params.get("group"));
+        handler.applyDatasetIdToUploadParams(params, "Ragflow-RAG", "ds-1");
+        assertThat(params).containsEntry("datasetId", "ds-1");
     }
 
     @Test
-    void applyGroupToUploadParams_NonRagflowRAG_doesNotAddGroup() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+    void applyDatasetIdToUploadParams_noOpForNonRagflow() {
         Map<String, Object> params = new HashMap<>();
-        handler.applyGroupToUploadParams(params, "CBG-RAG", "abc-uuid");
-        assertNull(params.get("group"));
+        handler.applyDatasetIdToUploadParams(params, "CBG-RAG", "ds-1");
+        assertThat(params).doesNotContainKey("datasetId");
     }
 
     @Test
-    void applyGroupToUploadParams_RagflowRAG_withBlankCoreRepoId_doesNotAddGroup() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
+    void applyDatasetIdToUploadParams_noOpForBlankDatasetId() {
         Map<String, Object> params = new HashMap<>();
-        handler.applyGroupToUploadParams(params, "Ragflow-RAG", "");
-        assertNull(params.get("group"));
+        handler.applyDatasetIdToUploadParams(params, "Ragflow-RAG", "");
+        assertThat(params).doesNotContainKey("datasetId");
+        handler.applyDatasetIdToUploadParams(params, "Ragflow-RAG", null);
+        assertThat(params).doesNotContainKey("datasetId");
     }
 
     @Test
-    void applyGroupDescriptionToSplitRequest_RagflowRAG_withRepoName_setsDescription() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
-        SplitRequest req = new SplitRequest();
-        req.setRagType("Ragflow-RAG");
-        handler.applyGroupDescriptionToSplitRequest(req, "客服知识库");
-        assertEquals("客服知识库", req.getGroupDescription());
+    void applyDatasetIdToUploadParams_nullParamsIsNoOp() {
+        handler.applyDatasetIdToUploadParams(null, "Ragflow-RAG", "ds-1");
     }
 
     @Test
-    void applyGroupDescriptionToSplitRequest_NonRagflowRAG_doesNotSetDescription() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
-        SplitRequest req = new SplitRequest();
-        req.setRagType("CBG-RAG");
-        handler.applyGroupDescriptionToSplitRequest(req, "客服知识库");
-        assertNull(req.getGroupDescription());
+    @DisplayName("createRagflowDataset returns datasetId on success")
+    void createRagflowDataset_success() {
+        try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
+            okHttp.when(() -> OkHttpUtil.post(anyString(), anyString()))
+                    .thenReturn("{\"code\":0,\"message\":\"success\",\"data\":{\"datasetId\":\"ds-abc-123\"}}");
+
+            String result = handler.createRagflowDataset("uuid-name", "kb_alpha");
+
+            assertThat(result).isEqualTo("ds-abc-123");
+        }
     }
 
     @Test
-    void applyGroupDescriptionToUploadParams_RagflowRAG_withRepoName_addsDescription() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
-        Map<String, Object> params = new HashMap<>();
-        handler.applyGroupDescriptionToUploadParams(params, "Ragflow-RAG", "客服知识库");
-        assertEquals("客服知识库", params.get("groupDescription"));
+    @DisplayName("createRagflowDataset throws on non-zero code")
+    void createRagflowDataset_nonZeroCode() {
+        try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
+            okHttp.when(() -> OkHttpUtil.post(anyString(), anyString()))
+                    .thenReturn("{\"code\":10003,\"message\":\"upstream failure\",\"data\":null}");
+
+            assertThatThrownBy(() -> handler.createRagflowDataset("n", "d"))
+                    .isInstanceOf(BusinessException.class);
+        }
     }
 
     @Test
-    void applyGroupDescriptionToUploadParams_RagflowRAG_withBlankRepoName_doesNotAdd() {
-        KnowledgeV2ServiceCallHandler handler = new KnowledgeV2ServiceCallHandler();
-        Map<String, Object> params = new HashMap<>();
-        handler.applyGroupDescriptionToUploadParams(params, "Ragflow-RAG", "");
-        assertNull(params.get("groupDescription"));
+    @DisplayName("createRagflowDataset throws when datasetId blank")
+    void createRagflowDataset_blankDatasetId() {
+        try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
+            okHttp.when(() -> OkHttpUtil.post(anyString(), anyString()))
+                    .thenReturn("{\"code\":0,\"message\":\"\",\"data\":{\"datasetId\":\"\"}}");
+
+            assertThatThrownBy(() -> handler.createRagflowDataset("n", "d"))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("createRagflowDataset throws on null/blank response")
+    void createRagflowDataset_nullResponse() {
+        try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
+            okHttp.when(() -> OkHttpUtil.post(anyString(), anyString()))
+                    .thenReturn("");
+
+            assertThatThrownBy(() -> handler.createRagflowDataset("n", "d"))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Test
+    void knowledgeQuery_usesPlainPostWithoutInternalHeaders() {
+        QueryRequest request = new QueryRequest();
+        request.setQuery("hello");
+        request.setTopN(3);
+        request.setRagType("Ragflow-RAG");
+        QueryMatchObj match = new QueryMatchObj();
+        match.setRepoId(Collections.singletonList("repo-1"));
+        match.setDatasetId(Collections.singletonList("ds-1"));
+        request.setMatch(match);
+
+        try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
+            okHttp.when(() -> OkHttpUtil.post(
+                    eq("http://core-knowledge.local/v1/chunk/query"),
+                    anyString()))
+                    .thenReturn("{\"code\":0,\"message\":\"success\",\"data\":{\"results\":[]}}");
+
+            assertThat(handler.knowledgeQuery(request).getCode()).isZero();
+            okHttp.verify(() -> OkHttpUtil.post(
+                    eq("http://core-knowledge.local/v1/chunk/query"),
+                    anyMap(),
+                    anyString()), never());
+        }
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -137,6 +137,7 @@ class KnowledgeServiceTest {
         mockRepo.setId(100L);
         mockRepo.setName("Test Repository");
         mockRepo.setCoreRepoId("core-repo-001");
+        mockRepo.setRagflowDatasetId("ds-real-id-001");
         mockRepo.setTag("AIUI-RAG2");
         mockRepo.setDeleted(false);
         mockRepo.setEnableAudit(false);
@@ -275,6 +276,92 @@ class KnowledgeServiceTest {
             verify(knowledgeMapper, times(1)).insert(any(MysqlKnowledge.class));
         }
 
+        @Test
+        @DisplayName("Create knowledge with Ragflow-RAG passes datasetId to saveChunk")
+        void testCreateKnowledge_RagflowRAG_PassesDatasetId() {
+            BizConfig bizConfig = new BizConfig();
+            bizConfig.setCbgRagCompatibleSources(Arrays.asList(
+                    ProjectContent.FILE_SOURCE_CBG_RAG_STR,
+                    ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR));
+            new ProjectContent().setBizConfig(bizConfig);
+            try {
+                mockRepo.setTag(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+                mockFileInfo.setSource(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+
+                when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
+                when(repoService.getById(anyLong())).thenReturn(mockRepo);
+                when(repoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(mockRepo);
+                doNothing().when(dataPermissionCheckTool).checkRepoBelong(any(Repo.class));
+                when(fileInfoV2Mapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(mockFileInfo);
+
+                KnowledgeResponse knowledgeResponse = new KnowledgeResponse();
+                knowledgeResponse.setCode(0);
+                knowledgeResponse.setMessage("success");
+                JSONArray dataArray = new JSONArray();
+                JSONObject cbgData = new JSONObject();
+                cbgData.put("id", "ragflow-knowledge-001");
+                cbgData.put("dataIndex", "0");
+                dataArray.add(cbgData);
+                knowledgeResponse.setData(dataArray);
+
+                ArgumentCaptor<KnowledgeRequest> requestCaptor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+                when(knowledgeV2ServiceCallHandler.saveChunk(requestCaptor.capture()))
+                        .thenReturn(knowledgeResponse);
+                when(knowledgeMapper.insert(any(MysqlKnowledge.class))).thenReturn(1);
+
+                Knowledge result = knowledgeService.createKnowledge(mockKnowledgeVO);
+
+                assertThat(result).isNotNull();
+                assertThat(requestCaptor.getValue().getGroup()).isEqualTo("core-repo-001");
+                assertThat(requestCaptor.getValue().getDatasetId()).isEqualTo("ds-real-id-001");
+            } finally {
+                new ProjectContent().setBizConfig(null);
+            }
+        }
+
+        @Test
+        @DisplayName("Create knowledge with legacy Ragflow-RAG repo leaves datasetId unset")
+        void testCreateKnowledge_RagflowRAG_LegacyNullDatasetId() {
+            BizConfig bizConfig = new BizConfig();
+            bizConfig.setCbgRagCompatibleSources(Arrays.asList(
+                    ProjectContent.FILE_SOURCE_CBG_RAG_STR,
+                    ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR));
+            new ProjectContent().setBizConfig(bizConfig);
+            try {
+                mockRepo.setTag(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+                mockRepo.setRagflowDatasetId(null);
+                mockFileInfo.setSource(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+
+                when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
+                when(repoService.getById(anyLong())).thenReturn(mockRepo);
+                when(repoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(mockRepo);
+                doNothing().when(dataPermissionCheckTool).checkRepoBelong(any(Repo.class));
+                when(fileInfoV2Mapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(mockFileInfo);
+
+                KnowledgeResponse knowledgeResponse = new KnowledgeResponse();
+                knowledgeResponse.setCode(0);
+                knowledgeResponse.setMessage("success");
+                JSONArray dataArray = new JSONArray();
+                JSONObject cbgData = new JSONObject();
+                cbgData.put("id", "ragflow-knowledge-001");
+                cbgData.put("dataIndex", "0");
+                dataArray.add(cbgData);
+                knowledgeResponse.setData(dataArray);
+
+                ArgumentCaptor<KnowledgeRequest> requestCaptor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+                when(knowledgeV2ServiceCallHandler.saveChunk(requestCaptor.capture()))
+                        .thenReturn(knowledgeResponse);
+                when(knowledgeMapper.insert(any(MysqlKnowledge.class))).thenReturn(1);
+
+                Knowledge result = knowledgeService.createKnowledge(mockKnowledgeVO);
+
+                assertThat(result).isNotNull();
+                assertThat(requestCaptor.getValue().getDatasetId()).isNull();
+            } finally {
+                new ProjectContent().setBizConfig(null);
+            }
+        }
+
         /**
          * Test knowledge creation with audit enabled and pass.
          */
@@ -396,6 +483,35 @@ class KnowledgeServiceTest {
             assertThat(result.getContent().getString("content")).isEqualTo("Updated content");
             verify(knowledgeMapper, times(1)).updateById(any(MysqlKnowledge.class));
             verify(knowledgeV2ServiceCallHandler, times(1)).updateChunk(any());
+        }
+
+        @Test
+        @DisplayName("Update knowledge with Ragflow-RAG passes datasetId to updateChunk")
+        void testUpdateKnowledge_RagflowRAG_PassesDatasetId() {
+            mockRepo.setTag(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+            mockFileInfo.setSource(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+            mockKnowledgeVO.setId("knowledge-001");
+            mockKnowledgeVO.setContent("Updated content");
+
+            when(knowledgeMapper.selectById(anyString())).thenReturn(mockMysqlKnowledge);
+            when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
+            when(repoService.getById(anyLong())).thenReturn(mockRepo);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(mockFileInfo);
+            when(repoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(mockRepo);
+            doNothing().when(dataPermissionCheckTool).checkRepoBelong(any(Repo.class));
+
+            KnowledgeResponse knowledgeResponse = new KnowledgeResponse();
+            knowledgeResponse.setCode(0);
+            ArgumentCaptor<KnowledgeRequest> requestCaptor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            when(knowledgeV2ServiceCallHandler.updateChunk(requestCaptor.capture()))
+                    .thenReturn(knowledgeResponse);
+            when(knowledgeMapper.updateById(any(MysqlKnowledge.class))).thenReturn(1);
+
+            Knowledge result = knowledgeService.updateKnowledge(mockKnowledgeVO);
+
+            assertThat(result).isNotNull();
+            assertThat(requestCaptor.getValue().getGroup()).isEqualTo("core-repo-001");
+            assertThat(requestCaptor.getValue().getDatasetId()).isEqualTo("ds-real-id-001");
         }
 
         /**
@@ -1811,7 +1927,7 @@ class KnowledgeServiceTest {
             dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
             response.setData(dataArray);
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1822,7 +1938,7 @@ class KnowledgeServiceTest {
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
             // Then
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any(), any());
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any());
             verify(previewKnowledgeMapper, times(1)).insertBatch(anyList());
             verify(fileInfoV2Service, times(1)).updateById(any(FileInfoV2.class));
         }
@@ -1852,7 +1968,7 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1864,10 +1980,10 @@ class KnowledgeServiceTest {
 
             // Then
             verify(s3Util, times(1)).getObject(anyString());
-            // CBG-RAG multipart form must not carry documentId; coreRepoId is
+            // CBG-RAG multipart form must not carry documentId; datasetId is
             // null because CBG-RAG keeps the legacy single-dataset behavior.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
-                    any(), any(), any(), any(), any(), isNull(), isNull(), isNull());
+                    any(), any(), any(), any(), any(), isNull(), isNull());
         }
 
         /** Ragflow-RAG first slice: lastUuid=null forwards as oldDocId=null. */
@@ -1891,7 +2007,7 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1902,9 +2018,8 @@ class KnowledgeServiceTest {
             // When
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
-            // Then: oldDocId=null; coreRepoId and repoName forwarded.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
-                    any(), any(), any(), any(), any(), isNull(), eq("core-repo-001"), eq("Test Repository"));
+                    any(), any(), any(), any(), any(), isNull(), eq("ds-real-id-001"));
         }
 
         /** Ragflow-RAG re-slice: existing lastUuid forwards as oldDocId. */
@@ -1928,7 +2043,7 @@ class KnowledgeServiceTest {
             response.setData(dataArray);
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -1939,9 +2054,8 @@ class KnowledgeServiceTest {
             // When
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
-            // Then: oldDocId carries previous; coreRepoId and repoName forwarded.
             verify(knowledgeV2ServiceCallHandler, times(1)).documentUpload(
-                    any(), any(), any(), any(), any(), eq("doc-old-ragflow"), eq("core-repo-001"), eq("Test Repository"));
+                    any(), any(), any(), any(), any(), eq("doc-old-ragflow"), eq("ds-real-id-001"));
         }
 
         /**
@@ -1959,7 +2073,7 @@ class KnowledgeServiceTest {
             response.setCode(1);
             response.setMessage("Extraction failed");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -1986,7 +2100,7 @@ class KnowledgeServiceTest {
             response.setCode(11111);
             response.setMessage("Error (inner error message)");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2012,7 +2126,7 @@ class KnowledgeServiceTest {
             response.setCode(0);
             response.setData(new JSONArray());
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2039,7 +2153,7 @@ class KnowledgeServiceTest {
             response.setCode(0);
             response.setData(new JSONArray());
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2096,7 +2210,7 @@ class KnowledgeServiceTest {
             dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
             response.setData(dataArray);
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -2107,7 +2221,7 @@ class KnowledgeServiceTest {
             knowledgeService.knowledgeExtractAsync(contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
 
             // Then
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any(), any());
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any());
         }
     }
 
@@ -2156,7 +2270,7 @@ class KnowledgeServiceTest {
             dealFileResult.setParseSuccess(true);
             dealFileResult.setTaskId("task-001");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -2170,7 +2284,7 @@ class KnowledgeServiceTest {
                     mockFileInfo, mockExtractTask, mockFileService);
 
             // Then
-            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any(), any());
+            verify(knowledgeV2ServiceCallHandler, times(1)).documentSplit(any(), any());
             verify(mockFileService, times(1)).saveTaskAndUpdateFileStatus(mockFileInfo.getId());
             verify(mockFileService, times(1)).embeddingFile(mockFileInfo.getId(), mockFileInfo.getSpaceId());
         }
@@ -2190,7 +2304,7 @@ class KnowledgeServiceTest {
             response.setCode(1);
             response.setMessage("Extraction failed");
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2231,7 +2345,7 @@ class KnowledgeServiceTest {
             dealFileResult.setTaskId("task-001");
 
             when(s3Util.getObject(anyString())).thenReturn(new java.io.ByteArrayInputStream("test".getBytes()));
-            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentUpload(any(), any(), any(), any(), any(), any(), any())).thenReturn(response);
             when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
             when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
             when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
@@ -2265,7 +2379,7 @@ class KnowledgeServiceTest {
             response.setCode(0);
             response.setData(new JSONArray());
 
-            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any(), any())).thenReturn(response);
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
 
@@ -2280,97 +2394,99 @@ class KnowledgeServiceTest {
     }
 
     /**
-     * coreRepoId routing tests.
+     * datasetId routing tests.
      *
      * <p>
-     * Tests for {@code coreRepoId} resolution and forwarding through delete paths.
+     * Tests for {@code datasetId} resolution and forwarding through delete paths.
      */
     @Nested
-    @DisplayName("coreRepoId routing tests")
-    class CoreRepoIdRoutingTests {
+    @DisplayName("datasetId routing tests")
+    class DatasetIdRoutingTests {
 
         @Test
-        @DisplayName("resolveCoreRepoIdForRagflow returns null for non-Ragflow-RAG sources")
-        void resolveCoreRepoIdForRagflow_NonRagflowRAG_returnsNull() {
+        @DisplayName("resolveRagflowDatasetIdOrNull returns null for non-Ragflow-RAG sources")
+        void resolveRagflowDatasetIdOrNull_NonRagflowRAG_returnsNull() {
             FileInfoV2 file = new FileInfoV2();
             file.setSource("CBG-RAG");
             file.setRepoId(42L);
             String result = ReflectionTestUtils.invokeMethod(
-                    knowledgeService, "resolveCoreRepoIdForRagflow", file);
+                    knowledgeService, "resolveRagflowDatasetIdOrNull", file);
             assertThat(result).isNull();
         }
 
         @Test
-        @DisplayName("resolveCoreRepoIdForRagflow throws when Ragflow-RAG file lacks repoId")
-        void resolveCoreRepoIdForRagflow_RagflowRAG_nullRepoId_throws() {
+        @DisplayName("resolveRagflowDatasetIdOrNull throws when Ragflow-RAG file lacks repoId")
+        void resolveRagflowDatasetIdOrNull_RagflowRAG_nullRepoId_throws() {
             FileInfoV2 file = new FileInfoV2();
             file.setSource("Ragflow-RAG");
             file.setRepoId(null);
             file.setId(99L);
             BusinessException ex = assertThrows(BusinessException.class,
                     () -> ReflectionTestUtils.invokeMethod(
-                            knowledgeService, "resolveCoreRepoIdForRagflow", file));
+                            knowledgeService, "resolveRagflowDatasetIdOrNull", file));
             assertThat(ex.getResponseEnum()).isEqualTo(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
 
         @Test
-        @DisplayName("resolveCoreRepoIdForRagflow throws when Repo missing")
-        void resolveCoreRepoIdForRagflow_RagflowRAG_repoNotFound_throws() {
+        @DisplayName("resolveRagflowDatasetIdOrNull throws when Repo missing")
+        void resolveRagflowDatasetIdOrNull_RagflowRAG_repoNotFound_throws() {
             FileInfoV2 file = new FileInfoV2();
             file.setSource("Ragflow-RAG");
             file.setRepoId(42L);
             when(repoService.getById(42L)).thenReturn(null);
             BusinessException ex = assertThrows(BusinessException.class,
                     () -> ReflectionTestUtils.invokeMethod(
-                            knowledgeService, "resolveCoreRepoIdForRagflow", file));
+                            knowledgeService, "resolveRagflowDatasetIdOrNull", file));
             assertThat(ex.getResponseEnum()).isEqualTo(ResponseEnum.REPO_STATUS_ILLEGAL);
         }
 
         @Test
-        @DisplayName("resolveCoreRepoIdForRagflow throws when coreRepoId blank")
-        void resolveCoreRepoIdForRagflow_RagflowRAG_emptyCoreRepoId_throws() {
-            FileInfoV2 file = new FileInfoV2();
-            file.setSource("Ragflow-RAG");
-            file.setRepoId(42L);
-            Repo repo = new Repo();
-            repo.setCoreRepoId(null);
-            when(repoService.getById(42L)).thenReturn(repo);
-            BusinessException ex = assertThrows(BusinessException.class,
-                    () -> ReflectionTestUtils.invokeMethod(
-                            knowledgeService, "resolveCoreRepoIdForRagflow", file));
-            assertThat(ex.getResponseEnum()).isEqualTo(ResponseEnum.REPO_STATUS_ILLEGAL);
-        }
-
-        @Test
-        @DisplayName("resolveCoreRepoIdForRagflow returns coreRepoId on happy path")
-        void resolveCoreRepoIdForRagflow_happyPath_returnsCoreRepoId() {
+        @DisplayName("resolveRagflowDatasetIdOrNull returns null when ragflowDatasetId blank (legacy fallback)")
+        void resolveRagflowDatasetIdOrNull_RagflowRAG_blankDatasetId_returnsNull() {
             FileInfoV2 file = new FileInfoV2();
             file.setSource("Ragflow-RAG");
             file.setRepoId(42L);
             Repo repo = new Repo();
             repo.setCoreRepoId("abc-uuid");
+            repo.setRagflowDatasetId(null);
             when(repoService.getById(42L)).thenReturn(repo);
             String result = ReflectionTestUtils.invokeMethod(
-                    knowledgeService, "resolveCoreRepoIdForRagflow", file);
-            assertThat(result).isEqualTo("abc-uuid");
+                    knowledgeService, "resolveRagflowDatasetIdOrNull", file);
+            assertThat(result).isNull();
         }
 
         @Test
-        @DisplayName("deleteKnowledgeDoc sets group on Ragflow-RAG request")
-        void deleteKnowledgeDoc_RagflowRAG_setsGroupOnRequest() {
+        @DisplayName("resolveRagflowDatasetIdOrNull returns ragflowDatasetId on happy path")
+        void resolveRagflowDatasetIdOrNull_happyPath_returnsDatasetId() {
+            FileInfoV2 file = new FileInfoV2();
+            file.setSource("Ragflow-RAG");
+            file.setRepoId(42L);
+            Repo repo = new Repo();
+            repo.setCoreRepoId("abc-uuid");
+            repo.setRagflowDatasetId("ds-real-id-001");
+            when(repoService.getById(42L)).thenReturn(repo);
+            String result = ReflectionTestUtils.invokeMethod(
+                    knowledgeService, "resolveRagflowDatasetIdOrNull", file);
+            assertThat(result).isEqualTo("ds-real-id-001");
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeDoc sets datasetId on Ragflow-RAG request")
+        void deleteKnowledgeDoc_RagflowRAG_setsDatasetIdOnRequest() {
             JSONArray deleteDocIds = new JSONArray();
-            deleteDocIds.add("doc-rf-001");
+            deleteDocIds.add("doc-ragflow-001");
 
-            FileInfoV2 rfFile = new FileInfoV2();
-            rfFile.setSource("Ragflow-RAG");
-            rfFile.setRepoId(100L);
-            rfFile.setId(1L);
-            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(rfFile);
+            FileInfoV2 ragflowFile = new FileInfoV2();
+            ragflowFile.setSource("Ragflow-RAG");
+            ragflowFile.setRepoId(100L);
+            ragflowFile.setId(1L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(ragflowFile);
 
-            Repo rfRepo = new Repo();
-            rfRepo.setId(100L);
-            rfRepo.setCoreRepoId("rf-core-uuid");
-            when(repoService.getById(100L)).thenReturn(rfRepo);
+            Repo ragflowRepo = new Repo();
+            ragflowRepo.setId(100L);
+            ragflowRepo.setCoreRepoId("ragflow-core-uuid");
+            ragflowRepo.setRagflowDatasetId("ds-real-id-001");
+            when(repoService.getById(100L)).thenReturn(ragflowRepo);
 
             KnowledgeResponse response = new KnowledgeResponse();
             response.setCode(0);
@@ -2380,12 +2496,13 @@ class KnowledgeServiceTest {
 
             ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
             verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
-            assertThat(captor.getValue().getGroup()).isEqualTo("rf-core-uuid");
+            assertThat(captor.getValue().getDatasetId()).isEqualTo("ds-real-id-001");
+            assertThat(captor.getValue().getGroup()).isNull();
         }
 
         @Test
-        @DisplayName("deleteKnowledgeDoc leaves group null for non-Ragflow-RAG (AIUI/CBG)")
-        void deleteKnowledgeDoc_NonRagflowRAG_doesNotSetGroup() {
+        @DisplayName("deleteKnowledgeDoc leaves datasetId null for non-Ragflow-RAG (AIUI/CBG)")
+        void deleteKnowledgeDoc_NonRagflowRAG_doesNotSetDatasetId() {
             JSONArray deleteDocIds = new JSONArray();
             deleteDocIds.add("doc-aiui-001");
 
@@ -2402,37 +2519,67 @@ class KnowledgeServiceTest {
 
             ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
             verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
-            assertThat(captor.getValue().getGroup()).isNull();
+            assertThat(captor.getValue().getDatasetId()).isNull();
             // Repo should not be loaded for non-Ragflow-RAG sources.
             verify(repoService, never()).getById(anyLong());
+        }
+
+        @Test
+        @DisplayName("deleteKnowledgeDoc leaves datasetId null for Ragflow-RAG with legacy NULL repo")
+        void deleteKnowledgeDoc_RagflowRAG_legacyNullDatasetId_skipsDatasetId() {
+            JSONArray deleteDocIds = new JSONArray();
+            deleteDocIds.add("doc-ragflow-legacy");
+
+            FileInfoV2 ragflowFile = new FileInfoV2();
+            ragflowFile.setSource("Ragflow-RAG");
+            ragflowFile.setRepoId(100L);
+            ragflowFile.setId(1L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(ragflowFile);
+
+            Repo legacyRepo = new Repo();
+            legacyRepo.setId(100L);
+            legacyRepo.setCoreRepoId("legacy-core-uuid");
+            legacyRepo.setRagflowDatasetId(null);
+            when(repoService.getById(100L)).thenReturn(legacyRepo);
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            when(knowledgeV2ServiceCallHandler.deleteDocOrChunk(any())).thenReturn(response);
+
+            knowledgeService.deleteKnowledgeDoc(deleteDocIds, null);
+
+            ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
+            verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
+            assertThat(captor.getValue().getDatasetId()).isNull();
         }
 
         @Test
         @DisplayName("deleteKnowledgeDoc skips invalid Ragflow-RAG metadata and continues")
         void deleteKnowledgeDoc_RagflowRAG_invalidMetadata_skipsAndContinues() {
             JSONArray deleteDocIds = new JSONArray();
-            deleteDocIds.add("doc-rf-invalid");
-            deleteDocIds.add("doc-rf-valid");
+            deleteDocIds.add("doc-ragflow-invalid");
+            deleteDocIds.add("doc-ragflow-valid");
 
             FileInfoV2 invalidFile = new FileInfoV2();
             invalidFile.setSource("Ragflow-RAG");
             invalidFile.setRepoId(404L);
             invalidFile.setId(1L);
-            invalidFile.setUuid("doc-rf-invalid");
+            invalidFile.setUuid("doc-ragflow-invalid");
 
             FileInfoV2 validFile = new FileInfoV2();
             validFile.setSource("Ragflow-RAG");
             validFile.setRepoId(100L);
             validFile.setId(2L);
-            validFile.setUuid("doc-rf-valid");
+            validFile.setUuid("doc-ragflow-valid");
             when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(invalidFile, validFile);
 
-            Repo rfRepo = new Repo();
-            rfRepo.setId(100L);
-            rfRepo.setCoreRepoId("rf-core-uuid");
+            Repo ragflowRepo = new Repo();
+            ragflowRepo.setId(100L);
+            ragflowRepo.setCoreRepoId("ragflow-core-uuid");
+            ragflowRepo.setRagflowDatasetId("ds-real-id-001");
             when(repoService.getById(anyLong())).thenAnswer(invocation -> {
                 Long repoId = invocation.getArgument(0);
-                return Long.valueOf(100L).equals(repoId) ? rfRepo : null;
+                return Long.valueOf(100L).equals(repoId) ? ragflowRepo : null;
             });
 
             KnowledgeResponse response = new KnowledgeResponse();
@@ -2443,27 +2590,28 @@ class KnowledgeServiceTest {
 
             ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
             verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
-            assertThat(captor.getValue().getDocId()).isEqualTo("doc-rf-valid");
-            assertThat(captor.getValue().getGroup()).isEqualTo("rf-core-uuid");
+            assertThat(captor.getValue().getDocId()).isEqualTo("doc-ragflow-valid");
+            assertThat(captor.getValue().getDatasetId()).isEqualTo("ds-real-id-001");
         }
 
         @Test
-        @DisplayName("deleteKnowledgeChunks sets group on Ragflow-RAG request")
-        void deleteKnowledgeChunks_RagflowRAG_setsGroupOnRequest() {
-            String docId = "doc-rf-001";
+        @DisplayName("deleteKnowledgeChunks sets datasetId on Ragflow-RAG request")
+        void deleteKnowledgeChunks_RagflowRAG_setsDatasetIdOnRequest() {
+            String docId = "doc-ragflow-001";
             JSONArray chunkIds = new JSONArray();
             chunkIds.add("chunk-001");
 
-            FileInfoV2 rfFile = new FileInfoV2();
-            rfFile.setSource("Ragflow-RAG");
-            rfFile.setRepoId(100L);
-            rfFile.setId(1L);
-            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(rfFile);
+            FileInfoV2 ragflowFile = new FileInfoV2();
+            ragflowFile.setSource("Ragflow-RAG");
+            ragflowFile.setRepoId(100L);
+            ragflowFile.setId(1L);
+            when(fileInfoV2Service.getOnly(any(QueryWrapper.class))).thenReturn(ragflowFile);
 
-            Repo rfRepo = new Repo();
-            rfRepo.setId(100L);
-            rfRepo.setCoreRepoId("rf-core-uuid");
-            when(repoService.getById(100L)).thenReturn(rfRepo);
+            Repo ragflowRepo = new Repo();
+            ragflowRepo.setId(100L);
+            ragflowRepo.setCoreRepoId("ragflow-core-uuid");
+            ragflowRepo.setRagflowDatasetId("ds-real-id-001");
+            when(repoService.getById(100L)).thenReturn(ragflowRepo);
 
             KnowledgeResponse response = new KnowledgeResponse();
             response.setCode(0);
@@ -2473,12 +2621,13 @@ class KnowledgeServiceTest {
 
             ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
             verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
-            assertThat(captor.getValue().getGroup()).isEqualTo("rf-core-uuid");
+            assertThat(captor.getValue().getDatasetId()).isEqualTo("ds-real-id-001");
+            assertThat(captor.getValue().getGroup()).isNull();
         }
 
         @Test
-        @DisplayName("deleteKnowledgeChunks leaves group null for non-Ragflow-RAG (AIUI/CBG)")
-        void deleteKnowledgeChunks_NonRagflowRAG_doesNotSetGroup() {
+        @DisplayName("deleteKnowledgeChunks leaves datasetId null for non-Ragflow-RAG (AIUI/CBG)")
+        void deleteKnowledgeChunks_NonRagflowRAG_doesNotSetDatasetId() {
             String docId = "doc-aiui-001";
             JSONArray chunkIds = new JSONArray();
             chunkIds.add("chunk-001");
@@ -2496,14 +2645,14 @@ class KnowledgeServiceTest {
 
             ArgumentCaptor<KnowledgeRequest> captor = ArgumentCaptor.forClass(KnowledgeRequest.class);
             verify(knowledgeV2ServiceCallHandler).deleteDocOrChunk(captor.capture());
-            assertThat(captor.getValue().getGroup()).isNull();
+            assertThat(captor.getValue().getDatasetId()).isNull();
             verify(repoService, never()).getById(anyLong());
         }
 
         @Test
         @DisplayName("deleteKnowledgeChunks skips invalid Ragflow-RAG metadata")
         void deleteKnowledgeChunks_RagflowRAG_invalidMetadata_skipsDelete() {
-            String docId = "doc-rf-invalid";
+            String docId = "doc-ragflow-invalid";
             JSONArray chunkIds = new JSONArray();
             chunkIds.add("chunk-001");
 

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/RepoServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/RepoServiceTest.java
@@ -11,6 +11,7 @@ import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.service.data.IDatasetFileService;
 import com.iflytek.astron.console.toolkit.common.constant.ProjectContent;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
+import com.iflytek.astron.console.toolkit.config.properties.BizConfig;
 import com.iflytek.astron.console.toolkit.config.properties.RepoAuthorizedConfig;
 import com.iflytek.astron.console.toolkit.entity.table.ConfigInfo;
 import com.iflytek.astron.console.toolkit.entity.table.group.GroupVisibility;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -174,6 +176,17 @@ class RepoServiceTest {
 
         // Set baseMapper for ServiceImpl - Required for MyBatis-Plus
         ReflectionTestUtils.setField(repoService, "baseMapper", repoMapper);
+        ReflectionTestUtils.setField(repoService, "self", repoService);
+
+        BizConfig bizConfig = new BizConfig();
+        bizConfig.setCbgRagCompatibleSources(Arrays.asList(
+                ProjectContent.FILE_SOURCE_CBG_RAG_STR,
+                ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR));
+        bizConfig.setAiuiRagCompatibleSources(
+                Arrays.asList(ProjectContent.FILE_SOURCE_AIUI_RAG2_STR));
+        bizConfig.setSparkRagCompatibleSources(
+                Arrays.asList(ProjectContent.FILE_SOURCE_SPARK_RAG_STR));
+        new ProjectContent().setBizConfig(bizConfig);
 
         // Initialize mock RepoVO
         mockRepoVO = new RepoVO();
@@ -454,6 +467,133 @@ class RepoServiceTest {
                 // Then
                 assertThat(result).isNotNull();
                 verify(repoMapper, times(1)).insert(any(Repo.class));
+            }
+        }
+
+        @Test
+        @DisplayName("createRepo with Ragflow-RAG tag persists ragflow dataset id")
+        void createRepo_ragflowRag_persistsDatasetId() {
+            try (MockedStatic<UserInfoManagerHandler> userMock = mockStatic(UserInfoManagerHandler.class);
+                    MockedStatic<SpaceInfoUtil> spaceMock = mockStatic(SpaceInfoUtil.class)) {
+
+                userMock.when(UserInfoManagerHandler::getUserId).thenReturn("user-001");
+                spaceMock.when(SpaceInfoUtil::getSpaceId).thenReturn(null);
+
+                mockRepoVO.setName("kb_alpha");
+                mockRepoVO.setTag(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+                mockRepoVO.setOuterRepoId("caller-controlled-id");
+                mockRepoVO.setVisibility(0);
+
+                when(repoMapper.selectOne(any(), anyBoolean())).thenReturn(null);
+                when(knowledgeV2ServiceCallHandler.createRagflowDataset(anyString(), eq("kb_alpha")))
+                        .thenReturn("ds-real-id-001");
+                when(repoMapper.insert(any(Repo.class))).thenAnswer(invocation -> {
+                    Repo r = invocation.getArgument(0);
+                    r.setId(42L);
+                    return 1;
+                });
+                doNothing().when(groupVisibilityService).setRepoVisibility(anyLong(), anyInt(), anyInt(), anyList());
+
+                Repo saved = repoService.createRepo(mockRepoVO);
+
+                assertThat(saved.getRagflowDatasetId()).isEqualTo("ds-real-id-001");
+                assertThat(saved.getTag()).isEqualTo(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+                assertThat(saved.getCoreRepoId()).isNotEqualTo("caller-controlled-id");
+                assertThat(saved.getOuterRepoId()).isEqualTo(saved.getCoreRepoId());
+                assertThat(saved.getCoreRepoId()).hasSize(32);
+                ArgumentCaptor<String> datasetNameCaptor = ArgumentCaptor.forClass(String.class);
+                verify(knowledgeV2ServiceCallHandler).createRagflowDataset(datasetNameCaptor.capture(), eq("kb_alpha"));
+                assertThat(datasetNameCaptor.getValue()).isNotEqualTo(saved.getCoreRepoId());
+                assertThat(datasetNameCaptor.getValue()).isEqualTo("kb_alpha-" + saved.getCoreRepoId());
+                verify(repoMapper, times(1)).insert(any(Repo.class));
+            }
+        }
+
+        @Test
+        @DisplayName("createRepo with Ragflow-RAG tag keeps dataset name within max length")
+        void createRepo_ragflowRag_truncatesReadableDatasetNameOnly() {
+            try (MockedStatic<UserInfoManagerHandler> userMock = mockStatic(UserInfoManagerHandler.class);
+                    MockedStatic<SpaceInfoUtil> spaceMock = mockStatic(SpaceInfoUtil.class)) {
+
+                userMock.when(UserInfoManagerHandler::getUserId).thenReturn("user-001");
+                spaceMock.when(SpaceInfoUtil::getSpaceId).thenReturn(null);
+
+                String longRepoName = "k".repeat(300);
+                mockRepoVO.setName(longRepoName);
+                mockRepoVO.setTag(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+                mockRepoVO.setVisibility(0);
+
+                when(repoMapper.selectOne(any(), anyBoolean())).thenReturn(null);
+                when(knowledgeV2ServiceCallHandler.createRagflowDataset(anyString(), eq(longRepoName)))
+                        .thenReturn("ds-real-id-002");
+                when(repoMapper.insert(any(Repo.class))).thenAnswer(invocation -> {
+                    Repo r = invocation.getArgument(0);
+                    r.setId(43L);
+                    return 1;
+                });
+                doNothing().when(groupVisibilityService).setRepoVisibility(anyLong(), anyInt(), anyInt(), anyList());
+
+                Repo saved = repoService.createRepo(mockRepoVO);
+
+                ArgumentCaptor<String> datasetNameCaptor = ArgumentCaptor.forClass(String.class);
+                verify(knowledgeV2ServiceCallHandler).createRagflowDataset(datasetNameCaptor.capture(), eq(longRepoName));
+                assertThat(datasetNameCaptor.getValue()).hasSize(255);
+                assertThat(datasetNameCaptor.getValue()).endsWith("-" + saved.getCoreRepoId());
+            }
+        }
+
+        @Test
+        @DisplayName("createRepo rolls back when RAGFlow create fails")
+        void createRepo_ragflowFailure_doesNotPersist() {
+            try (MockedStatic<UserInfoManagerHandler> userMock = mockStatic(UserInfoManagerHandler.class);
+                    MockedStatic<SpaceInfoUtil> spaceMock = mockStatic(SpaceInfoUtil.class)) {
+
+                userMock.when(UserInfoManagerHandler::getUserId).thenReturn("user-001");
+                spaceMock.when(SpaceInfoUtil::getSpaceId).thenReturn(null);
+
+                mockRepoVO.setName("kb_failing");
+                mockRepoVO.setTag(ProjectContent.FILE_SOURCE_RAG_FLOW_RAG_STR);
+
+                when(repoMapper.selectOne(any(), anyBoolean())).thenReturn(null);
+                when(knowledgeV2ServiceCallHandler.createRagflowDataset(anyString(), eq("kb_failing")))
+                        .thenThrow(new BusinessException(
+                                ResponseEnum.REPO_CREATE_RAGFLOW_FAILED,
+                                "RAGFlow unreachable"));
+
+                assertThatThrownBy(() -> repoService.createRepo(mockRepoVO))
+                        .isInstanceOf(BusinessException.class)
+                        .extracting("responseEnum")
+                        .isEqualTo(ResponseEnum.REPO_CREATE_RAGFLOW_FAILED);
+
+                verify(repoMapper, never()).insert(any(Repo.class));
+            }
+        }
+
+        @Test
+        @DisplayName("createRepo with non-Ragflow tag does not call RAGFlow")
+        void createRepo_nonRagflowTag_skipsRagflow() {
+            try (MockedStatic<UserInfoManagerHandler> userMock = mockStatic(UserInfoManagerHandler.class);
+                    MockedStatic<SpaceInfoUtil> spaceMock = mockStatic(SpaceInfoUtil.class)) {
+
+                userMock.when(UserInfoManagerHandler::getUserId).thenReturn("user-001");
+                spaceMock.when(SpaceInfoUtil::getSpaceId).thenReturn(null);
+
+                mockRepoVO.setName("cbg_kb");
+                mockRepoVO.setTag(ProjectContent.FILE_SOURCE_CBG_RAG_STR);
+                mockRepoVO.setVisibility(0);
+
+                when(repoMapper.selectOne(any(), anyBoolean())).thenReturn(null);
+                when(repoMapper.insert(any(Repo.class))).thenAnswer(invocation -> {
+                    Repo r = invocation.getArgument(0);
+                    r.setId(43L);
+                    return 1;
+                });
+                doNothing().when(groupVisibilityService).setRepoVisibility(anyLong(), anyInt(), anyInt(), anyList());
+
+                Repo saved = repoService.createRepo(mockRepoVO);
+
+                assertThat(saved.getRagflowDatasetId()).isNull();
+                verifyNoInteractions(knowledgeV2ServiceCallHandler);
             }
         }
     }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceRagflowDatasetIdTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceRagflowDatasetIdTest.java
@@ -1,0 +1,83 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizNodeData;
+import com.iflytek.astron.console.toolkit.entity.table.repo.FileInfoV2;
+import com.iflytek.astron.console.toolkit.entity.table.repo.Repo;
+import com.iflytek.astron.console.toolkit.mapper.repo.FileInfoV2Mapper;
+import com.iflytek.astron.console.toolkit.mapper.repo.RepoMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowServiceRagflowDatasetIdTest {
+
+    @Mock
+    private FileInfoV2Mapper fileInfoV2Mapper;
+
+    @Mock
+    private RepoMapper repoMapper;
+
+    private WorkflowService workflowService;
+
+    @BeforeEach
+    void setUp() {
+        workflowService = new WorkflowService();
+        ReflectionTestUtils.setField(workflowService, "fileInfoV2Mapper", fileInfoV2Mapper);
+        ReflectionTestUtils.setField(workflowService, "repoMapper", repoMapper);
+    }
+
+    @Test
+    void setDocIdsAddsRagflowDatasetIdsFromRepoTable() {
+        BizNodeData data = new BizNodeData();
+        data.setNodeParam(new JSONObject());
+        data.getNodeParam().put("datasetIds", new JSONArray(List.of("untrusted-dataset")));
+        JSONArray repoIds = new JSONArray(List.of("repo-a", "repo-b"));
+
+        FileInfoV2 fileInfo = new FileInfoV2();
+        fileInfo.setUuid("doc-a");
+        when(fileInfoV2Mapper.getFileInfoV2ByCoreRepoId("repo-a")).thenReturn(List.of(fileInfo));
+        when(fileInfoV2Mapper.getFileInfoV2ByCoreRepoId("repo-b")).thenReturn(Collections.emptyList());
+
+        Repo repo = new Repo();
+        repo.setCoreRepoId("repo-a");
+        repo.setRagflowDatasetId("dataset-a");
+        when(repoMapper.listInRepoCoreIds(List.of("repo-a", "repo-b"))).thenReturn(List.of(repo));
+
+        ReflectionTestUtils.invokeMethod(workflowService, "setDocIds", data, repoIds);
+
+        assertThat(data.getNodeParam().getJSONArray("docIds")).containsExactly("doc-a");
+        assertThat(data.getNodeParam().getJSONArray("datasetIds")).containsExactly("dataset-a");
+    }
+
+    @Test
+    void enrichKnowledgeDocIdsAddsDatasetIdsToAgentMatch() {
+        JSONArray knowledgeArray = new JSONArray();
+        JSONObject knowledge = new JSONObject();
+        JSONObject match = new JSONObject();
+        match.put("repoIds", new JSONArray(List.of("repo-a")));
+        match.put("datasetIds", new JSONArray(List.of("untrusted-dataset")));
+        knowledge.put("match", match);
+        knowledgeArray.add(knowledge);
+
+        Repo repo = new Repo();
+        repo.setCoreRepoId("repo-a");
+        repo.setRagflowDatasetId("dataset-a");
+        when(repoMapper.listInRepoCoreIds(List.of("repo-a"))).thenReturn(List.of(repo));
+
+        ReflectionTestUtils.invokeMethod(workflowService, "enrichKnowledgeDocIds", knowledgeArray);
+
+        assertThat(match.getJSONArray("datasetIds")).containsExactly("dataset-a");
+    }
+}

--- a/core/agent/api/schemas/workflow_agent_inputs.py
+++ b/core/agent/api/schemas/workflow_agent_inputs.py
@@ -20,6 +20,7 @@ class CustomCompletionInstructionInputs(BaseModel):
 class CustomCompletionPluginKnowledgeMatchInputs(BaseModel):
     repo_ids: list[str] = Field(default_factory=list[str])
     doc_ids: list[str] = Field(default_factory=list[str])
+    dataset_ids: list[str] = Field(default_factory=list[str])
 
 
 class CustomCompletionPluginKnowledgeInputs(BaseModel):

--- a/core/agent/service/builder/workflow_agent_builder.py
+++ b/core/agent/service/builder/workflow_agent_builder.py
@@ -24,6 +24,7 @@ class KnowledgeQueryParams:
 
     repo_ids: list[str]
     doc_ids: list[str]
+    dataset_ids: list[str]
     top_k: int
     score_threshold: float
     rag_type: str
@@ -126,6 +127,7 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
         for knowledge in knowledge_list:
             repo_ids = knowledge.match.repo_ids or []
             doc_ids = knowledge.match.doc_ids or []
+            dataset_ids = knowledge.match.dataset_ids or []
 
             # 添加调试日志
             span.add_info_events(
@@ -134,6 +136,7 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
                     "repo_type": knowledge.repo_type,
                     "repo_ids": repo_ids,
                     "doc_ids": doc_ids,
+                    "dataset_ids": dataset_ids,
                 }
             )
 
@@ -155,6 +158,7 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
             params = KnowledgeQueryParams(
                 repo_ids=repo_ids,
                 doc_ids=doc_ids,
+                dataset_ids=dataset_ids,
                 top_k=top_k,
                 score_threshold=score_threshold,
                 rag_type=repo_type,
@@ -228,6 +232,7 @@ class WorkflowAgentRunnerBuilder(BaseApiBuilder):
             top_k=params.top_k,
             repo_ids=params.repo_ids,
             doc_ids=params.doc_ids,
+            dataset_ids=params.dataset_ids,
             score_threshold=params.score_threshold,
             rag_type=params.rag_type,
         ).gen()

--- a/core/agent/service/plugin/knowledge.py
+++ b/core/agent/service/plugin/knowledge.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 import aiohttp
 from common.otlp.trace.span import Span
 from openai import BaseModel
+from pydantic import Field
 
 from agent.exceptions.plugin_exc import KnowledgeQueryExc, PluginExc
 from agent.service.plugin.base import BasePlugin
@@ -20,6 +21,7 @@ class KnowledgePluginFactory(BaseModel):
     top_k: int
     repo_ids: List[str]
     doc_ids: List[str]
+    dataset_ids: List[str] = Field(default_factory=list)
     score_threshold: float
     rag_type: str
 
@@ -44,6 +46,8 @@ class KnowledgePluginFactory(BaseModel):
                 if "match" not in data:
                     data["match"] = {}
                 data["match"]["docIds"] = self.doc_ids
+            if self.rag_type == "Ragflow-RAG" and self.dataset_ids:
+                data["match"]["datasetId"] = self.dataset_ids
 
             sp.add_info_events({"request-data": json.dumps(data, ensure_ascii=False)})
 
@@ -62,8 +66,9 @@ class KnowledgePluginFactory(BaseModel):
                     timeout = aiohttp.ClientTimeout(
                         total=int(os.getenv("KNOWLEDGE_CALL_TIMEOUT", "90"))
                     )
+                    headers = self._headers()
                     async with session.post(
-                        query_url, json=data, timeout=timeout
+                        query_url, headers=headers, json=data, timeout=timeout
                     ) as response:
 
                         sp.add_info_events(
@@ -81,3 +86,6 @@ class KnowledgePluginFactory(BaseModel):
                         raise KnowledgeQueryExc
             except asyncio.TimeoutError as e:
                 raise KnowledgeQueryExc from e
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Content-Type": "application/json"}

--- a/core/agent/tests/test_knowledge_plugin.py
+++ b/core/agent/tests/test_knowledge_plugin.py
@@ -47,6 +47,7 @@ class TestKnowledgePluginFactory:
             top_k=3,
             repo_ids=["repo1"],
             doc_ids=["doc1"],
+            dataset_ids=[],
             score_threshold=0.3,
             rag_type="AIUI-RAG2",
         )
@@ -214,6 +215,39 @@ class TestKnowledgePluginFactory:
                 assert captured_data["topN"] == "3"
                 assert "match" in captured_data
                 assert captured_data["ragType"] == "AIUI-RAG2"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_ragflow_with_dataset_ids(
+        self, factory: KnowledgePluginFactory
+    ) -> None:
+        """Test Ragflow-RAG route data"""
+        factory.rag_type = "Ragflow-RAG"
+        factory.dataset_ids = ["dataset-1"]
+        span = Span(app_id="test_app", uid="test_uid")
+        captured_data: dict[str, Any] = {}
+        captured_headers: dict[str, str] = {}
+
+        def mock_post(*args: Any, **kwargs: Any) -> AsyncMock:  # noqa: ANN001
+            captured_data.update(kwargs.get("json", {}))
+            captured_headers.update(kwargs.get("headers", {}))
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value={"data": {"results": []}})
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.read = AsyncMock(return_value=b'{"data": {}}')
+            mock_resp.__aenter__.return_value = mock_resp
+            mock_resp.__aexit__.return_value = False
+            return mock_resp
+
+        with patch.dict(
+            os.environ,
+            {"CHUNK_QUERY_URL": "http://test.com/query"},
+        ):
+            with patch("aiohttp.ClientSession.post", new=mock_post):
+                await factory.retrieve(span)
+
+        assert captured_data["match"]["datasetId"] == ["dataset-1"]
+        assert captured_headers == {"Content-Type": "application/json"}
 
 
 class TestKnowledgePlugin:

--- a/core/agent/tests/test_workflow_agent_builder.py
+++ b/core/agent/tests/test_workflow_agent_builder.py
@@ -362,6 +362,7 @@ class TestWorkflowAgentRunnerBuilder:
         params = KnowledgeQueryParams(
             repo_ids=["repo1"],
             doc_ids=["doc1"],
+            dataset_ids=["dataset1"],
             top_k=3,
             score_threshold=0.3,
             rag_type="AIUI-RAG2",
@@ -379,6 +380,15 @@ class TestWorkflowAgentRunnerBuilder:
             result = await builder.exec_query_knowledge(params, span)
 
             assert result == mock_result
+            mock_factory.assert_called_once_with(
+                query=builder.inputs.get_last_message_content(),
+                top_k=3,
+                repo_ids=["repo1"],
+                doc_ids=["doc1"],
+                dataset_ids=["dataset1"],
+                score_threshold=0.3,
+                rag_type="AIUI-RAG2",
+            )
 
 
 class TestKnowledgeQueryParams:
@@ -389,6 +399,7 @@ class TestKnowledgeQueryParams:
         params = KnowledgeQueryParams(
             repo_ids=["repo1"],
             doc_ids=["doc1"],
+            dataset_ids=[],
             top_k=3,
             score_threshold=0.3,
             rag_type="AIUI-RAG2",
@@ -396,6 +407,7 @@ class TestKnowledgeQueryParams:
 
         assert params.repo_ids == ["repo1"]
         assert params.doc_ids == ["doc1"]
+        assert params.dataset_ids == []
         assert params.top_k == 3
         assert params.score_threshold == 0.3
         assert params.rag_type == "AIUI-RAG2"

--- a/core/agent/tests/test_workflow_agent_inputs_and_plugin_inputs.py
+++ b/core/agent/tests/test_workflow_agent_inputs_and_plugin_inputs.py
@@ -32,6 +32,7 @@ class TestWorkflowAgentInputsModels:
         m = CustomCompletionPluginKnowledgeMatchInputs()
         assert m.repo_ids == []
         assert m.doc_ids == []
+        assert m.dataset_ids == []
 
     def test_plugin_knowledge_inputs_constraints(self) -> None:
         k = CustomCompletionPluginKnowledgeInputs(

--- a/core/knowledge/api/v1/api.py
+++ b/core/knowledge/api/v1/api.py
@@ -15,6 +15,7 @@ from common.service.otlp.metric.metric_service import OtlpMetricService
 from common.service.otlp.span.span_service import OtlpSpanService
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from loguru import logger
+from pydantic import BaseModel, Field
 
 from knowledge.consts.error_code import CodeEnum
 from knowledge.domain.entity.chunk_dto import (
@@ -32,6 +33,7 @@ from knowledge.exceptions.exception import (
     ProtocolParamException,
     ThirdPartyException,
 )
+from knowledge.infra.ragflow.ragflow_utils import RagflowUtils
 from knowledge.service.rag_strategy_factory import RAGStrategyFactory
 from knowledge.service.rq.rewrite_query import rewrite_query
 
@@ -143,9 +145,56 @@ async def handle_rag_operation(
 
 
 # --- Route Handler Functions ---
+
+
+class DatasetCreateRequest(BaseModel):
+    """Request body for POST /v1/dataset/create."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Dataset name (readable and unique)",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        max_length=1024,
+        description="Human-readable label for the dataset UI",
+    )
+
+
+@rag_router.post("/dataset/create")
+async def create_dataset_endpoint(
+    req: DatasetCreateRequest,
+) -> Union[SuccessDataResponse, ErrorResponse]:
+    """Create or reuse a RAGFlow dataset and return its id."""
+    try:
+        dataset_id = await RagflowUtils.ensure_dataset(
+            req.name, description=req.description
+        )
+        return SuccessDataResponse(data={"datasetId": dataset_id})
+    except ThirdPartyException as e:
+        logger.error(f"create_dataset_endpoint ThirdParty err: {e}")
+        error_code = type("ErrorCode", (), {"code": e.code, "msg": e.message})()
+        return ErrorResponse(code_enum=error_code, message=e.message)
+    except CustomException as e:
+        logger.error(f"create_dataset_endpoint Custom err: {e}")
+        error_code = type("ErrorCode", (), {"code": e.code, "msg": e.message})()
+        return ErrorResponse(code_enum=error_code, message=e.message)
+    except Exception as e:  # pylint: disable=W0718
+        logger.exception(
+            f"create_dataset_endpoint unexpected err for name={req.name}: {e}"
+        )
+        return ErrorResponse(
+            code_enum=CodeEnum.RAGFLOW_RAGError,
+            message=f"{CodeEnum.RAGFLOW_RAGError.msg}({str(e)})",
+        )
+
+
 @rag_router.post("/document/split")
 async def file_split(
-    split_request: FileSplitReq, app_id: str = Depends(get_app_id)
+    split_request: FileSplitReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Parse the text provided by the user first, then perform chunking.
@@ -181,7 +230,7 @@ async def file_split(
             cutOff=split_request.cutOff,
             document_id=split_request.documentId,
             group=split_request.group,
-            groupDescription=split_request.groupDescription,
+            datasetId=split_request.datasetId,
         )
 
 
@@ -239,16 +288,15 @@ async def file_upload(
     group: Optional[str] = Form(
         None,
         description=(
-            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
-            "When omitted, falls back to the default dataset."
+            "Knowledge base group used by non-Ragflow strategies "
+            "(CBG/SparkDesk/AIUI). Ignored by Ragflow-RAG."
         ),
     ),
-    groupDescription: Optional[str] = Form(
+    datasetId: Optional[str] = Form(
         None,
         description=(
-            "Human-readable label written into RAGFlow dataset description "
-            "on first creation; helps operators identify the dataset in the "
-            "RAGFlow UI without resolving UUIDs."
+            "RAGFlow dataset.id for Ragflow-RAG routing; "
+            "None or empty uses the default dataset."
         ),
     ),
     app_id: str = Depends(get_app_id),
@@ -264,9 +312,8 @@ async def file_upload(
         lengthRange: Split length range as JSON string (form-data mode)
         separator: Separator list as JSON string (form-data mode)
         documentId: Existing RAGFlow doc id for re-slice upsert (form-data mode)
-        group: RAGFlow dataset group (form-data mode)
-        groupDescription: Human-readable label written into the RAGFlow dataset
-            description on first creation (form-data mode)
+        group: Knowledge base group for non-Ragflow strategies (form-data mode)
+        datasetId: RAGFlow dataset.id for Ragflow-RAG routing (form-data mode)
         app_id: Application identifier
 
     Returns:
@@ -286,7 +333,7 @@ async def file_upload(
                         "separator": separator,
                         "documentId": documentId,
                         "group": group,
-                        "groupDescription": groupDescription,
+                        "datasetId": datasetId,
                     },
                     ensure_ascii=False,
                 )
@@ -318,13 +365,14 @@ async def file_upload(
             separator=parsed_separator,
             document_id=documentId,
             group=group,
-            groupDescription=groupDescription,
+            datasetId=datasetId,
         )
 
 
 @rag_router.post("/chunks/save")
 async def chunk_save(
-    save_request: ChunkSaveReq, app_id: str = Depends(get_app_id)
+    save_request: ChunkSaveReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Save the chunked data to the database, or add new chunks.
@@ -353,12 +401,14 @@ async def chunk_save(
             group=save_request.group,
             uid=save_request.uid,
             chunks=save_request.chunks,
+            datasetId=save_request.datasetId,
         )
 
 
 @rag_router.post("/chunk/update")
 async def chunk_update(
-    update_request: ChunkUpdateReq, app_id: str = Depends(get_app_id)
+    update_request: ChunkUpdateReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Update knowledge chunks.
@@ -387,12 +437,14 @@ async def chunk_update(
             group=update_request.group,
             uid=update_request.uid,
             chunks=update_request.chunks,
+            datasetId=update_request.datasetId,
         )
 
 
 @rag_router.post("/chunk/delete")
 async def chunk_delete(
-    delete_request: ChunkDeleteReq, app_id: str = Depends(get_app_id)
+    delete_request: ChunkDeleteReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Delete knowledge chunks.
@@ -420,12 +472,14 @@ async def chunk_delete(
             docId=delete_request.docId,
             chunkIds=delete_request.chunkIds,
             group=delete_request.group,
+            datasetId=delete_request.datasetId,
         )
 
 
 @rag_router.post("/chunk/query")
 async def chunk_query(
-    query_request: ChunkQueryReq, app_id: str = Depends(get_app_id)
+    query_request: ChunkQueryReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Retrieve similar document chunks based on user input content.
@@ -462,6 +516,8 @@ async def chunk_query(
         extra_kwargs: Dict[str, Any] = {}
         if query_request.ragflow_ext is not None:
             extra_kwargs["ragflow_ext"] = query_request.ragflow_ext
+        if query_request.match.datasetId is not None:
+            extra_kwargs["datasetId"] = query_request.match.datasetId
 
         return await handle_rag_operation(
             span_context=span_context,
@@ -479,7 +535,8 @@ async def chunk_query(
 
 @rag_router.post("/document/chunk")
 async def query_doc(
-    query_request: QueryDocReq, app_id: str = Depends(get_app_id)
+    query_request: QueryDocReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Query document chunk information.
@@ -503,12 +560,14 @@ async def query_doc(
             operation_callable=strategy.query_doc,
             docId=query_request.docId,
             group=query_request.group,
+            datasetId=query_request.datasetId,
         )
 
 
 @rag_router.post("/document/name")
 async def query_doc_name(
-    query_request: QueryDocReq, app_id: str = Depends(get_app_id)
+    query_request: QueryDocReq,
+    app_id: str = Depends(get_app_id),
 ) -> Union[SuccessDataResponse, ErrorResponse]:
     """
     Query document name information.
@@ -532,4 +591,5 @@ async def query_doc_name(
             operation_callable=strategy.query_doc_name,
             docId=query_request.docId,
             group=query_request.group,
+            datasetId=query_request.datasetId,
         )

--- a/core/knowledge/domain/entity/chunk_dto.py
+++ b/core/knowledge/domain/entity/chunk_dto.py
@@ -10,6 +10,21 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+_GROUP_DESC = (
+    "Knowledge base group used by non-Ragflow strategies (CBG/SparkDesk/AIUI). "
+    "Ignored by Ragflow-RAG, which routes via datasetId."
+)
+
+_DATASET_ID_DESC = (
+    "RAGFlow dataset.id for Ragflow-RAG routing; "
+    "None or empty uses the default dataset."
+)
+
+_DATASET_ID_LIST_DESC = (
+    "RAGFlow dataset.id values for Ragflow-RAG routing; "
+    "None or empty uses the default dataset."
+)
+
 
 class RAGType(str, Enum):
     """Define RAG type enumeration"""
@@ -18,6 +33,11 @@ class RAGType(str, Enum):
     CBG_RAG = "CBG-RAG"
     SparkDesk_RAG = "SparkDesk-RAG"
     RagFlow_RAG = "Ragflow-RAG"
+
+
+def _require_group_for_non_ragflow(rag_type: RAGType, group: Optional[str]) -> None:
+    if rag_type != RAGType.RagFlow_RAG and not group:
+        raise ValueError("group is required when ragType is not Ragflow-RAG")
 
 
 class FileSplitReq(BaseModel):
@@ -34,7 +54,8 @@ class FileSplitReq(BaseModel):
         cutOff: Cutoff marker list, optional
         titleSplit: Whether to split by title, default is False
         documentId: Existing RAGFlow doc id for re-slice upsert, optional
-        group: RAGFlow dataset group, optional
+        group: Knowledge base group used by non-Ragflow strategies, optional
+        datasetId: RAGFlow dataset.id for direct routing, optional
     """
 
     file: str = Field(..., min_length=1, description="Required, minimum length 1")
@@ -60,18 +81,11 @@ class FileSplitReq(BaseModel):
     )
     group: Optional[str] = Field(
         default=None,
-        description=(
-            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
-            "When omitted, falls back to the default dataset."
-        ),
+        description=_GROUP_DESC,
     )
-    groupDescription: Optional[str] = Field(
+    datasetId: Optional[str] = Field(
         default=None,
-        description=(
-            "Human-readable label written into RAGFlow dataset description "
-            "on first creation; helps operators identify the dataset in the "
-            "RAGFlow UI without resolving UUIDs."
-        ),
+        description=_DATASET_ID_DESC,
     )
 
 
@@ -81,19 +95,32 @@ class ChunkSaveReq(BaseModel):
 
     Attributes:
         docId: Document ID, required
-        group: Group identifier, required
+        group: Knowledge base group used by non-Ragflow strategies, optional
         uid: User ID, optional
         chunks: Chunk list, must contain at least one element
         ragType: RAG type
+        datasetId: RAGFlow dataset.id for direct routing, optional
     """
 
     docId: str = Field(..., min_length=1, description="Required, minimum length 1")
-    group: str = Field(..., min_length=1, description="Required, minimum length 1")
+    group: Optional[str] = Field(
+        default=None,
+        description=_GROUP_DESC,
+    )
     uid: Optional[str] = Field(default=None, description="User ID")
     chunks: List[Any] = Field(
         ..., min_length=1, description="Chunk list, must contain at least one element"
     )
     ragType: RAGType = Field(..., description="RAG type")
+    datasetId: Optional[str] = Field(
+        default=None,
+        description=_DATASET_ID_DESC,
+    )
+
+    @model_validator(mode="after")
+    def _group_required_for_non_ragflow(self) -> "ChunkSaveReq":
+        _require_group_for_non_ragflow(self.ragType, self.group)
+        return self
 
 
 class ChunkUpdateReq(BaseModel):
@@ -102,14 +129,18 @@ class ChunkUpdateReq(BaseModel):
 
     Attributes:
         docId: Document ID, required
-        group: Group identifier, required
+        group: Knowledge base group used by non-Ragflow strategies, optional
         uid: User ID, optional
         chunks: Chunk dictionary list, must contain at least one element
         ragType: RAG type
+        datasetId: RAGFlow dataset.id for direct routing, optional
     """
 
     docId: str = Field(..., min_length=1, description="Required, minimum length 1")
-    group: str = Field(..., min_length=1, description="Required, minimum length 1")
+    group: Optional[str] = Field(
+        default=None,
+        description=_GROUP_DESC,
+    )
     uid: Optional[str] = Field(default=None, description="User ID")
     chunks: List[dict] = Field(
         ...,
@@ -117,6 +148,15 @@ class ChunkUpdateReq(BaseModel):
         description="Chunk dictionary list, must contain at least one element",
     )
     ragType: RAGType = Field(..., description="RAG type")
+    datasetId: Optional[str] = Field(
+        default=None,
+        description=_DATASET_ID_DESC,
+    )
+
+    @model_validator(mode="after")
+    def _group_required_for_non_ragflow(self) -> "ChunkUpdateReq":
+        _require_group_for_non_ragflow(self.ragType, self.group)
+        return self
 
 
 class ChunkDeleteReq(BaseModel):
@@ -127,7 +167,8 @@ class ChunkDeleteReq(BaseModel):
         docId: Document ID, required
         chunkIds: Chunk ID list, optional
         ragType: RAG type
-        group: RAGFlow dataset group, optional
+        group: Knowledge base group used by non-Ragflow strategies, optional
+        datasetId: RAGFlow dataset.id for direct routing, optional
     """
 
     docId: str = Field(..., min_length=1, description="Required, minimum length 1")
@@ -135,10 +176,11 @@ class ChunkDeleteReq(BaseModel):
     ragType: RAGType = Field(..., description="RAG type")
     group: Optional[str] = Field(
         default=None,
-        description=(
-            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
-            "When omitted, falls back to the default dataset."
-        ),
+        description=_GROUP_DESC,
+    )
+    datasetId: Optional[str] = Field(
+        default=None,
+        description=_DATASET_ID_DESC,
     )
 
 
@@ -158,6 +200,10 @@ class QueryMatch(BaseModel):
         ...,
         min_length=1,
         description="Knowledge base ID list, must contain at least one element",
+    )
+    datasetId: Optional[List[str]] = Field(
+        default=None,
+        description=_DATASET_ID_LIST_DESC,
     )
     threshold: float = Field(
         default=0, ge=0, le=1, description="Optional, default value 0, range 0~1"
@@ -261,15 +307,17 @@ class QueryDocReq(BaseModel):
     Attributes:
         docId: Document ID, required
         ragType: RAG type
-        group: RAGFlow dataset group, optional
+        group: Knowledge base group used by non-Ragflow strategies, optional
+        datasetId: RAGFlow dataset.id for direct routing, optional
     """
 
     docId: str = Field(..., min_length=1, description="Required, minimum length 1")
     ragType: RAGType = Field(..., description="RAG type")
     group: Optional[str] = Field(
         default=None,
-        description=(
-            "RAGFlow dataset group (coreRepoId for Ragflow-RAG). "
-            "When omitted, falls back to the default dataset."
-        ),
+        description=_GROUP_DESC,
+    )
+    datasetId: Optional[str] = Field(
+        default=None,
+        description=_DATASET_ID_DESC,
     )

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -16,8 +16,6 @@ from typing import Any, Dict, List, Optional, Union
 import aiohttp
 from fastapi import UploadFile
 
-from knowledge.consts.error_code import CodeEnum
-from knowledge.exceptions.exception import ThirdPartyException
 from knowledge.infra.ragflow.ragflow_client import (
     create_dataset,
     list_datasets,
@@ -43,44 +41,6 @@ class RagflowUtils:
     def get_default_dataset_name() -> str:
         """Return ``RAGFLOW_DEFAULT_GROUP`` or ``DEFAULT_RAGFLOW_DATASET_NAME`` (unset/empty fall back)."""
         return os.getenv("RAGFLOW_DEFAULT_GROUP") or DEFAULT_RAGFLOW_DATASET_NAME
-
-    @staticmethod
-    async def get_dataset_id_by_name(dataset_name: str) -> Optional[str]:
-        """Look up a dataset ID by name.
-
-        Returns ``None`` for not-found cases:
-        * ``code == 0`` with empty / non-matching data
-        * ``code == 108`` with a "lacks permission" message — RAGFlow
-          collapses "dataset does not exist" and "no access" into the same
-          response, so callers cannot distinguish them. Treating this as
-          not-found preserves fail-closed semantics for query routing.
-
-        Other non-zero codes raise ``ThirdPartyException``; transport
-        exceptions propagate.
-        """
-        from knowledge.infra.ragflow import ragflow_client
-
-        datasets_response = await ragflow_client.list_datasets(name=dataset_name)
-        code = datasets_response.get("code")
-        if code == 0:
-            datasets = datasets_response.get("data", [])
-            for dataset in datasets:
-                if dataset.get("name") == dataset_name:
-                    return dataset.get("id")
-            return None
-        msg = datasets_response.get("message", "Unknown error")
-        if code == 108 and "lacks permission" in msg.lower():
-            logger.info(
-                "Dataset %r not found on RAGFlow (code=108: %s); "
-                "treating as not-found",
-                dataset_name,
-                msg,
-            )
-            return None
-        raise ThirdPartyException(
-            msg=f"RAGFlow list_datasets name={dataset_name}: code={code} message={msg}",
-            e=CodeEnum.RAGFLOW_RAGError,
-        )
 
     @staticmethod
     def convert_ragflow_query_response(

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -6,11 +6,10 @@ RAGFlow Strategy Implementation Module
 Provides document processing and knowledge management strategy based on RAGFlow
 """
 
-import asyncio
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from knowledge.consts.error_code import CodeEnum
 from knowledge.domain.entity.chunk_dto import RagflowQueryExt
@@ -21,6 +20,8 @@ from knowledge.service.rag_strategy import RAGStrategy
 from knowledge.utils.verification import check_not_empty
 
 logger = logging.getLogger(__name__)
+
+_DATASET_ID_KWARG = "datasetId"
 
 
 class RagflowRAGStrategy(RAGStrategy):
@@ -40,7 +41,7 @@ class RagflowRAGStrategy(RAGStrategy):
         threshold: Optional[float] = 0,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Query RAGFlow with repo-aware dataset routing."""
+        """Query RAGFlow using datasetId when provided."""
         try:
             logger.info(
                 "Starting RAGFlow query: query=%s, doc_ids=%s, repo_ids=%s",
@@ -50,13 +51,8 @@ class RagflowRAGStrategy(RAGStrategy):
             )
             ext: Optional[RagflowQueryExt] = kwargs.get("ragflow_ext")
 
-            dataset_ids, missing = await self._resolve_query_datasets(repo_ids)
-            if missing:
-                logger.warning(
-                    "RAGFlow datasets missing for repos: %s "
-                    "(fail-closed: skipping these repos)",
-                    missing,
-                )
+            dataset_ids_input = kwargs.get(_DATASET_ID_KWARG)
+            dataset_ids = await self._resolve_query_datasets(dataset_ids_input)
             if not dataset_ids:
                 return self._empty_query_result(query)
 
@@ -90,26 +86,24 @@ class RagflowRAGStrategy(RAGStrategy):
             ) from e
 
     async def _resolve_query_datasets(
-        self, repo_ids: Optional[List[str]]
-    ) -> Tuple[List[str], List[str]]:
-        """Resolve RAGFlow dataset_ids from repo_ids; return (found, missing)."""
-        if not repo_ids:
+        self, dataset_ids: Optional[List[str]]
+    ) -> List[str]:
+        """Return requested dataset ids or the default dataset id."""
+        if not dataset_ids:
             default_name = RagflowUtils.get_default_dataset_name()
-            ds_id = await RagflowUtils.get_dataset_id_by_name(default_name)
-            return ([ds_id] if ds_id else [], [])
+            ds_id = await RagflowUtils.ensure_dataset(default_name)
+            return [ds_id] if ds_id else []
+        return list(dataset_ids)
 
-        # Concurrent lookup: multi-repo query latency = 1 × RTT, not N × RTT.
-        results = await asyncio.gather(
-            *(RagflowUtils.get_dataset_id_by_name(rid) for rid in repo_ids)
-        )
-        dataset_ids: List[str] = []
-        missing: List[str] = []
-        for repo_id, ds_id in zip(repo_ids, results):
-            if ds_id:
-                dataset_ids.append(ds_id)
-            else:
-                missing.append(repo_id)
-        return (dataset_ids, missing)
+    async def _resolve_dataset_id(
+        self,
+        dataset_id_input: Optional[str],
+    ) -> Optional[str]:
+        """Return requested dataset id or the default dataset id."""
+        if dataset_id_input:
+            return dataset_id_input
+        default_name = RagflowUtils.get_default_dataset_name()
+        return await RagflowUtils.ensure_dataset(default_name)
 
     def _build_retrieval_payload(
         self,
@@ -187,7 +181,7 @@ class RagflowRAGStrategy(RAGStrategy):
         return {"query": query, "count": len(results), "results": results}
 
     def _empty_query_result(self, query: str) -> Dict[str, Any]:
-        """Unified empty-result format for fail-closed query paths."""
+        """Unified empty-result format for query paths."""
         return {"query": query, "count": 0, "results": []}
 
     def _validate_split_parameters(
@@ -293,7 +287,7 @@ class RagflowRAGStrategy(RAGStrategy):
         Split file into chunks using RAGFlow.
 
         Complete process:
-        1. Check or create dataset (using group as dataset name)
+        1. Resolve target dataset by id
         2. File download/reading and type detection
         3. Upload document to RAGFlow
         4. Trigger parsing
@@ -308,7 +302,7 @@ class RagflowRAGStrategy(RAGStrategy):
             separator: List of separators
             titleSplit: Whether to split by title
             cutOff: Truncation rules
-            **kwargs: Other parameters, including group (dataset name), file
+            **kwargs: Other parameters, including datasetId (RAGFlow dataset.id), file
 
         Returns:
             List of chunk results in format:
@@ -323,12 +317,6 @@ class RagflowRAGStrategy(RAGStrategy):
                 }
             ]
         """
-        # ``group`` falls back to the default dataset (legacy callers may omit it);
-        # ``group_description`` deliberately has no fallback — when the upstream
-        # caller does not supply a human-readable label, ensure_dataset uses its
-        # own "Automatically created dataset: {group}" placeholder on first create.
-        group = kwargs.get("group") or RagflowUtils.get_default_dataset_name()
-        group_description = kwargs.get("groupDescription")
         file = kwargs.get("file")
 
         # Parameter validation
@@ -344,18 +332,20 @@ class RagflowRAGStrategy(RAGStrategy):
         input_type = "file upload" if file else "URL/path"
         display_name = getattr(file, "filename", fileUrl) if file else fileUrl
         logger.info(
-            "Starting split request: %s (%s), group: %s",
+            "Starting split request: %s (%s)",
             display_name,
             input_type,
-            group,
         )
 
         try:
-            # Step 1: Dataset management
-            dataset_id = await RagflowUtils.ensure_dataset(
-                group, description=group_description
-            )
-            logger.info("Using dataset: %s, name: %s", dataset_id, group)
+            # Step 1: Resolve dataset
+            dataset_id = await self._resolve_dataset_id(kwargs.get(_DATASET_ID_KWARG))
+            if not dataset_id:
+                raise CustomException(
+                    CodeEnum.RAGFLOW_RAGError,
+                    "Unable to resolve RAGFlow dataset",
+                )
+            logger.info("Using dataset: %s", dataset_id)
 
             if document_id:
                 logger.info("re-slice upsert old_doc_id=%s", document_id)
@@ -401,23 +391,17 @@ class RagflowRAGStrategy(RAGStrategy):
     async def _validate_chunks_save_config(
         self,
         doc_id: str,
-        group: Optional[str] = None,
-        description: Optional[str] = None,
+        dataset_id: Optional[str] = None,
     ) -> str:
-        """Resolve dataset for chunks_save; lazy-creates if missing."""
-        group_name = group or RagflowUtils.get_default_dataset_name()
-
-        dataset_id = await RagflowUtils.ensure_dataset(
-            group_name, description=description
-        )
-        if not dataset_id:
-            logger.error(f"Unable to find or create dataset: {group_name}")
+        """Resolve dataset for chunks_save."""
+        resolved = await self._resolve_dataset_id(dataset_id)
+        if not resolved:
+            logger.error("Unable to resolve RAGFlow dataset for chunks_save")
             raise CustomException(
                 CodeEnum.ChunkSaveFailed,
-                f"Unable to find or create dataset: {group_name}",
+                "Unable to resolve RAGFlow dataset",
             )
-
-        return dataset_id
+        return resolved
 
     async def _validate_document_exists(self, dataset_id: str, doc_id: str) -> None:
         """Validate that the document exists in RAGFlow.
@@ -677,14 +661,20 @@ class RagflowRAGStrategy(RAGStrategy):
         return saved_chunks
 
     async def chunks_save(
-        self, docId: str, group: str, uid: str, chunks: List[object], **kwargs: Any
+        self,
+        docId: str,
+        group: Optional[str],
+        uid: str,
+        chunks: List[object],
+        **kwargs: Any,
     ) -> List[Dict[str, Any]]:
         """
         Save knowledge chunks using RAGFlow.
 
         Args:
             docId: Document ID
-            group: Group (dataset name)
+            group: Required by the abstract base for cross-strategy
+                compatibility; unused here. Ragflow routes by datasetId.
             uid: User ID
             chunks: List of knowledge chunks, each chunk contains:
                    - docId: Document ID
@@ -693,7 +683,7 @@ class RagflowRAGStrategy(RAGStrategy):
                    - content: Text content
                    - context: Context
                    - references: Reference information
-            **kwargs: Other parameters
+            **kwargs: Other parameters, including datasetId (RAGFlow dataset.id)
 
         Returns:
             List of save results in format:
@@ -718,12 +708,12 @@ class RagflowRAGStrategy(RAGStrategy):
             )
 
         logger.info(
-            f"Starting chunk save request: docId={docId}, group={group}, chunks_count={len(chunks)}"
+            f"Starting chunk save request: docId={docId}, chunks_count={len(chunks)}"
         )
 
         try:
             dataset_id = await self._validate_chunks_save_config(
-                docId, group, description=kwargs.get("groupDescription")
+                docId, dataset_id=kwargs.get(_DATASET_ID_KWARG)
             )
             logger.info(f"Using dataset: {dataset_id}")
 
@@ -750,21 +740,16 @@ class RagflowRAGStrategy(RAGStrategy):
             logger.error(f"Chunk save operation failed: {e}")
             raise CustomException(CodeEnum.ChunkSaveFailed, str(e))
 
-    async def _validate_chunks_update_config(self, group: Optional[str] = None) -> str:
-        """Resolve dataset for chunks_update; never lazy-creates.
-
-        Update against a non-existent dataset is a logic error and surfaces
-        as ``ChunkUpdateFailed``.
-        """
-        group_name = group or RagflowUtils.get_default_dataset_name()
-
-        dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
-        if not dataset_id:
-            err = f"Dataset {group_name!r} not found in RAGFlow, cannot update chunk"
+    async def _validate_chunks_update_config(
+        self, dataset_id: Optional[str] = None
+    ) -> str:
+        """Resolve dataset for chunks_update."""
+        resolved = await self._resolve_dataset_id(dataset_id)
+        if not resolved:
+            err = "Unable to resolve RAGFlow dataset for chunks_update"
             logger.error(err)
             raise CustomException(CodeEnum.ChunkUpdateFailed, err)
-
-        return dataset_id
+        return resolved
 
     async def _process_chunk_update(
         self,
@@ -853,7 +838,7 @@ class RagflowRAGStrategy(RAGStrategy):
     async def chunks_update(
         self,
         docId: str,
-        group: str,
+        group: Optional[str],
         uid: str,
         chunks: List[Dict[str, Any]],
         **kwargs: Any,
@@ -863,7 +848,8 @@ class RagflowRAGStrategy(RAGStrategy):
 
         Args:
             docId: Document ID
-            group: Group (dataset name)
+            group: Required by the abstract base for cross-strategy
+                compatibility; unused here. Ragflow routes by datasetId.
             uid: User ID
             chunks: List of knowledge chunks, each chunk contains:
                    - docId: Document ID
@@ -873,7 +859,7 @@ class RagflowRAGStrategy(RAGStrategy):
                    - context: Context
                    - references: Reference information
                    - docInfo: Document information
-            **kwargs: Other parameters
+            **kwargs: Other parameters, including datasetId (RAGFlow dataset.id)
 
         Returns:
             Update result data:
@@ -887,11 +873,13 @@ class RagflowRAGStrategy(RAGStrategy):
             )
 
         logger.info(
-            f"Processing chunk update request: docId={docId}, group={group}, chunks_count={len(chunks)}"
+            f"Processing chunk update request: docId={docId}, chunks_count={len(chunks)}"
         )
 
         try:
-            dataset_id = await self._validate_chunks_update_config(group)
+            dataset_id = await self._validate_chunks_update_config(
+                kwargs.get(_DATASET_ID_KWARG)
+            )
             logger.info(f"Using dataset: {dataset_id}")
 
             failed_chunks: Dict[str, str] = {}
@@ -924,7 +912,6 @@ class RagflowRAGStrategy(RAGStrategy):
         self,
         docId: str,
         chunkIds: List[str],
-        group: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -933,11 +920,8 @@ class RagflowRAGStrategy(RAGStrategy):
         Args:
             docId: Document ID
             chunkIds: List of chunk IDs to delete
-            group: Optional RAGFlow dataset name. ``None`` falls back to the
-                configured default group. Resolution does NOT lazy-create —
-                if the dataset does not exist the delete is a no-op
-                (idempotent).
-            **kwargs: Additional parameters
+            **kwargs: Additional parameters, including datasetId (RAGFlow
+                dataset.id). When omitted/empty, uses the default dataset.
 
         Returns:
             None if successful
@@ -954,20 +938,19 @@ class RagflowRAGStrategy(RAGStrategy):
 
         logger.info(
             f"Processing chunk deletion request: docId={docId}, "
-            f"group={group}, chunks_count={len(chunkIds)}"
+            f"chunks_count={len(chunkIds)}"
         )
 
         try:
-            group_name = group or RagflowUtils.get_default_dataset_name()
-            dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
-            if dataset_id is None:
+            dataset_id = await self._resolve_dataset_id(kwargs.get(_DATASET_ID_KWARG))
+            if not dataset_id:
                 logger.info(
-                    f"Dataset {group_name!r} not found in RAGFlow, "
-                    f"treating delete as no-op (idempotent)"
+                    "Unable to resolve RAGFlow dataset, "
+                    "treating delete as no-op (idempotent)"
                 )
                 return None
 
-            logger.info(f"Using dataset: {group_name} (ID: {dataset_id})")
+            logger.info(f"Using dataset: {dataset_id}")
 
             # 2. Call RAGFlow deletion API directly
             delete_response = await ragflow_client.delete_chunks(
@@ -996,20 +979,15 @@ class RagflowRAGStrategy(RAGStrategy):
                 CodeEnum.ChunkDeleteFailed, f"Deletion operation failed: {str(e)}"
             )
 
-    async def query_doc(
-        self, docId: str, group: Optional[str] = None, **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+    async def query_doc(self, docId: str, **kwargs: Any) -> List[Dict[str, Any]]:
         """Query all chunk information for a document using RAGFlow."""
         try:
             logger.info(f"Starting document chunk query: docId={docId}")
 
-            group_name = group or RagflowUtils.get_default_dataset_name()
-            dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
+            dataset_id = await self._resolve_dataset_id(kwargs.get(_DATASET_ID_KWARG))
             if not dataset_id:
                 logger.warning(
-                    "RAGFlow dataset missing for group %r "
-                    "(fail-closed: returning empty)",
-                    group_name,
+                    "Unable to resolve RAGFlow dataset for query_doc; returning empty"
                 )
                 return []
 
@@ -1082,19 +1060,16 @@ class RagflowRAGStrategy(RAGStrategy):
             ) from e
 
     async def query_doc_name(
-        self, docId: str, group: Optional[str] = None, **kwargs: Any
+        self, docId: str, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
         """Query document name and information using RAGFlow."""
         try:
             logger.info(f"Starting document info query: docId={docId}")
 
-            group_name = group or RagflowUtils.get_default_dataset_name()
-            dataset_id = await RagflowUtils.get_dataset_id_by_name(group_name)
+            dataset_id = await self._resolve_dataset_id(kwargs.get(_DATASET_ID_KWARG))
             if not dataset_id:
                 logger.warning(
-                    "RAGFlow dataset missing for group %r "
-                    "(fail-closed: returning None)",
-                    group_name,
+                    "Unable to resolve RAGFlow dataset for query_doc_name; returning None"
                 )
                 return None
 

--- a/core/knowledge/tests/api/v1/chunk_query_test.py
+++ b/core/knowledge/tests/api/v1/chunk_query_test.py
@@ -190,6 +190,28 @@ async def test_ragflow_ext_not_in_kwargs_when_unset(
 
 
 @pytest.mark.asyncio
+async def test_dataset_id_forwarded_as_internal_contract(
+    app: Any, infra_mocks: Tuple[MagicMock, MagicMock]
+) -> None:
+    """Service-injected datasetId is forwarded to the Ragflow strategy."""
+    from fastapi.testclient import TestClient
+
+    strategy_mock = _make_strategy_mock()
+    with (
+        patch(_GET_SPAN_AND_METRIC, return_value=infra_mocks),
+        patch(_REWRITE_QUERY, new=AsyncMock(return_value="rewritten-query")),
+        patch(_GET_STRATEGY, return_value=strategy_mock),
+    ):
+        client = TestClient(app)
+        body = _base_request_body()
+        body["match"]["datasetId"] = ["ds-console"]
+        response = client.post("/knowledge/v1/chunk/query", json=body)
+
+    assert response.status_code == 200
+    assert strategy_mock.query.await_args.kwargs["datasetId"] == ["ds-console"]
+
+
+@pytest.mark.asyncio
 async def test_validation_error_when_ragflow_ext_with_non_ragflow_ragtype(
     app: Any,
 ) -> None:

--- a/core/knowledge/tests/api/v1/dataset_create_endpoint_test.py
+++ b/core/knowledge/tests/api/v1/dataset_create_endpoint_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for POST /knowledge/v1/dataset/create admin endpoint.
+
+Covers:
+- success: ensure_dataset returns dataset_id, response wraps it
+- ensure_dataset raises ThirdPartyException -> propagates as non-zero code
+- ensure_dataset raises bare Exception -> wrapped as RAGFLOW_RAGError
+- blank name rejected via project's global validation handler (HTTP 200 + non-zero code)
+- description optional
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from knowledge.consts.error_code import CodeEnum
+from knowledge.exceptions.exception import ThirdPartyException
+
+_ENSURE_DATASET = "knowledge.api.v1.api.RagflowUtils.ensure_dataset"
+
+
+@pytest.fixture
+def client() -> Any:
+    from knowledge.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+def test_create_dataset_success(client: Any) -> None:
+    with patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-abc-123")):
+        resp = client.post(
+            "/knowledge/v1/dataset/create",
+            json={"name": "uuid-name", "description": "kb_alpha"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 0
+    assert body["data"] == {"datasetId": "ds-abc-123"}
+
+
+def test_create_dataset_third_party_propagates(client: Any) -> None:
+    err = ThirdPartyException(msg="RAGFlow unreachable", e=CodeEnum.RAGFLOW_RAGError)
+    with patch(_ENSURE_DATASET, new=AsyncMock(side_effect=err)):
+        resp = client.post(
+            "/knowledge/v1/dataset/create",
+            json={"name": "uuid-name", "description": "kb_alpha"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != 0
+    assert "RAGFlow unreachable" in body["message"]
+
+
+def test_create_dataset_unexpected_wrapped(client: Any) -> None:
+    with patch(_ENSURE_DATASET, new=AsyncMock(side_effect=RuntimeError("boom"))):
+        resp = client.post(
+            "/knowledge/v1/dataset/create",
+            json={"name": "uuid-name", "description": "kb_alpha"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != 0
+    assert "boom" in body["message"]
+
+
+def test_create_dataset_blank_name_rejected(client: Any) -> None:
+    """The project's global RequestValidationError handler returns
+    HTTP 200 with an application-level non-zero code instead of the
+    stock 422 for any pydantic validation failure (see knowledge/main.py).
+    """
+    resp = client.post(
+        "/knowledge/v1/dataset/create",
+        json={"name": "", "description": "kb_alpha"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != 0
+
+
+def test_create_dataset_description_optional(client: Any) -> None:
+    with patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-only-name")):
+        resp = client.post(
+            "/knowledge/v1/dataset/create",
+            json={"name": "uuid-name"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["data"] == {"datasetId": "ds-only-name"}

--- a/core/knowledge/tests/domain/entity/chunk_dto_test.py
+++ b/core/knowledge/tests/domain/entity/chunk_dto_test.py
@@ -90,33 +90,33 @@ class TestFileSplitReq:
         )
         assert req.documentId == "doc-abc-123"
 
-    def test_group_default_none(self) -> None:
-        """FileSplitReq.group is Optional, default None for backward compat."""
+    def test_dataset_id_default_none(self) -> None:
+        """FileSplitReq.datasetId is Optional, default None."""
         req = FileSplitReq(file="test content", ragType=RAGType.RagFlow_RAG)
+        assert req.datasetId is None
+
+    def test_dataset_id_accepts_string(self) -> None:
+        """FileSplitReq.datasetId accepts an explicit RAGFlow dataset.id."""
+        req = FileSplitReq(
+            file="test content",
+            ragType=RAGType.RagFlow_RAG,
+            datasetId="ds-abc-uuid",
+        )
+        assert req.datasetId == "ds-abc-uuid"
+
+    def test_group_default_none(self) -> None:
+        """FileSplitReq.group is Optional, default None."""
+        req = FileSplitReq(file="test content", ragType=RAGType.AIUI_RAG2)
         assert req.group is None
 
     def test_group_accepts_string(self) -> None:
-        """FileSplitReq.group accepts explicit RAGFlow dataset group/name."""
+        """FileSplitReq.group accepts a knowledge base group name."""
         req = FileSplitReq(
             file="test content",
-            ragType=RAGType.RagFlow_RAG,
-            group="abc-uuid",
+            ragType=RAGType.AIUI_RAG2,
+            group="legacy-name",
         )
-        assert req.group == "abc-uuid"
-
-    def test_group_description_default_none(self) -> None:
-        """FileSplitReq.groupDescription is Optional, default None."""
-        req = FileSplitReq(file="test content", ragType=RAGType.RagFlow_RAG)
-        assert req.groupDescription is None
-
-    def test_group_description_accepts_string(self) -> None:
-        """FileSplitReq.groupDescription accepts a human-readable label."""
-        req = FileSplitReq(
-            file="test content",
-            ragType=RAGType.RagFlow_RAG,
-            groupDescription="客服知识库",
-        )
-        assert req.groupDescription == "客服知识库"
+        assert req.group == "legacy-name"
 
 
 class TestChunkSaveReq:
@@ -126,33 +126,64 @@ class TestChunkSaveReq:
         """Test valid creation with required fields."""
         req = ChunkSaveReq(
             docId="doc123",
-            group="test-group",
+            group="group1",
             chunks=[{"content": "test chunk"}],
             ragType=RAGType.AIUI_RAG2,
         )
         assert req.docId == "doc123"
-        assert req.group == "test-group"
         assert req.chunks == [{"content": "test chunk"}]
         assert req.ragType == RAGType.AIUI_RAG2
         assert req.uid is None  # default value
+        assert req.datasetId is None  # default value
 
     def test_with_uid(self) -> None:
         """Test creation with optional uid field."""
         req = ChunkSaveReq(
             docId="doc123",
-            group="test-group",
+            group="group1",
             uid="user456",
             chunks=[{"content": "test chunk"}],
             ragType=RAGType.AIUI_RAG2,
         )
         assert req.uid == "user456"
 
+    def test_with_dataset_id(self) -> None:
+        """Test creation with explicit datasetId for direct routing."""
+        req = ChunkSaveReq(
+            docId="doc123",
+            chunks=[{"content": "test chunk"}],
+            ragType=RAGType.RagFlow_RAG,
+            datasetId="ds-abc-123",
+        )
+        assert req.datasetId == "ds-abc-123"
+
+    def test_group_required_for_non_ragflow(self) -> None:
+        """ChunkSaveReq requires group for non-Ragflow strategies."""
+        with pytest.raises(ValidationError) as exc_info:
+            ChunkSaveReq(
+                docId="doc123",
+                chunks=[{"content": "test"}],
+                ragType=RAGType.AIUI_RAG2,
+            )
+
+        assert "group is required when ragType is not Ragflow-RAG" in str(
+            exc_info.value
+        )
+
+    def test_group_accepts_string(self) -> None:
+        """ChunkSaveReq.group accepts a knowledge base group name."""
+        req = ChunkSaveReq(
+            docId="doc123",
+            group="legacy-name",
+            chunks=[{"content": "test"}],
+            ragType=RAGType.AIUI_RAG2,
+        )
+        assert req.group == "legacy-name"
+
     def test_empty_chunks_validation(self) -> None:
         """Test chunks list empty validation."""
         with pytest.raises(ValidationError) as exc_info:
-            ChunkSaveReq(
-                docId="doc123", group="test-group", chunks=[], ragType=RAGType.AIUI_RAG2
-            )
+            ChunkSaveReq(docId="doc123", chunks=[], ragType=RAGType.AIUI_RAG2)
 
         errors = exc_info.value.errors()
         assert len(errors) == 1
@@ -167,7 +198,10 @@ class TestChunkSaveReq:
             {"content": "chunk 3"},
         ]
         req = ChunkSaveReq(
-            docId="doc123", group="test-group", chunks=chunks, ragType=RAGType.AIUI_RAG2
+            docId="doc123",
+            group="group1",
+            chunks=chunks,
+            ragType=RAGType.AIUI_RAG2,
         )
         assert req.chunks == chunks
 
@@ -176,7 +210,6 @@ class TestChunkSaveReq:
         with pytest.raises(ValidationError) as exc_info:
             ChunkSaveReq(
                 docId="",
-                group="test-group",
                 chunks=[{"content": "test"}],
                 ragType=RAGType.AIUI_RAG2,
             )
@@ -194,25 +227,58 @@ class TestChunkUpdateReq:
         """Test valid creation."""
         req = ChunkUpdateReq(
             docId="doc123",
-            group="test-group",
+            group="group1",
             chunks=[{"id": "chunk1", "content": "updated content"}],
             ragType=RAGType.AIUI_RAG2,
         )
         assert req.docId == "doc123"
-        assert req.group == "test-group"
         assert req.chunks == [{"id": "chunk1", "content": "updated content"}]
         assert req.ragType == RAGType.AIUI_RAG2
+        assert req.datasetId is None
 
     def test_chunks_must_be_dict(self) -> None:
         """Test chunks must be dictionary objects."""
         req = ChunkUpdateReq(
             docId="doc123",
-            group="test-group",
+            group="group1",
             chunks=[{"id": "chunk1"}, {"id": "chunk2"}],
             ragType=RAGType.AIUI_RAG2,
         )
         assert len(req.chunks) == 2
         assert all(isinstance(chunk, dict) for chunk in req.chunks)
+
+    def test_with_dataset_id(self) -> None:
+        """Test creation with explicit datasetId for direct routing."""
+        req = ChunkUpdateReq(
+            docId="doc123",
+            chunks=[{"id": "chunk1", "content": "x"}],
+            ragType=RAGType.RagFlow_RAG,
+            datasetId="ds-abc-123",
+        )
+        assert req.datasetId == "ds-abc-123"
+
+    def test_group_required_for_non_ragflow(self) -> None:
+        """ChunkUpdateReq requires group for non-Ragflow strategies."""
+        with pytest.raises(ValidationError) as exc_info:
+            ChunkUpdateReq(
+                docId="doc123",
+                chunks=[{"id": "c1"}],
+                ragType=RAGType.AIUI_RAG2,
+            )
+
+        assert "group is required when ragType is not Ragflow-RAG" in str(
+            exc_info.value
+        )
+
+    def test_group_accepts_string(self) -> None:
+        """ChunkUpdateReq.group accepts a knowledge base group name."""
+        req = ChunkUpdateReq(
+            docId="doc123",
+            group="legacy-name",
+            chunks=[{"id": "c1"}],
+            ragType=RAGType.AIUI_RAG2,
+        )
+        assert req.group == "legacy-name"
 
 
 class TestChunkDeleteReq:
@@ -239,20 +305,35 @@ class TestChunkDeleteReq:
         req = ChunkDeleteReq(docId="doc123", chunkIds=[], ragType=RAGType.AIUI_RAG2)
         assert req.chunkIds == []
 
-    def test_group_default_none(self) -> None:
-        """ChunkDeleteReq.group is Optional, default None for backward compat."""
+    def test_dataset_id_default_none(self) -> None:
+        """ChunkDeleteReq.datasetId is Optional, default None."""
         req = ChunkDeleteReq(docId="doc123", ragType=RAGType.RagFlow_RAG)
-        assert req.group is None
+        assert req.datasetId is None
 
-    def test_group_accepts_string(self) -> None:
-        """ChunkDeleteReq.group accepts explicit RAGFlow dataset group/name."""
+    def test_dataset_id_accepts_string(self) -> None:
+        """ChunkDeleteReq.datasetId accepts an explicit RAGFlow dataset.id."""
         req = ChunkDeleteReq(
             docId="doc123",
             chunkIds=["c1"],
             ragType=RAGType.RagFlow_RAG,
-            group="abc-uuid",
+            datasetId="ds-abc-123",
         )
-        assert req.group == "abc-uuid"
+        assert req.datasetId == "ds-abc-123"
+
+    def test_group_default_none(self) -> None:
+        """ChunkDeleteReq.group is Optional, default None."""
+        req = ChunkDeleteReq(docId="doc123", ragType=RAGType.AIUI_RAG2)
+        assert req.group is None
+
+    def test_group_accepts_string(self) -> None:
+        """ChunkDeleteReq.group accepts a knowledge base group name."""
+        req = ChunkDeleteReq(
+            docId="doc123",
+            chunkIds=["c1"],
+            ragType=RAGType.AIUI_RAG2,
+            group="legacy-name",
+        )
+        assert req.group == "legacy-name"
 
 
 class TestQueryMatch:
@@ -417,15 +498,29 @@ class TestQueryDocReq:
         assert "docId" in field_names
         assert "ragType" in field_names
 
-    def test_group_default_none(self) -> None:
-        """group is Optional, default None for backward compat."""
+    def test_dataset_id_default_none(self) -> None:
+        """QueryDocReq.datasetId is Optional, default None."""
         req = QueryDocReq(docId="doc123", ragType=RAGType.RagFlow_RAG)
+        assert req.datasetId is None
+
+    def test_dataset_id_accepts_string(self) -> None:
+        """QueryDocReq.datasetId accepts an explicit RAGFlow dataset.id."""
+        req = QueryDocReq(
+            docId="doc123", ragType=RAGType.RagFlow_RAG, datasetId="ds-abc-123"
+        )
+        assert req.datasetId == "ds-abc-123"
+
+    def test_group_default_none(self) -> None:
+        """QueryDocReq.group is Optional, default None."""
+        req = QueryDocReq(docId="doc123", ragType=RAGType.AIUI_RAG2)
         assert req.group is None
 
     def test_group_accepts_string(self) -> None:
-        """group accepts explicit string value."""
-        req = QueryDocReq(docId="doc123", ragType=RAGType.RagFlow_RAG, group="abc-uuid")
-        assert req.group == "abc-uuid"
+        """QueryDocReq.group accepts a knowledge base group name."""
+        req = QueryDocReq(
+            docId="doc123", ragType=RAGType.AIUI_RAG2, group="legacy-name"
+        )
+        assert req.group == "legacy-name"
 
 
 class TestIntegrationCases:
@@ -639,3 +734,33 @@ class TestChunkQueryReqScopeValidator:
         ):
             req = ChunkQueryReq(**self._kwargs_for(rag_type))
             assert req.ragflow_ext is None
+
+
+class TestMatchDatasetId:
+    """Tests for QueryMatch.datasetId (by-id routing field)."""
+
+    def test_dataset_id_default_none(self) -> None:
+        from knowledge.domain.entity.chunk_dto import ChunkQueryReq
+
+        req = ChunkQueryReq(
+            query="q",
+            topN=3,
+            match={"repoId": ["r1"], "threshold": 0.5},
+            ragType="Ragflow-RAG",
+        )
+        assert req.match.datasetId is None
+
+    def test_dataset_id_accepts_list(self) -> None:
+        from knowledge.domain.entity.chunk_dto import ChunkQueryReq
+
+        req = ChunkQueryReq(
+            query="q",
+            topN=3,
+            match={
+                "repoId": ["r1"],
+                "datasetId": ["ds-1", "ds-2"],
+                "threshold": 0.5,
+            },
+            ragType="Ragflow-RAG",
+        )
+        assert req.match.datasetId == ["ds-1", "ds-2"]

--- a/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
@@ -6,28 +6,19 @@ Unit tests for ``RagflowUtils`` helpers used by the RAGFlow strategy.
 Covers:
 
 - ``get_default_dataset_name``: unified ``RAGFLOW_DEFAULT_GROUP`` reader
-  across the four strategy call sites (``split`` / ``chunks_save`` /
-  ``chunks_update`` / ``chunks_delete``).
-- ``get_dataset_id_by_name``: dataset-lookup failures should propagate
-  instead of collapsing into ``None``.
+  used as the fallback dataset for write/lookup paths when no explicit
+  dataset id is supplied.
+- ``ensure_dataset``: lazy create + best-effort description sync.
 """
 
 from unittest.mock import AsyncMock, patch
 
-import aiohttp
 import pytest
 
-from knowledge.exceptions.exception import ThirdPartyException
 from knowledge.infra.ragflow.ragflow_utils import (
     DEFAULT_RAGFLOW_DATASET_NAME,
     RagflowUtils,
 )
-
-# Mock the module-level ``list_datasets`` import resolved inside
-# ``get_dataset_id_by_name``. The helper reaches it via
-# ``ragflow_client.list_datasets``; patching the client attribute covers
-# both dotted and direct-import access paths.
-_LIST_DATASETS = "knowledge.infra.ragflow.ragflow_client.list_datasets"
 
 
 class TestGetDefaultDatasetName:
@@ -48,74 +39,6 @@ class TestGetDefaultDatasetName:
     ) -> None:
         monkeypatch.setenv("RAGFLOW_DEFAULT_GROUP", "")
         assert RagflowUtils.get_default_dataset_name() == DEFAULT_RAGFLOW_DATASET_NAME
-
-
-class TestGetDatasetIdByName:
-    """Tests for ``RagflowUtils.get_dataset_id_by_name``."""
-
-    @pytest.mark.asyncio
-    async def test_returns_id_on_matching_dataset(self) -> None:
-        """code=0 + matching dataset => returns dataset id."""
-        resp = {"code": 0, "data": [{"id": "ds-1", "name": "MyKB"}]}
-        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
-            result = await RagflowUtils.get_dataset_id_by_name("MyKB")
-        assert result == "ds-1"
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_no_match(self) -> None:
-        """Back-compat: code=0 + empty data => ``None`` so the caller can
-        treat it as 'dataset not configured', preserving the
-        fallback-to-empty-result behavior for genuine no-match cases."""
-        resp = {"code": 0, "data": []}
-        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
-            result = await RagflowUtils.get_dataset_id_by_name("MissingKB")
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_raises_on_transport_exception(self) -> None:
-        """aiohttp errors propagate instead of being collapsed into ``None``."""
-        with patch(
-            _LIST_DATASETS,
-            new=AsyncMock(side_effect=aiohttp.ClientConnectionError("down")),
-        ):
-            with pytest.raises(aiohttp.ClientConnectionError):
-                await RagflowUtils.get_dataset_id_by_name("AnyKB")
-
-    @pytest.mark.asyncio
-    async def test_raises_on_non_zero_code(self) -> None:
-        """Non-zero code (auth / argument / operating error) => ThirdPartyException.
-        Genuine protocol failures still surface; only the not-found shapes
-        below are folded into ``None``."""
-        resp = {"code": 109, "message": "Authentication failed"}
-        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
-            with pytest.raises(ThirdPartyException) as exc_info:
-                await RagflowUtils.get_dataset_id_by_name("AnyKB")
-        assert "Authentication failed" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_code_108_lacks_permission(self) -> None:
-        """code=108 with 'lacks permission' message => not-found => ``None``.
-
-        RAGFlow returns this shape for both nonexistent and inaccessible
-        datasets; callers cannot tell them apart, so the safe fail-closed
-        behavior is to treat it as not-found rather than raising.
-        """
-        resp = {
-            "code": 108,
-            "message": "User 'u-1' lacks permission for dataset 'MissingKB'",
-        }
-        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
-            result = await RagflowUtils.get_dataset_id_by_name("MissingKB")
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_raises_on_code_108_unrelated_message(self) -> None:
-        """code=108 without 'lacks permission' marker still raises so we don't
-        silently swallow other 108-class errors."""
-        resp = {"code": 108, "message": "Some other 108 error"}
-        with patch(_LIST_DATASETS, new=AsyncMock(return_value=resp)):
-            with pytest.raises(ThirdPartyException):
-                await RagflowUtils.get_dataset_id_by_name("AnyKB")
 
 
 # ---------------------------------------------------------------------------

--- a/core/knowledge/tests/service/impl/ragflow_strategy_chunks_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_chunks_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Tests for RagflowRAGStrategy chunks_save / chunks_update / chunks_delete
-group routing behavior."""
+dataset routing behavior."""
 
 import logging
 from unittest.mock import AsyncMock, patch
@@ -15,23 +15,20 @@ _ENSURE_DATASET = "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_d
 _GET_DATASET_NAME = (
     "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
 )
-_GET_DATASET_ID = (
-    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
-)
 
 
 # ----------------------------------------------------------------------
-# chunks_save (lazy create via ensure_dataset)
+# chunks_save
 # ----------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_chunks_save_routes_to_group_dataset_with_lazy_create() -> None:
-    """chunks_save with explicit group calls ensure_dataset(group)."""
+async def test_chunks_save_passes_through_explicit_dataset_id() -> None:
+    """chunks_save with non-empty datasetId skips ensure_dataset."""
     strategy = RagflowRAGStrategy()
     with patch(
         _ENSURE_DATASET,
-        new=AsyncMock(return_value="ds-abc"),
+        new=AsyncMock(),
     ) as mock_ensure, patch.object(
         strategy,
         "_validate_document_exists",
@@ -43,24 +40,28 @@ async def test_chunks_save_routes_to_group_dataset_with_lazy_create() -> None:
     ), patch.object(
         strategy,
         "_process_chunks_batch",
-        new=AsyncMock(return_value=([{"id": "c1"}], [])),
-    ), patch.object(
+        new=AsyncMock(
+            return_value=([{"id": "c1", "datasetId": "ds-explicit-123"}], [])
+        ),
+    ) as mock_batch, patch.object(
         strategy,
         "_handle_chunk_results",
         new=AsyncMock(return_value=[{"id": "c1"}]),
     ):
         await strategy.chunks_save(
             docId="doc-1",
-            group="abc-uuid",
+            group=None,
             uid="user-1",
             chunks=[{"content": "hello"}],
+            datasetId="ds-explicit-123",
         )
-        mock_ensure.assert_awaited_once_with("abc-uuid", description=None)
+        mock_ensure.assert_not_called()
+        assert mock_batch.await_args.args[1] == "ds-explicit-123"
 
 
 @pytest.mark.asyncio
-async def test_chunks_save_with_null_group_falls_back_to_default() -> None:
-    """chunks_save with group=None falls back to RAGFLOW_DEFAULT_GROUP."""
+async def test_chunks_save_with_null_dataset_id_falls_back_to_default() -> None:
+    """chunks_save with datasetId=None ensures the default dataset exists."""
     strategy = RagflowRAGStrategy()
     with patch(
         _GET_DATASET_NAME,
@@ -90,79 +91,71 @@ async def test_chunks_save_with_null_group_falls_back_to_default() -> None:
             group=None,
             uid="user-1",
             chunks=[{"content": "hello"}],
+            datasetId=None,
         )
-        mock_ensure.assert_awaited_once_with("default-group", description=None)
+        mock_ensure.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
-async def test_chunks_save_lazy_creates_when_group_dataset_missing() -> None:
-    """chunks_save uses ensure_dataset which lazy creates if missing."""
-    strategy = RagflowRAGStrategy()
-    with patch(
-        _ENSURE_DATASET,
-        new=AsyncMock(return_value="ds-newly-created"),
-    ) as mock_ensure, patch.object(
-        strategy,
-        "_validate_document_exists",
-        new=AsyncMock(return_value=None),
-    ), patch.object(
-        strategy,
-        "_get_existing_chunks",
-        new=AsyncMock(return_value={}),
-    ), patch.object(
-        strategy,
-        "_process_chunks_batch",
-        new=AsyncMock(return_value=([{"id": "c1"}], [])),
-    ), patch.object(
-        strategy,
-        "_handle_chunk_results",
-        new=AsyncMock(return_value=[{"id": "c1"}]),
-    ):
-        await strategy.chunks_save(
-            docId="doc-1",
-            group="brand-new-repo",
-            uid="user-1",
-            chunks=[{"content": "hello"}],
-        )
-        mock_ensure.assert_awaited_once_with("brand-new-repo", description=None)
-
-
-# ----------------------------------------------------------------------
-# chunks_update (no-create, raise on missing)
-# ----------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_chunks_update_routes_to_group_dataset() -> None:
-    """chunks_update with explicit group resolves dataset by group."""
-    strategy = RagflowRAGStrategy()
-    with patch(
-        _GET_DATASET_ID,
-        new=AsyncMock(return_value="ds-abc"),
-    ) as mock_lookup, patch(
-        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_chunk",
-        new=AsyncMock(return_value={"code": 0}),
-    ):
-        await strategy.chunks_update(
-            docId="doc-1",
-            group="abc-uuid",
-            uid="user-1",
-            chunks=[{"chunkId": "c1", "content": "new"}],
-        )
-        mock_lookup.assert_awaited_once_with("abc-uuid")
-
-
-@pytest.mark.asyncio
-async def test_chunks_update_with_null_group_falls_back_to_default() -> None:
-    """chunks_update with group=None falls back to default."""
+async def test_chunks_save_raises_when_default_group_unresolvable() -> None:
+    """ensure_dataset returning falsy raises ChunkSaveFailed."""
     strategy = RagflowRAGStrategy()
     with patch(
         _GET_DATASET_NAME,
         return_value="default-group",
     ), patch(
-        _GET_DATASET_ID,
+        _ENSURE_DATASET,
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(CustomException) as exc_info:
+            await strategy.chunks_save(
+                docId="doc-1",
+                group=None,
+                uid="user-1",
+                chunks=[{"content": "hello"}],
+                datasetId=None,
+            )
+        assert "Unable to resolve" in str(exc_info.value)
+
+
+# ----------------------------------------------------------------------
+# chunks_update
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunks_update_passes_through_explicit_dataset_id() -> None:
+    """chunks_update with non-empty datasetId skips ensure_dataset."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _ENSURE_DATASET,
+        new=AsyncMock(),
+    ) as mock_ensure, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_chunk",
+        new=AsyncMock(return_value={"code": 0}),
+    ) as mock_update_chunk:
+        await strategy.chunks_update(
+            docId="doc-1",
+            group=None,
+            uid="user-1",
+            chunks=[{"chunkId": "c1", "content": "new"}],
+            datasetId="ds-explicit-123",
+        )
+        mock_ensure.assert_not_called()
+        assert mock_update_chunk.await_args.kwargs["dataset_id"] == "ds-explicit-123"
+
+
+@pytest.mark.asyncio
+async def test_chunks_update_with_null_dataset_id_falls_back_to_default() -> None:
+    """chunks_update with datasetId=None ensures the default dataset exists."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _GET_DATASET_NAME,
+        return_value="default-group",
+    ), patch(
+        _ENSURE_DATASET,
         new=AsyncMock(return_value="ds-default"),
-    ) as mock_lookup, patch(
+    ) as mock_ensure, patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.update_chunk",
         new=AsyncMock(return_value={"code": 0}),
     ):
@@ -171,86 +164,93 @@ async def test_chunks_update_with_null_group_falls_back_to_default() -> None:
             group=None,
             uid="user-1",
             chunks=[{"chunkId": "c1", "content": "new"}],
+            datasetId=None,
         )
-        mock_lookup.assert_awaited_once_with("default-group")
+        mock_ensure.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
-async def test_chunks_update_raises_when_dataset_missing() -> None:
-    """chunks_update raises when dataset not found in RAGFlow."""
+async def test_chunks_update_raises_when_default_group_unresolvable() -> None:
+    """ensure_dataset returning falsy raises ChunkUpdateFailed."""
     strategy = RagflowRAGStrategy()
     with patch(
-        _GET_DATASET_ID,
+        _GET_DATASET_NAME,
+        return_value="default-group",
+    ), patch(
+        _ENSURE_DATASET,
         new=AsyncMock(return_value=None),
     ):
         with pytest.raises(CustomException) as exc_info:
             await strategy.chunks_update(
                 docId="doc-1",
-                group="ghost-uuid",
+                group=None,
                 uid="user-1",
                 chunks=[{"chunkId": "c1", "content": "x"}],
+                datasetId=None,
             )
-        # Strong assertion: error message must mention all three signals
         msg = str(exc_info.value).lower()
-        assert "not found" in msg
+        assert "unable to resolve" in msg
         assert "update" in msg
-        assert "ghost-uuid" in msg
 
 
 # ----------------------------------------------------------------------
-# chunks_delete (signature add group + silent skip)
+# chunks_delete
 # ----------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_chunks_delete_routes_to_group_dataset() -> None:
-    """chunks_delete with explicit group resolves dataset by group."""
+async def test_chunks_delete_passes_through_explicit_dataset_id() -> None:
+    """chunks_delete with non-empty datasetId skips ensure_dataset."""
     strategy = RagflowRAGStrategy()
     with patch(
-        _GET_DATASET_ID,
-        new=AsyncMock(return_value="ds-abc"),
-    ) as mock_lookup, patch(
+        _ENSURE_DATASET,
+        new=AsyncMock(),
+    ) as mock_ensure, patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_chunks",
         new=AsyncMock(return_value={"code": 0}),
-    ):
+    ) as mock_delete:
         await strategy.chunks_delete(
             docId="doc-1",
             chunkIds=["c1", "c2"],
-            group="abc-uuid",
+            datasetId="ds-explicit-123",
         )
-        mock_lookup.assert_awaited_once_with("abc-uuid")
+        mock_ensure.assert_not_called()
+        assert mock_delete.await_args.kwargs["dataset_id"] == "ds-explicit-123"
 
 
 @pytest.mark.asyncio
-async def test_chunks_delete_with_null_group_falls_back_to_default() -> None:
-    """chunks_delete with group=None falls back to default."""
+async def test_chunks_delete_with_null_dataset_id_falls_back_to_default() -> None:
+    """chunks_delete with datasetId=None ensures the default dataset exists."""
     strategy = RagflowRAGStrategy()
     with patch(
         _GET_DATASET_NAME,
         return_value="default-group",
     ), patch(
-        _GET_DATASET_ID,
+        _ENSURE_DATASET,
         new=AsyncMock(return_value="ds-default"),
-    ) as mock_lookup, patch(
+    ) as mock_ensure, patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_chunks",
         new=AsyncMock(return_value={"code": 0}),
     ):
         await strategy.chunks_delete(
             docId="doc-1",
             chunkIds=["c1"],
-            group=None,
+            datasetId=None,
         )
-        mock_lookup.assert_awaited_once_with("default-group")
+        mock_ensure.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
-async def test_chunks_delete_silent_skip_when_dataset_missing(
+async def test_chunks_delete_silent_skip_when_dataset_unresolvable(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """chunks_delete returns no-op + logs info when dataset missing."""
+    """chunks_delete is a no-op when ensure_dataset cannot resolve the default."""
     strategy = RagflowRAGStrategy()
     with patch(
-        _GET_DATASET_ID,
+        _GET_DATASET_NAME,
+        return_value="default-group",
+    ), patch(
+        _ENSURE_DATASET,
         new=AsyncMock(return_value=None),
     ), patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.delete_chunks",
@@ -263,7 +263,7 @@ async def test_chunks_delete_silent_skip_when_dataset_missing(
             await strategy.chunks_delete(
                 docId="doc-1",
                 chunkIds=["c1"],
-                group="ghost-uuid",
+                datasetId=None,
             )
         mock_delete.assert_not_called()
         assert any(

--- a/core/knowledge/tests/service/impl/ragflow_strategy_error_propagation_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_error_propagation_test.py
@@ -21,9 +21,7 @@ from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 _GET_DATASET_NAME = (
     "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
 )
-_GET_DATASET_ID = (
-    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
-)
+_ENSURE_DATASET = "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset"
 _LIST_CHUNKS = (
     "knowledge.service.impl.ragflow_strategy.ragflow_client.list_document_chunks"
 )
@@ -33,10 +31,6 @@ _GET_DOC_INFO = (
 _RETRIEVAL = (
     "knowledge.service.impl.ragflow_strategy.ragflow_client.retrieval_with_dataset"
 )
-# Reach all the way to the client so the dataset-lookup helper runs for
-# real; lets the full ``/chunk/query`` path be exercised when RAGFlow fails
-# during the dataset-lookup stage.
-_LIST_DATASETS = "knowledge.infra.ragflow.ragflow_client.list_datasets"
 
 
 # ----------------------------------------------------------------------
@@ -50,7 +44,7 @@ async def test_query_raises_on_transport_exception() -> None:
     strategy = RagflowRAGStrategy()
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(
             _RETRIEVAL,
             new=AsyncMock(
@@ -73,7 +67,7 @@ async def test_query_raises_on_ragflow_error_code() -> None:
     }
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(_RETRIEVAL, new=AsyncMock(return_value=bad_response)),
     ):
         with pytest.raises(ThirdPartyException) as exc_info:
@@ -91,55 +85,8 @@ async def test_query_returns_empty_results_when_no_chunks_matched() -> None:
     }
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(_RETRIEVAL, new=AsyncMock(return_value=empty_response)),
-    ):
-        result = await strategy.query("hello", top_k=6)
-    assert result == {"query": "hello", "count": 0, "results": []}
-
-
-@pytest.mark.asyncio
-async def test_query_raises_when_dataset_lookup_transport_fails() -> None:
-    """Dataset-lookup transport failures propagate through the query path."""
-    strategy = RagflowRAGStrategy()
-    with (
-        patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(
-            _LIST_DATASETS,
-            new=AsyncMock(side_effect=aiohttp.ClientConnectionError("down")),
-        ),
-    ):
-        with pytest.raises(ThirdPartyException):
-            await strategy.query("hello", top_k=6)
-
-
-@pytest.mark.asyncio
-async def test_query_raises_when_dataset_lookup_returns_non_zero_code() -> None:
-    """Non-zero ``list_datasets`` code propagates as ThirdPartyException
-    instead of being treated as 'dataset not configured'."""
-    strategy = RagflowRAGStrategy()
-    failing_list: Dict[str, Any] = {
-        "code": 109,
-        "message": "Authentication failed",
-    }
-    with (
-        patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_LIST_DATASETS, new=AsyncMock(return_value=failing_list)),
-    ):
-        with pytest.raises(ThirdPartyException) as exc_info:
-            await strategy.query("hello", top_k=6)
-    assert "Authentication failed" in str(exc_info.value)
-
-
-@pytest.mark.asyncio
-async def test_query_returns_empty_results_when_dataset_not_configured() -> None:
-    """``list_datasets`` reporting no matching name (code=0, empty data)
-    keeps the empty-results response instead of raising."""
-    strategy = RagflowRAGStrategy()
-    no_match: Dict[str, Any] = {"code": 0, "data": []}
-    with (
-        patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_LIST_DATASETS, new=AsyncMock(return_value=no_match)),
     ):
         result = await strategy.query("hello", top_k=6)
     assert result == {"query": "hello", "count": 0, "results": []}
@@ -156,7 +103,7 @@ async def test_query_doc_raises_on_transport_exception() -> None:
     strategy = RagflowRAGStrategy()
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(
             _LIST_CHUNKS,
             new=AsyncMock(
@@ -179,7 +126,7 @@ async def test_query_doc_raises_on_ragflow_error_code() -> None:
     }
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(_LIST_CHUNKS, new=AsyncMock(return_value=bad_response)),
     ):
         with pytest.raises(ThirdPartyException) as exc_info:
@@ -189,7 +136,7 @@ async def test_query_doc_raises_on_ragflow_error_code() -> None:
 
 @pytest.mark.asyncio
 async def test_query_doc_preserves_third_party_exception() -> None:
-    """Existing ThirdPartyException instances propagate unchanged."""
+    """Existing ThirdPartyException instances from dataset resolution propagate."""
     strategy = RagflowRAGStrategy()
     original = ThirdPartyException(
         msg="dataset lookup failed",
@@ -197,7 +144,7 @@ async def test_query_doc_preserves_third_party_exception() -> None:
     )
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(side_effect=original)),
+        patch(_ENSURE_DATASET, new=AsyncMock(side_effect=original)),
     ):
         with pytest.raises(ThirdPartyException) as exc_info:
             await strategy.query_doc("doc-x")
@@ -214,7 +161,7 @@ async def test_query_doc_returns_empty_list_when_document_has_no_chunks() -> Non
     }
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(_LIST_CHUNKS, new=AsyncMock(return_value=empty_response)),
     ):
         result = await strategy.query_doc("doc-x")
@@ -232,7 +179,7 @@ async def test_query_doc_name_raises_on_transport_exception() -> None:
     strategy = RagflowRAGStrategy()
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(
             _GET_DOC_INFO,
             new=AsyncMock(side_effect=aiohttp.ClientError("connection reset")),
@@ -253,7 +200,7 @@ async def test_query_doc_name_preserves_third_party_exception() -> None:
     )
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(_GET_DOC_INFO, new=AsyncMock(side_effect=original)),
     ):
         with pytest.raises(ThirdPartyException) as exc_info:
@@ -267,7 +214,7 @@ async def test_query_doc_name_returns_none_when_document_truly_missing() -> None
     strategy = RagflowRAGStrategy()
     with (
         patch(_GET_DATASET_NAME, return_value="ds-name"),
-        patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+        patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
         patch(_GET_DOC_INFO, new=AsyncMock(return_value=None)),
     ):
         result = await strategy.query_doc_name("doc-x")

--- a/core/knowledge/tests/service/impl/ragflow_strategy_query_ext_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_query_ext_test.py
@@ -20,15 +20,11 @@ from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 _GET_DATASET_NAME = (
     "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
 )
-_GET_DATASET_ID = (
-    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
-)
+_ENSURE_DATASET = "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset"
 _RETRIEVAL = (
     "knowledge.service.impl.ragflow_strategy.ragflow_client.retrieval_with_dataset"
 )
-_CONVERT = (
-    "knowledge.service.impl.ragflow_strategy.RagflowUtils.convert_ragflow_query_response"
-)
+_CONVERT = "knowledge.service.impl.ragflow_strategy.RagflowUtils.convert_ragflow_query_response"
 
 
 class TestRagflowQueryPayloadBaseline:
@@ -42,7 +38,7 @@ class TestRagflowQueryPayloadBaseline:
         )
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(_RETRIEVAL, new=mock_retrieval),
             patch(_CONVERT, return_value=[]),
         ):
@@ -66,7 +62,7 @@ class TestRagflowQueryPayloadBaseline:
         )
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(_RETRIEVAL, new=mock_retrieval),
             patch(_CONVERT, return_value=[]),
         ):
@@ -87,7 +83,7 @@ class TestRagflowQueryTopKSemantics:
         )
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(_RETRIEVAL, new=mock_retrieval),
             patch(_CONVERT, return_value=[]),
         ):
@@ -107,7 +103,7 @@ class TestRagflowQueryTopKSemantics:
         )
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(_RETRIEVAL, new=mock_retrieval),
             patch(_CONVERT, return_value=[]),
         ):
@@ -128,7 +124,7 @@ class TestRagflowQueryTopKSemantics:
         ]
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(
                 _RETRIEVAL,
                 new=AsyncMock(
@@ -154,7 +150,7 @@ class TestRagflowQueryTopKSemantics:
         ]
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(
                 _RETRIEVAL,
                 new=AsyncMock(
@@ -178,7 +174,7 @@ class TestRagflowQueryPayloadWithExt:
         )
         with (
             patch(_GET_DATASET_NAME, return_value="ds-name"),
-            patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-1")),
+            patch(_ENSURE_DATASET, new=AsyncMock(return_value="ds-1")),
             patch(_RETRIEVAL, new=mock_retrieval),
             patch(_CONVERT, return_value=[]),
         ):

--- a/core/knowledge/tests/service/impl/ragflow_strategy_query_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_query_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for RagflowRAGStrategy.query() multi-repo dataset routing."""
+"""Tests for RagflowRAGStrategy.query() datasetId routing."""
 
 import logging
 from unittest.mock import AsyncMock, patch
@@ -14,9 +14,7 @@ from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 _GET_DATASET_NAME = (
     "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_default_dataset_name"
 )
-_GET_DATASET_ID = (
-    "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_dataset_id_by_name"
-)
+_ENSURE_DATASET = "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset"
 _RETRIEVAL = (
     "knowledge.service.impl.ragflow_strategy.ragflow_client.retrieval_with_dataset"
 )
@@ -32,71 +30,51 @@ _CONVERT = (
 
 
 @pytest.mark.asyncio
-async def test_resolve_query_datasets_no_repo_ids_uses_default() -> None:
-    """repo_ids=None falls back to default group dataset."""
+async def test_resolve_query_datasets_no_ids_uses_default() -> None:
+    """datasetId=None uses the default dataset."""
     strategy = RagflowRAGStrategy()
     with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
-    ):
-        dataset_ids, missing = await strategy._resolve_query_datasets(None)
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock:
+        dataset_ids = await strategy._resolve_query_datasets(None)
         assert dataset_ids == ["ds-default"]
-        assert missing == []
-
-
-@pytest.mark.asyncio
-async def test_resolve_query_datasets_no_repo_ids_default_missing() -> None:
-    """Default dataset missing returns ([], [])."""
-    strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value=None)
-    ):
-        dataset_ids, missing = await strategy._resolve_query_datasets(None)
-        assert dataset_ids == []
-        assert missing == []
+        ensure_mock.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
 async def test_resolve_query_datasets_empty_list_uses_default() -> None:
-    """Empty repo_ids list also falls to default."""
+    """Empty list also uses the default dataset."""
     strategy = RagflowRAGStrategy()
     with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
-    ):
-        dataset_ids, missing = await strategy._resolve_query_datasets([])
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock:
+        dataset_ids = await strategy._resolve_query_datasets([])
         assert dataset_ids == ["ds-default"]
-        assert missing == []
+        ensure_mock.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
-async def test_resolve_query_datasets_single_repo_present() -> None:
-    """Single repo_ids, dataset exists."""
+async def test_resolve_query_datasets_explicit_ids_passthrough() -> None:
+    """Explicit dataset_ids are returned unchanged; ensure_dataset is NOT awaited."""
     strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")):
-        dataset_ids, missing = await strategy._resolve_query_datasets(["abc-uuid"])
+    with patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock:
+        dataset_ids = await strategy._resolve_query_datasets(["ds-1", "ds-2"])
+        assert dataset_ids == ["ds-1", "ds-2"]
+        ensure_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_datasets_single_id_passthrough() -> None:
+    """Single dataset id is returned unchanged."""
+    strategy = RagflowRAGStrategy()
+    with patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock:
+        dataset_ids = await strategy._resolve_query_datasets(["ds-abc"])
         assert dataset_ids == ["ds-abc"]
-        assert missing == []
-
-
-@pytest.mark.asyncio
-async def test_resolve_query_datasets_multi_repo_partial_missing() -> None:
-    """Multiple repo_ids, some datasets missing."""
-    strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(side_effect=["ds-abc", None])):
-        dataset_ids, missing = await strategy._resolve_query_datasets(
-            ["abc-uuid", "def-not-exist"]
-        )
-        assert dataset_ids == ["ds-abc"]
-        assert missing == ["def-not-exist"]
-
-
-@pytest.mark.asyncio
-async def test_resolve_query_datasets_all_missing() -> None:
-    """All repo_ids datasets missing returns ([], [...all])."""
-    strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(side_effect=[None, None])):
-        dataset_ids, missing = await strategy._resolve_query_datasets(["xxx", "yyy"])
-        assert dataset_ids == []
-        assert missing == ["xxx", "yyy"]
+        ensure_mock.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -206,13 +184,8 @@ async def test_execute_retrieval_returns_converted_results() -> None:
 
 
 @pytest.mark.asyncio
-async def test_query_single_repo_routes_to_repo_dataset() -> None:
-    """Single repo_ids runs full query pipeline and returns hits.
-
-    Discriminates repo-routing vs default-routing: default name maps to a
-    different dataset id, so a query() that ignores repo_ids would fail
-    this assertion.
-    """
+async def test_query_with_explicit_dataset_ids_skips_ensure() -> None:
+    """Caller-supplied datasetId is forwarded as-is."""
     strategy = RagflowRAGStrategy()
     fake_resp = {
         "code": 0,
@@ -221,74 +194,92 @@ async def test_query_single_repo_routes_to_repo_dataset() -> None:
         },
     }
     converted = [{"docId": "d1", "content": "hit", "score": 0.9}]
-
-    async def _resolve(name: str) -> str:
-        # Distinct ids per name — proves we routed via repo_ids, not default.
-        return "ds-abc" if name == "abc-uuid" else "ds-DEFAULT"
-
-    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(side_effect=_resolve)
-    ), patch(
+    with patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock, patch(
         _RETRIEVAL, new=AsyncMock(return_value=fake_resp)
     ) as mock_retrieval, patch(
         _CONVERT, return_value=converted
     ):
         result = await strategy.query(
             query="hello",
-            repo_ids=["abc-uuid"],
             doc_ids=None,
             top_k=5,
+            datasetId=["ds-real-1", "ds-real-2"],
         )
+        ensure_mock.assert_not_called()
         sent_payload = mock_retrieval.await_args.kwargs["request_data"]
-        # Routes to the repo's dataset, not the default one.
-        assert sent_payload["dataset_ids"] == ["ds-abc"]
+        assert sent_payload["dataset_ids"] == ["ds-real-1", "ds-real-2"]
         assert result["count"] == 1
         assert result["results"][0]["docId"] == "d1"
 
 
 @pytest.mark.asyncio
-async def test_query_all_missing_datasets_returns_empty(caplog) -> None:
-    """All repo datasets missing returns empty + warning, no RAGFlow call."""
+async def test_query_falls_back_to_default_group_when_dataset_id_none() -> None:
+    """datasetId=None uses the default dataset."""
     strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(return_value=None)), patch(
-        _RETRIEVAL, new=AsyncMock()
-    ) as mock_retrieval:
-        with caplog.at_level(
-            logging.WARNING, logger="knowledge.service.impl.ragflow_strategy"
-        ):
-            result = await strategy.query(
-                query="hello",
-                repo_ids=["xxx", "yyy"],
-                doc_ids=None,
-                top_k=5,
-            )
-        mock_retrieval.assert_not_called()
-        assert result == {"query": "hello", "count": 0, "results": []}
-        assert any("missing" in r.message.lower() for r in caplog.records)
+    fake_resp = {"code": 0, "data": {"chunks": []}}
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock, patch(
+        _RETRIEVAL, new=AsyncMock(return_value=fake_resp)
+    ) as mock_retrieval, patch(
+        _CONVERT, return_value=[]
+    ):
+        await strategy.query(query="hello", doc_ids=None, top_k=5, datasetId=None)
+        ensure_mock.assert_awaited_once_with("default-group")
+        sent_payload = mock_retrieval.await_args.kwargs["request_data"]
+        assert sent_payload["dataset_ids"] == ["ds-default"]
 
 
 @pytest.mark.asyncio
-async def test_query_repo_and_doc_ids_double_filter() -> None:
-    """repo_ids + doc_ids: payload has both repo dataset and docs."""
+async def test_query_falls_back_to_default_group_when_dataset_id_omitted() -> None:
+    """Omitting datasetId is equivalent to datasetId=None."""
     strategy = RagflowRAGStrategy()
     fake_resp = {"code": 0, "data": {"chunks": []}}
-
-    async def _resolve(name: str) -> str:
-        return "ds-abc" if name == "abc-uuid" else "ds-DEFAULT"
-
     with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(side_effect=_resolve)
-    ), patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock, patch(_RETRIEVAL, new=AsyncMock(return_value=fake_resp)), patch(
+        _CONVERT, return_value=[]
+    ):
+        await strategy.query(query="hello", top_k=5)
+        ensure_mock.assert_awaited_once_with("default-group")
+
+
+@pytest.mark.asyncio
+async def test_query_default_dataset_unresolvable_returns_empty(caplog) -> None:
+    """When ensure_dataset returns falsy, query yields empty."""
+    strategy = RagflowRAGStrategy()
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value=None)
+    ), patch(_RETRIEVAL, new=AsyncMock()) as mock_retrieval:
+        with caplog.at_level(
+            logging.INFO, logger="knowledge.service.impl.ragflow_strategy"
+        ):
+            result = await strategy.query(query="hello", top_k=5)
+        mock_retrieval.assert_not_called()
+        assert result == {"query": "hello", "count": 0, "results": []}
+
+
+@pytest.mark.asyncio
+async def test_query_doc_ids_passthrough_with_explicit_dataset_id() -> None:
+    """doc_ids combine with explicit datasetId for double filter."""
+    strategy = RagflowRAGStrategy()
+    fake_resp = {"code": 0, "data": {"chunks": []}}
+    with patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as ensure_mock, patch(
         _RETRIEVAL, new=AsyncMock(return_value=fake_resp)
     ) as mock_retrieval, patch(
         _CONVERT, return_value=[]
     ):
         await strategy.query(
             query="hello",
-            repo_ids=["abc-uuid"],
             doc_ids=["doc1", "doc2"],
             top_k=5,
+            datasetId=["ds-abc"],
         )
+        ensure_mock.assert_not_called()
         sent_payload = mock_retrieval.await_args.kwargs["request_data"]
         assert sent_payload["dataset_ids"] == ["ds-abc"]
         assert sent_payload["document_ids"] == ["doc1", "doc2"]
@@ -298,20 +289,18 @@ async def test_query_repo_and_doc_ids_double_filter() -> None:
 async def test_query_propagates_ragflow_errors() -> None:
     """RAGFlow exception bubbles as ThirdPartyException, NOT empty."""
     strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")), patch(
-        _RETRIEVAL, new=AsyncMock(side_effect=RuntimeError("RAGFlow 5xx"))
-    ):
+    with patch(_RETRIEVAL, new=AsyncMock(side_effect=RuntimeError("RAGFlow 5xx"))):
         with pytest.raises(ThirdPartyException):
             await strategy.query(
                 query="hello",
-                repo_ids=["abc-uuid"],
                 doc_ids=None,
                 top_k=5,
+                datasetId=["ds-abc"],
             )
 
 
 # ---------------------------------------------------------------------------
-# query_doc / query_doc_name (read paths) — group routing
+# query_doc / query_doc_name
 # ---------------------------------------------------------------------------
 
 _LIST_CHUNKS = (
@@ -323,78 +312,76 @@ _GET_DOC_INFO = (
 
 
 @pytest.mark.asyncio
-async def test_query_doc_routes_to_group_dataset() -> None:
-    """query_doc with explicit group resolves dataset by group, not default."""
+async def test_query_doc_passes_through_explicit_dataset_id() -> None:
+    """query_doc with non-empty datasetId skips ensure_dataset."""
     strategy = RagflowRAGStrategy()
-    with patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")
-    ) as mock_lookup, patch(
+    with patch(_ENSURE_DATASET, new=AsyncMock()) as mock_ensure, patch(
         _LIST_CHUNKS,
         new=AsyncMock(return_value={"code": 0, "data": {"total": 0, "chunks": []}}),
-    ):
-        await strategy.query_doc(docId="doc-1", group="abc-uuid")
-        mock_lookup.assert_awaited_once_with("abc-uuid")
+    ) as mock_list:
+        await strategy.query_doc(docId="doc-1", datasetId="ds-explicit-123")
+        mock_ensure.assert_not_called()
+        assert mock_list.await_args.args[0] == "ds-explicit-123"
 
 
 @pytest.mark.asyncio
-async def test_query_doc_with_null_group_falls_back_to_default() -> None:
-    """query_doc with group=None falls back to default group."""
+async def test_query_doc_with_null_dataset_id_falls_back_to_default() -> None:
+    """query_doc with datasetId=None ensures the default dataset exists."""
     strategy = RagflowRAGStrategy()
     with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
-    ) as mock_lookup, patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as mock_ensure, patch(
         _LIST_CHUNKS,
         new=AsyncMock(return_value={"code": 0, "data": {"total": 0, "chunks": []}}),
     ):
-        await strategy.query_doc(docId="doc-1", group=None)
-        mock_lookup.assert_awaited_once_with("default-group")
+        await strategy.query_doc(docId="doc-1", datasetId=None)
+        mock_ensure.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
-async def test_query_doc_returns_empty_when_dataset_missing() -> None:
-    """query_doc returns [] when dataset for group not found."""
+async def test_query_doc_returns_empty_when_default_unresolvable() -> None:
+    """query_doc returns [] when ensure_dataset cannot resolve the default."""
     strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(return_value=None)), patch(
-        _LIST_CHUNKS, new=AsyncMock()
-    ) as mock_list:
-        result = await strategy.query_doc(docId="doc-1", group="ghost-uuid")
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value=None)
+    ), patch(_LIST_CHUNKS, new=AsyncMock()) as mock_list:
+        result = await strategy.query_doc(docId="doc-1", datasetId=None)
         assert result == []
         mock_list.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_query_doc_name_routes_to_group_dataset() -> None:
-    """query_doc_name with explicit group resolves dataset by group."""
+async def test_query_doc_name_passes_through_explicit_dataset_id() -> None:
+    """query_doc_name with non-empty datasetId skips ensure_dataset."""
     strategy = RagflowRAGStrategy()
-    with patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value="ds-abc")
-    ) as mock_lookup, patch(
+    with patch(_ENSURE_DATASET, new=AsyncMock()) as mock_ensure, patch(
         _GET_DOC_INFO, new=AsyncMock(return_value={"name": "f.pdf", "run": "DONE"})
-    ):
-        await strategy.query_doc_name(docId="doc-1", group="abc-uuid")
-        mock_lookup.assert_awaited_once_with("abc-uuid")
+    ) as mock_info:
+        await strategy.query_doc_name(docId="doc-1", datasetId="ds-explicit-123")
+        mock_ensure.assert_not_called()
+        assert mock_info.await_args.args[0] == "ds-explicit-123"
 
 
 @pytest.mark.asyncio
-async def test_query_doc_name_with_null_group_falls_back_to_default() -> None:
-    """query_doc_name with group=None falls back to default group."""
+async def test_query_doc_name_with_null_dataset_id_falls_back_to_default() -> None:
+    """query_doc_name with datasetId=None ensures the default dataset exists."""
     strategy = RagflowRAGStrategy()
     with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
-        _GET_DATASET_ID, new=AsyncMock(return_value="ds-default")
-    ) as mock_lookup, patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value="ds-default")
+    ) as mock_ensure, patch(
         _GET_DOC_INFO, new=AsyncMock(return_value={"name": "f.pdf", "run": "DONE"})
     ):
-        await strategy.query_doc_name(docId="doc-1", group=None)
-        mock_lookup.assert_awaited_once_with("default-group")
+        await strategy.query_doc_name(docId="doc-1", datasetId=None)
+        mock_ensure.assert_awaited_once_with("default-group")
 
 
 @pytest.mark.asyncio
-async def test_query_doc_name_returns_none_when_dataset_missing() -> None:
-    """query_doc_name returns None when dataset for group not found."""
+async def test_query_doc_name_returns_none_when_default_unresolvable() -> None:
+    """query_doc_name returns None when ensure_dataset cannot resolve."""
     strategy = RagflowRAGStrategy()
-    with patch(_GET_DATASET_ID, new=AsyncMock(return_value=None)), patch(
-        _GET_DOC_INFO, new=AsyncMock()
-    ) as mock_info:
-        result = await strategy.query_doc_name(docId="doc-1", group="ghost-uuid")
+    with patch(_GET_DATASET_NAME, return_value="default-group"), patch(
+        _ENSURE_DATASET, new=AsyncMock(return_value=None)
+    ), patch(_GET_DOC_INFO, new=AsyncMock()) as mock_info:
+        result = await strategy.query_doc_name(docId="doc-1", datasetId=None)
         assert result is None
         mock_info.assert_not_called()

--- a/core/workflow/engine/nodes/agent/agent_node.py
+++ b/core/workflow/engine/nodes/agent/agent_node.py
@@ -65,6 +65,7 @@ class Match(BaseModel):
 
     repoIds: List[str] = Field(min_length=1)
     docIds: List[str] | None = Field(default=None, min_length=1)
+    datasetIds: List[str] | None = Field(default=None, min_length=1)
 
 
 class Knowledge(BaseModel):

--- a/core/workflow/engine/nodes/knowledge/knowledge_client.py
+++ b/core/workflow/engine/nodes/knowledge/knowledge_client.py
@@ -16,8 +16,6 @@ class KnowledgeConfig:
     Documentation: http://10.1.87.65:3000/project/427/interface/api/17187
     """
 
-    # TODO: Move knowledge base URL to configuration file
-
     def __init__(
         self,
         top_n: str,
@@ -27,6 +25,7 @@ class KnowledgeConfig:
         query: str,
         flow_id: str = "",
         doc_ids: list = [],
+        dataset_ids: list[str] = [],
         threshold: float = 0.1,
         history: list[HistoryItem] = [],
     ):
@@ -49,6 +48,7 @@ class KnowledgeConfig:
         self.query = query
         self.flow_id = flow_id
         self.doc_ids = doc_ids
+        self.dataset_ids = dataset_ids
         self.threshold = threshold
         self.history = history
 
@@ -61,7 +61,7 @@ class KnowledgeClient:
     using the provided configuration parameters.
     """
 
-    headers = {"Content-Type": "application/json"}
+    BASE_HEADERS = {"Content-Type": "application/json"}
 
     def __init__(self, *, config: KnowledgeConfig):
         """
@@ -91,11 +91,11 @@ class KnowledgeClient:
             event_log_node_trace = kwargs.get("event_log_node_trace")
             if event_log_node_trace:
                 event_log_node_trace.append_config_data(
-                    {"url": url, "req_headers": self.headers, "req_body": payload}
+                    {"url": url, "req_headers": self.headers(), "req_body": payload}
                 )
             session = HttpClient.get_session()
             async with session.post(
-                url, headers=self.headers, json=json.loads(payload)
+                url, headers=self.headers(), json=json.loads(payload)
             ) as resp:
                 background_json = json.loads(await resp.text())
                 # background_json = requests.request("POST", url, headers=self.headers, data=payload).json()
@@ -134,20 +134,27 @@ class KnowledgeClient:
 
         :return: JSON string containing the request payload
         """
+        match = {
+            "repoId": self.config.repo_id,
+            "docIds": self.config.doc_ids,
+            "flowId": self.config.flow_id,
+            "threshold": self.config.threshold,
+        }
+        if self.config.rag_type == "Ragflow-RAG" and self.config.dataset_ids:
+            match["datasetId"] = self.config.dataset_ids
+
         _payload = json.dumps(
             {
                 "query": self.config.query,
                 "topN": self.config.top_n,
                 "ragType": self.config.rag_type,
-                "match": {
-                    "repoId": self.config.repo_id,
-                    "docIds": self.config.doc_ids,
-                    "flowId": self.config.flow_id,
-                    "threshold": self.config.threshold,
-                },
+                "match": match,
                 "history": [item.dict() for item in self.config.history],
             },
             ensure_ascii=True,
         )
 
         return _payload
+
+    def headers(self) -> dict[str, str]:
+        return dict(self.BASE_HEADERS)

--- a/core/workflow/engine/nodes/knowledge/knowledge_expert_node.py
+++ b/core/workflow/engine/nodes/knowledge/knowledge_expert_node.py
@@ -34,6 +34,7 @@ class RepositoryInfo(BaseModel):
     description: str = Field(default="")
     repoId: str = Field(..., min_length=1)
     docIds: list[str] = Field(default_factory=list)
+    datasetId: str = Field(default="")
 
 
 class RepoAndDocIds(BaseModel):
@@ -46,6 +47,7 @@ class RepoAndDocIds(BaseModel):
 
     repo_ids: list[str] = Field(default_factory=list)
     doc_ids: list[str] = Field(default_factory=list)
+    dataset_ids: list[str] = Field(default_factory=list)
 
 
 class KnowledgeExpertNode(BaseNode):
@@ -92,14 +94,18 @@ class KnowledgeExpertNode(BaseNode):
 
         :return: RepoAndDocIds object containing repo_ids and doc_ids
         """
-        repo_ids, doc_ids = [], []
+        repo_ids, doc_ids, dataset_ids = [], [], []
         if self.repos:
             for repo in self.repos:
                 if repo.repoId:
                     repo_ids.append(repo.repoId)
                 if repo.docIds:
                     doc_ids.extend(repo.docIds)
-        return RepoAndDocIds(repo_ids=repo_ids, doc_ids=doc_ids)
+                if repo.datasetId:
+                    dataset_ids.append(repo.datasetId)
+        return RepoAndDocIds(
+            repo_ids=repo_ids, doc_ids=doc_ids, dataset_ids=dataset_ids
+        )
 
     async def execute(
         self, variable_pool: VariablePool, span: Span, **kwargs: Any
@@ -142,6 +148,7 @@ class KnowledgeExpertNode(BaseNode):
                 query=str(query),
                 flow_id=flow_id,
                 doc_ids=repo_and_doc_ids.doc_ids,
+                dataset_ids=repo_and_doc_ids.dataset_ids,
                 threshold=self.score,
             )
             # Perform knowledge base search

--- a/core/workflow/engine/nodes/knowledge/knowledge_node.py
+++ b/core/workflow/engine/nodes/knowledge/knowledge_node.py
@@ -51,6 +51,7 @@ class RepositoryInfo(BaseModel):
     description: str = Field(default="")
     repoId: str = Field(..., min_length=1)
     docIds: list[str] = Field(default_factory=list)
+    datasetId: str = Field(default="")
 
 
 class RepoAndDocIds(BaseModel):
@@ -63,6 +64,7 @@ class RepoAndDocIds(BaseModel):
 
     repo_ids: list[str] = Field(default_factory=list)
     doc_ids: list[str] = Field(default_factory=list)
+    dataset_ids: list[str] = Field(default_factory=list)
 
 
 class KnowledgeNode(BaseLLMNode):
@@ -81,6 +83,7 @@ class KnowledgeNode(BaseLLMNode):
     docIds: list[str] = Field(
         default_factory=list
     )  # Optional list of specific document IDs to search
+    datasetIds: list[str] = Field(default_factory=list)
     score: float = Field(default=0.1)  # Minimum similarity threshold for results
     enableChatHistoryV2: EnableChatHistoryV2 = Field(
         default_factory=EnableChatHistoryV2
@@ -235,14 +238,22 @@ class KnowledgeNode(BaseLLMNode):
         :return: RepoAndDocIds object containing repo_ids and doc_ids
         """
         if self.repos:
-            repo_ids, doc_ids = [], []
+            repo_ids, doc_ids, dataset_ids = [], [], []
             for repo in self.repos:
                 if repo.repoId:
                     repo_ids.append(repo.repoId)
                 if repo.docIds:
                     doc_ids.extend(repo.docIds)
-            return RepoAndDocIds(repo_ids=repo_ids, doc_ids=doc_ids)
-        return RepoAndDocIds(repo_ids=self.repoId, doc_ids=self.docIds)
+                if repo.datasetId:
+                    dataset_ids.append(repo.datasetId)
+            return RepoAndDocIds(
+                repo_ids=repo_ids, doc_ids=doc_ids, dataset_ids=dataset_ids
+            )
+        return RepoAndDocIds(
+            repo_ids=self.repoId,
+            doc_ids=self.docIds,
+            dataset_ids=self.datasetIds,
+        )
 
     async def execute(
         self, variable_pool: VariablePool, span: Span, **kwargs: Any
@@ -314,6 +325,7 @@ class KnowledgeNode(BaseLLMNode):
                 query=str(query),
                 flow_id=flow_id,
                 doc_ids=repo_and_doc_ids.doc_ids,
+                dataset_ids=repo_and_doc_ids.dataset_ids,
                 threshold=self.score,
                 history=history,
             )

--- a/core/workflow/tests/engine/nodes/knowledge/test_knowledge_client.py
+++ b/core/workflow/tests/engine/nodes/knowledge/test_knowledge_client.py
@@ -1,0 +1,36 @@
+import json
+
+from workflow.engine.nodes.knowledge.knowledge_client import (
+    KnowledgeClient,
+    KnowledgeConfig,
+)
+
+
+def test_payload_includes_dataset_ids_for_ragflow() -> None:
+    config = KnowledgeConfig(
+        top_n="3",
+        rag_type="Ragflow-RAG",
+        repo_id=["repo-1"],
+        dataset_ids=["dataset-1"],
+        url="http://knowledge/knowledge/v1/chunk/query",
+        query="hello",
+    )
+
+    payload = json.loads(KnowledgeClient(config=config).payload())
+
+    assert payload["match"]["datasetId"] == ["dataset-1"]
+
+
+def test_headers_use_base_json_headers() -> None:
+    config = KnowledgeConfig(
+        top_n="3",
+        rag_type="Ragflow-RAG",
+        repo_id=["repo-1"],
+        dataset_ids=["dataset-1"],
+        url="http://knowledge/knowledge/v1/chunk/query",
+        query="hello",
+    )
+
+    headers = KnowledgeClient(config=config).headers()
+
+    assert headers == {"Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
本 PR 为 Astron repo 持久化 RAGFlow 返回的真实 `dataset.id`，并在 RAGFlow-RAG 的运行时链路中优先使用该 ID 进行路由，避免继续依赖共享默认知识库或可变的 dataset name。

这样新创建的 RAGFlow-RAG 知识库可以稳定关联到各自独立的 RAGFlow dataset，并覆盖 console、core knowledge、agent、workflow 相关调用链路。

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Related Issue
Fixes #1214

## Changes
- 通过 Flyway migration 为 `repo` 表新增 nullable 字段 `ragflow_dataset_id`。
- 创建 RAGFlow-RAG 知识库时，保存 RAGFlow 返回的 `datasetId`。
- `tag=Ragflow-RAG` 创建知识库时强制服务端生成 `coreRepoId` UUID，忽略请求体中可能传入的 `outerRepoId`，防止多个 Astron repo 共用同一个 RAGFlow dataset。
- 创建 RAGFlow dataset 时使用"Astron 知识库名称 + 唯一后缀"作为 dataset name，例如 `kb_alpha-<coreRepoId>`，同时以 `dataset.id` 作为稳定运行时身份。
- 删除运行时按 dataset name 反查 dataset.id 的逻辑，RAGFlow-RAG 路径统一通过 `dataset.id` 直接路由。
- console backend 在调用 core knowledge 时，从服务端 `Repo` 表注入 `ragflowDatasetId`。
- core knowledge 的 RAGFlow-RAG split、chunk 写入、query 路径支持按 `datasetId` 路由。
- agent 和 workflow 的知识库调用链路透传 RAGFlow dataset ID。
- 收紧 `ChunkSaveReq` / `ChunkUpdateReq` 的 schema：非 `Ragflow-RAG` 类型继续要求 `group` 必填，保留 AIUI、CBG、SparkDesk 等旧契约。
- 对历史缺少 `ragflow_dataset_id` 的 repo 保持兼容，继续走既有默认 RAGFlow dataset 路径。

## Testing
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

测试命令：

\`\`\`bash
cd core/knowledge
./.venv/bin/python -m pytest \\
  tests/api/v1/chunk_query_test.py \\
  tests/api/v1/dataset_create_endpoint_test.py \\
  tests/domain/entity/chunk_dto_test.py \\
  -q
\`\`\`

结果：\`81 passed\`

\`\`\`bash
cd core/agent
./.venv/bin/python -m pytest \\
  tests/test_knowledge_plugin.py \\
  tests/test_workflow_agent_builder.py \\
  tests/test_workflow_agent_inputs_and_plugin_inputs.py \\
  -q
\`\`\`

结果：\`27 passed\`

\`\`\`bash
cd core/workflow
PYTHONPATH=".." ./.venv/bin/python -m pytest \\
  tests/engine/nodes/knowledge/test_knowledge_client.py \\
  -q
\`\`\`

结果：\`2 passed\`

\`\`\`bash
cd console/backend
mvn -pl toolkit -am \\
  -Dtest=KnowledgeV2ServiceCallHandlerTest,KnowledgeServiceTest,RepoServiceTest,WorkflowServiceRagflowDatasetIdTest \\
  -Dsurefire.failIfNoSpecifiedTests=false \\
  test
\`\`\`

结果：\`184 tests passed\`, \`BUILD SUCCESS\`

额外检查：

\`\`\`bash
git diff --check
\`\`\`

结果：通过

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (not needed; no user-facing docs changed)
- [x] Breaking changes documented (not applicable; no breaking change intended)