### PR TITLE
fix: prevent SSRF via unsafe tool debug redirects

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
  * <li>Restricts protocols to HTTP/HTTPS;</li>
  * <li>Prohibits user information (user:pass@host format);</li>
  * <li>Rejects IPv6 and IPv4-mapped IPv6 (can be relaxed as needed);</li>
- * <li>Resolves one 301/302/303 redirect and then performs blacklist/whitelist validation;</li>
+ * <li>Resolves a bounded redirect chain and performs blacklist/whitelist validation on each hop;</li>
  * <li>Blocks common short link domains;</li>
  * <li>Supports IP blacklist, network segment blacklist, and domain whitelist (configuration source:
  * ConfigInfo table).</li>
@@ -55,7 +55,9 @@ public class UrlCheckTool {
     // ===== Other constants =====
     private static final int CONNECT_TIMEOUT_MS = (int) Duration.ofSeconds(5).toMillis();
     private static final int READ_TIMEOUT_MS = (int) Duration.ofSeconds(5).toMillis();
+    private static final int MAX_REDIRECTS = 5;
     private static final Pattern DOMAIN_PATTERN = Pattern.compile("https?://([^/]+)", Pattern.CASE_INSENSITIVE);
+    private static final Set<Integer> REDIRECT_STATUS_CODES = Set.of(301, 302, 303, 307, 308);
 
     // Common short link domains
     private static final Set<String> SHORT_LINK_DOMAINS = Set.of(
@@ -63,11 +65,11 @@ public class UrlCheckTool {
             "monojson.com", "t.cn", "url.cn", "dwz.cn");
 
     /**
-     * Gets the redirected URL after at most one redirect.
+     * Gets the direct redirected URL without following it automatically.
      *
      * <p>
-     * Implementation details: Prefers HEAD method; if 405/HEAD not supported, falls back to GET;
-     * Disables auto-follow, only retrieves Location header.
+     * Implementation details: Uses HEAD method only, disables auto-follow, and only retrieves the
+     * Location header.
      * </p>
      *
      * @param url the original URL to check for redirects
@@ -78,35 +80,34 @@ public class UrlCheckTool {
             return url;
 
         try {
-            URL u = new URL(url);
-            HttpURLConnection conn = (HttpURLConnection) u.openConnection();
-            conn.setInstanceFollowRedirects(false);
-            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
-            conn.setReadTimeout(READ_TIMEOUT_MS);
-
-            // Prefer HEAD, fallback to GET on failure
-            try {
-                conn.setRequestMethod("HEAD");
-            } catch (ProtocolException ignored) {
-                try {
-                    conn.setRequestMethod("GET");
-                } catch (ProtocolException e) {
-                    log.warn("setRequestMethod failed: {}", e.getMessage());
-                }
-            }
-
-            int code = conn.getResponseCode();
-            if (code == HttpURLConnection.HTTP_MOVED_TEMP
-                    || code == HttpURLConnection.HTTP_MOVED_PERM
-                    || code == HttpURLConnection.HTTP_SEE_OTHER) {
-                String redirect = conn.getHeaderField("Location");
-                return StringUtils.isNotBlank(redirect) ? redirect : url;
+            RedirectLookupResult result = lookupRedirect(url);
+            if (REDIRECT_STATUS_CODES.contains(result.statusCode)
+                    && StringUtils.isNotBlank(result.location)) {
+                return new URL(new URL(url), result.location).toString();
             }
         } catch (IOException e) {
             // Use original URL on network exception
             log.debug("getRedirectUrl error: {}", e.toString());
         }
         return url;
+    }
+
+    private RedirectLookupResult lookupRedirect(String url) throws IOException {
+        HttpURLConnection conn = null;
+        try {
+            URL u = new URL(url);
+            conn = (HttpURLConnection) u.openConnection();
+            conn.setInstanceFollowRedirects(false);
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestMethod("HEAD");
+            int code = conn.getResponseCode();
+            return new RedirectLookupResult(code, conn.getHeaderField("Location"));
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
     }
 
     /**
@@ -149,14 +150,14 @@ public class UrlCheckTool {
     }
 
     /**
-     * Blacklist/whitelist validation (considering one redirect).
+     * Blacklist/whitelist validation (considering a bounded redirect chain).
      * <ol>
      * <li>First validate the original URL before any connection;</li>
      * <li>Domain in whitelist → allow;</li>
      * <li>Resolve A record to get IPv4/IPv6 (this policy focuses on IPv4 validation);</li>
      * <li>Hit IP blacklist → reject;</li>
      * <li>Hit network segment blacklist (CIDR) → reject;</li>
-     * <li>Then follow redirect and validate the redirected URL.</li>
+     * <li>Then inspect redirects and validate every redirected URL before proceeding.</li>
      * </ol>
      * Silently returns on parsing exception (doesn't affect main flow), let upper layer handle
      * uniformly.
@@ -170,16 +171,21 @@ public class UrlCheckTool {
             List<String> segmentBlackList = readCsvConfig(NETWORK_SEGMENT_CATEGORY);
             List<String> domainWhiteList = readCsvConfig(DOMAIN_WHITE_CATEGORY);
 
-            // Step 1: Validate original URL BEFORE making any connection
-            validateUrlAgainstBlacklist(url, ipBlackList, segmentBlackList, domainWhiteList);
+            String currentUrl = url;
+            Set<String> visitedUrls = new HashSet<>();
+            for (int i = 0; i <= MAX_REDIRECTS; i++) {
+                validateUrlAgainstBlacklist(currentUrl, ipBlackList, segmentBlackList, domainWhiteList);
+                if (!visitedUrls.add(currentUrl)) {
+                    throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
+                }
 
-            // Step 2: Get redirect URL (now safe to make connection)
-            String redirectUrl = getRedirectUrl(url);
-
-            // Step 3: If redirected to different URL, validate the target too
-            if (!url.equals(redirectUrl)) {
-                validateUrlAgainstBlacklist(redirectUrl, ipBlackList, segmentBlackList, domainWhiteList);
+                String redirectUrl = getRedirectUrl(currentUrl);
+                if (currentUrl.equals(redirectUrl)) {
+                    return;
+                }
+                currentUrl = redirectUrl;
             }
+            throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
 
         } catch (BusinessException e) {
             throw e;
@@ -436,5 +442,8 @@ public class UrlCheckTool {
             log.warn("readCsvConfig error, category={}, err={}", category, e.toString());
             return Collections.emptyList();
         }
+    }
+
+    private record RedirectLookupResult(int statusCode, String location) {
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
@@ -1,0 +1,76 @@
+package com.iflytek.astron.console.toolkit.tool;
+
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.toolkit.entity.table.ConfigInfo;
+import com.iflytek.astron.console.toolkit.mapper.ConfigInfoMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UrlCheckToolTest {
+
+    @Test
+    void checkBlackListRejectsTemporaryRedirectToBlacklistedIp() throws Exception {
+        ConfigInfoMapper mapper = mockConfigMapper("169.254.169.254", "");
+        UrlCheckTool tool = new UrlCheckTool(mapper);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/redirect", exchange -> {
+            exchange.getResponseHeaders().set("Location", "http://169.254.169.254/latest/meta-data/");
+            exchange.sendResponseHeaders(307, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/redirect";
+            assertThrows(BusinessException.class, () -> tool.checkBlackList(url));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void checkBlackListRejectsBlacklistedTargetAfterMultipleRedirects() {
+        ConfigInfoMapper mapper = mockConfigMapper("169.254.169.254", "");
+        UrlCheckTool tool = new RedirectingUrlCheckTool(mapper, Map.of(
+                "http://example.com/start", "http://example.org/hop",
+                "http://example.org/hop", "http://169.254.169.254/latest/meta-data/"));
+
+        assertThrows(BusinessException.class, () -> tool.checkBlackList("http://example.com/start"));
+    }
+
+    private static ConfigInfoMapper mockConfigMapper(String ipBlackList, String segmentBlackList) {
+        ConfigInfoMapper mapper = mock(ConfigInfoMapper.class);
+        when(mapper.getListByCategory("IP_BLACK_LIST")).thenReturn(List.of(config(ipBlackList)));
+        when(mapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST")).thenReturn(List.of(config(segmentBlackList)));
+        when(mapper.getListByCategory("DOMAIN_WHITE_LIST")).thenReturn(Collections.emptyList());
+        return mapper;
+    }
+
+    private static ConfigInfo config(String value) {
+        ConfigInfo config = new ConfigInfo();
+        config.setValue(value);
+        return config;
+    }
+
+    private static final class RedirectingUrlCheckTool extends UrlCheckTool {
+        private final Map<String, String> redirects;
+
+        private RedirectingUrlCheckTool(ConfigInfoMapper configInfoMapper, Map<String, String> redirects) {
+            super(configInfoMapper);
+            this.redirects = redirects;
+        }
+
+        @Override
+        public String getRedirectUrl(String url) {
+            return redirects.getOrDefault(url, url);
+        }
+    }
+}

--- a/core/plugin/link/infra/tool_exector/process.py
+++ b/core/plugin/link/infra/tool_exector/process.py
@@ -175,7 +175,9 @@ class HttpRun:
         }
 
         async with aiohttp.ClientSession() as session:
-            async with session.request(self.method, url, **kwargs) as response:
+            async with session.request(
+                self.method, url, allow_redirects=False, **kwargs
+            ) as response:
                 response_text = await response.text()
                 status_code = response.status
 

--- a/core/plugin/link/tests/unit/test_infra_fixed.py
+++ b/core/plugin/link/tests/unit/test_infra_fixed.py
@@ -3,6 +3,7 @@ Unit tests for infrastructure modules - Fixed version
 Tests CRUD operations with correct method names
 """
 
+import asyncio
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -219,6 +220,53 @@ class TestHttpRun:
 
         assert HttpRun is not None
         assert isinstance(HttpRun, type)
+
+    def test_execute_request_disables_http_redirects(
+        self, sample_http_run_params: Any
+    ) -> None:
+        """Test HTTP execution does not follow redirects automatically."""
+
+        class MockResponseContext:
+            status = 200
+
+            async def __aenter__(self) -> Any:
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            async def text(self) -> str:
+                return "ok"
+
+        class MockSession:
+            def __init__(self) -> None:
+                self.request_kwargs = None
+
+            async def __aenter__(self) -> Any:
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            def request(self, *args: Any, **kwargs: Any) -> MockResponseContext:
+                self.request_kwargs = kwargs
+                return MockResponseContext()
+
+        http_run = HttpRun(**sample_http_run_params)
+        span_context = Mock()
+        session = MockSession()
+
+        with patch(
+            "plugin.link.infra.tool_exector.process.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result, status_code = asyncio.run(
+                http_run._execute_request("https://api.example.com/test", span_context)
+            )
+
+        assert result == "ok"
+        assert status_code == 200
+        assert session.request_kwargs["allow_redirects"] is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- validate every URL in bounded redirect chains before following debug redirects
- disable automatic redirects in link plugin HTTP execution
- add regression tests for Java URL validation and Python redirect handling

## Tests
- not run during publish workflow