### PR TITLE
docs: add English docs site pairs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,68 +2,161 @@ import { defineConfig } from "vitepress";
 
 const base = process.env.DOCS_BASE || "/";
 
+const socialLinks = [
+  { icon: "github", link: "https://github.com/iflytek/astron-agent" }
+];
+
 export default defineConfig({
   title: "Astron Agent",
   description: "企业级、商业友好的 Agentic Workflow 开发平台文档站。",
-  lang: "zh-CN",
   base,
   cleanUrls: true,
   ignoreDeadLinks: true,
-  themeConfig: {
-    logo: "/logo.svg",
-    siteTitle: "Astron Agent",
-    nav: [
-      { text: "首页", link: "/" },
-      { text: "快速开始", link: "/guide/quick-start" },
-      { text: "部署与运维", link: "/guide/deploy" },
-      { text: "架构与开发", link: "/PROJECT_MODULES_zh" },
-      { text: "贡献协作", link: "/CONTRIBUTING_CN" }
-    ],
-    sidebar: [
-      {
-        text: "入门指南",
-        items: [
+  locales: {
+    root: {
+      label: "简体中文",
+      lang: "zh-CN",
+      title: "Astron Agent",
+      description: "企业级、商业友好的 Agentic Workflow 开发平台文档站。",
+      themeConfig: {
+        logo: "/logo.svg",
+        siteTitle: "Astron Agent",
+        nav: [
+          { text: "首页", link: "/" },
           { text: "快速开始", link: "/guide/quick-start" },
-          { text: "部署指南", link: "/guide/deploy" },
-          { text: "配置说明", link: "/guide/config" },
-          { text: "FAQ", link: "/faq" },
-          { text: "README（中文）", link: "/README-zh" }
-        ]
-      },
-      {
-        text: "部署与运维",
-        items: [
-          { text: "标准部署指南", link: "/DEPLOYMENT_GUIDE_zh" },
-          { text: "鉴权部署指南", link: "/DEPLOYMENT_GUIDE_WITH_AUTH_zh" },
-          { text: "鉴权 + RPA 部署指南", link: "/DEPLOYMENT_GUIDE_WITH_AUTH_RPA_zh" },
-          { text: "部署常见问题", link: "/DEPLOYMENT_FAQ_zh" },
-          { text: "配置文档", link: "/CONFIGURATION_zh" }
-        ]
-      },
-      {
-        text: "架构与开发",
-        items: [
-          { text: "模块说明", link: "/PROJECT_MODULES_zh" },
-          { text: "Makefile 使用指南", link: "/Makefile-readme-zh" }
-        ]
-      },
-      {
-        text: "贡献协作",
-        items: [
-          { text: "贡献指南", link: "/CONTRIBUTING_CN" },
-          { text: "Pre-commit 使用指南", link: "/PRE-COMMIT_zh" }
-        ]
+          { text: "部署与运维", link: "/guide/deploy" },
+          { text: "架构与开发", link: "/PROJECT_MODULES_zh" },
+          { text: "贡献协作", link: "/CONTRIBUTING_CN" }
+        ],
+        sidebar: [
+          {
+            text: "入门指南",
+            items: [
+              { text: "快速开始", link: "/guide/quick-start" },
+              { text: "部署指南", link: "/guide/deploy" },
+              { text: "配置说明", link: "/guide/config" },
+              { text: "FAQ", link: "/faq" },
+              { text: "README（中文）", link: "/README-zh" }
+            ]
+          },
+          {
+            text: "部署与运维",
+            items: [
+              { text: "标准部署指南", link: "/DEPLOYMENT_GUIDE_zh" },
+              { text: "鉴权部署指南", link: "/DEPLOYMENT_GUIDE_WITH_AUTH_zh" },
+              { text: "鉴权 + RPA 部署指南", link: "/DEPLOYMENT_GUIDE_WITH_AUTH_RPA_zh" },
+              { text: "部署常见问题", link: "/DEPLOYMENT_FAQ_zh" },
+              { text: "配置文档", link: "/CONFIGURATION_zh" }
+            ]
+          },
+          {
+            text: "架构与开发",
+            items: [
+              { text: "模块说明", link: "/PROJECT_MODULES_zh" },
+              { text: "Makefile 使用指南", link: "/Makefile-readme-zh" }
+            ]
+          },
+          {
+            text: "贡献协作",
+            items: [
+              { text: "贡献指南", link: "/CONTRIBUTING_CN" },
+              { text: "Pre-commit 使用指南", link: "/PRE-COMMIT_zh" }
+            ]
+          }
+        ],
+        socialLinks,
+        search: {
+          provider: "local"
+        },
+        langMenuLabel: "语言",
+        returnToTopLabel: "返回顶部",
+        sidebarMenuLabel: "菜单",
+        darkModeSwitchLabel: "主题",
+        outline: {
+          label: "页面导航"
+        },
+        docFooter: {
+          prev: "上一页",
+          next: "下一页"
+        },
+        footer: {
+          message: "Apache 2.0 Licensed.",
+          copyright: "Copyright © iFLYTEK Astron Agent"
+        }
       }
-    ],
-    socialLinks: [
-      { icon: "github", link: "https://github.com/iflytek/astron-agent" }
-    ],
-    search: {
-      provider: "local"
     },
-    footer: {
-      message: "Apache 2.0 Licensed.",
-      copyright: "Copyright © iFLYTEK Astron Agent"
+    en: {
+      label: "English",
+      lang: "en-US",
+      link: "/en/",
+      title: "Astron Agent",
+      description: "Documentation for the enterprise-grade, commercially-friendly Agentic Workflow platform.",
+      themeConfig: {
+        logo: "/logo.svg",
+        siteTitle: "Astron Agent",
+        nav: [
+          { text: "Home", link: "/en/" },
+          { text: "Quick Start", link: "/en/guide/quick-start" },
+          { text: "Deployment", link: "/en/guide/deploy" },
+          { text: "Architecture", link: "/en/PROJECT_MODULES" },
+          { text: "Contributing", link: "/en/CONTRIBUTING" }
+        ],
+        sidebar: [
+          {
+            text: "Getting Started",
+            items: [
+              { text: "Quick Start", link: "/en/guide/quick-start" },
+              { text: "Deployment Guide", link: "/en/guide/deploy" },
+              { text: "Configuration", link: "/en/guide/config" },
+              { text: "FAQ", link: "/en/faq" },
+              { text: "Project README", link: "/en/README" }
+            ]
+          },
+          {
+            text: "Deployment And Operations",
+            items: [
+              { text: "Full Deployment Guide", link: "/en/DEPLOYMENT_GUIDE" },
+              { text: "Auth Deployment Guide", link: "/en/DEPLOYMENT_GUIDE_WITH_AUTH" },
+              { text: "Auth + RPA Deployment Guide", link: "/en/DEPLOYMENT_GUIDE_WITH_AUTH_RPA" },
+              { text: "Deployment FAQ", link: "/en/DEPLOYMENT_FAQ" },
+              { text: "Configuration Reference", link: "/en/CONFIGURATION" }
+            ]
+          },
+          {
+            text: "Architecture And Development",
+            items: [
+              { text: "Project Modules", link: "/en/PROJECT_MODULES" },
+              { text: "Makefile Guide", link: "/en/Makefile-readme" },
+              { text: "Pre-commit Guide", link: "/en/PRE-COMMIT" }
+            ]
+          },
+          {
+            text: "Contribution",
+            items: [
+              { text: "Contributing Guide", link: "/en/CONTRIBUTING" }
+            ]
+          }
+        ],
+        socialLinks,
+        search: {
+          provider: "local"
+        },
+        langMenuLabel: "Languages",
+        returnToTopLabel: "Back to top",
+        sidebarMenuLabel: "Menu",
+        darkModeSwitchLabel: "Theme",
+        outline: {
+          label: "On this page"
+        },
+        docFooter: {
+          prev: "Previous page",
+          next: "Next page"
+        },
+        footer: {
+          message: "Apache 2.0 Licensed.",
+          copyright: "Copyright © iFLYTEK Astron Agent"
+        }
+      }
     }
   }
 });

--- a/docs/.vitepress/theme/AstronHomePage.vue
+++ b/docs/.vitepress/theme/AstronHomePage.vue
@@ -1,59 +1,275 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted } from "vue";
-import { withBase } from "vitepress";
+import { computed, onBeforeUnmount, onMounted } from "vue";
+import { useData, withBase } from "vitepress";
+
+import archImage from "../../imgs/arch.png";
+import heroPreviewImage from "../../imgs/Astron_Readme.png";
+import structureEnImage from "../../imgs/structure.png";
+import structureZhImage from "../../imgs/structure-zh.png";
+import wecomGroupImage from "../../imgs/WeCom_Group.png";
 
 const revealSelector = ".js-reveal";
 let observer: IntersectionObserver | null = null;
 
-const featureCards = [
-  {
-    title: "企业级高可用",
-    description: "覆盖开发、构建、配置、部署与治理流程，适用于企业内外网及复杂运行环境。"
-  },
-  {
-    title: "灵活模型接入",
-    description: "支持从 API 快速验证到企业级 MaaS 与私有化模型集群部署的多种接入方式。"
-  },
-  {
-    title: "工具与 MCP 生态",
-    description: "兼容多类 AI 能力与工具调用模式，帮助 Agent 高效调用外部能力与业务系统。"
-  },
-  {
-    title: "原生 RPA 融合",
-    description: "让 Agent 不止能分析和决策，还能跨系统执行流程，实现自动化闭环。"
-  },
-  {
-    title: "商业友好开源",
-    description: "采用 Apache 2.0 协议发布，可自由修改、分发和商用，便于企业长期演进。"
-  },
-  {
-    title: "多模块协同架构",
-    description: "控制台、核心服务、知识、记忆、租户、插件与部署配置解耦，便于扩展和维护。"
-  }
-];
+const { lang } = useData();
 
-const resourceCards = [
-  {
-    title: "快速开始",
-    description: "两步完成本地体验，先拉起 Docker Compose 环境再进入控制台。",
-    href: "/guide/quick-start"
+const zhContent = {
+  nav: {
+    quickStart: "快速开始",
+    deploy: "部署指南",
+    config: "配置说明",
+    faq: "FAQ",
+    github: "GitHub"
   },
-  {
-    title: "部署指南",
-    description: "查看 Docker、Helm 与环境变量准备方式，按场景选择部署路径。",
-    href: "/guide/deploy"
+  eyebrow: "Open Source · Apache 2.0 · Enterprise Ready",
+  heroTitleTop: "构建面向企业落地的",
+  heroTitleBottom: "Agentic Workflow 平台",
+  heroText:
+    "Astron Agent 聚合 AI 工作流编排、模型管理、MCP 与工具集成、RPA 自动化以及多团队协作能力，帮助企业以更低成本快速构建高可用、可扩展、可运营的智能体应用。",
+  primaryAction: "查看源码",
+  secondaryAction: "体验 Astron Cloud",
+  metrics: [
+    {
+      title: "企业级高可用",
+      description: "支持面向生产环境的部署与运维"
+    },
+    {
+      title: "MCP + RPA",
+      description: "实现从决策到动作的执行闭环"
+    },
+    {
+      title: "多语言微服务",
+      description: "覆盖前端、Java、Python、Go 核心能力"
+    }
+  ],
+  featureEyebrow: "Why Astron Agent",
+  featureTitle: "围绕企业生产场景设计",
+  featureText: "面向高可靠部署、跨系统连接与业务落地，提供从平台底座到业务编排的完整能力。",
+  featureCards: [
+    {
+      title: "企业级高可用",
+      description: "覆盖开发、构建、配置、部署与治理流程，适用于企业内外网及复杂运行环境。"
+    },
+    {
+      title: "灵活模型接入",
+      description: "支持从 API 快速验证到企业级 MaaS 与私有化模型集群部署的多种接入方式。"
+    },
+    {
+      title: "工具与 MCP 生态",
+      description: "兼容多类 AI 能力与工具调用模式，帮助 Agent 高效调用外部能力与业务系统。"
+    },
+    {
+      title: "原生 RPA 融合",
+      description: "让 Agent 不止能分析和决策，还能跨系统执行流程，实现自动化闭环。"
+    },
+    {
+      title: "商业友好开源",
+      description: "采用 Apache 2.0 协议发布，可自由修改、分发和商用，便于企业长期演进。"
+    },
+    {
+      title: "多模块协同架构",
+      description: "控制台、核心服务、知识、记忆、租户、插件与部署配置解耦，便于扩展和维护。"
+    }
+  ],
+  architectureEyebrow: "Architecture",
+  architectureTitle: "统一控制台 + 核心服务集群",
+  architectureText:
+    "前端、控制台后端、Agent / Workflow / Knowledge / Memory / Tenant 等服务职责清晰，适合多团队协作开发。",
+  architectureCards: [
+    {
+      title: "总体架构",
+      description: "控制台前后端、核心执行引擎与插件系统协同工作，形成端到端的智能体平台能力。",
+      image: archImage,
+      alt: "Astron Agent architecture diagram"
+    },
+    {
+      title: "模块结构",
+      description: "仓库涵盖 React + TypeScript、Java Spring Boot、Python FastAPI 与 Go 服务，支持模块化演进。",
+      image: structureZhImage,
+      alt: "Astron Agent structure diagram"
+    }
+  ],
+  quickStartEyebrow: "Quick Start",
+  quickStartTitle: "文档化接入路径",
+  quickStartText: "首页保留品牌视觉，落地使用说明则进入文档页维护，便于后续持续扩展。",
+  quickStartCards: {
+    firstTitle: "1. 阅读快速开始",
+    firstText: "先完成本地体验，再按需要切换到生产部署和配置章节。",
+    firstCode: "docs/guide/quick-start.md\ndocs/guide/deploy.md\ndocs/guide/config.md",
+    secondTitle: "2. 进入文档目录",
+    secondText: "文档站支持侧边栏导航、全文搜索和静态构建，适合持续补充内容。",
+    primaryAction: "开始阅读",
+    secondaryAction: "查看 FAQ"
   },
-  {
-    title: "配置说明",
-    description: "了解基础设施、模型、存储与鉴权相关配置项，降低上线前排障成本。",
-    href: "/guide/config"
+  resourcesEyebrow: "Resources",
+  resourcesTitle: "文档、社区与部署入口",
+  resourcesText: "从首页进入稳定的信息架构，把说明文档和社区入口统一收敛到 Pages 文档站。",
+  resourceCards: [
+    {
+      title: "快速开始",
+      description: "两步完成本地体验，先拉起 Docker Compose 环境再进入控制台。",
+      href: "/guide/quick-start"
+    },
+    {
+      title: "部署指南",
+      description: "查看 Docker、Helm 与环境变量准备方式，按场景选择部署路径。",
+      href: "/guide/deploy"
+    },
+    {
+      title: "配置说明",
+      description: "了解基础设施、模型、存储与鉴权相关配置项，降低上线前排障成本。",
+      href: "/guide/config"
+    },
+    {
+      title: "FAQ",
+      description: "收敛常见问题、定位思路和下一步排查入口，减少重复沟通。",
+      href: "/faq"
+    }
+  ],
+  communityEyebrow: "Community",
+  communityTitle: "加入社区，共建 Astron Agent",
+  communityText: "欢迎通过 GitHub Issues、Discussions 与企业微信群参与反馈、共建与协作。",
+  communityPrimaryAction: "提交 Issue",
+  communitySecondaryAction: "参与讨论",
+  communityImageAlt: "Astron Agent community group",
+  footerText: "企业级、商业友好的 Agentic Workflow 开发平台。",
+  footerDocsLink: "文档入口"
+};
+
+const enContent = {
+  nav: {
+    quickStart: "Quick Start",
+    deploy: "Deployment",
+    config: "Configuration",
+    faq: "FAQ",
+    github: "GitHub"
   },
-  {
-    title: "FAQ",
-    description: "收敛常见问题、定位思路和下一步排查入口，减少重复沟通。",
-    href: "/faq"
-  }
-];
+  eyebrow: "Open Source · Apache 2.0 · Enterprise Ready",
+  heroTitleTop: "Build An Enterprise-Ready",
+  heroTitleBottom: "Agentic Workflow Platform",
+  heroText:
+    "Astron Agent brings together AI workflow orchestration, model management, MCP and tool integrations, RPA automation, and team collaboration to help enterprises build reliable, scalable agent applications faster.",
+  primaryAction: "View Source",
+  secondaryAction: "Try Astron Cloud",
+  metrics: [
+    {
+      title: "Production Ready",
+      description: "Supports deployment and operations for real production environments"
+    },
+    {
+      title: "MCP + RPA",
+      description: "Closes the loop from decision making to real execution"
+    },
+    {
+      title: "Polyglot Services",
+      description: "Covers core capabilities across frontend, Java, Python, and Go"
+    }
+  ],
+  featureEyebrow: "Why Astron Agent",
+  featureTitle: "Designed For Real Enterprise Workloads",
+  featureText:
+    "Built for reliable deployment, cross-system integration, and practical delivery, from platform foundations to business workflow orchestration.",
+  featureCards: [
+    {
+      title: "Enterprise Reliability",
+      description: "Covers development, build, configuration, deployment, and governance for complex enterprise environments."
+    },
+    {
+      title: "Flexible Model Access",
+      description: "Supports everything from rapid API validation to enterprise MaaS and private model cluster integration."
+    },
+    {
+      title: "Tools And MCP Ecosystem",
+      description: "Connects agents with external capabilities and business systems through diverse tool invocation patterns."
+    },
+    {
+      title: "Native RPA Integration",
+      description: "Lets agents analyze, decide, and execute workflows across systems to complete automation loops."
+    },
+    {
+      title: "Commercial-Friendly Open Source",
+      description: "Released under Apache 2.0 so teams can modify, distribute, and commercialize with confidence."
+    },
+    {
+      title: "Modular Service Architecture",
+      description: "Decouples console, core services, knowledge, memory, tenant, plugin, and deployment concerns for long-term evolution."
+    }
+  ],
+  architectureEyebrow: "Architecture",
+  architectureTitle: "Unified Console Plus Core Service Cluster",
+  architectureText:
+    "Frontend, console backend, and Agent / Workflow / Knowledge / Memory / Tenant services have clear boundaries for multi-team collaboration.",
+  architectureCards: [
+    {
+      title: "Platform Architecture",
+      description: "The console, execution engine, and plugin system work together to deliver an end-to-end agent platform.",
+      image: archImage,
+      alt: "Astron Agent architecture diagram"
+    },
+    {
+      title: "Repository Structure",
+      description: "The monorepo combines React + TypeScript, Java Spring Boot, Python FastAPI, and Go services in a modular layout.",
+      image: structureEnImage,
+      alt: "Astron Agent repository structure diagram"
+    }
+  ],
+  quickStartEyebrow: "Quick Start",
+  quickStartTitle: "Documentation-First Onboarding",
+  quickStartText:
+    "The homepage keeps the product narrative concise, while operational details live in versioned documentation for continuous expansion.",
+  quickStartCards: {
+    firstTitle: "1. Start With The Guide",
+    firstText: "Get a local environment running first, then move on to deployment and configuration details as needed.",
+    firstCode: "docs/en/guide/quick-start.md\ndocs/en/guide/deploy.md\ndocs/en/guide/config.md",
+    secondTitle: "2. Explore The Docs",
+    secondText: "The docs site provides sidebar navigation, local search, and static builds that are easy to maintain over time.",
+    primaryAction: "Read The Docs",
+    secondaryAction: "Open FAQ"
+  },
+  resourcesEyebrow: "Resources",
+  resourcesTitle: "Docs, Community, And Deployment Paths",
+  resourcesText:
+    "Move from the landing page into a stable information architecture that keeps documentation and community entry points in one place.",
+  resourceCards: [
+    {
+      title: "Quick Start",
+      description: "Get a local experience running in two steps before diving deeper into the platform.",
+      href: "/guide/quick-start"
+    },
+    {
+      title: "Deployment Guide",
+      description: "Choose between Docker, Helm, and environment setup paths based on your scenario.",
+      href: "/guide/deploy"
+    },
+    {
+      title: "Configuration",
+      description: "Review infrastructure, model, storage, and authentication settings before production rollout.",
+      href: "/guide/config"
+    },
+    {
+      title: "FAQ",
+      description: "Find the main troubleshooting paths and reduce repeated onboarding questions.",
+      href: "/faq"
+    }
+  ],
+  communityEyebrow: "Community",
+  communityTitle: "Join The Community",
+  communityText: "Share feedback, implementation ideas, and collaboration requests through GitHub Issues, Discussions, and the WeCom group.",
+  communityPrimaryAction: "Open An Issue",
+  communitySecondaryAction: "Join Discussions",
+  communityImageAlt: "Astron Agent community group",
+  footerText: "An enterprise-grade, commercially-friendly Agentic Workflow development platform.",
+  footerDocsLink: "Documentation"
+};
+
+const isEnglish = computed(() => lang.value === "en-US");
+const content = computed(() => (isEnglish.value ? enContent : zhContent));
+
+const localizePath = (path: string) => {
+  const localePrefix = isEnglish.value ? "/en" : "";
+  const normalizedPath = path === "/" ? "/" : path;
+  return withBase(`${localePrefix}${normalizedPath}`);
+};
 
 onMounted(() => {
   const cards = Array.from(document.querySelectorAll<HTMLElement>(revealSelector));
@@ -86,44 +302,42 @@ onBeforeUnmount(() => {
           <span>Astron Agent</span>
         </a>
         <div class="astron-home__nav-links">
-          <a :href="withBase('/guide/quick-start')">快速开始</a>
-          <a :href="withBase('/guide/deploy')">部署指南</a>
-          <a :href="withBase('/guide/config')">配置说明</a>
-          <a :href="withBase('/faq')">FAQ</a>
-          <a class="astron-home__nav-cta" href="https://github.com/iflytek/astron-agent" target="_blank" rel="noreferrer">GitHub</a>
+          <a :href="localizePath('/guide/quick-start')">{{ content.nav.quickStart }}</a>
+          <a :href="localizePath('/guide/deploy')">{{ content.nav.deploy }}</a>
+          <a :href="localizePath('/guide/config')">{{ content.nav.config }}</a>
+          <a :href="localizePath('/faq')">FAQ</a>
+          <a class="astron-home__nav-cta" href="https://github.com/iflytek/astron-agent" target="_blank" rel="noreferrer">{{ content.nav.github }}</a>
         </div>
       </nav>
 
       <section class="astron-home__hero-main astron-container">
         <div class="astron-home__copy">
-          <span class="astron-home__eyebrow">Open Source · Apache 2.0 · Enterprise Ready</span>
-          <h1>构建面向企业落地的<br>Agentic Workflow 平台</h1>
+          <span class="astron-home__eyebrow">{{ content.eyebrow }}</span>
+          <h1>
+            <span>{{ content.heroTitleTop }}</span><br>
+            <span>{{ content.heroTitleBottom }}</span>
+          </h1>
           <p class="astron-home__text">
-            Astron Agent 聚合 AI 工作流编排、模型管理、MCP 与工具集成、RPA 自动化以及多团队协作能力，
-            帮助企业以更低成本快速构建高可用、可扩展、可运营的智能体应用。
+            {{ content.heroText }}
           </p>
           <div class="astron-home__actions">
-            <a class="astron-home__button astron-home__button--primary" href="https://github.com/iflytek/astron-agent" target="_blank" rel="noreferrer">查看源码</a>
-            <a class="astron-home__button astron-home__button--secondary" href="https://agent.xfyun.cn" target="_blank" rel="noreferrer">体验 Astron Cloud</a>
+            <a class="astron-home__button astron-home__button--primary" href="https://github.com/iflytek/astron-agent" target="_blank" rel="noreferrer">{{ content.primaryAction }}</a>
+            <a class="astron-home__button astron-home__button--secondary" href="https://agent.xfyun.cn" target="_blank" rel="noreferrer">{{ content.secondaryAction }}</a>
           </div>
           <ul class="astron-home__metrics">
-            <li class="js-reveal">
-              <strong>企业级高可用</strong>
-              <span>支持面向生产环境的部署与运维</span>
-            </li>
-            <li class="js-reveal">
-              <strong>MCP + RPA</strong>
-              <span>实现从决策到动作的执行闭环</span>
-            </li>
-            <li class="js-reveal">
-              <strong>多语言微服务</strong>
-              <span>覆盖前端、Java、Python、Go 核心能力</span>
+            <li
+              v-for="metric in content.metrics"
+              :key="metric.title"
+              class="js-reveal"
+            >
+              <strong>{{ metric.title }}</strong>
+              <span>{{ metric.description }}</span>
             </li>
           </ul>
         </div>
         <div class="astron-home__visual js-reveal">
           <div class="astron-home__hero-card">
-            <img :src="withBase('/imgs/Astron_Readme.png')" alt="Astron Agent preview">
+            <img :src="heroPreviewImage" alt="Astron Agent preview">
           </div>
         </div>
       </section>
@@ -133,12 +347,12 @@ onBeforeUnmount(() => {
       <section class="astron-home__section">
         <div class="astron-container">
           <div class="astron-home__section-heading js-reveal">
-            <span class="astron-home__eyebrow">Why Astron Agent</span>
-            <h2>围绕企业生产场景设计</h2>
-            <p>面向高可靠部署、跨系统连接与业务落地，提供从平台底座到业务编排的完整能力。</p>
+            <span class="astron-home__eyebrow">{{ content.featureEyebrow }}</span>
+            <h2>{{ content.featureTitle }}</h2>
+            <p>{{ content.featureText }}</p>
           </div>
           <div class="astron-home__feature-grid">
-            <article v-for="card in featureCards" :key="card.title" class="astron-home__panel js-reveal">
+            <article v-for="card in content.featureCards" :key="card.title" class="astron-home__panel js-reveal">
               <h3>{{ card.title }}</h3>
               <p>{{ card.description }}</p>
             </article>
@@ -149,23 +363,20 @@ onBeforeUnmount(() => {
       <section class="astron-home__section astron-home__section--accent">
         <div class="astron-container">
           <div class="astron-home__section-heading js-reveal">
-            <span class="astron-home__eyebrow">Architecture</span>
-            <h2>统一控制台 + 核心服务集群</h2>
-            <p>前端、控制台后端、Agent / Workflow / Knowledge / Memory / Tenant 等服务职责清晰，适合多团队协作开发。</p>
+            <span class="astron-home__eyebrow">{{ content.architectureEyebrow }}</span>
+            <h2>{{ content.architectureTitle }}</h2>
+            <p>{{ content.architectureText }}</p>
           </div>
           <div class="astron-home__architecture-grid">
-            <article class="astron-home__media-card js-reveal">
-              <img :src="withBase('/imgs/arch.png')" alt="Astron Agent architecture diagram">
+            <article
+              v-for="card in content.architectureCards"
+              :key="card.title"
+              class="astron-home__media-card js-reveal"
+            >
+              <img :src="card.image" :alt="card.alt">
               <div>
-                <h3>总体架构</h3>
-                <p>控制台前后端、核心执行引擎与插件系统协同工作，形成端到端的智能体平台能力。</p>
-              </div>
-            </article>
-            <article class="astron-home__media-card js-reveal">
-              <img :src="withBase('/imgs/structure-zh.png')" alt="Astron Agent structure diagram">
-              <div>
-                <h3>模块结构</h3>
-                <p>仓库涵盖 React + TypeScript、Java Spring Boot、Python FastAPI 与 Go 服务，支持模块化演进。</p>
+                <h3>{{ card.title }}</h3>
+                <p>{{ card.description }}</p>
               </div>
             </article>
           </div>
@@ -175,24 +386,22 @@ onBeforeUnmount(() => {
       <section class="astron-home__section">
         <div class="astron-container">
           <div class="astron-home__section-heading js-reveal">
-            <span class="astron-home__eyebrow">Quick Start</span>
-            <h2>文档化接入路径</h2>
-            <p>首页保留品牌视觉，落地使用说明则进入文档页维护，便于后续持续扩展。</p>
+            <span class="astron-home__eyebrow">{{ content.quickStartEyebrow }}</span>
+            <h2>{{ content.quickStartTitle }}</h2>
+            <p>{{ content.quickStartText }}</p>
           </div>
           <div class="astron-home__quickstart-grid">
             <article class="astron-home__code-card js-reveal">
-              <h3>1. 阅读快速开始</h3>
-              <p>先完成本地体验，再按需要切换到生产部署和配置章节。</p>
-              <pre><code>docs/guide/quick-start.md
-docs/guide/deploy.md
-docs/guide/config.md</code></pre>
+              <h3>{{ content.quickStartCards.firstTitle }}</h3>
+              <p>{{ content.quickStartCards.firstText }}</p>
+              <pre><code>{{ content.quickStartCards.firstCode }}</code></pre>
             </article>
             <article class="astron-home__code-card js-reveal">
-              <h3>2. 进入文档目录</h3>
-              <p>文档站支持侧边栏导航、全文搜索和静态构建，适合持续补充内容。</p>
+              <h3>{{ content.quickStartCards.secondTitle }}</h3>
+              <p>{{ content.quickStartCards.secondText }}</p>
               <div class="astron-home__actions">
-                <a class="astron-home__button astron-home__button--primary" :href="withBase('/guide/quick-start')">开始阅读</a>
-                <a class="astron-home__button astron-home__button--secondary" :href="withBase('/faq')">查看 FAQ</a>
+                <a class="astron-home__button astron-home__button--primary" :href="localizePath('/guide/quick-start')">{{ content.quickStartCards.primaryAction }}</a>
+                <a class="astron-home__button astron-home__button--secondary" :href="localizePath('/faq')">{{ content.quickStartCards.secondaryAction }}</a>
               </div>
             </article>
           </div>
@@ -202,16 +411,16 @@ docs/guide/config.md</code></pre>
       <section class="astron-home__section astron-home__section--accent">
         <div class="astron-container">
           <div class="astron-home__section-heading js-reveal">
-            <span class="astron-home__eyebrow">Resources</span>
-            <h2>文档、社区与部署入口</h2>
-            <p>从首页进入稳定的信息架构，把说明文档和社区入口统一收敛到 Pages 文档站。</p>
+            <span class="astron-home__eyebrow">{{ content.resourcesEyebrow }}</span>
+            <h2>{{ content.resourcesTitle }}</h2>
+            <p>{{ content.resourcesText }}</p>
           </div>
           <div class="astron-home__resource-grid">
             <a
-              v-for="resource in resourceCards"
+              v-for="resource in content.resourceCards"
               :key="resource.title"
               class="astron-home__panel astron-home__resource-card js-reveal"
-              :href="withBase(resource.href)"
+              :href="localizePath(resource.href)"
             >
               <h3>{{ resource.title }}</h3>
               <p>{{ resource.description }}</p>
@@ -223,16 +432,16 @@ docs/guide/config.md</code></pre>
       <section class="astron-home__section">
         <div class="astron-container astron-home__community">
           <div class="astron-home__community-copy js-reveal">
-            <span class="astron-home__eyebrow">Community</span>
-            <h2>加入社区，共建 Astron Agent</h2>
-            <p>欢迎通过 GitHub Issues、Discussions 与企业微信群参与反馈、共建与协作。</p>
+            <span class="astron-home__eyebrow">{{ content.communityEyebrow }}</span>
+            <h2>{{ content.communityTitle }}</h2>
+            <p>{{ content.communityText }}</p>
             <div class="astron-home__actions">
-              <a class="astron-home__button astron-home__button--primary" href="https://github.com/iflytek/astron-agent/issues" target="_blank" rel="noreferrer">提交 Issue</a>
-              <a class="astron-home__button astron-home__button--secondary" href="https://github.com/iflytek/astron-agent/discussions" target="_blank" rel="noreferrer">参与讨论</a>
+              <a class="astron-home__button astron-home__button--primary" href="https://github.com/iflytek/astron-agent/issues" target="_blank" rel="noreferrer">{{ content.communityPrimaryAction }}</a>
+              <a class="astron-home__button astron-home__button--secondary" href="https://github.com/iflytek/astron-agent/discussions" target="_blank" rel="noreferrer">{{ content.communitySecondaryAction }}</a>
             </div>
           </div>
           <div class="astron-home__community-card js-reveal">
-            <img :src="withBase('/imgs/WeCom_Group.png')" alt="Astron Agent community group">
+            <img :src="wecomGroupImage" :alt="content.communityImageAlt">
           </div>
         </div>
       </section>
@@ -242,12 +451,12 @@ docs/guide/config.md</code></pre>
       <div class="astron-container astron-home__footer-inner">
         <div>
           <strong>Astron Agent</strong>
-          <p>企业级、商业友好的 Agentic Workflow 开发平台。</p>
+          <p>{{ content.footerText }}</p>
         </div>
         <div class="astron-home__footer-links">
           <a href="https://github.com/iflytek/astron-agent" target="_blank" rel="noreferrer">GitHub</a>
           <a href="https://agent.xfyun.cn" target="_blank" rel="noreferrer">Astron Cloud</a>
-          <a :href="withBase('/guide/quick-start')">文档入口</a>
+          <a :href="localizePath('/guide/quick-start')">{{ content.footerDocsLink }}</a>
         </div>
       </div>
     </footer>

--- a/docs/en/CONFIGURATION.md
+++ b/docs/en/CONFIGURATION.md
@@ -1,0 +1,338 @@
+# Environment Variables Configuration Guide
+
+This document provides detailed descriptions of all environment variables required by the system, including middleware, service ports, authentication, business modules, and more.
+
+## Quick Start
+
+### Required Manual Configuration Fields
+
+Before deploying with Docker Compose, the following environment variables **must be manually configured**. For detailed configuration steps and instructions, please refer to the [Deployment Guide](/en/DEPLOYMENT_GUIDE).
+
+**Key Configuration Items Overview**:
+
+- **iFlytek Open Platform Credentials** (requires application):
+  - `PLATFORM_APP_ID`, `PLATFORM_API_KEY`, `PLATFORM_API_SECRET`
+  - `SPARK_API_PASSWORD`, `SPARK_RTASR_API_KEY`
+
+- **Casdoor Authentication Configuration** (requires Casdoor service deployment):
+  - `CONSOLE_CASDOOR_URL`, `CONSOLE_CASDOOR_ID`
+  - `CONSOLE_CASDOOR_APP`, `CONSOLE_CASDOOR_ORG`
+
+- **RAGFlow Knowledge Base Configuration** (if using RAGFlow as knowledge base):
+  - `RAGFLOW_BASE_URL`, `RAGFLOW_API_TOKEN`, `RAGFLOW_DEFAULT_GROUP`
+
+- **Host Address Configuration**:
+  - `HOST_BASE_ADDRESS` - Set to your server address or domain name
+
+### Configuration Item Descriptions
+
+Configuration items in this document are marked as follows:
+
+- **User Required**: Fields that must be manually configured (no default value or require external service application)
+- **Use Default**: Recommended to use the default configuration provided by Docker Compose (modify if using external middleware)
+- **Required**: Must exist but default value is provided (usually no modification needed)
+- **Optional**: Non-essential configuration, can be enabled as needed
+- **Conditional**: Fields that need to be configured only in specific scenarios
+
+---
+
+## 1. Middleware Configuration Module
+
+> **Independent Deployment Note**:
+> - If using Docker Compose one-click deployment, the following configurations can use container names (such as `postgres`, `mysql`, `redis`, `kafka`, `minio`) as host addresses
+> - If middleware services are **deployed separately** (not in the same Docker network), you need to replace the container names in the following configurations with actual IP addresses or domain names, and synchronize the corresponding connection information (such as username, password, port, etc.):
+>   - PostgreSQL related: `POSTGRES_HOST`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT`, etc.
+>   - MySQL related: `MYSQL_HOST`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_URL`, etc.
+>   - Redis related: `REDIS_ADDR`, `REDIS_HOST`, `REDIS_PASSWORD`, `REDIS_PORT`, etc.
+>   - Kafka related: `KAFKA_SERVERS` and authentication information (if needed)
+>   - MinIO related: `OSS_ENDPOINT`, `OSS_DOWNLOAD_HOST`, `OSS_ACCESS_KEY_ID`, `OSS_SECRET_KEY`, etc.
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| POSTGRES_USER | Use Default | string | PostgreSQL database username | spark |
+| POSTGRES_PASSWORD | Use Default | string | PostgreSQL database password | spark123 |
+| POSTGRES_HOST | Use Default | string | PostgreSQL database host address | postgres |
+| POSTGRES_PORT | Use Default | int | PostgreSQL database port number | 5432 |
+| MYSQL_ROOT_PASSWORD | Use Default | string | MySQL database root user password | root123 |
+| MYSQL_USER | Use Default | string | MySQL database username | root |
+| MYSQL_PASSWORD | Use Default | string | MySQL database password (defaults from MYSQL_ROOT_PASSWORD) | root123 |
+| MYSQL_HOST | Use Default | string | MySQL database host address | mysql |
+| MYSQL_PORT | Use Default | int | MySQL database port number | 3306 |
+| MYSQL_URL | Use Default | string | MySQL database JDBC connection URL | jdbc:mysql://mysql:3306/astron_console |
+| REDIS_PASSWORD | Optional | string | Redis password (empty means no password) | (empty) |
+| REDIS_DATABASE | Use Default | int | Redis database index (0-15) | 0 |
+| REDIS_IS_CLUSTER | Use Default | bool | Whether Redis is in cluster mode | false |
+| REDIS_CLUSTER_ADDR | Optional | string | Redis cluster address (used in cluster mode) | redis1:6379,redis2:6379 |
+| REDIS_EXPIRE | Use Default | int | Redis cache expiration time (seconds) | 3600 |
+| REDIS_ADDR | Use Default | string | Redis connection address (standalone mode) | redis:6379 |
+| REDIS_HOST | Use Default | string | Redis host address | redis |
+| REDIS_PORT | Use Default | int | Redis port number | 6379 |
+| ELASTICSEARCH_SECURITY_ENABLED | Use Default | bool | Whether Elasticsearch has security authentication enabled | false |
+| ES_JAVA_OPTS | Use Default | string | Elasticsearch JVM parameter configuration | -Xms512m -Xmx512m |
+| EXPOSE_KAFKA_PORT | Use Default | int | Kafka externally exposed port number | 9092 |
+| KAFKA_REPLICATION_FACTOR | Use Default | int | Kafka replication factor | 1 |
+| KAFKA_CLUSTER_ID | Use Default | string | Kafka cluster ID | MkU3OEVBNTcwNTJENDM2Qk |
+| KAFKA_TIMEOUT | Use Default | int | Kafka connection timeout (seconds) | 60 |
+| KAFKA_SERVERS | Use Default | string | Kafka server address list | kafka:29092 |
+| MINIO_ROOT_USER | Use Default | string | MinIO administrator username | minioadmin |
+| MINIO_ROOT_PASSWORD | Use Default | string | MinIO administrator password | minioadmin123 |
+| EXPOSE_MINIO_PORT | Use Default | int | MinIO API externally exposed port number | 18998 |
+| EXPOSE_MINIO_CONSOLE_PORT | Use Default | int | MinIO console externally exposed port number | 18999 |
+| OSS_TYPE | Use Default | string | Object storage type (s3/oss/obs, etc.) | s3 |
+| OSS_ENDPOINT | Use Default | url | Object storage service endpoint address | http://minio:9000 |
+| OSS_ACCESS_KEY_ID | Use Default | string | Object storage access key ID | ${MINIO_ROOT_USER:-minioadmin} |
+| OSS_ACCESS_KEY_SECRET | Use Default | string | Object storage access key Secret | ${MINIO_ROOT_PASSWORD:-minioadmin123} |
+| OSS_BUCKET_NAME | Use Default | string | Object storage bucket name | workflow |
+| OSS_TTL | Use Default | int | Object storage URL validity period (seconds) | 157788000 |
+| OSS_DOWNLOAD_HOST | Use Default | url | Object storage download access address | http://minio:9000 |
+
+---
+
+## 2. Monitoring Configuration Module (OTLP)
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| OTLP_ENABLE | Required | int | Whether to enable OTLP monitoring (0=disabled, 1=enabled) | 0 |
+| OTLP_ENDPOINT | Required | string | OTLP service endpoint address | 127.0.0.1:4317 |
+| OTLP_METRIC_TIMEOUT | Required | int | OTLP metric reporting timeout (milliseconds) | 3000 |
+| OTLP_METRIC_EXPORT_INTERVAL_MILLIS | Required | int | OTLP metric export interval (milliseconds) | 3000 |
+| OTLP_METRIC_EXPORT_TIMEOUT_MILLIS | Required | int | OTLP metric export timeout (milliseconds) | 3000 |
+| OTLP_TRACE_TIMEOUT | Required | int | OTLP trace timeout (milliseconds) | 3000 |
+| OTLP_TRACE_MAX_QUEUE_SIZE | Required | int | OTLP trace queue maximum size | 2048 |
+| OTLP_TRACE_SCHEDULE_DELAY_MILLIS | Required | int | OTLP trace schedule delay (milliseconds) | 3000 |
+| OTLP_TRACE_MAX_EXPORT_BATCH_SIZE | Required | int | OTLP trace batch export maximum size | 2048 |
+| OTLP_TRACE_EXPORT_TIMEOUT_MILLIS | Required | int | OTLP trace export timeout (milliseconds) | 3000 |
+
+---
+
+## 3. Basic Service Port Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| EXPOSE_NGINX_PORT | Required | int | Nginx externally exposed port number | 80 |
+| CORE_TENANT_PORT | Required | int | Tenant core service port number | 5052 |
+| CORE_DATABASE_PORT | Required | int | Database core service port number | 7990 |
+| CORE_RPA_PORT | Required | int | RPA core service port number | 17198 |
+| CORE_LINK_PORT | Required | int | Link core service port number | 18888 |
+| CORE_AITOOLS_PORT | Required | int | AITools core service port number | 18668 |
+| CORE_AGENT_PORT | Required | int | Agent core service port number | 17870 |
+| CORE_KNOWLEDGE_PORT | Required | int | Knowledge core service port number | 20010 |
+| CORE_WORKFLOW_PORT | Required | int | Workflow core service port number | 7880 |
+
+---
+
+## 4. Authentication Configuration Module (Casdoor)
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| CONSOLE_CASDOOR_URL | User Required | url | Casdoor authentication server address | http://your-casdoor-server:8000 |
+| CONSOLE_CASDOOR_ID | User Required | string | Casdoor OAuth2 client ID | astron-agent-client |
+| CONSOLE_CASDOOR_APP | User Required | string | Casdoor application name | astron-agent-app |
+| CONSOLE_CASDOOR_ORG | User Required | string | Casdoor organization name | built-in |
+
+---
+
+## 5. Tenant Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| DATABASE_DB_TYPE | Required | string | Database type | mysql |
+| DATABASE_USERNAME | Required | string | Database username (defaults from MYSQL_USER) | ${MYSQL_USER:-root} |
+| DATABASE_PASSWORD | Required | string | Database password (defaults from MYSQL_PASSWORD) | ${MYSQL_PASSWORD:-root123} |
+| DATABASE_URL | Required | string | Database connection URL | (mysql:3306)/tenant |
+| DATABASE_MAX_OPEN_CONNS | Required | int | Database maximum connections | 5 |
+| DATABASE_MAX_IDLE_CONNS | Required | int | Database maximum idle connections | 5 |
+| LOG_PATH | Required | string | Log file path | log.txt |
+
+---
+
+## 6. Database Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| DATABASE_POSTGRES_DATABASE | Required | string | PostgreSQL database name | sparkdb_manager |
+
+---
+
+## 7. RPA Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| RPA_URL | Required | url | RPA service base address | https://newapi.iflyrpa.com |
+| XIAOWU_RPA_TASK_CREATE_URL | Required | url | Xiaowu RPA task creation API address (defaults from RPA_URL) | ${RPA_URL}/api/rpa-openapi/workflows/execute-async |
+| XIAOWU_RPA_TASK_QUERY_URL | Required | url | Xiaowu RPA task query API address (defaults from RPA_URL) | ${RPA_URL}/api/rpa-openapi/executions |
+
+---
+
+## 8. Link Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| LINK_MYSQL_DB | Required | string | MySQL database name used by Link module | spark-link |
+
+---
+
+## 9. Agent Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| SERVICE_HOST | Required | string | Service listening host address | 0.0.0.0 |
+| SERVICE_WORKERS | Required | int | Service worker process count | 1 |
+| SERVICE_RELOAD | Required | bool | Whether to enable service hot reload | false |
+| SERVICE_WS_PING_INTERVAL | Required | bool/int | WebSocket heartbeat interval | false |
+| SERVICE_WS_PING_TIMEOUT | Required | bool/int | WebSocket heartbeat timeout | false |
+| AGENT_MYSQL_DB | Required | string | MySQL database name used by Agent module | agent |
+| UPLOAD_NODE_TRACE | Required | bool | Whether to upload node trace data | true |
+| UPLOAD_METRICS | Required | bool | Whether to upload metrics data | true |
+| AGENT_KAFKA_TOPIC | Required | string | Kafka topic name used by Agent | spark-agent-builder |
+| GET_LINK_URL | Required | url | API address to get tool link | http://core-link:18888/api/v1/tools |
+| VERSIONS_LINK_URL | Required | url | API address to get tool version | http://core-link:18888/api/v1/tools/versions |
+| RUN_LINK_URL | Required | url | API address to run tool | http://core-link:18888/api/v1/tools/http_run |
+| GET_WORKFLOWS_URL | Required | url | API address to get workflow (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/sparkflow/v1/protocol/get |
+| WORKFLOW_SSE_BASE_URL | Required | url | Workflow SSE (Server-Sent Events) base address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1 |
+| CHUNK_QUERY_URL | Required | url | Knowledge base chunk query API address (port defaults from CORE_KNOWLEDGE_PORT) | http://core-knowledge:${CORE_KNOWLEDGE_PORT:-20010}/knowledge/v1/chunk/query |
+| LIST_MCP_PLUGIN_URL | Required | url | API address to list MCP plugins | http://core-link:18888/api/v1/mcp/tool_list |
+| RUN_MCP_PLUGIN_URL | Required | url | API address to run MCP plugin | http://core-link:18888/api/v1/mcp/call_tool |
+| APP_AUTH_HOST | Required | string | Application authentication service host address (port defaults from CORE_TENANT_PORT) | core-tenant:${CORE_TENANT_PORT:-5052} |
+| APP_AUTH_PROT | Required | string | Application authentication service protocol (http/https) | http |
+| APP_AUTH_API_KEY | Required | string | Application authentication API Key | 7b709739e8da44536127a333c7603a83 |
+| APP_AUTH_SECRET | Required | string | Application authentication Secret | NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy |
+
+---
+
+## 10. Knowledge Module Configuration
+
+> **Knowledge Base Selection Note**: The system supports two knowledge base methods. Choose one based on your needs:
+> - **RAGFlow**: Use RAGFlow knowledge base service (requires configuration of RAGFLOW_* related variables)
+> - **Spark Knowledge Base**: Use iFlytek Spark knowledge base service (requires configuration of XINGHUO_DATASET_ID)
+>
+> Whichever method you choose, the corresponding configuration items are required; configuration items for the unchosen method can be left empty.
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| RAGFLOW_BASE_URL | Conditional | url | RAGFlow service base address (required when using RAGFlow) | http://localhost:10080 |
+| RAGFLOW_API_TOKEN | Conditional | string | RAGFlow API access token (required when using RAGFlow) | your-ragflow-token |
+| RAGFLOW_TIMEOUT | Conditional | int | RAGFlow request timeout (seconds) (required when using RAGFlow) | 60 |
+| RAGFLOW_DEFAULT_GROUP | Conditional | string | RAGFlow default group name (required when using RAGFlow) | Astron Knowledge Base |
+| XINGHUO_DATASET_ID | Conditional | string | Spark knowledge base dataset ID (required when using Spark knowledge base) | (empty) |
+
+---
+
+## 11. Workflow Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| WORKFLOW_MYSQL_DB | Required | string | MySQL database name used by Workflow module | workflow |
+| WORKFLOW_KAFKA_TOPIC | Required | string | Kafka topic name used by Workflow | spark-agent-builder |
+| RUNTIME_ENV | Required | string | Runtime environment (dev/test/prod) | dev |
+
+---
+
+## 12. Console Module Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| HOST_BASE_ADDRESS | User Required | url | Host base address | http://localhost |
+| CONSOLE_DOMAIN | Required | url | Console domain address (defaults from HOST_BASE_ADDRESS and EXPOSE_NGINX_PORT) | ${HOST_BASE_ADDRESS}:${EXPOSE_NGINX_PORT} |
+| OSS_REMOTE_ENDPOINT | Required | url | Object storage remote endpoint address (defaults from HOST_BASE_ADDRESS and EXPOSE_MINIO_PORT) | ${HOST_BASE_ADDRESS}:${EXPOSE_MINIO_PORT} |
+| OSS_BUCKET_CONSOLE | Required | string | Object storage bucket name used by Console | console-oss |
+| OSS_PRESIGN_EXPIRY_SECONDS_CONSOLE | Required | int | Console presigned URL expiration time (seconds) | 600 |
+| REDIS_DATABASE_CONSOLE | Required | int | Redis database index used by Console | 1 |
+| OAUTH2_ISSUER_URI | Required | url | OAuth2 issuer URI (defaults from CONSOLE_CASDOOR_URL) | ${CONSOLE_CASDOOR_URL:-http://auth-server:8000} |
+| OAUTH2_JWK_SET_URI | Required | url | OAuth2 JWK key set URI (defaults from CONSOLE_CASDOOR_URL) | ${CONSOLE_CASDOOR_URL:-http://auth-server:8000}/.well-known/jwks |
+| OAUTH2_AUDIENCE | Required | string | OAuth2 audience identifier (defaults from CONSOLE_CASDOOR_ID) | ${CONSOLE_CASDOOR_ID:-your-oauth2-client-id} |
+| PLATFORM_APP_ID | User Required | string | iFlytek Open Platform application ID | your-app-id |
+| PLATFORM_API_KEY | User Required | string | iFlytek Open Platform API Key | your-api-key |
+| PLATFORM_API_SECRET | User Required | string | iFlytek Open Platform API Secret | your-api-secret |
+| AI_ABILITY_CHAT_BASE_URL | Optional | url | Text model service address (OpenAI-compatible API) (defaults from PLATFORM_API_KEY) | ${PLATFORM_API_KEY} |
+| AI_ABILITY_CHAT_MODEL | Optional | string | Text model name | ${AI_ABILITY_CHAT_MODEL} |
+| AI_ABILITY_CHAT_API_KEY | Optional | string | Text model API Key | ${AI_ABILITY_CHAT_API_KEY} |
+| SPARK_RTASR_API_KEY | User Required | string | Spark real-time speech-to-text API Key | your-rtasr-api-key |
+| SPARK_API_PASSWORD | User Required | string | Spark large model API password | your-api-password |
+| SPARK_APP_ID | Required | string | Spark service application ID (defaults from PLATFORM_APP_ID) | ${PLATFORM_APP_ID} |
+| SPARK_API_KEY | Required | string | Spark service API Key (defaults from PLATFORM_API_KEY) | ${PLATFORM_API_KEY} |
+| SPARK_API_SECRET | Required | string | Spark service API Secret (defaults from PLATFORM_API_SECRET) | ${PLATFORM_API_SECRET} |
+| SPARK_RTASR_APPID | Required | string | Spark real-time speech-to-text application ID (defaults from PLATFORM_APP_ID) | ${PLATFORM_APP_ID} |
+| SPARK_RTASR_KEY | Required | string | Spark real-time speech-to-text Key (defaults from SPARK_RTASR_API_KEY) | ${SPARK_RTASR_API_KEY} |
+| SPARK_IMAGE_APP_ID | Required | string | Spark image generation application ID (defaults from PLATFORM_APP_ID) | ${PLATFORM_APP_ID} |
+| SPARK_IMAGE_API_KEY | Required | string | Spark image generation API Key (defaults from PLATFORM_API_KEY) | ${PLATFORM_API_KEY} |
+| SPARK_IMAGE_API_SECRET | Required | string | Spark image generation API Secret (defaults from PLATFORM_API_SECRET) | ${PLATFORM_API_SECRET} |
+| WECHAT_COMPONENT_APPID | Optional | string | WeChat third-party platform AppID | your-wechat-component-appid |
+| WECHAT_COMPONENT_SECRET | Optional | string | WeChat third-party platform Secret | your-wechat-secret |
+| WECHAT_TOKEN | Optional | string | WeChat message verification Token | your-wechat-token |
+| WECHAT_ENCODING_AES_KEY | Optional | string | WeChat message encryption key | your-wechat-encoding-aes-key |
+| WORKFLOW_CHAT_URL | Required | url | Workflow chat API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/chat/completions |
+| WORKFLOW_DEBUG_URL | Required | url | Workflow debug API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/debug/chat/completions |
+| WORKFLOW_RESUME_URL | Required | url | Workflow resume API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/resume |
+| TENANT_ID | Required | string | Tenant ID | 680ab54f |
+| TENANT_KEY | Required | string | Tenant API Key | 7b709739e8da44536127a333c7603a83 |
+| TENANT_SECRET | Required | string | Tenant Secret | NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy |
+| COMMON_APPID | Required | string | Common application ID (defaults from TENANT_ID) | ${TENANT_ID} |
+| COMMON_APIKEY | Required | string | Common API Key (defaults from TENANT_KEY) | ${TENANT_KEY} |
+| COMMON_API_SECRET | Required | string | Common API Secret (defaults from TENANT_SECRET) | ${TENANT_SECRET} |
+| ADMIN_UID | Required | string | Administrator user ID | 9999 |
+| APP_URL | Required | url | Application service API address (port defaults from CORE_TENANT_PORT) | http://core-tenant:${CORE_TENANT_PORT:-5052}/v2/app |
+| KNOWLEDGE_URL | Required | url | Knowledge base service API address (port defaults from CORE_KNOWLEDGE_PORT) | http://core-knowledge:${CORE_KNOWLEDGE_PORT:-20010}/knowledge |
+| TOOL_URL | Required | url | Tool service API address | http://core-link:18888 |
+| WORKFLOW_URL | Required | url | Workflow service API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880} |
+| SPARK_DB_URL | Required | url | Spark database service API address (port defaults from CORE_DATABASE_PORT) | http://core-database:${CORE_DATABASE_PORT:-7990} |
+| LOCAL_MODEL_URL | Required | url | Local model service address | http://127.0.0.1:33778 |
+
+---
+
+## 13. MaaS Platform Configuration Module
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| MAAS_APP_ID | Required | string | MaaS platform application ID (defaults from PLATFORM_APP_ID) | ${PLATFORM_APP_ID} |
+| MAAS_API_KEY | Required | string | MaaS platform API Key (defaults from PLATFORM_API_KEY) | ${PLATFORM_API_KEY} |
+| MAAS_API_SECRET | Required | string | MaaS platform API Secret (defaults from PLATFORM_API_SECRET) | ${PLATFORM_API_SECRET} |
+| MAAS_CONSUMER_ID | Required | string | MaaS consumer ID (defaults from TENANT_ID) | ${TENANT_ID} |
+| MAAS_CONSUMER_KEY | Required | string | MaaS consumer Key (defaults from TENANT_KEY) | ${TENANT_KEY} |
+| MAAS_CONSUMER_SECRET | Required | string | MaaS consumer Secret (defaults from TENANT_SECRET) | ${TENANT_SECRET} |
+| MAAS_WORKFLOW_VERSION | Required | url | MaaS workflow version API address | http://127.0.0.1:8080/workflow/version |
+| MAAS_SYNCHRONIZE_WORK_FLOW | Required | url | MaaS synchronize workflow API address | http://127.0.0.1:8080/workflow |
+| MAAS_PUBLISH | Required | url | MaaS publish API address | http://127.0.0.1:8080/workflow/publish |
+| MAAS_CLONE_WORK_FLOW | Required | url | MaaS clone workflow API address | http://127.0.0.1:8080/workflow/internal-clone |
+| MAAS_GET_INPUTS | Required | url | MaaS get inputs information API address | http://127.0.0.1:8080/workflow/get-inputs-info |
+| MAAS_CAN_PUBLISH_URL | Required | url | MaaS check can publish API address | http://127.0.0.1:8080/workflow/can-publish |
+| MAAS_PUBLISH_API | Required | url | MaaS publish API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/publish |
+| MAAS_AUTH_API | Required | url | MaaS authentication API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/auth |
+| MAAS_MCP_REGISTER | Required | url | MaaS MCP register API address | http://127.0.0.1:8080/workflow/release |
+| MAAS_WORKFLOW_CONFIG | Required | url | MaaS workflow configuration API address | http://127.0.0.1:8080/workflow/get-flow-advanced-config |
+| BOT_API_CBM_BASE_URL | Required | url | Bot API CBM base address (supports ws/wss, note written as ws(s):// in env.example) | wss://spark-openapi.cn-huabei-1.xf-yun.com |
+| BOT_API_MAAS_BASE_URL | Required | url | Bot API MaaS base address (note written as http(s):// in env.example) | https://xingchen-api.xf-yun.com |
+| TENANT_CREATE_APP | Required | url | Tenant create application API address (port defaults from CORE_TENANT_PORT) | http://core-tenant:${CORE_TENANT_PORT:-5052}/v2/app |
+| TENANT_GET_APP_DETAIL | Required | url | Tenant get application details API address (port defaults from CORE_TENANT_PORT) | http://core-tenant:${CORE_TENANT_PORT:-5052}/v2/app/details |
+
+---
+
+## 14. Third-Party Service Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| DEEPSEEK_URL | Required | url | DeepSeek API endpoint address | https://api.deepseek.com/chat/completions |
+| DEEPSEEK_API_KEY | Optional | string | DeepSeek API Key | sk-xxx |
+
+---
+
+## 15. Other System Configuration
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| SERVICE_LOCATION | Required | string | Service availability zone (dx/hf/gz) | hf |
+| HEALTH_CHECK_INTERVAL | Required | string | Health check interval time | 30s |
+| HEALTH_CHECK_TIMEOUT | Required | string | Health check timeout | 10s |
+| HEALTH_CHECK_RETRIES | Required | int | Health check retry count | 60 |
+| NETWORK_SUBNET | Required | string | Docker network subnet configuration | 172.20.0.0/16 |
+
+---
+
+## Related Documentation
+
+- [Deployment Guide](/en/DEPLOYMENT_GUIDE) - Detailed deployment steps
+- [Quick Start](/en/README) - Quick start guide
+
+## Contributing
+
+If you find any errors in the configuration description or need to add more information, please feel free to submit an Issue or Pull Request.

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -1,0 +1,436 @@
+# Contributing to Astron Agent
+
+Thank you for your interest in contributing to Astron Agent! We welcome contributions from the community and appreciate your help in making this project better.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Development Environment Setup](#development-environment-setup)
+- [Project Structure](#project-structure)
+- [Development Workflow](#development-workflow)
+- [Code Quality Standards](#code-quality-standards)
+- [Testing Guidelines](#testing-guidelines)
+- [Documentation](#documentation)
+- [Submitting Changes](#submitting-changes)
+- [Issue Guidelines](#issue-guidelines)
+- [Pull Request Guidelines](#pull-request-guidelines)
+- [Release Process](#release-process)
+- [Community Guidelines](#community-guidelines)
+
+## Code of Conduct
+
+This project adheres to a code of conduct. By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
+
+Please read our [Code of Conduct](https://github.com/iflytek/astron-agent/blob/main/.github/code_of_conduct.md) for details on our commitment to providing a welcoming and inclusive environment for all contributors.
+
+## Getting Started
+
+### Prerequisites
+
+Before contributing, ensure you have the following installed:
+
+- **Java 21+** (for backend services)
+- **Maven 3.8+** (for Java project management)
+- **Node.js 18+** (for frontend development)
+- **Python 3.9+** (for core services)
+- **Go 1.21+** (for tenant service)
+- **Docker & Docker Compose** (for containerized services)
+- **Git** (for version control)
+
+### Fork and Clone
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/your-username/astron-agent.git
+   cd astron-agent
+   ```
+3. Add the upstream repository:
+   ```bash
+   git remote add upstream https://github.com/iflytek/astron-agent.git
+   ```
+
+## Development Environment Setup
+
+### One-time Setup
+
+Run the automated setup script to install all required tools and configure your environment:
+
+```bash
+make dev-setup
+```
+
+This command will:
+- Install language-specific development tools
+- Configure Git hooks for code quality
+- Set up branch naming conventions
+- Install dependencies for all modules
+
+### Manual Setup
+
+If you prefer manual setup or need to install specific components:
+
+```bash
+# Install development tools
+make install-tools
+
+# Check tool installation status
+make check-tools
+
+# Install Git hooks
+make hooks-install
+```
+
+### Pre-commit Setup (Recommended)
+
+We use [pre-commit](https://pre-commit.com/) for automated code quality checks and secret scanning. This is the **recommended way** to ensure code quality before committing.
+
+```bash
+# Install pre-commit (if not already installed)
+pip install pre-commit
+
+# Install pre-commit hooks
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+Pre-commit will automatically run on every commit to:
+- Check code formatting (Black, Prettier, gofmt, Spotless)
+- Run linters (flake8, ESLint, golangci-lint, Checkstyle)
+- Perform type checking (mypy, TypeScript)
+- Scan for secrets (gitleaks)
+- Validate commit message format
+
+For detailed usage instructions, see the [Pre-commit Usage Guide](/en/PRE-COMMIT).
+
+## Project Structure
+
+Astron Agent is a microservices-based platform with the following structure:
+
+```
+astron-agent/
+├── console/                    # Console subsystem
+│   ├── backend/               # Java Spring Boot services
+│   │   ├── auth/              # Authentication service
+│   │   ├── commons/           # Shared utilities
+│   │   ├── hub/               # Main business logic
+│   │   ├── toolkit/           # Toolkit services
+│   │   └── config/            # Quality configuration
+│   └── frontend/              # React TypeScript SPA
+├── core/                      # Core platform services
+│   ├── agent/                 # Agent execution engine (Python)
+│   ├── common/                # Shared Python libraries
+│   ├── knowledge/             # Knowledge base service (Python)
+│   ├── memory/                # Memory management
+│   ├── plugin/                # Plugin system
+│   ├── tenant/                # Multi-tenant service (Go)
+│   └── workflow/              # Workflow orchestration (Python)
+├── docs/                      # Documentation
+├── makefiles/                 # Build system components
+└── .github/                   # GitHub configuration
+    └── quality-requirements/  # Code quality standards
+```
+
+## Development Workflow
+
+### Branch Management
+
+Follow our branch naming conventions:
+
+| Branch Type | Format | Example | Purpose |
+|-------------|--------|---------|---------|
+| Feature | `feature/feature-name` | `feature/user-auth` | New features |
+| Bugfix | `bugfix/issue-name` | `bugfix/login-error` | Bug fixes |
+| Hotfix | `hotfix/patch-name` | `hotfix/security-patch` | Emergency fixes |
+| Documentation | `doc/doc-name` | `doc/api-guide` | Documentation updates |
+
+### Creating Branches
+
+Use the Makefile commands for consistent branch creation:
+
+```bash
+# Create feature branch
+make new-feature name=user-authentication
+
+# Create bugfix branch
+make new-bugfix name=login-timeout
+
+# Create hotfix branch
+make new-hotfix name=security-vulnerability
+```
+
+### Daily Development Commands
+
+```bash
+# Format all code
+make format
+
+# Run code quality checks with pre-commit (recommended)
+pre-commit run --all-files
+
+# Run tests
+make test
+
+# Build all projects
+make build
+```
+
+## Code Quality Standards
+
+### Multi-language Support
+
+Astron Agent supports multiple programming languages with unified quality standards:
+
+| Language | Formatting | Quality Tools | Standards |
+|----------|------------|---------------|-----------|
+| **Go** | gofmt + goimports + gofumpt | golangci-lint + staticcheck | Go standard format, complexity ≤10 |
+| **Java** | Spotless (Google Java Format) | Checkstyle + PMD + SpotBugs | Google Java Style, complexity ≤10 |
+| **Python** | black + isort | flake8 + mypy + pylint | PEP 8, complexity ≤10 |
+| **TypeScript** | prettier | eslint + tsc | ESLint rules, strict typing |
+
+### Code Quality Requirements
+
+All code must pass the following checks:
+
+- **Formatting**: Automatic code formatting applied
+- **Linting**: No linting errors or warnings
+- **Type Checking**: Strict type checking (TypeScript/Python)
+- **Complexity**: Cyclomatic complexity ≤10
+- **Testing**: Adequate test coverage
+- **Documentation**: Clear code comments and documentation
+
+### Code Quality Checks with Pre-commit
+
+We use pre-commit as the unified code quality checking tool. It automatically runs on staged files during commit, or you can run it manually:
+
+```bash
+# Check only staged files (automatically runs on git commit)
+pre-commit run
+
+# Check all files in the repository
+pre-commit run --all-files
+
+# Run a specific hook
+pre-commit run black --all-files
+pre-commit run eslint-check --all-files
+pre-commit run golangci-lint --all-files
+```
+
+For more details, see the [Pre-commit Usage Guide](/en/PRE-COMMIT).
+
+## Testing Guidelines
+
+### Test Structure
+
+- **Unit Tests**: Test individual components in isolation
+- **Integration Tests**: Test component interactions
+- **End-to-End Tests**: Test complete user workflows
+
+### Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run specific language tests
+make test-go
+make test-java
+make test-python
+make test-typescript
+
+# Run with coverage
+make test-coverage
+```
+
+### Test Requirements
+
+- All new features must include tests
+- Bug fixes must include regression tests
+- Test coverage should not decrease
+- Tests must be deterministic and fast
+
+## Documentation
+
+### Code Documentation
+
+- Use clear, concise comments
+- Document public APIs and interfaces
+- Include usage examples where appropriate
+- Follow language-specific documentation standards
+
+### Project Documentation
+
+- Update README files for significant changes
+- Document new features and APIs
+- Maintain up-to-date installation and setup guides
+- Include troubleshooting information
+
+## Submitting Changes
+
+### Commit Message Format
+
+Follow the Conventional Commits specification:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+- `feat`: New features
+- `fix`: Bug fixes
+- `docs`: Documentation updates
+- `style`: Code formatting
+- `refactor`: Code refactoring
+- `test`: Test-related changes
+- `chore`: Build tools, dependency updates
+
+**Examples:**
+```bash
+feat(auth): add OAuth2 authentication support
+fix(api): resolve user info query endpoint
+docs(guide): improve quick start guide
+```
+
+### Pre-commit Checklist
+
+Before committing, ensure:
+
+- [ ] Pre-commit hooks are installed (`pre-commit install && pre-commit install --hook-type commit-msg`)
+- [ ] Code quality checks pass (`pre-commit run --all-files`)
+- [ ] Tests pass (`make test`)
+- [ ] Branch naming follows conventions
+- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) format
+- [ ] Documentation is updated if needed
+
+> **Note**: If pre-commit hooks are installed, code quality and commit message format will be automatically checked on each commit.
+
+## Issue Guidelines
+
+### Reporting Bugs
+
+When reporting bugs, include:
+
+1. **Clear description** of the issue
+2. **Steps to reproduce** the problem
+3. **Expected behavior** vs actual behavior
+4. **Environment details** (OS, versions, etc.)
+5. **Relevant logs** or error messages
+6. **Screenshots** if applicable
+
+### Feature Requests
+
+For feature requests, include:
+
+1. **Clear description** of the feature
+2. **Use case** and motivation
+3. **Proposed solution** or approach
+4. **Alternative solutions** considered
+5. **Additional context** or references
+
+## Pull Request Guidelines
+
+### Before Submitting
+
+- [ ] Fork the repository and create a feature branch
+- [ ] Make your changes following the coding standards
+- [ ] Add tests for new functionality
+- [ ] Update documentation as needed
+- [ ] Ensure all checks pass locally
+- [ ] Rebase on the latest main branch
+
+### PR Description Template
+
+```markdown
+## Description
+Brief description of changes
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Testing
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing completed
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Documentation updated
+- [ ] No breaking changes (or documented)
+```
+
+### Review Process
+
+1. **Automated Checks**: All PRs must pass automated quality checks
+2. **Code Review**: At least one maintainer must approve
+3. **Testing**: All tests must pass
+4. **Documentation**: Documentation must be updated if needed
+
+## Release Process
+
+### Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)
+
+### Release Workflow
+
+1. Create release branch from main
+2. Update version numbers and changelog
+3. Run full test suite
+4. Create release PR for review
+5. Merge and tag release
+6. Deploy to production
+
+## Community Guidelines
+
+### Communication
+
+- Be respectful and inclusive
+- Use clear, constructive language
+- Provide helpful feedback
+- Ask questions when needed
+
+### Getting Help
+
+- Check existing documentation first
+- Search existing issues and discussions
+- Ask questions in discussions or issues
+- Join community channels if available
+
+### Recognition
+
+Contributors will be recognized in:
+- Release notes
+- Contributors list
+- Community highlights
+
+## Additional Resources
+
+- [Pre-commit Usage Guide](/en/PRE-COMMIT)
+- [Branch and Commit Standards](https://github.com/iflytek/astron-agent/blob/main/.github/quality-requirements/branch-commit-standards.md)
+- [Code Quality Requirements](https://github.com/iflytek/astron-agent/blob/main/.github/quality-requirements/code-requirements.md)
+- [Makefile Usage Guide](/en/Makefile-readme)
+- [Project README](/en/README)
+
+## Questions?
+
+If you have questions about contributing, please:
+
+1. Check the documentation in the `docs/` directory
+2. Review existing issues and discussions
+3. Create a new issue with the "question" label
+4. Contact the maintainers
+
+Thank you for contributing to Astron Agent! 🚀

--- a/docs/en/DEPLOYMENT_FAQ.md
+++ b/docs/en/DEPLOYMENT_FAQ.md
@@ -1,0 +1,70 @@
+# Deployment FAQ
+
+This document collects common deployment questions and practical troubleshooting paths for Astron Agent.
+
+---
+
+## 1. How Do I Upgrade An Existing Deployment
+
+If you already have Astron Agent running and want to upgrade to the latest version, follow these steps:
+
+### Upgrade Steps
+
+```bash
+# Enter the astronAgent directory
+cd docker/astronAgent
+
+# Stop all services, including Casdoor
+docker compose -f docker-compose-with-auth.yaml down
+
+# Fetch the latest code
+git fetch
+git pull
+
+# Pull the latest images
+docker compose -f docker-compose-with-auth.yaml pull
+
+# Reconfigure and start again based on the deployment docs
+# Refer to DEPLOYMENT_GUIDE_WITH_AUTH for the latest setup steps
+```
+
+### Notes
+
+- Back up important data before upgrading
+- If you use the deployment without authentication, replace `docker-compose-with-auth.yaml` with `docker-compose.yaml`
+- Review whether configuration files need updates after the upgrade
+- Start the services only after confirming all environment variables are correct
+
+---
+
+## 2. What If The Web Page Does Not Open After Deployment
+
+Use the following checklist step by step. Back up important data before performing destructive operations.
+
+1. Run `docker compose -f docker-compose-with-auth.yaml down -v` to clear containers and volumes. This removes all persisted data.
+2. Run `git restore docker` to discard local changes under the `docker` directory and return to the repository version.
+3. Set the `ASTRON_AGENT_VERSION` environment variable to a stable release such as `v1.0.0-rc.x`.
+4. Reconfigure the remaining environment variables according to the deployment guide and verify the values carefully.
+5. Run `docker compose -f docker-compose-with-auth.yaml up -d` to start all services again.
+6. Clear the browser cache or open the page in an incognito window.
+
+---
+
+## 3. What If Official Docker Images Fail To Pull Because Of Network Issues
+
+1. For Astron Agent images, edit `docker/astronAgent/docker-compose.yaml` and replace the `ghcr.io/` prefix in the relevant `image` fields with `ghcr.nju.edu.cn/`.
+2. For middleware and other third-party images, switch Docker to a domestic mirror such as `https://docker.nju.edu.cn`, `https://docker.xuanyuan.me`, or `https://docker.mirrors.ustc.edu.cn`.
+
+---
+
+## 4. What If `git clone` Fails Because Of Network Issues
+
+1. Use a GitHub mirror to clone the repository, for example: `git clone https://gitclone.com/github.com/iflytek/astron-agent.git`
+2. If you need more mirrors, check continuously updated mirror lists such as `https://freevaults.com/github-mirror-daily-updates.html`.
+
+---
+
+## Related Documentation
+
+- [Deployment Guide With Auth](/en/DEPLOYMENT_GUIDE_WITH_AUTH)
+- [Deployment Guide Without Auth](/en/DEPLOYMENT_GUIDE)

--- a/docs/en/DEPLOYMENT_GUIDE.md
+++ b/docs/en/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,280 @@
+# astronAgent Complete Deployment Guide
+
+This guide will help you start all components of the astronAgent project in the correct order, including authentication, knowledge base, and core services.
+
+## 📋 Project Architecture Overview
+
+The astronAgent project consists of the following three main components:
+
+1. **Casdoor** - Identity authentication and single sign-on service (required component, provides SSO functionality)
+2. **RagFlow** - Knowledge base and document retrieval service (optional component, deploy as needed)
+3. **astronAgent** - Core business service cluster (required component)
+
+## 🚀 Deployment Steps
+
+### Prerequisites
+
+**Agent System Requirements**
+- CPU >= 2 Core
+- RAM >= 4 GiB
+- Disk >= 50 GB
+
+**RAGFlow Requirements**
+- CPU >= 4 Core
+- RAM >= 16 GB
+- Disk >= 50 GB
+
+### Step 1: Start Casdoor Identity Authentication Service
+
+Casdoor is an open-source identity and access management platform that provides support for multiple authentication protocols including OAuth 2.0, OIDC, and SAML.
+
+To start the Casdoor service, run our [docker-compose-with-auth.yaml](/docker/astronAgent/docker-compose-with-auth.yaml) file. Before running the installation commands, please ensure that Docker and Docker Compose are installed on your machine.
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Start Casdoor service
+docker compose -f docker-compose-auth.yml up -d
+```
+
+**Service Information:**
+- Access Address: http://localhost:8000
+- Container Name: casdoor
+- Default Configuration: Production mode (GIN_MODE=release)
+
+### Step 2: Start RagFlow Knowledge Base Service (Optional)
+
+RagFlow is an open-source RAG (Retrieval-Augmented Generation) engine that provides accurate question-answering services using deep document understanding technology.
+
+To start the RagFlow service, run our [docker-compose.yml](/docker/ragflow/docker-compose.yml) file or [docker-compose-macos.yml](/docker/ragflow/docker-compose-macos.yml). Before running the installation commands, please ensure that Docker and Docker Compose are installed on your machine.
+
+```bash
+# Navigate to RagFlow directory
+cd docker/ragflow
+
+# Add executable permissions to all sh files
+chmod +x *.sh
+
+# Start RagFlow service (including all dependencies)
+docker compose up -d
+```
+
+**Access Address:**
+- RagFlow Web Interface: http://localhost:18080
+
+**Model Configuration Steps:**
+1. Click on your avatar to enter the **Model Providers** page, select **Add Model**, fill in the corresponding **API address** and **API Key**, and add both **Chat model** and **Embedding model** respectively.
+2. In the upper right corner of the same page, click **Set Default Models** to set the **Chat model** and **Embedding model** added in the first step as defaults.
+
+
+**Important Configuration Notes:**
+- Elasticsearch is used by default. To use opensearch or infinity, modify the DOC_ENGINE configuration in .env
+- GPU acceleration is supported, start with `docker-compose-gpu.yml`
+
+### Step 3: Integrate Casdoor and RagFlow Services Configuration (Configure as needed)
+
+Before starting astronAgent services, configure the relevant connection information to integrate Casdoor and RagFlow.
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Copy environment variable configuration
+cp .env.example .env
+```
+
+#### 3.1 Configure Knowledge Base Service Connection (Optional)
+
+Edit the docker/astronAgent/.env file to configure RagFlow connection information:
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Edit environment variable configuration
+vim .env
+```
+
+**Key Configuration Items:**
+
+```env
+# RAGFlow Configuration
+RAGFLOW_BASE_URL=http://localhost:18080
+RAGFLOW_API_TOKEN=ragflow-your-api-token-here
+RAGFLOW_TIMEOUT=60
+RAGFLOW_DEFAULT_GROUP=星辰知识库
+```
+
+**Obtaining RagFlow API Token:**
+1. Visit RagFlow Web Interface: http://localhost:18080
+2. Log in and click on your avatar to enter user settings
+3. Click API to generate an API KEY
+4. Update the generated API KEY to RAGFLOW_API_TOKEN in the .env file
+
+#### 3.2 Configure Casdoor Authentication Integration (Required)
+
+Edit the docker/astronAgent/.env file to configure Casdoor connection information:
+
+**Key Configuration Items:**
+
+```env
+# Casdoor Configuration
+CONSOLE_CASDOOR_URL=http://your-casdoor-server:8000
+CONSOLE_CASDOOR_ID=your-casdoor-client-id
+CONSOLE_CASDOOR_APP=your-casdoor-app-name
+CONSOLE_CASDOOR_ORG=your-casdoor-org-name
+```
+
+**Obtaining Casdoor Configuration Information:**
+1. Visit the Casdoor management console: [http://localhost:8000](http://localhost:8000)
+2. Log in with the default administrator account: `admin / 123`
+3. **Create Organization**
+   Go to the [http://localhost:8000/organizations](http://localhost:8000/organizations) page, click "Add", fill in the organization name, save and exit.
+4. **Create Application and Bind Organization**
+   Go to the [http://localhost:8000/applications](http://localhost:8000/applications) page, click "Add".
+
+   When creating the application, fill in the following information:
+   - **Name**: Custom application name, e.g., `agent`
+   - **Redirect URL**: Set to the project's callback address. If the Nginx exposed port is `80`, use `http://your-local-ip/callback`; if it's another port (e.g., `888`), use `http://your-local-ip:888/callback`
+   - **Organization**: Select the organization name you just created
+5. After saving the application, record the following information and map it to the project configuration items:
+
+| Casdoor Information Item | Example Value | Corresponding `.env` Configuration Item |
+|--------------------------|---------------|------------------------------------------|
+| Casdoor Service Address (URL) | `http://localhost:8000` | `CONSOLE_CASDOOR_URL=http://localhost:8000` |
+| Client ID | `your-casdoor-client-id` | `CONSOLE_CASDOOR_ID=your-casdoor-client-id` |
+| Application Name (Name) | `your-casdoor-app-name` | `CONSOLE_CASDOOR_APP=your-casdoor-app-name` |
+| Organization Name (Organization) | `your-casdoor-org-name` | `CONSOLE_CASDOOR_ORG=your-casdoor-org-name` |
+
+6. Fill in the above configuration information into the project's environment variable file:
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Edit environment variable configuration
+vim .env
+```
+
+### Step 4: Start astronAgent Core Services (Required Deployment Step)
+
+#### 4.1 Configure iFLYTEK Open Platform APP_ID, API_KEY, and Related Information
+
+For documentation, see: https://www.xfyun.cn/doc/platform/quickguide.html
+
+After creating your application, you may need to purchase or claim API authorization service quotas for the corresponding capabilities:
+- Spark LLM API: https://xinghuo.xfyun.cn/sparkapi
+  (For the LLM API, you'll need an additional SPARK_API_PASSWORD available on the page)
+  (1、The text generation/optimization feature for instruction-based assistants requires Spark Ultra. It can be enabled at: https://console.xfyun.cn/services/bm4
+2、The AI generation and AI code generation capabilities for workflow agents require Spark 3.5 Max and DeepSeek V3.
+Spark 3.5 Max: https://console.xfyun.cn/services/bm35
+DeepSeek V3: https://maas.xfyun.cn/modelSquare)
+- Real-time Speech Recognition API: https://console.xfyun.cn/services/rta
+- Image Generation API: https://www.xfyun.cn/services/wtop
+- Talk Agent: https://www.xfyun.cn/services/VirtualHumans
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+PLATFORM_APP_ID=your-app-id
+PLATFORM_API_KEY=your-api-key
+PLATFORM_API_SECRET=your-api-secret
+
+SPARK_API_PASSWORD=your-api-password
+SPARK_RTASR_API_KEY=your-rtasr-api-key
+
+# For configuring platform AI generation capabilities (compatible with OpenAI protocols), such as prompt optimization and one-sentence agent creation.
+AI_ABILITY_CHAT_BASE_URL=your-model-url
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 4.2 If You Want to Use Spark RAG Cloud Service, Configure as Follows (Optional)
+
+Spark RAG cloud service provides two usage methods:
+
+##### Method 1: Obtain from the Web Interface
+
+1. Use the APP_ID and API_SECRET created on the iFLYTEK Open Platform
+2. Directly obtain the Spark dataset ID from the web interface, see: [xinghuo_rag_tool.html](/xinghuo_rag_tool.html)
+
+##### Method 2: Using cURL Command Line
+
+If you prefer using command-line tools, you can create a dataset with the following cURL command:
+
+```bash
+# Create Spark RAG dataset
+curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
+    -H "Accept: application/json" \
+    -H "appId: your_app_id" \
+    -H "timestamp: $(date +%s)" \
+    -H "signature: $(echo -n "$(echo -n "your_app_id$(date +%s)" | md5sum | awk '{print $1}')" | openssl dgst -sha1 -hmac 'your_api_secret' -binary | base64)" \
+    -F "name=我的数据集"
+```
+
+**Notes:**
+- Please replace `your_app_id` with your actual APP ID
+- Please replace `your_api_secret` with your actual API Secret
+
+After obtaining the dataset ID, please update it in the docker/astronAgent/.env file:
+```env
+XINGHUO_DATASET_ID=
+```
+
+#### 4.3 Start astronAgent Services
+
+Before starting, please configure some required environment variables and ensure nginx and minio ports are exposed
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Modify configuration as needed
+vim .env
+```
+
+```env
+HOST_BASE_ADDRESS=http://localhost (astronAgent service host address)
+```
+
+To start astronAgent services, run our [docker-compose.yaml](/docker/astronAgent/docker-compose.yaml) file. Before running the installation commands, please ensure that Docker and Docker Compose are installed on your machine.
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Start all services
+docker compose up -d
+```
+
+## 📊 Service Access Addresses
+
+After startup, you can access the services at the following addresses:
+
+### Authentication Service
+- **Casdoor Admin Interface**: http://localhost:8000
+
+### Knowledge Base Service
+- **RagFlow Web Interface**: http://localhost:18080
+
+### AstronAgent Core Services
+- **Console Frontend (nginx proxy)**: http://localhost/
+
+## 📚 Additional Resources
+
+- [AstronAgent Official Documentation](https://www.xfyun.cn/doc/spark/Agent01-%E5%B9%B3%E5%8F%B0%E4%BB%8B%E7%BB%8D.html)
+- [Casdoor Official Documentation](https://casdoor.org/docs/overview)
+- [RagFlow Official Documentation](https://ragflow.io/docs)
+- [Docker Compose Official Documentation](https://docs.docker.com/compose/)
+
+## 🤝 Technical Support
+
+If you encounter issues, please:
+
+1. Check the log files of related services
+2. Review the official documentation and troubleshooting guides
+3. Submit an Issue on the project's GitHub repository
+4. Contact the technical support team
+
+---
+
+**Note**: For first-time deployment, it is recommended to verify all functionalities in a test environment before deploying to production.

--- a/docs/en/DEPLOYMENT_GUIDE_WITH_AUTH.md
+++ b/docs/en/DEPLOYMENT_GUIDE_WITH_AUTH.md
@@ -1,0 +1,271 @@
+# AstronAgent Complete Deployment Guide
+
+This guide will help you start all components of the AstronAgent project in the correct order, including authentication, knowledge base, and core services.
+
+## 📋 Project Architecture Overview
+
+The AstronAgent project consists of the following three main components:
+
+1. **Casdoor** - Identity authentication and single sign-on service (required component, provides SSO functionality)
+2. **RagFlow** - Knowledge base and document retrieval service (optional component, deploy as needed)
+3. **AstronAgent** - Core business service cluster (required component)
+
+## 🚀 Deployment Steps
+
+### Prerequisites
+
+**Agent System Requirements**
+- CPU >= 2 Core
+- RAM >= 4 GiB
+- Disk >= 50 GB
+
+**RAGFlow Requirements**
+- CPU >= 4 Core
+- RAM >= 16 GB
+- Disk >= 50 GB
+
+### Step 1: Start RagFlow Knowledge Base Service (Optional, deploy as needed)
+
+RagFlow is an open-source RAG (Retrieval-Augmented Generation) engine that provides accurate question-answering services using deep document understanding technology.
+
+To start the RagFlow service, run our [docker-compose.yml](/docker/ragflow/docker-compose.yml) file or [docker-compose-macos.yml](/docker/ragflow/docker-compose-macos.yml). Before running the installation commands, please ensure that Docker and Docker Compose are installed on your machine.
+
+```bash
+# Navigate to RagFlow directory
+cd docker/ragflow
+
+# Add executable permissions to all sh files
+chmod +x *.sh
+
+# Start RagFlow service (including all dependencies)
+docker compose up -d
+
+# Check service status
+docker compose ps
+
+# View service logs
+docker compose logs -f ragflow
+```
+
+**Access Address:**
+- RagFlow Web Interface: http://localhost:18080
+
+**Model Configuration Steps:**
+1. Click on your avatar to enter the **Model Providers** page, select **Add Model**, fill in the corresponding **API address** and **API Key**, and add both **Chat model** and **Embedding model** respectively.
+2. In the upper right corner of the same page, click **Set Default Models** to set the **Chat model** and **Embedding model** added in the first step as defaults.
+
+
+**Important Configuration Notes:**
+- Elasticsearch is used by default. To use opensearch or infinity, modify the DOC_ENGINE configuration in .env
+- GPU acceleration is supported, start with `docker-compose-gpu.yml`
+
+### Step 2: Configure AstronAgent Environment Variables
+
+Before starting AstronAgent services, you need to configure the relevant connection information.
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Copy environment variable configuration
+cp .env.example .env
+```
+
+#### 2.1 Configure Knowledge Base Service Connection (Optional,If RagFlow is deployed)
+
+Edit the docker/astronAgent/.env file to configure RagFlow connection information:
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Edit environment variable configuration
+vim .env
+```
+
+**Key Configuration Items:**
+
+```env
+# RAGFlow Configuration
+RAGFLOW_BASE_URL=http://localhost:18080
+RAGFLOW_API_TOKEN=ragflow-your-api-token-here
+RAGFLOW_TIMEOUT=60
+RAGFLOW_DEFAULT_GROUP=星辰知识库
+```
+
+**Obtaining RagFlow API Token:**
+1. Visit RagFlow Web Interface: http://localhost:18080
+2. Log in and click on your avatar to enter user settings
+3. Click API to generate an API KEY
+4. Update the generated API KEY to RAGFLOW_API_TOKEN in the .env file
+
+#### 2.2 Configure iFLYTEK Open Platform APP_ID, API_KEY, and Related Information (Optional, some built-in features require the use of capabilities from the Open Platform)
+
+For documentation, see: https://www.xfyun.cn/doc/platform/quickguide.html
+
+After creating your application, you may need to purchase or claim API authorization service quotas for the corresponding capabilities:
+- Spark LLM API: https://xinghuo.xfyun.cn/sparkapi
+  (For the LLM API, you'll need an additional SPARK_API_PASSWORD available on the page : https://console.xfyun.cn/services/bm4)
+- Real-time Speech Recognition API: https://console.xfyun.cn/services/rta
+- Image Generation API: https://www.xfyun.cn/services/wtop
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+PLATFORM_APP_ID=your-app-id
+PLATFORM_API_KEY=your-api-key
+PLATFORM_API_SECRET=your-api-secret
+
+SPARK_API_PASSWORD=your-api-password
+SPARK_RTASR_API_KEY=your-rtasr-api-key
+```
+
+#### 2.3 Configure the default model interface (OpenAI protocol) for the Agent
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+AI_ABILITY_CHAT_BASE_URL=https://spark-api-open.xf-yun.com/v1
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 2.4 Configure Spark RAG Cloud Service (Optional)
+
+Spark RAG cloud service provides two usage methods:
+
+##### Method 1: Obtain from the Web Interface
+
+1. Use the APP_ID and API_SECRET created on the iFLYTEK Open Platform
+2. Directly obtain the Spark dataset ID from the web interface, see: [xinghuo_rag_tool.html](/xinghuo_rag_tool.html)
+
+##### Method 2: Using cURL Command Line
+
+If you prefer using command-line tools, you can create a dataset with the following cURL command:
+
+```bash
+# Create Spark RAG dataset
+curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
+    -H "Accept: application/json" \
+    -H "appId: your_app_id" \
+    -H "timestamp: $(date +%s)" \
+    -H "signature: $(echo -n "$(echo -n "your_app_id$(date +%s)" | md5sum | awk '{print $1}')" | openssl dgst -sha1 -hmac 'your_api_secret' -binary | base64)" \
+    -F "name=我的数据集"
+```
+
+**Notes:**
+- Please replace `your_app_id` with your actual APP ID
+- Please replace `your_api_secret` with your actual API Secret
+
+After obtaining the dataset ID, please update it in the docker/astronAgent/.env file:
+```env
+XINGHUO_DATASET_ID=
+```
+
+#### 2.5 Configure Service Host Address
+
+Edit the docker/astronAgent/.env file to configure the AstronAgent service host address:
+
+```env
+HOST_BASE_ADDRESS=http://localhost
+```
+
+**Note:**
+- If you're using a domain name for access, replace `localhost` with your domain name
+- Ensure nginx and minio ports are properly exposed
+
+### Step 3: Start AstronAgent Core Services (Including Casdoor Authentication Service)
+
+To start AstronAgent services, run our [docker-compose-with-auth.yaml](/docker/astronAgent/docker-compose-with-auth.yaml) file. **This file has integrated the Casdoor authentication service through the `include` mechanism** and will automatically start Casdoor.
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Start all services (including Casdoor)
+docker compose -f docker-compose-with-auth.yaml up -d
+```
+
+**Note:**
+- Default Casdoor login credentials: username: `admin`, password: `123`
+
+### Step 4: Modify Casdoor Authentication (Optional)
+
+You can create new applications and organizations in Casdoor as needed, and update the configuration information in the `.env` file (default organization and application already exist).
+
+#### 4.1 Configure Casdoor Application
+
+**Obtaining Casdoor Configuration Information:**
+1. Visit the Casdoor management console: [http://localhost:8000](http://localhost:8000)
+2. Log in with the default administrator account: `admin / 123`
+3. **Create Organization**
+   Go to the [http://localhost:8000/organizations](http://localhost:8000/organizations) page, click "Add", fill in the organization name, save and exit.
+4. **Create Application and Bind Organization**
+   Go to the [http://localhost:8000/applications](http://localhost:8000/applications) page, click "Add".
+
+   When creating the application, fill in the following information:
+   - **Name**: Custom application name, e.g., `agent`
+   - **Redirect URL**: Set to the project's callback address. If the Nginx exposed port is `80`, use `http://your-local-ip/callback`; if it's another port (e.g., `888`), use `http://your-local-ip:888/callback`
+   - **Organization**: Select the organization name you just created
+5. After saving the application, record the following information and map it to the project configuration items:
+
+| Casdoor Information Item | Example Value | Corresponding `.env` Configuration Item |
+|--------------------------|---------------|------------------------------------------|
+| Casdoor Service Address (URL) | `http://localhost:8000` | `CONSOLE_CASDOOR_URL=http://localhost:8000` |
+| Client ID | `your-casdoor-client-id` | `CONSOLE_CASDOOR_ID=your-casdoor-client-id` |
+| Application Name (Name) | `your-casdoor-app-name` | `CONSOLE_CASDOOR_APP=your-casdoor-app-name` |
+| Organization Name (Organization) | `your-casdoor-org-name` | `CONSOLE_CASDOOR_ORG=your-casdoor-org-name` |
+
+6. Fill in the above configuration information into the project's environment variable file:
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Edit environment variable configuration
+vim .env
+```
+
+**Add or update the following configuration items in the .env file:**
+```env
+# Casdoor Configuration
+CONSOLE_CASDOOR_URL=http://localhost:8000
+CONSOLE_CASDOOR_ID=your-casdoor-client-id
+CONSOLE_CASDOOR_APP=your-casdoor-app-name
+CONSOLE_CASDOOR_ORG=your-casdoor-org-name
+```
+
+7. Restart AstronAgent services to apply the new configuration:
+```bash
+docker compose restart console-frontend console-hub
+```
+
+## 📊 Service Access Addresses
+
+After startup, you can access the services at the following addresses:
+
+### Authentication Service
+- **Casdoor Admin Interface**: http://localhost:8000
+
+### Knowledge Base Service
+- **RagFlow Web Interface**: http://localhost:18080
+
+### AstronAgent Core Services
+- **Console Frontend (nginx proxy)**: http://localhost/
+
+## 📚 Additional Resources
+
+- [AstronAgent Official Documentation](https://www.xfyun.cn/doc/spark/Agent01-%E5%B9%B3%E5%8F%B0%E4%BB%8B%E7%BB%8D.html)
+- [Casdoor Official Documentation](https://casdoor.org/docs/overview)
+- [RagFlow Official Documentation](https://ragflow.io/docs)
+- [Docker Compose Official Documentation](https://docs.docker.com/compose/)
+
+## 🤝 Technical Support
+
+If you encounter issues, please:
+
+1. Check the log files of related services
+2. Review the official documentation and troubleshooting guides
+3. Submit an Issue on the project's GitHub repository
+4. Contact the technical support team
+
+---
+
+**Note**: For first-time deployment, it is recommended to verify all functionalities in a test environment before deploying to production.

--- a/docs/en/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
+++ b/docs/en/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
@@ -1,0 +1,275 @@
+# AstronAgent Project Complete Deployment Guide
+
+This guide will help you start all components of the AstronAgent project in the correct order, including authentication, RPA, knowledge base, and core services.
+
+## 📋 Project Architecture Overview
+
+The AstronAgent project consists of the following four main components:
+
+1. **Casdoor** - Identity authentication and single sign-on service (required deployment component, provides SSO functionality)
+2. **RagFlow** - Knowledge base and document retrieval service (optional deployment component, deploy as needed)
+3. **AstronAgent** - Core business service cluster (required deployment component)
+4. **RPA** - Enterprise-grade Robotic Process Automation service (backend automatic deployment)
+
+## 🚀 Deployment Steps
+
+### Prerequisites
+
+**Agent System Requirements**
+- CPU >= 2 Core
+- RAM >= 4 GiB
+- Disk >= 50 GB
+
+**RAGFlow Requirements**
+- CPU >= 4 Core
+- RAM >= 16 GB
+- Disk >= 50 GB
+
+### Step 1: Start RagFlow Knowledge Base Service (Optional, deploy as needed)
+
+RagFlow is an open-source RAG (Retrieval-Augmented Generation) engine that provides accurate question-answering services using deep document understanding technology.
+
+To start the RagFlow service, run our [docker-compose.yml](/docker/ragflow/docker-compose.yml) file or [docker-compose-macos.yml](/docker/ragflow/docker-compose-macos.yml). Before running the installation command, please ensure Docker and Docker Compose are installed on your machine.
+
+```bash
+# Navigate to the RagFlow directory
+cd docker/ragflow
+
+# Add executable permissions to all sh files
+chmod +x *.sh
+
+# Start RagFlow service (includes all dependencies)
+docker compose up -d
+
+# Check service status
+docker compose ps
+
+# View service logs
+docker compose logs -f ragflow
+```
+
+**Access URLs:**
+- RagFlow Web Interface: http://localhost:18080
+
+**Model Configuration Steps:**
+1. Click on your avatar to enter the **Model Providers** page, select **Add Model**, fill in the corresponding **API address** and **API Key**, and add both **Chat model** and **Embedding model**.
+2. In the upper right corner of the same page, click **Set Default Models** and set the **Chat model** and **Embedding model** added in step 1 as default.
+
+
+**Important Configuration Notes:**
+- Elasticsearch is used by default. To use opensearch or infinity, modify the DOC_ENGINE configuration in .env
+- GPU acceleration is supported, use `docker-compose-gpu.yml` to start
+
+### Step 2: Configure AstronAgent Environment Variables
+
+Before starting AstronAgent services, you need to configure the relevant connection information.
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Copy environment variable configuration
+cp .env.example .env
+```
+
+#### 2.1 Configure Knowledge Base Service Connection (Optional,If RagFlow is deployed)
+
+Edit the docker/astronAgent/.env file to configure RagFlow connection information:
+
+```bash
+# Navigate to astronAgent directory
+cd docker/astronAgent
+
+# Edit environment variable configuration
+vim .env
+```
+
+**Key Configuration Items:**
+
+```env
+# RAGFlow Configuration
+RAGFLOW_BASE_URL=http://localhost:18080
+RAGFLOW_API_TOKEN=ragflow-your-api-token-here
+RAGFLOW_TIMEOUT=60
+RAGFLOW_DEFAULT_GROUP=星辰知识库
+```
+
+**Obtaining RagFlow API Token:**
+1. Visit RagFlow Web Interface: http://localhost:18080
+2. Log in and click on your avatar to enter user settings
+3. Click API to generate an API KEY
+4. Update the generated API KEY to RAGFLOW_API_TOKEN in the .env file
+
+#### 2.2 Configure iFLYTEK Open Platform APP_ID, API_KEY, and Related Information (Optional, some built-in features require the use of capabilities from the Open Platform)
+
+For documentation, see: https://www.xfyun.cn/doc/platform/quickguide.html
+
+After creating your application, you may need to purchase or claim API authorization service quotas for the corresponding capabilities:
+- Spark LLM API: https://xinghuo.xfyun.cn/sparkapi
+  (For the LLM API, you'll need an additional SPARK_API_PASSWORD available on the page : https://console.xfyun.cn/services/bm4)
+- Real-time Speech Recognition API: https://console.xfyun.cn/services/rta
+- Image Generation API: https://www.xfyun.cn/services/wtop
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+PLATFORM_APP_ID=your-app-id
+PLATFORM_API_KEY=your-api-key
+PLATFORM_API_SECRET=your-api-secret
+
+SPARK_API_PASSWORD=your-api-password
+SPARK_RTASR_API_KEY=your-rtasr-api-key
+```
+
+#### 2.3 Configure the default model interface (OpenAI protocol) for the Agent
+
+Edit the docker/astronAgent/.env file and update the relevant environment variables:
+```env
+AI_ABILITY_CHAT_BASE_URL=https://spark-api-open.xf-yun.com/v1
+AI_ABILITY_CHAT_MODEL=your-model-id
+AI_ABILITY_CHAT_API_KEY=your-api-key
+```
+
+#### 2.4 Configure Spark RAG Cloud Service (Optional)
+
+Spark RAG cloud service provides two usage methods:
+
+##### Method 1: Obtain from the Web Interface
+
+1. Use the APP_ID and API_SECRET created on the iFLYTEK Open Platform
+2. Directly obtain the Spark dataset ID from the web interface, see: [xinghuo_rag_tool.html](/xinghuo_rag_tool.html)
+
+##### Method 2: Using cURL Command Line
+
+If you prefer using command-line tools, you can create a dataset with the following cURL command:
+
+```bash
+# Create Spark RAG dataset
+curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
+    -H "Accept: application/json" \
+    -H "appId: your_app_id" \
+    -H "timestamp: $(date +%s)" \
+    -H "signature: $(echo -n "$(echo -n "your_app_id$(date +%s)" | md5sum | awk '{print $1}')" | openssl dgst -sha1 -hmac 'your_api_secret' -binary | base64)" \
+    -F "name=我的数据集"
+```
+
+**Notes:**
+- Please replace `your_app_id` with your actual APP ID
+- Please replace `your_api_secret` with your actual API Secret
+
+After obtaining the dataset ID, please update it in the docker/astronAgent/.env file:
+```env
+XINGHUO_DATASET_ID=
+```
+
+#### 2.5 Configure Service Host Address
+
+Edit the docker/astronAgent/.env file to configure the AstronAgent service host address:
+
+```env
+HOST_BASE_ADDRESS=http://localhost
+```
+
+**Note:**
+- If you're using a domain name for access, replace `localhost` with your domain name
+- Ensure nginx and minio ports are properly exposed
+
+### Step 3: Start AstronAgent Core Services (includes Casdoor authentication service, RPA backend service)
+
+To start the AstronAgent service, run our [docker-compose-with-auth-rpa.yaml](/docker/astronAgent/docker-compose-with-auth-rpa.yaml) file. **This file has integrated Casdoor and RPA backend services through the `include` mechanism**, and will automatically start Casdoor and RPA.
+
+```bash
+# Navigate to the astronAgent directory
+cd docker/astronAgent
+
+# Start all services (includes Casdoor, RPA)
+docker compose -f docker-compose-with-auth-rpa.yaml up -d
+```
+
+**Notes:**
+- Casdoor default login username: `admin`, password: `123`
+
+### Step 4: Modify Casdoor Authentication (Optional)
+
+You can create new applications and organizations in Casdoor as needed and update the configuration information in the `.env` file (default organization and application already exist).
+
+#### 4.1 Configure Casdoor Application
+
+**Get Casdoor Configuration Information:**
+1. Visit the Casdoor admin console: [http://localhost:8000](http://localhost:8000)
+2. Log in with the default admin account: `admin / 123`
+3. **Create Organization**
+   Go to the [http://localhost:8000/organizations](http://localhost:8000/organizations) page, click "Add", fill in the organization name, save and exit.
+4. **Create Application and Bind Organization**
+   Go to the [http://localhost:8000/applications](http://localhost:8000/applications) page, click "Add".
+
+   Fill in the following information when creating the application:
+   - **Name**: Custom application name, e.g., `agent`
+   - **Redirect URL**: Set to the project's callback address. If Nginx exposes port `80`, use `http://your-local-ip/callback`; if it's another port (e.g., `888`), use `http://your-local-ip:888/callback`
+   - **Organization**: Select the organization name just created
+5. After saving the application, record the following information and match it with the project configuration items:
+
+| Casdoor Information | Example Value | Corresponding `.env` Configuration |
+|---------------------|---------------|-------------------------------------|
+| Casdoor service URL | `http://localhost:8000` | `CONSOLE_CASDOOR_URL=http://localhost:8000` |
+| Client ID | `your-casdoor-client-id` | `CONSOLE_CASDOOR_ID=your-casdoor-client-id` |
+| Application Name | `your-casdoor-app-name` | `CONSOLE_CASDOOR_APP=your-casdoor-app-name` |
+| Organization Name | `your-casdoor-org-name` | `CONSOLE_CASDOOR_ORG=your-casdoor-org-name` |
+
+6. Fill in the above configuration information in the project's environment variable file:
+```bash
+# Navigate to the astronAgent directory
+cd docker/astronAgent
+
+# Edit environment variable configuration
+vim .env
+```
+
+**Add or update the following configuration items in the .env file:**
+```env
+# Casdoor configuration
+CONSOLE_CASDOOR_URL=http://localhost:8000
+CONSOLE_CASDOOR_ID=your-casdoor-client-id
+CONSOLE_CASDOOR_APP=your-casdoor-app-name
+CONSOLE_CASDOOR_ORG=your-casdoor-org-name
+```
+
+7. Restart the AstronAgent service to apply the new configuration:
+```bash
+docker compose restart console-frontend console-hub
+```
+
+## 📊 Service Access URLs
+
+After startup is complete, you can access the services at the following addresses:
+
+### Authentication Service
+- **Casdoor Admin Interface**: http://localhost:8000
+
+### Knowledge Base Service
+- **RagFlow Web Interface**: http://localhost:18080
+
+### AstronAgent Core Services
+- **Console Frontend (nginx proxy)**: http://localhost/
+
+### RPA Core Services
+- **RPA Backend Service Entry (nginx proxy)**: http://localhost:32742
+
+## 📚 Additional Resources
+
+- [AstronAgent Official Documentation](https://www.xfyun.cn/doc/spark/Agent01-%E5%B9%B3%E5%8F%B0%E4%BB%8B%E7%BB%8D.html)
+- [Casdoor Official Documentation](https://casdoor.org/docs/overview)
+- [RagFlow Official Documentation](https://ragflow.io/docs)
+- [Docker Compose Official Documentation](https://docs.docker.com/compose/)
+
+## 🤝 Technical Support
+
+If you encounter issues, please:
+
+1. Check the relevant service log files
+2. Review the official documentation and troubleshooting guide
+3. Submit an issue on the project's GitHub repository
+4. Contact the technical support team
+
+---
+
+**Note**: For first-time deployment, it is recommended to validate all functionalities in a test environment before deploying to production.

--- a/docs/en/Makefile-readme.md
+++ b/docs/en/Makefile-readme.md
@@ -1,0 +1,222 @@
+# 🚀 Multi-Language CI/CD Toolchain
+
+> **Unified development workflow for Go, Java, Python, TypeScript**
+
+## Quick Start
+
+### One-time Setup
+```bash
+make setup
+```
+Installs all language tools, configures Git hooks, and sets up branch strategy.
+
+### Daily Commands
+```bash
+make format    # Format all code
+make check     # Quality checks
+make test      # Run tests
+make build     # Build projects
+make push      # Safe push with pre-checks
+make clean     # Clean build artifacts
+```
+
+### Project Status
+```bash
+make status    # Show project information
+make info      # Show tool versions
+```
+
+## Local Development Configuration
+
+For efficient local development, you can create a `.localci.toml` file in the root directory to override the default configuration:
+
+### Create Local Configuration
+```bash
+# Copy the default configuration
+cp makefiles/localci.toml .localci.toml
+
+# Edit to enable only the modules you're working on
+# Set enabled = true for active modules, false for others
+```
+
+### Example Local Configuration
+```toml
+[meta]
+version = 1
+
+[[python.apps]]
+name = "core-agent"
+dir = "core/agent"
+enabled = true    # Only enable the module you're working on
+
+[[python.apps]]
+name = "core-memory"
+dir = "core/memory/database"
+enabled = false   # Disable other modules for faster execution
+
+# ... other modules set to enabled = false
+```
+
+### Benefits
+- **Faster execution**: Only processes enabled modules
+- **Focused development**: Work on specific modules without interference
+- **Easy switching**: Change `enabled` values to switch between modules
+
+## Core Commands
+
+### `make setup`
+One-time environment setup. Installs tools, configures Git hooks, sets branch strategy.
+
+### `make format`
+Formats code for all languages:
+- Go: `gofmt` + `goimports` + `gofumpt` + `golines`
+- Java: Maven `spotless:apply`
+- Python: `black` + `isort`
+- TypeScript: `prettier`
+
+### `make check` (alias: `make lint`)
+Quality checks for all languages:
+- Go: `gocyclo` + `staticcheck` + `golangci-lint`
+- Java: `checkstyle` + `pmd` + `spotbugs`
+- Python: `flake8` + `mypy` + `pylint`
+- TypeScript: `eslint` + `tsc`
+
+### `make test`
+Runs tests for all projects:
+- Go: `go test` with coverage
+- Java: `mvn test`
+- Python: `pytest` with coverage
+- TypeScript: `npm test`
+
+### `make build`
+Builds all projects:
+- Go: Build binaries
+- Java: Maven `package`
+- Python: Install dependencies
+- TypeScript: Vite `build`
+
+### `make push`
+Safe push with pre-checks:
+- Runs `format` and `check` automatically
+- Validates branch naming
+- Pushes to remote repository
+
+### `make clean`
+Cleans build artifacts for all languages.
+
+## Running Services
+
+```bash
+# Go service
+cd core/tenant && go run cmd/main.go
+
+# Java service
+cd console/backend && mvn spring-boot:run
+
+# Python services
+cd core/memory/database && python main.py
+cd core/agent && python main.py
+
+# TypeScript frontend
+cd console/frontend && npm run dev
+```
+
+## Additional Commands
+
+### `make status`
+Shows project information and active projects.
+
+### `make info`
+Displays tool versions and installation status.
+
+### `make fix`
+Auto-fixes code issues (formatting + some lint fixes).
+
+### `make ci`
+Complete CI pipeline: `format` + `check` + `test` + `build`.
+
+### `make hooks`
+Git hook management:
+- `make hooks-install` - Install complete hooks
+- `make hooks-install-basic` - Install lightweight hooks
+- `make hooks-uninstall` - Uninstall hooks
+
+### `make enable-legacy`
+Enables specialized language commands for backward compatibility.
+
+## Specialized Commands
+
+After running `make enable-legacy`, you can use language-specific commands:
+
+### Go Commands
+```bash
+make fmt-go              # Format Go code
+make check-go            # Go quality check
+make test-go             # Run Go tests
+make build-go            # Build Go project
+```
+
+### Java Commands
+```bash
+make fmt-java            # Format Java code
+make check-java          # Java quality check
+make test-java           # Run Java tests
+make build-java          # Build Java project
+```
+
+### Python Commands
+```bash
+make fmt-python          # Format Python code
+make check-python        # Python quality check
+make test-python         # Run Python tests
+```
+
+### TypeScript Commands
+```bash
+make fmt-typescript      # Format TypeScript code
+make check-typescript    # TypeScript quality check
+make test-typescript     # Run TypeScript tests
+make build-typescript    # Build TypeScript project
+```
+
+## Git Hooks
+
+### Install Hooks
+```bash
+make hooks-install       # Complete hooks (format+check)
+make hooks-install-basic # Lightweight hooks (format only)
+```
+
+### Branch Naming
+```bash
+feature/user-auth        # Feature branch
+bugfix/fix-login         # Bug fix
+hotfix/security-patch    # Hotfix
+```
+
+### Commit Messages
+```bash
+feat: add user authentication
+fix: resolve login timeout
+docs: update API documentation
+```
+
+## Troubleshooting
+
+### Common Issues
+```bash
+# Tool installation problems
+make info                # Check tool status
+make install-tools       # Reinstall tools
+
+# Project detection issues
+make status              # Check project status
+make _debug              # Debug detection
+
+# Hook problems
+make hooks-uninstall && make hooks-install
+
+# Local configuration issues
+rm .localci.toml         # Remove local config to use defaults
+cp makefiles/localci.toml .localci.toml  # Reset local config
+```

--- a/docs/en/PRE-COMMIT.md
+++ b/docs/en/PRE-COMMIT.md
@@ -1,0 +1,309 @@
+# Pre-commit Usage Guide
+
+This guide explains how to use pre-commit for local code quality checks and secret scanning in the Astron Agent project.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Basic Usage](#basic-usage)
+- [Available Hooks](#available-hooks)
+- [Fixing Issues](#fixing-issues)
+- [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+Pre-commit is a framework for managing and maintaining multi-language pre-commit hooks. In this project, we use it to:
+
+- **Code Formatting**: Ensure consistent code style across all languages
+- **Linting**: Detect code quality issues and potential bugs
+- **Type Checking**: Verify type annotations (Python, TypeScript)
+- **Secret Scanning**: Prevent accidental commit of secrets (gitleaks)
+- **Commit Message Validation**: Enforce Conventional Commits format
+
+## Installation
+
+### Prerequisites
+
+Ensure you have the following installed:
+
+- Python 3.9+
+- Node.js 18+ (for TypeScript/JavaScript checks)
+- Go 1.21+ (for Go checks)
+- Java 21+ and Maven 3.8+ (for Java checks)
+
+### Install pre-commit
+
+```bash
+# Install pre-commit using pip
+pip install pre-commit
+
+# Or using pipx (recommended for isolated installation)
+pipx install pre-commit
+
+# Or using Homebrew (macOS)
+brew install pre-commit
+```
+
+### Install Git Hooks
+
+```bash
+# Install pre-commit hooks
+pre-commit install
+
+# Install commit-msg hook for commit message validation
+pre-commit install --hook-type commit-msg
+```
+
+After installation, pre-commit will automatically run on every `git commit`.
+
+## Basic Usage
+
+### Automatic Check on Commit
+
+Once installed, pre-commit runs automatically when you commit:
+
+```bash
+git add .
+git commit -m "feat: add new feature"
+# Pre-commit hooks run automatically
+```
+
+If any check fails, the commit will be blocked. Fix the issues and try again.
+
+### Manual Execution
+
+```bash
+# Check only staged files
+pre-commit run
+
+# Check all files in the repository
+pre-commit run --all-files
+
+# Run a specific hook
+pre-commit run <hook-id>
+
+# Examples
+pre-commit run black --all-files
+pre-commit run eslint-check --all-files
+pre-commit run gitleaks --all-files
+```
+
+### Update Hooks
+
+```bash
+# Update all hooks to latest versions
+pre-commit autoupdate
+```
+
+## Available Hooks
+
+### Common Checks
+
+| Hook | Description |
+|------|-------------|
+| `check-yaml` | Validate YAML file syntax |
+| `check-json` | Validate JSON file syntax |
+| `check-added-large-files` | Prevent large files (>1MB) from being committed |
+| `check-merge-conflict` | Check for merge conflict markers |
+
+### Python Checks
+
+| Hook | Description | Scope |
+|------|-------------|-------|
+| `black` | Check code formatting | core/agent, core/workflow, core/knowledge, core/plugin |
+| `isort-*` | Check import sorting | Per-module (knowledge, workflow, agent, plugin) |
+| `flake8-*` | Lint for code issues | Per-module |
+| `mypy-*` | Type checking | Per-module |
+| `pylint-*` | Code analysis | Per-module |
+
+### TypeScript/JavaScript Checks
+
+| Hook | Description | Scope |
+|------|-------------|-------|
+| `prettier-check` | Check code formatting | console/frontend/src |
+| `eslint-check` | Lint for code issues | console/frontend/src |
+
+### Go Checks
+
+| Hook | Description | Scope |
+|------|-------------|-------|
+| `golangci-lint` | Comprehensive linting | core/tenant |
+| `go-fmt-check` | Check gofmt formatting | core/tenant |
+| `go-imports-check` | Check goimports formatting | core/tenant |
+| `go-vet` | Check for suspicious code | core/tenant |
+
+### Java Checks
+
+| Hook | Description | Scope |
+|------|-------------|-------|
+| `spotless-check` | Check Google Java Format | console/backend |
+| `checkstyle` | Check code style | console/backend |
+
+### Security
+
+| Hook | Description |
+|------|-------------|
+| `gitleaks` | Scan for secrets and credentials |
+
+### Commit Message
+
+| Hook | Description |
+|------|-------------|
+| `conventional-pre-commit` | Validate Conventional Commits format |
+
+## Fixing Issues
+
+Pre-commit runs in **check-only mode** - it reports issues but does not auto-fix them. Here's how to fix issues for each language:
+
+### Python
+
+```bash
+# Fix formatting with Black
+black .
+
+# Fix import sorting with isort
+isort .
+
+# Or fix specific directories
+cd core/knowledge && black . && isort .
+```
+
+### TypeScript/JavaScript
+
+```bash
+cd console/frontend
+
+# Fix formatting with Prettier
+npm run format
+# Or
+npx prettier --write "src/**/*.{ts,tsx,js,jsx,json,md}"
+
+# Fix linting issues (auto-fixable only)
+npx eslint "src/**/*.{ts,tsx}" --fix
+```
+
+### Go
+
+```bash
+cd core/tenant
+
+# Fix formatting
+gofmt -w .
+goimports -w .
+
+# Or use gofumpt for stricter formatting
+gofumpt -w .
+```
+
+### Java
+
+```bash
+cd console/backend
+
+# Fix formatting with Spotless
+mvn spotless:apply
+```
+
+## Configuration
+
+The pre-commit configuration is in `.pre-commit-config.yaml` at the project root.
+
+### Skip Specific Hooks
+
+```bash
+# Skip specific hooks for a single commit
+SKIP=black,eslint-check git commit -m "feat: urgent fix"
+
+# Skip all pre-commit hooks
+git commit --no-verify -m "feat: emergency commit"
+```
+
+> **Warning**: Use `--no-verify` sparingly. It bypasses all quality checks.
+
+### Run Only Specific File Types
+
+Pre-commit automatically detects which files changed and runs only relevant hooks. For example:
+- Changing `.py` files only triggers Python hooks
+- Changing `.ts` files only triggers TypeScript hooks
+
+## Troubleshooting
+
+### Hook Installation Issues
+
+```bash
+# Reinstall hooks
+pre-commit uninstall
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+### Clear Cache
+
+```bash
+# Clear pre-commit cache
+pre-commit clean
+```
+
+### Verbose Output
+
+```bash
+# Run with verbose output for debugging
+pre-commit run --all-files --verbose
+```
+
+### Common Issues
+
+#### 1. "command not found" errors
+
+Ensure the required tools are installed and in your PATH:
+
+```bash
+# Check Python tools
+python3 -m black --version
+python3 -m isort --version
+python3 -m flake8 --version
+
+# Check Node tools
+npx prettier --version
+npx eslint --version
+
+# Check Go tools
+golangci-lint --version
+gofmt -help
+
+# Check Java tools
+mvn --version
+```
+
+#### 2. Hook takes too long
+
+Some hooks (like Java checks) can be slow. They run only when relevant files change.
+
+#### 3. False positives in gitleaks
+
+If gitleaks flags a false positive (e.g., example API keys in documentation), you can:
+
+1. Add the file to `.gitleaksignore`
+2. Use inline comments to exclude specific lines
+
+### Getting Help
+
+If you encounter issues:
+
+1. Check the [pre-commit documentation](https://pre-commit.com/)
+2. Review the `.pre-commit-config.yaml` configuration
+3. Open an issue in the project repository
+
+## Best Practices
+
+1. **Run pre-commit before pushing**: Even though hooks run on commit, running `pre-commit run --all-files` before pushing ensures all files are checked.
+
+2. **Keep hooks updated**: Run `pre-commit autoupdate` periodically to get the latest hook versions.
+
+3. **Don't skip hooks**: Avoid using `--no-verify` unless absolutely necessary. If a check is consistently problematic, discuss with the team.
+
+4. **Fix issues immediately**: Don't accumulate technical debt. Fix formatting and linting issues as they arise.
+
+5. **Use CI as backup**: Our CI pipeline also runs these checks, so any missed issues will be caught before merge.

--- a/docs/en/PROJECT_MODULES.md
+++ b/docs/en/PROJECT_MODULES.md
@@ -1,0 +1,390 @@
+# Astron Agent Project Modules
+
+## Project Overview
+
+**Astron Agent** is an enterprise-grade, commercially-friendly Agentic Workflow development platform that integrates AI workflow orchestration, model management, AI & MCP tools, RPA automation, and team collaboration features.
+
+## Architecture Diagram
+
+![Astron Agent Architecture](../imgs/arch.png)
+
+---
+
+## Module List
+
+### UI Layer
+
+#### 1. Console Frontend
+
+**Module Path**: `console/frontend/`
+
+**Language**: TypeScript + React
+
+**Main Responsibilities**:
+- Provide web user interface (SPA - Single Page Application)
+- Agent creation and configuration UI
+- Visual workflow editor
+- Knowledge base management interface
+- Model management and configuration
+- Real-time chat window
+- Multi-tenant space management
+
+**Tech Stack**: React 18, TypeScript 5, Vite 5, Ant Design 5, Tailwind CSS, ReactFlow, Recoil/Zustand
+
+---
+
+### Console Backend Layer
+
+#### 2. Console Backend
+
+**Module Path**: `console/backend/`
+
+**Language**: Java
+
+**Main Responsibilities**:
+- Provide REST API and SSE interfaces for management console
+- User authentication and permission management
+- CRUD interfaces for Agent, Workflow, and Knowledge
+- Model management and configuration APIs
+- File upload/download services
+- Data statistics and analytics
+
+**Tech Stack**: Spring Boot 3.5.4, MyBatis Plus 3.5.7, Spring Security, OAuth2
+
+**Sub-modules**:
+- **hub**: Main API service module
+- **toolkit**: Utility module
+- **commons**: Common module (DTOs, utilities, etc.)
+
+---
+
+### Core Microservices Layer
+
+#### 3. Agent Service
+
+**Module Path**: `core/agent/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- Agent core execution engine
+- Support multiple Agent types (Chat Agent, CoT Agent, CoT Process Agent)
+- Agent lifecycle management
+- Tool invocation and plugin integration
+- Session management and context persistence
+
+**Tech Stack**: FastAPI, SQLAlchemy 2.0, Pydantic, OpenTelemetry
+
+**Architecture Design**: Follows DDD (Domain-Driven Design) with API layer, service layer, domain layer, and repository layer
+
+---
+
+#### 4. Workflow Service
+
+**Module Path**: `core/workflow/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- Workflow orchestration and execution engine (Spark Flow)
+- Multi-step process automation
+- Workflow version management
+- Event-driven asynchronous processing
+- Visual workflow runtime debugging
+
+**Tech Stack**: FastAPI, SQLModel, SQLAlchemy 2.0, Kafka (event streaming), LangChain
+
+**Event Mechanism**: Event communication via Kafka Topic `workflow-events`
+
+---
+
+#### 5. Knowledge Service
+
+**Module Path**: `core/knowledge/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- Knowledge base management and document processing
+- Document vectorization and semantic search
+- RAG (Retrieval-Augmented Generation) implementation
+- LLM integration and embeddings generation
+- Support for multiple document format parsing
+
+**Tech Stack**: FastAPI, RAGFlow SDK, OpenAI API, SQLModel, Redis
+
+**Event Mechanism**: Event communication via Kafka Topic `knowledge-events`
+
+---
+
+#### 6. Memory DB Service
+
+**Module Path**: `core/memory/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- Conversation history storage and retrieval
+- Context management (long-term and short-term memory)
+- Session data persistence
+
+**Tech Stack**: Python, database abstraction layer
+
+---
+
+#### 7. Tenant Service
+
+**Module Path**: `core/tenant/`
+
+**Language**: Go
+
+**Main Responsibilities**:
+- Multi-tenant management
+- Space isolation and permission control
+- Organization structure management
+- Resource quota management
+
+**Tech Stack**: Go 1.23, Gin framework, MySQL
+
+**Design Philosophy**: Implemented in Go for high performance and low memory overhead
+
+---
+
+### Plugin System
+
+#### 8. Plugin: AI Tools
+
+**Module Path**: `core/plugin/aitools/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- Integration with iFLYTEK AI tools (IFLYTEX API)
+- Third-party AI tool integration
+- Tool invocation management and result caching
+
+**Tech Stack**: FastAPI, HTTP Client
+
+---
+
+#### 9. Plugin: RPA
+
+**Module Path**: `core/plugin/rpa/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- RPA process automation
+- Process recording and playback
+- Automated script execution
+- Integration with external RPA executors
+
+**Tech Stack**: FastAPI, RPA SDK
+
+---
+
+#### 10. Plugin: Link
+
+**Module Path**: `core/plugin/link/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- External link resource integration
+- URL content fetching and processing
+- Link validation and metadata extraction
+
+**Tech Stack**: FastAPI, HTTP Client
+
+---
+
+### Common Services Layer
+
+#### 11. Common Module
+
+**Module Path**: `core/common/`
+
+**Language**: Python
+
+**Main Responsibilities**:
+- Provide cross-project common services and utilities
+- Authentication and audit system (MetrologyAuth)
+- Observability support (OTLP, OpenTelemetry)
+- Database, cache, and message queue connection management
+- Unified logging system
+- OSS (MinIO) object storage integration
+
+**Tech Stack**: Python, SQLModel, Redis Client, Kafka Client, OpenTelemetry
+
+**Core Value**: Provide unified infrastructure abstraction for all Python microservices
+
+---
+
+## Infrastructure Components (Data Mgmt & Messaging)
+
+### Data Persistence
+- **MySQL**: Primary database for structured data storage
+- **Redis**: Cache service, session storage, event registry
+- **PostgreSQL**: Optional auxiliary database
+
+### Message Queue
+- **Kafka**: Event streaming and inter-service communication
+  - Topic: `workflow-events` - Workflow events
+  - Topic: `knowledge-events` - Knowledge events
+  - Topic: `agent-events` - Agent events
+
+### Object Storage
+- **MinIO**: File storage service (PUT/GET operations)
+
+---
+
+## External Service Integrations
+
+### LLM Providers
+- Integration with multiple large language model services (OpenAI, Azure OpenAI, local models, etc.)
+- Unified LLM invocation interface
+
+### IFLYTEX API
+- iFLYTEK AI tool API integration
+- Invoked through AI Tools plugin
+
+### RPA Executors
+- External RPA automation executors
+- Task distribution and execution via RPA plugin
+
+---
+
+## Module Dependencies
+
+### Hierarchical Structure
+
+```
+UI Layer
+    └── Console Frontend (React/TS)
+         ↓ HTTP/REST/SSE
+
+Console Backend Layer
+    └── Console Backend (Java Spring Boot)
+         ↓ HTTP/REST
+
+Core Microservices Layer
+    ├── Agent Service (Python FastAPI)
+    ├── Workflow Service (Python FastAPI)
+    ├── Knowledge Service (Python FastAPI)
+    ├── Memory DB Service (Python)
+    ├── Tenant Service (Go Gin)
+    ├── Plugin: AI Tools (Python FastAPI)
+    ├── Plugin: Link (Python FastAPI)
+    └── Plugin: RPA (Python FastAPI)
+         ↓
+
+Common Services Layer
+    └── Common Module (Python)
+         ↓
+
+Data & Messaging Layer
+    ├── MySQL (Relational Database)
+    ├── Redis (Cache/Session)
+    ├── Kafka (Event Streaming)
+    └── MinIO (Object Storage)
+         ↓
+
+External Services
+    ├── LLM Providers (Large Language Models)
+    ├── IFLYTEX API (iFLYTEK API)
+    └── RPA Executors (RPA Executors)
+```
+
+### Communication Patterns
+
+| Communication Path | Protocol | Description |
+|-------------------|----------|-------------|
+| Frontend → Backend | HTTP/REST, SSE | REST API calls and server-sent events |
+| Backend → Core Services | HTTP/REST | RESTful API invocation |
+| Core Services ↔ Core Services | Kafka Topics | Asynchronous event-driven communication |
+| Core Services → MySQL | JDBC/SQLAlchemy | Data persistence |
+| Core Services → Redis | Redis Protocol | Cache read/write, session management |
+| Core Services → Kafka | Kafka Protocol | Publish/subscribe events |
+| Core Services → MinIO | MinIO API (PUT/GET) | File upload/download |
+| Plugins → External Services | HTTP/gRPC | External API calls |
+
+---
+
+## Module Dependency Matrix
+
+| Module | Dependencies | Dependents |
+|--------|-------------|------------|
+| **Console Frontend** | Console Backend | - |
+| **Console Backend** | Agent, Workflow, Knowledge, Tenant | Console Frontend |
+| **Agent Service** | Common, Plugins (AI Tools/Link/RPA), Memory | Workflow, Console Backend |
+| **Workflow Service** | Common, Agent, Plugins | Console Backend |
+| **Knowledge Service** | Common, LLM Providers | Agent, Workflow, Console Backend |
+| **Memory DB Service** | Common | Agent |
+| **Tenant Service** | MySQL | All services (tenant context) |
+| **Plugin: AI Tools** | Common, IFLYTEX API | Agent, Workflow |
+| **Plugin: RPA** | Common, RPA Executors | Agent, Workflow |
+| **Plugin: Link** | Common | Agent, Workflow |
+| **Common Module** | MySQL, Redis, Kafka, MinIO | All Python services |
+
+---
+
+## Technology Stack Summary
+
+| Layer | Module | Language/Framework | Version |
+|-------|--------|-------------------|---------|
+| **Frontend** | Console Frontend | TypeScript + React | TS 5.9.2, React 18.2.0 |
+| **Backend** | Console Backend | Java + Spring Boot | Java 21, Spring Boot 3.5.4 |
+| **Microservices** | Agent Service | Python + FastAPI | Python 3.11+, FastAPI 0.115+ |
+| | Workflow Service | Python + FastAPI | Python 3.11+, FastAPI 0.115+ |
+| | Knowledge Service | Python + FastAPI | Python 3.11+, FastAPI 0.115+ |
+| | Memory DB Service | Python | Python 3.11+ |
+| | Tenant Service | Go + Gin | Go 1.23, Gin 1.10.1 |
+| **Plugins** | AI Tools Plugin | Python + FastAPI | Python 3.11+, FastAPI 0.115+ |
+| | RPA Plugin | Python + FastAPI | Python 3.11+, FastAPI 0.115+ |
+| | Link Plugin | Python + FastAPI | Python 3.11+, FastAPI 0.115+ |
+| **Common** | Common Module | Python | Python 3.11+ |
+| **Data** | MySQL | Relational Database | MySQL 5.7+ |
+| | Redis | Cache/In-memory DB | Redis 6.0+ |
+| | Kafka | Message Queue | Kafka 2.5.0+ |
+| | MinIO | Object Storage | MinIO 8.5.10 |
+
+---
+
+## Development Standards
+
+### Python Modules
+- **Architecture**: DDD (Domain-Driven Design)
+- **Code Style**: Black + isort
+- **Type Checking**: MyPy
+- **Code Analysis**: Pylint, Flake8
+- **Testing**: Pytest (coverage ≥ 70%)
+
+### Java Modules
+- **Architecture**: Spring Boot layered architecture
+- **Code Style**: Checkstyle
+- **Code Analysis**: PMD
+- **Testing**: JUnit
+
+### TypeScript Modules
+- **Code Style**: ESLint + Prettier
+- **Type Checking**: TypeScript strict mode
+- **Testing**: Jest + React Testing Library
+
+### Go Modules
+- **Code Style**: Go fmt
+- **Code Analysis**: Go vet, Golint
+
+---
+
+## Related Documentation
+
+- [Project README](/en/README)
+- [Deployment Guide](/en/DEPLOYMENT_GUIDE)
+- [Configuration Guide](/en/CONFIGURATION)
+- [Agent Development Guide](../core/agent/CLAUDE.md)
+- [Frontend Development Guide](../console/frontend/CLAUDE.md)
+
+---
+
+**Document Version**: v1.0
+**Last Updated**: 2025-11-25

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,139 @@
+[![Astron_Readme](../imgs/Astron_Readme.png)](https://agent.xfyun.cn)
+
+<div align="center">
+
+[![License](https://img.shields.io/badge/license-apache2.0-blue.svg)](https://github.com/iflytek/astron-agent/blob/main/LICENSE)
+[![GitHub Stars](https://img.shields.io/github/stars/iflytek/astron-agent?style=social)](https://github.com/iflytek/astron-agent/stargazers)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/iflytek/astron-agent)
+
+[English](/en/README) | [简体中文](/README-zh)
+
+</div>
+
+## 🔭 What is Astron Agent
+Astron Agent is an **enterprise-grade, commercial-friendly** Agentic Workflow development platform that integrates AI workflow orchestration, model management, AI and MCP tool integration, RPA automation, and team collaboration features.
+The platform supports **high-availability** deployment, enabling organizations to rapidly build **scalable, production-ready** intelligent agent applications and establish their AI foundation for the future.
+
+### Why Choose Astron Agent?
+- **Stable and Reliable**: Built on the same core technology as the iFLYTEK Astron Agent Platform, providing enterprise-grade reliability with a fully available high-availability version open source.
+- **Cross-System Integration**: Natively integrates intelligent RPA, efficiently connecting internal and external enterprise systems, enabling seamless interaction between Agents and enterprise systems.
+- **Enterprise-Grade Open Ecosystem**: Deeply compatible with various industry models and tools, supporting custom extensions and flexibly adapting to diverse enterprise scenarios.
+- **Business-Friendly**: Released under the Apache 2.0 License, with no commercial restrictions, allowing free commercial use.
+
+### Key Features
+- **Enterprise-Grade High Availability:** Full-stack capabilities for development, building, optimization, and management. Supports one-click deployment with strong reliability.  
+- **Intelligent RPA Integration:** Enables cross-system process automation, empowering Agents with controllable execution to achieve a complete loop “from decision to action.”  
+- **Ready-to-Use Tool Ecosystem:** Integrates massive AI capabilities and tools from the [iFLYTEK Open Platform](https://www.xfyun.cn), validated by millions of developers, supporting plug-and-play integration without extra development.  
+- **Flexible Large Model Support:** Offers diverse access methods, from rapid API-based model access and validation to one-click deployment of enterprise-level MaaS (Model as a Service) on-premises clusters, meeting needs of all scales.  
+
+## 📰 News
+
+### 🔄 Ongoing
+
+### 📅 Past
+
+- **[Astron Hackathon @ 2025 iFLYTEK Global 1024 Developer Festival](https://luma.com/9zmbc6xb)**  🎤 <a href="https://github.com/mklong"><img src="https://github.com/mklong.png" width="20" align="center" /> @mklong</a>
+- **[Astron Agent Zhengzhou Meetup](https://github.com/iflytek/astron-agent/discussions/672)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/wowo-zZ"><img src="https://github.com/wowo-zZ.png" width="20" align="center" /> @wowo-zZ</a>
+- **[Astron on Campus @ Zhejiang University of Finance and Economics](https://mp.weixin.qq.com/s/oim_Z0ckgpFwf5jOskoJuA)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a>
+- **[Astron Agent & RPA · Qingdao Meetup Brings Agentic AI!](https://github.com/iflytek/astron-agent/discussions/740)**  🎤 <a href="https://github.com/vsxd"><img src="https://github.com/vsxd.png" width="20" align="center" /> @vsxd</a> <a href="https://github.com/doctorbruce"><img src="https://github.com/doctorbruce.png" width="20" align="center" /> @doctorbruce</a> <a href="https://github.com/MaxwellJean"><img src="https://github.com/MaxwellJean.png" width="20" align="center" /> @MaxwellJean</a>
+- **[Astron Training Camp · Cohort #1](https://www.aidaxue.com/astronCamp)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/Thomas1024-Astron"><img src="https://github.com/Thomas1024-Astron.png" width="20" align="center" /> @Thomas1024-Astron</a> <a href="https://github.com/abelzha"><img src="https://github.com/abelzha.png" width="20" align="center" /> @abelzha</a>
+- **[Astron Talk @ Chongqing Mini Tech Fest](https://mp.weixin.qq.com/s/HROf1zZpkPVDSsCQrv2jRg)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a>
+- **[Astron Agent @ MWC Barcelona 2026](https://www.iflytek.com/en/news-events/mwc2026.html)**
+- **[Astron Agent & RPA · Hefei Meetup](https://mp.weixin.qq.com/s/tDJaoOLUrjBlgMLDurvHCw)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/doctorbruce"><img src="https://github.com/doctorbruce.png" width="20" align="center" /> @doctorbruce</a>
+- **[Astron Industrial Intelligence Hackathon](https://awesome-astron-workflow.dev/activities/astron-industrial-intelligence-hackathon)**  🎤 <a href="https://github.com/lyj715824"><img src="https://github.com/lyj715824.png" width="20" align="center" /> @lyj715824</a> <a href="https://github.com/horizon220222"><img src="https://github.com/horizon220222.png" width="20" align="center" /> @horizon220222</a>
+
+## 🚀 Quick Start
+
+We offer two deployment methods to meet different scenarios:
+
+### Option 1: Docker Compose (Recommended for Quick Start)
+
+```bash
+# Clone the repository
+git clone https://github.com/iflytek/astron-agent.git
+
+# Navigate to the Docker deployment directory
+cd docker/astronAgent
+
+# Copy environment configuration
+cp .env.example .env
+
+# Configure environment variables
+vim .env
+```
+
+For environment variable configuration, please refer to the documentation: [DEPLOYMENT_GUIDE_WITH_AUTH.md](/en/DEPLOYMENT_GUIDE_WITH_AUTH#step-2-configure-astronagent-environment-variables)
+
+```bash
+# Start all services (including Casdoor)
+docker compose -f docker-compose-with-auth.yaml up -d
+```
+
+#### 📊 Service Access Addresses
+
+After startup, you can access the services at the following addresses:
+
+**Authentication Service**
+- **Casdoor Admin Interface**: http://localhost:8000
+
+**AstronAgent**
+- **Application Frontend (nginx proxy)**: http://localhost/
+
+**Note**
+- Default Casdoor login credentials: username: `admin`, password: `123`
+
+### Option 2: Helm (For Kubernetes Environments)
+
+> 🚧 **Note**: Helm charts are currently under development. Stay tuned for updates!
+
+```bash
+# Coming soon
+# helm repo add astron-agent https://iflytek.github.io/astron-agent
+# helm install astron-agent astron-agent/astron-agent
+```
+
+---
+
+> 📖 For complete deployment instructions and configuration details, see [Deployment Guide](/en/DEPLOYMENT_GUIDE_WITH_AUTH)
+
+## 📖 Using Astron Cloud
+
+**Try Astron**：Astron Cloud provides a ready-to-use environment for creating and managing Agents. Get quick access at [https://agent.xfyun.cn](https://agent.xfyun.cn).
+
+**Using Guide**：For detailed usage instructions, please refer to [Quick Start Guide](https://www.xfyun.cn/doc/spark/Agent03-%E5%BC%80%E5%8F%91%E6%8C%87%E5%8D%97.html).
+
+## 📚 Documentation
+
+- [🚀 Deployment Guide](/en/DEPLOYMENT_GUIDE)
+- [🔧 Configuration](/en/CONFIGURATION)
+- [🚀 Quick Start](https://www.xfyun.cn/doc/spark/Agent02-%E5%BF%AB%E9%80%9F%E5%BC%80%E5%A7%8B.html)
+- [📘 Development Guide](https://www.xfyun.cn/doc/spark/Agent03-%E5%BC%80%E5%8F%91%E6%8C%87%E5%8D%97.html#_1-%E6%8C%87%E4%BB%A4%E5%9E%8B%E6%99%BA%E8%83%BD%E4%BD%93%E5%BC%80%E5%8F%91)
+- [📖 Tutorial](https://scn5s6198j3j.feishu.cn/wiki/VefnwvPbridJBikCUb1cYXO9nYb)
+- [💡 Best Practices](https://www.xfyun.cn/doc/spark/AgentNew-%E6%8A%80%E6%9C%AF%E5%AE%9E%E8%B7%B5%E6%A1%88%E4%BE%8B.html)
+- [📱 Use Cases](https://www.xfyun.cn/doc/spark/Agent05-%E5%BA%94%E7%94%A8%E6%A1%88%E4%BE%8B.html)
+- [❓ FAQ](https://www.xfyun.cn/doc/spark/Agent06-FAQ.html)
+- [🌐 Open Source Workflows](https://awesome-astron-workflow.dev/#workflows)
+
+## 🤝 Contributing
+
+We welcome contributions of all kinds! Please see our [Contributing Guide](/en/CONTRIBUTING)
+
+## 🌟 Star History
+
+<div align="center">
+  <img src="https://api.star-history.com/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
+</div>
+
+## 📞 Support
+
+- 💬 Community Discussion: [GitHub Discussions](https://github.com/iflytek/astron-agent/discussions)
+- 🐛 Bug Reports: [Issues](https://github.com/iflytek/astron-agent/issues)
+- 👥 WeChat Work Group:
+
+<div align="center">
+  <img src="../imgs/WeCom_Group.png" alt="WeChat Work Group" width="300">
+</div>
+
+## 📄 Open Source License
+
+This project is licensed under the [Apache 2.0 License](https://github.com/iflytek/astron-agent/blob/main/LICENSE), allowing free use, modification, distribution, and commercial use without any restrictions.

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -1,0 +1,33 @@
+# FAQ
+
+This page answers the most common questions users run into when they first open the documentation site or start deployment work.
+
+## What Powers The GitHub Pages Site
+
+The Pages site no longer publishes the legacy `website/` directory directly. It now builds the VitePress docs site under `docs/` and publishes the generated static output.
+
+## Why Was The Site Moved To VitePress
+
+- Documentation can be maintained by directory instead of one large HTML file
+- Homepage, guides, configuration, and FAQ can evolve independently
+- GitHub Pages and Vercel only need to publish static build artifacts
+- Navigation, search, and future sections are easier to extend
+
+## Do I Need To Change GitHub Pages Settings
+
+Yes. The repository Pages settings should use `GitHub Actions` as the deployment source so the workflow can build and upload the docs output directory.
+
+## How Do I Preview The Docs Locally
+
+Run the following inside `docs/`:
+
+```bash
+npm install
+npm run docs:dev
+```
+
+## Where Should I Go For Deeper Troubleshooting
+
+- [Repository FAQ](https://github.com/iflytek/astron-agent/blob/main/FAQ.md)
+- [GitHub Discussions](https://github.com/iflytek/astron-agent/discussions)
+- [GitHub Issues](https://github.com/iflytek/astron-agent/issues)

--- a/docs/en/guide/config.md
+++ b/docs/en/guide/config.md
@@ -1,0 +1,42 @@
+# Configuration Overview
+
+This page summarizes the most important configuration domains so you can quickly decide which detailed reference to read next.
+
+## Key Configuration Areas
+
+### Infrastructure
+
+- Databases and caches
+- Object storage
+- Networking and reverse proxy
+- Container runtime environment
+
+### Models And AI Capabilities
+
+- Model gateway or MaaS connection settings
+- API keys and authentication details
+- Capability switches and routing strategies
+
+### Platform Capabilities
+
+- MCP and external tool integration
+- RPA execution environment
+- Multi-tenant, space, and team capabilities
+
+### Authentication And Security
+
+- Casdoor and identity integration
+- Environment variable management
+- Secret injection and permission boundaries in production
+
+## Recommended References
+
+- [Configuration Reference](/en/CONFIGURATION)
+- [Auth Deployment Guide](/en/DEPLOYMENT_GUIDE_WITH_AUTH)
+- [Project Modules](/en/PROJECT_MODULES)
+
+## Suggested Order
+
+1. Finish the minimum runnable configuration
+2. Add production dependencies and secret management
+3. Extend MCP, RPA, and optional modules for your business scenario

--- a/docs/en/guide/deploy.md
+++ b/docs/en/guide/deploy.md
@@ -1,0 +1,42 @@
+# Deployment Overview
+
+Astron Agent is easiest to adopt in two phases: get a working environment up first, then move toward production-grade deployment and operations. This page helps you choose the right path and jump into the detailed references.
+
+## Deployment Paths
+
+### Docker Compose
+
+Best for local evaluation, functional validation, and small-team integration work.
+
+- Benefits: fast startup, low setup cost, ideal for local and test environments
+- Typical use cases: demos, developer collaboration, first architecture validation
+- Suggested entry: [Quick Start](/en/guide/quick-start)
+
+### Helm / Kubernetes
+
+Best for standardized production deployment, scaling, and long-term operations.
+
+- Benefits: better for multi-instance rollout, elasticity, and unified operations
+- Typical use cases: enterprise clusters, CI/CD, environment isolation
+- Related directory: `helm/`
+
+## What To Decide Before Deployment
+
+- Prepare database, cache, and object storage dependencies
+- Confirm model access strategy and secret management
+- Decide whether authentication is required
+- Evaluate whether you need RPA, plugin, and tenant capabilities
+
+## Recommended References
+
+- [Auth Deployment Guide](/en/DEPLOYMENT_GUIDE_WITH_AUTH)
+- [Auth + RPA Deployment Guide](/en/DEPLOYMENT_GUIDE_WITH_AUTH_RPA)
+- [Full Deployment Guide](/en/DEPLOYMENT_GUIDE)
+- [Deployment FAQ](/en/DEPLOYMENT_FAQ)
+- [Configuration Reference](/en/CONFIGURATION)
+
+## Typical Guidance
+
+- Need the fastest path: start with Docker Compose
+- Need unified identity: review the authentication-related deployment docs first
+- Planning production rollout: combine deployment, configuration, and FAQ together

--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -1,0 +1,44 @@
+# Quick Start
+
+This page keeps the shortest path for first-time evaluation. Start with a local environment, then move to the full deployment and configuration references when needed.
+
+## Who Should Start Here
+
+- Developers who want to try the full flow locally first
+- Teams that need a sign-in capable demo environment quickly
+- Users who plan to move from Docker Compose to Helm or production settings later
+
+## Two Steps To Get Running
+
+### 1. Clone The Repository And Prepare Environment Variables
+
+```bash
+git clone https://github.com/iflytek/astron-agent.git
+cd astron-agent/docker/astronAgent
+cp .env.example .env
+```
+
+After copying the file, fill in model, database, object storage, and authentication settings as required.
+
+### 2. Start The Services
+
+```bash
+docker compose -f docker-compose-with-auth.yaml up -d
+```
+
+Once the stack is ready, the default entry points are:
+
+- Astron Agent frontend: `http://localhost/`
+- Casdoor admin console: `http://localhost:8000`
+
+## Recommended Reading Order
+
+1. Read the [Deployment Overview](/en/guide/deploy)
+2. Continue with [Configuration Overview](/en/guide/config)
+3. Check the [FAQ](/en/faq) when you need troubleshooting paths
+
+## Deeper References
+
+- [Project README](/en/README)
+- [Auth Deployment Guide](/en/DEPLOYMENT_GUIDE_WITH_AUTH)
+- [Full Deployment Guide](/en/DEPLOYMENT_GUIDE)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,5 @@
+---
+layout: astron-home
+title: Astron Agent
+description: Homepage of the Astron Agent documentation site.
+---


### PR DESCRIPTION
## Summary
- add `/en/` deep documentation pages so the docs site has paired English pages under the main branch
- wire English locale navigation and sidebar to the new deep pages
- keep the homepage i18n entry aligned with the docs structure

## Scope
- `docs/.vitepress/config.mts`
- `docs/.vitepress/theme/AstronHomePage.vue`
- `docs/en/**`

## Why
- the previous publish branch is not on the same history as `main`, so this PR bridges the docs site changes back into `main`
## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
