### PR TITLE
docs(model): refresh MiniMax model examples to M-series (M3 / M2.7)

### DIFF
--- a/console/frontend/src/locales/en-En/model.ts
+++ b/console/frontend/src/locales/en-En/model.ts
@@ -157,7 +157,7 @@ const translation = {
   providerHintOpenAI:
     'Use an OpenAI-compatible endpoint such as /v1/chat/completions.',
   providerHintMiniMax:
-    'Use the MiniMax official endpoint and a model such as MiniMax-Text-01.',
+    'Use the MiniMax official endpoint and a model such as MiniMax-M3.',
   providerHintZhipu:
     'Use the Zhipu AI official endpoint and a model such as glm-4.5 or glm-4-flash.',
   providerHintQwen:
@@ -174,7 +174,7 @@ const translation = {
     'Use an Anthropic Messages API endpoint and a Claude model such as Sonnet or Opus.',
   providerHintGoogle:
     'Use a Gemini API endpoint and a Gemini model such as gemini-2.5-flash.',
-  minimaxModelPlaceholder: 'e.g. MiniMax-Text-01',
+  minimaxModelPlaceholder: 'e.g. MiniMax-M3 or MiniMax-M2.7',
   minimaxEndpointPlaceholder: 'Please enter the MiniMax API endpoint',
   zhipuModelPlaceholder: 'e.g. glm-4.5 or glm-4-flash',
   zhipuEndpointPlaceholder: 'Please enter the Zhipu AI API endpoint',

--- a/console/frontend/src/locales/zh-ZH/model.ts
+++ b/console/frontend/src/locales/zh-ZH/model.ts
@@ -152,7 +152,7 @@ const translation = {
   providerDoubao: '豆包',
   providerHintOpenAI: '使用 OpenAI 接口地址，例如 /v1/chat/completions。',
   providerHintMiniMax:
-    '使用 MiniMax 官方接口地址，并填写 MiniMax-Text-01 等模型名称。',
+    '使用 MiniMax 官方接口地址，并填写 MiniMax-M3 等模型名称。',
   providerHintZhipu:
     '使用智谱官方接口地址，并填写 glm-4.5、glm-4-flash 等模型名称。',
   providerHintQwen:
@@ -169,7 +169,7 @@ const translation = {
     '使用 Anthropic Messages API 地址，并填写 Claude Sonnet / Opus 等模型名。',
   providerHintGoogle:
     '使用 Gemini API 地址，并填写 gemini-2.5-flash 等模型名。',
-  minimaxModelPlaceholder: '例如 MiniMax-Text-01',
+  minimaxModelPlaceholder: '例如 MiniMax-M3 或 MiniMax-M2.7',
   minimaxEndpointPlaceholder: '请输入 MiniMax API 地址',
   zhipuModelPlaceholder: '例如 glm-4.5 或 glm-4-flash',
   zhipuEndpointPlaceholder: '请输入智谱 API 地址',

--- a/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
+++ b/console/frontend/src/pages/model-management/official-model/official-model-home.tsx
@@ -111,7 +111,7 @@ const OfficialModelContent: React.FC = () => {
       {
         provider: ModelProviderType.MINIMAX,
         title: 'MiniMax',
-        subtitle: 'MiniMax-Text-01',
+        subtitle: 'MiniMax-M3 / MiniMax-M2.7',
         description: t('model.providerCardMiniMaxDesc'),
         accentClass: 'from-[#FFF3E8] via-[#FFF8F2] to-white',
         endpoint: 'https://api.minimaxi.com/v1',


### PR DESCRIPTION
## Description

The MiniMax provider in the model-management UI still points users at the legacy `MiniMax-Text-01` example. Minimax has since shipped the M-series (M1 → M2 → M2.5 → M2.7 → M3), and `MiniMax-M3` is the current flagship. This PR updates the user-facing example/placeholder text so the official provider card and the model configuration form recommend the current models instead.

Changes are limited to display strings:
- `console/frontend/src/locales/zh-ZH/model.ts` — `providerHintMiniMax` + `minimaxModelPlaceholder`
- `console/frontend/src/locales/en-En/model.ts` — same two keys
- `console/frontend/src/pages/model-management/official-model/official-model-home.tsx` — provider card subtitle (`MiniMax-M3 / MiniMax-M2.7`, matching the `/`-separated style of the Gemini, Zhipu, Qwen, and Doubao cards)

## Type of Change
- [x] Documentation update

## Out of scope (intentionally not changed)
- Provider keyword maps (`PROVIDER_MINIMAX`, `OPENAI_COMPATIBLE_PROVIDERS`, `requiresCustomModelCredentialInjection`) — provider name unchanged.
- API endpoint (`https://api.minimaxi.com/v1`) — unchanged.
- TTS / non-MiniMax providers — unchanged.

## Testing
- [x] Self-reviewed the diff (`git diff` only shows the five string replacements)
- [x] No type, signature, or runtime logic changes; both locale files and the React card render the same shape
- [x] No occurrences of `MiniMax-Text-01` remain in the repo

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes