### PR TITLE
fix: enforce shared space publish approval

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/PublishApprovalServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/PublishApprovalServiceImpl.java
@@ -62,8 +62,7 @@ public class PublishApprovalServiceImpl implements PublishApprovalService {
         Long effectiveSpaceId = resolveEffectiveSpaceId(submitDto);
         submitDto.setSpaceId(effectiveSpaceId);
         normalizePublishSnapshotSpaceId(submitDto);
-        SpaceTypeEnum spaceType = resolveSpaceType(effectiveSpaceId);
-        if (spaceType == null || !spaceType.isTeam()) {
+        if (effectiveSpaceId == null) {
             return directDecision();
         }
 
@@ -83,6 +82,7 @@ public class PublishApprovalServiceImpl implements PublishApprovalService {
             return directDecision();
         }
 
+        SpaceTypeEnum spaceType = resolveSpaceType(effectiveSpaceId);
         validateApprovalTarget(submitDto);
         PublishApproval approval = buildApproval(submitDto, spaceType);
         PublishApproval existing = findActiveApproval(approval);
@@ -209,7 +209,7 @@ public class PublishApprovalServiceImpl implements PublishApprovalService {
     private Long resolveEffectiveSpaceId(PublishApprovalSubmitDto submitDto) {
         Long requestSpaceId = submitDto.getSpaceId();
         ResourceSpace resourceSpace = resolveResourceSpace(submitDto);
-        return resourceSpace.found() ? resourceSpace.spaceId() : requestSpaceId;
+        return resourceSpace.found() && resourceSpace.spaceId() != null ? resourceSpace.spaceId() : requestSpaceId;
     }
 
     private ResourceSpace resolveResourceSpace(PublishApprovalSubmitDto submitDto) {
@@ -419,7 +419,7 @@ public class PublishApprovalServiceImpl implements PublishApprovalService {
         LocalDateTime now = LocalDateTime.now();
         PublishApproval approval = new PublishApproval();
         approval.setSpaceId(submitDto.getSpaceId());
-        approval.setSpaceType(spaceType.getCode());
+        approval.setSpaceType(spaceType == null ? null : spaceType.getCode());
         approval.setResourceType(submitDto.getResourceType().name());
         approval.setResourceId(submitDto.getResourceId());
         approval.setResourceName(submitDto.getResourceName());

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/PublishApprovalServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/PublishApprovalServiceImplTest.java
@@ -92,12 +92,26 @@ class PublishApprovalServiceImplTest {
     @Test
     void personalSpacePublishShouldNotCreateApproval() {
         PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.PUBLISH);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.FREE);
+        submit.setSpaceId(null);
 
         PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
 
         assertThat(decision.getApprovalRequired()).isFalse();
         assertThat(decision.getStatus()).isNull();
+        verify(spaceService, never()).getSpaceType(any());
+        verify(spaceUserService, never()).getRole(any(), any());
+        verify(publishApprovalMapper, never()).insert(any(PublishApproval.class));
+    }
+
+    @Test
+    void personalSpaceOwnerPublishShouldNotCreateApproval() {
+        PublishApprovalSubmitDto submit = submitDto("owner-uid", PublishApprovalActionEnum.PUBLISH);
+        when(spaceUserService.getRole(100L, "owner-uid")).thenReturn(SpaceRoleEnum.OWNER);
+
+        PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
+
+        assertThat(decision.getApprovalRequired()).isFalse();
+        verify(spaceService, never()).getSpaceType(100L);
         verify(publishApprovalMapper, never()).insert(any(PublishApproval.class));
     }
 
@@ -282,7 +296,6 @@ class PublishApprovalServiceImplTest {
     @Test
     void teamAdminPublishShouldNotCreateApproval() {
         PublishApprovalSubmitDto submit = submitDto("admin-uid", PublishApprovalActionEnum.PUBLISH);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "admin-uid")).thenReturn(SpaceRoleEnum.ADMIN);
 
         PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
@@ -292,9 +305,9 @@ class PublishApprovalServiceImplTest {
     }
 
     @Test
-    void teamMemberPublishToMarketShouldCreatePendingApproval() {
+    void spaceMemberPublishToMarketShouldCreatePendingApproval() {
         PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.PUBLISH);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
+        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.FREE);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
         when(chatBotBaseMapper.checkBotPermission(42, "member-uid", 100L)).thenReturn(1);
         when(publishApprovalMapper.selectOne(any())).thenReturn(null);
@@ -314,6 +327,7 @@ class PublishApprovalServiceImplTest {
         verify(publishApprovalMapper).insert(captor.capture());
         PublishApproval approval = captor.getValue();
         assertThat(approval.getSpaceId()).isEqualTo(100L);
+        assertThat(approval.getSpaceType()).isEqualTo(SpaceTypeEnum.FREE.getCode());
         assertThat(approval.getResourceType()).isEqualTo(PublishApprovalResourceTypeEnum.BOT.name());
         assertThat(approval.getPublishType()).isEqualTo(PublishApprovalTypeEnum.MARKET.name());
         assertThat(approval.getApprovalStatus()).isEqualTo(PublishApprovalStatusEnum.PENDING.name());
@@ -442,24 +456,34 @@ class PublishApprovalServiceImplTest {
     }
 
     @Test
-    void personalBotPublishShouldIgnoreStaleTeamRequestSpaceId() {
+    void botWithoutResourceSpaceShouldUseRequestSpaceIdForApproval() {
         PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.PUBLISH);
         submit.setSpaceId(100L);
         ChatBotBase botBase = new ChatBotBase();
         botBase.setId(42);
         botBase.setSpaceId(null);
         when(chatBotBaseMapper.selectById(42)).thenReturn(botBase);
+        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.FREE);
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
+        when(chatBotBaseMapper.checkBotPermission(42, "member-uid", 100L)).thenReturn(1);
+        when(publishApprovalMapper.selectOne(any())).thenReturn(null);
+        when(publishApprovalMapper.insert(any(PublishApproval.class))).thenAnswer(invocation -> {
+            PublishApproval approval = invocation.getArgument(0);
+            approval.setId(127L);
+            return 1;
+        });
 
         PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
 
-        assertThat(decision.getApprovalRequired()).isFalse();
-        verify(spaceService, never()).getSpaceType(100L);
-        verify(spaceUserService, never()).getRole(any(), any());
-        verify(publishApprovalMapper, never()).insert(any(PublishApproval.class));
+        assertThat(decision.getApprovalRequired()).isTrue();
+        assertThat(decision.getApprovalId()).isEqualTo(127L);
+        ArgumentCaptor<PublishApproval> captor = ArgumentCaptor.forClass(PublishApproval.class);
+        verify(publishApprovalMapper).insert(captor.capture());
+        assertThat(captor.getValue().getSpaceId()).isEqualTo(100L);
     }
 
     @Test
-    void personalWorkflowPublishShouldIgnoreStaleTeamRequestSpaceId() {
+    void workflowWithoutResourceSpaceShouldUseRequestSpaceIdForApproval() {
         PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.PUBLISH);
         submit.setResourceType(PublishApprovalResourceTypeEnum.WORKFLOW);
         submit.setResourceId("1000");
@@ -468,13 +492,22 @@ class PublishApprovalServiceImplTest {
         workflow.setId(1000L);
         workflow.setSpaceId(null);
         when(workflowMapper.selectById(1000L)).thenReturn(workflow);
+        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.FREE);
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
+        when(publishApprovalMapper.selectOne(any())).thenReturn(null);
+        when(publishApprovalMapper.insert(any(PublishApproval.class))).thenAnswer(invocation -> {
+            PublishApproval approval = invocation.getArgument(0);
+            approval.setId(128L);
+            return 1;
+        });
 
         PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
 
-        assertThat(decision.getApprovalRequired()).isFalse();
-        verify(spaceService, never()).getSpaceType(100L);
-        verify(spaceUserService, never()).getRole(any(), any());
-        verify(publishApprovalMapper, never()).insert(any(PublishApproval.class));
+        assertThat(decision.getApprovalRequired()).isTrue();
+        assertThat(decision.getApprovalId()).isEqualTo(128L);
+        ArgumentCaptor<PublishApproval> captor = ArgumentCaptor.forClass(PublishApproval.class);
+        verify(publishApprovalMapper).insert(captor.capture());
+        assertThat(captor.getValue().getSpaceId()).isEqualTo(100L);
     }
 
     @Test
@@ -517,7 +550,6 @@ class PublishApprovalServiceImplTest {
     void teamMemberPublishToReservedChannelShouldNotCreateApproval() {
         PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.PUBLISH);
         submit.setPublishType(PublishApprovalTypeEnum.MCP);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
 
         PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
@@ -529,7 +561,6 @@ class PublishApprovalServiceImplTest {
     @Test
     void nonSpaceMemberShouldNotCreatePendingApproval() {
         PublishApprovalSubmitDto submit = submitDto("stranger-uid", PublishApprovalActionEnum.PUBLISH);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "stranger-uid")).thenReturn(null);
 
         assertThatThrownBy(() -> publishApprovalService.submitIfRequired(submit))
@@ -597,9 +628,30 @@ class PublishApprovalServiceImplTest {
     }
 
     @Test
+    void spaceMemberShouldCreateApiApprovalForOwnedAppInFreeSpace() {
+        PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.PUBLISH);
+        submit.setPublishType(PublishApprovalTypeEnum.API);
+        submit.setTargetId("app-1");
+        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.FREE);
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
+        when(chatBotBaseMapper.checkBotPermission(42, "member-uid", 100L)).thenReturn(1);
+        when(appMstService.getByAppId("member-uid", "app-1")).thenReturn(AppMst.builder().appId("app-1").build());
+        when(publishApprovalMapper.selectOne(any())).thenReturn(null);
+        when(publishApprovalMapper.insert(any(PublishApproval.class))).thenAnswer(invocation -> {
+            PublishApproval approval = invocation.getArgument(0);
+            approval.setId(129L);
+            return 1;
+        });
+
+        PublishApprovalDecisionDto decision = publishApprovalService.submitIfRequired(submit);
+
+        assertThat(decision.getApprovalRequired()).isTrue();
+        assertThat(decision.getApprovalId()).isEqualTo(129L);
+    }
+
+    @Test
     void teamMemberOfflineShouldBeRejectedWithoutApproval() {
         PublishApprovalSubmitDto submit = submitDto("member-uid", PublishApprovalActionEnum.OFFLINE);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
 
         assertThatThrownBy(() -> publishApprovalService.submitIfRequired(submit))
@@ -618,7 +670,6 @@ class PublishApprovalServiceImplTest {
         botBase.setId(42);
         botBase.setSpaceId(100L);
         when(chatBotBaseMapper.selectById(42)).thenReturn(botBase);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
 
         assertThatThrownBy(() -> publishApprovalService.submitIfRequired(submit))
@@ -639,7 +690,6 @@ class PublishApprovalServiceImplTest {
         workflow.setId(1000L);
         workflow.setSpaceId(100L);
         when(workflowMapper.selectById(1000L)).thenReturn(workflow);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
 
         assertThatThrownBy(() -> publishApprovalService.submitIfRequired(submit))

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -28,13 +28,11 @@ import com.iflytek.astron.console.commons.entity.user.UserInfo;
 import com.iflytek.astron.console.commons.entity.workflow.Workflow;
 import com.iflytek.astron.console.commons.enums.bot.BotTypeEnum;
 import com.iflytek.astron.console.commons.enums.space.SpaceRoleEnum;
-import com.iflytek.astron.console.commons.enums.space.SpaceTypeEnum;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.mapper.UserLangChainInfoMapper;
 import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
 import com.iflytek.astron.console.commons.response.ApiResult;
 import com.iflytek.astron.console.commons.service.bot.BotMarketDataService;
-import com.iflytek.astron.console.commons.service.space.SpaceService;
 import com.iflytek.astron.console.commons.service.space.SpaceUserService;
 import com.iflytek.astron.console.commons.util.RequestContextUtil;
 import com.iflytek.astron.console.commons.util.SseEmitterUtil;
@@ -210,8 +208,6 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
     ApiUrl apiUrl;
     @Autowired
     DataPermissionCheckTool dataPermissionCheckTool;
-    @Autowired
-    private SpaceService spaceService;
     @Autowired
     private SpaceUserService spaceUserService;
     @Autowired
@@ -3197,7 +3193,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         Workflow workflow = getById(id);
         Long effectiveSpaceId = resolveCurrentWorkflowSpaceId(workflow);
         assertWorkflowBelongsToCurrentContext(workflow, effectiveSpaceId);
-        assertTeamSpaceMember(effectiveSpaceId);
+        assertSpacePublishManager(effectiveSpaceId);
         WorkflowReq req = new WorkflowReq();
         // req.setStatus(WorkflowConst.Status.UNPUBLISHED);
         req.setAppId(workflow.getAppId());
@@ -3215,7 +3211,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         Workflow workflow = getById(id);
         Long effectiveSpaceId = resolveCurrentWorkflowSpaceId(workflow);
         assertWorkflowBelongsToCurrentContext(workflow, effectiveSpaceId);
-        assertTeamPublishManager(effectiveSpaceId);
+        assertSpacePublishManager(effectiveSpaceId);
         WorkflowReq req = new WorkflowReq();
         req.setAppId(workflow.getAppId());
         return update(Wrappers.lambdaUpdate(Workflow.class)
@@ -3243,30 +3239,14 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         }
     }
 
-    private void assertTeamSpaceMember(Long spaceId) {
-        SpaceTypeEnum spaceType = resolveSpaceType(spaceId);
-        if (spaceType == null || !spaceType.isTeam()) {
-            return;
-        }
-        SpaceRoleEnum role = spaceUserService.getRole(spaceId, UserInfoManagerHandler.getUserId());
-        if (role == null) {
-            throw new BusinessException(ResponseEnum.INSUFFICIENT_PERMISSIONS);
-        }
-    }
-
-    private void assertTeamPublishManager(Long spaceId) {
-        SpaceTypeEnum spaceType = resolveSpaceType(spaceId);
-        if (spaceType == null || !spaceType.isTeam()) {
+    private void assertSpacePublishManager(Long spaceId) {
+        if (spaceId == null) {
             return;
         }
         SpaceRoleEnum role = spaceUserService.getRole(spaceId, UserInfoManagerHandler.getUserId());
         if (SpaceRoleEnum.OWNER != role && SpaceRoleEnum.ADMIN != role) {
             throw new BusinessException(ResponseEnum.INSUFFICIENT_PERMISSIONS);
         }
-    }
-
-    private SpaceTypeEnum resolveSpaceType(Long spaceId) {
-        return spaceId == null ? null : spaceService.getSpaceType(spaceId);
     }
 
     public boolean isSimpleIo(Long id) {

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServicePublishPermissionTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServicePublishPermissionTest.java
@@ -7,9 +7,7 @@ import com.iflytek.astron.console.commons.config.JwtClaimsFilter;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.entity.workflow.Workflow;
 import com.iflytek.astron.console.commons.enums.space.SpaceRoleEnum;
-import com.iflytek.astron.console.commons.enums.space.SpaceTypeEnum;
 import com.iflytek.astron.console.commons.exception.BusinessException;
-import com.iflytek.astron.console.commons.service.space.SpaceService;
 import com.iflytek.astron.console.commons.service.space.SpaceUserService;
 import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
 import org.junit.jupiter.api.AfterEach;
@@ -41,8 +39,6 @@ class WorkflowServicePublishPermissionTest {
     @Mock
     private DataPermissionCheckTool dataPermissionCheckTool;
     @Mock
-    private SpaceService spaceService;
-    @Mock
     private SpaceUserService spaceUserService;
 
     private WorkflowService workflowService;
@@ -56,7 +52,6 @@ class WorkflowServicePublishPermissionTest {
     void setUp() {
         workflowService = spy(new WorkflowService());
         ReflectionTestUtils.setField(workflowService, "dataPermissionCheckTool", dataPermissionCheckTool);
-        ReflectionTestUtils.setField(workflowService, "spaceService", spaceService);
         ReflectionTestUtils.setField(workflowService, "spaceUserService", spaceUserService);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -71,10 +66,9 @@ class WorkflowServicePublishPermissionTest {
     }
 
     @Test
-    void teamMemberShouldNotSetWorkflowCanPublish() {
+    void spaceMemberShouldNotSetWorkflowCanPublish() {
         Workflow workflow = workflow(100L);
         doReturn(workflow).when(workflowService).getById(1L);
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
 
         assertThatThrownBy(() -> workflowService.canPublishSet(1L))
@@ -86,11 +80,10 @@ class WorkflowServicePublishPermissionTest {
     }
 
     @Test
-    void teamAdminShouldSetWorkflowCanPublish() {
+    void spaceAdminShouldSetWorkflowCanPublish() {
         Workflow workflow = workflow(100L);
         doReturn(workflow).when(workflowService).getById(1L);
         doReturn(true).when(workflowService).update(any(Wrapper.class));
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
         when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.ADMIN);
 
         Object result = workflowService.canPublishSet(1L);
@@ -101,12 +94,54 @@ class WorkflowServicePublishPermissionTest {
     }
 
     @Test
-    void canPublishSetNotShouldCheckWorkflowBelongAndTeamMember() {
+    void spaceMemberShouldNotSetWorkflowCanPublishNot() {
+        Workflow workflow = workflow(100L);
+        doReturn(workflow).when(workflowService).getById(1L);
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
+
+        assertThatThrownBy(() -> workflowService.canPublishSetNot(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ResponseEnum.INSUFFICIENT_PERMISSIONS.getCode());
+
+        verifyNoInteractions(dataPermissionCheckTool);
+        verify(workflowService, never()).update(any(Wrapper.class));
+    }
+
+    @Test
+    void spaceAdminShouldSetWorkflowCanPublishNot() {
         Workflow workflow = workflow(100L);
         doReturn(workflow).when(workflowService).getById(1L);
         doReturn(true).when(workflowService).update(any(Wrapper.class));
-        when(spaceService.getSpaceType(100L)).thenReturn(SpaceTypeEnum.TEAM);
-        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.MEMBER);
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.ADMIN);
+
+        Object result = workflowService.canPublishSetNot(1L);
+
+        assertThat(result).isEqualTo(true);
+        verifyNoInteractions(dataPermissionCheckTool);
+        verify(workflowService).update(any(Wrapper.class));
+    }
+
+    @Test
+    void spaceOwnerShouldSetWorkflowCanPublish() {
+        Workflow workflow = workflow(100L);
+        doReturn(workflow).when(workflowService).getById(1L);
+        doReturn(true).when(workflowService).update(any(Wrapper.class));
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.OWNER);
+
+        Object result = workflowService.canPublishSet(1L);
+
+        assertThat(result).isEqualTo(true);
+        verifyNoInteractions(dataPermissionCheckTool);
+        verify(workflowService).update(any(Wrapper.class));
+    }
+
+    @Test
+    void spaceOwnerShouldSetWorkflowCanPublishNot() {
+        Workflow workflow = workflow(100L);
+        doReturn(workflow).when(workflowService).getById(1L);
+        doReturn(true).when(workflowService).update(any(Wrapper.class));
+        when(spaceUserService.getRole(100L, "member-uid")).thenReturn(SpaceRoleEnum.OWNER);
 
         Object result = workflowService.canPublishSetNot(1L);
 


### PR DESCRIPTION
## Summary
- enforce publish approval for shared/team spaces based on current space membership instead of relying on space type
- require current space OWNER/ADMIN for workflow publish management offline operations
- add regression tests for shared-space publish approval and workflow publish permission checks

## Tests
- mvn -pl hub -am -Dtest=PublishApprovalServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl toolkit -am -Dtest=WorkflowServicePublishPermissionTest -Dsurefire.failIfNoSpecifiedTests=false test
- git diff --check