### PR TITLE
feat: add team publish approval flow

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -27,6 +27,7 @@ import com.iflytek.astron.console.commons.service.data.ChatListDataService;
 import com.iflytek.astron.console.commons.service.data.DatasetDataService;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.commons.service.data.UserLangChainLogService;
+import com.iflytek.astron.console.commons.service.workflow.WorkflowVersionLookupService;
 import com.iflytek.astron.console.commons.util.BotFileParamUtil;
 import com.iflytek.astron.console.commons.util.I18nUtil;
 import com.iflytek.astron.console.commons.util.MaasUtil;
@@ -101,6 +102,9 @@ public class BotServiceImpl implements BotService {
 
     @Autowired
     private ChatBotPromptStructMapper chatBotPromptStructMapper;
+
+    @Autowired
+    private WorkflowVersionLookupService workflowVersionLookupService;
 
     @Value("${bot.default.avatar}")
     private String DEFAULT_AVATAR;
@@ -706,29 +710,42 @@ public class BotServiceImpl implements BotService {
             botInfo.setPcBackground(background);
         }
 
-        if (workflowVersion != null && uid.equals(chatBotBase.getUid())) {
-            updateWorkflowStatus(botInfo, botId, workflowVersion);
-        }
+        updateWorkflowStatus(botInfo, botId, normalizeWorkflowVersion(workflowVersion));
     }
 
     private void updateWorkflowStatus(BotInfoDto botInfo, Integer botId, String workflowVersion) {
         try {
             String flowId = userLangChainDataService.findFlowIdByBotId(botId);
-            JSONObject releaseStatusJson = getWorkflowApiResponse("http://127.0.0.1:8080/workflow/version/publish-result?flowId=" + flowId + "&name=" + workflowVersion);
-            JSONObject versionResult = getWorkflowApiResponse("http://127.0.0.1:8080/workflow/version/get-max-version?botId=" + botId);
-
-            if (!releaseStatusJson.getJSONArray("data").isEmpty()) {
-                String releaseStatus = releaseStatusJson.getJSONArray("data").getJSONObject(0).getString("publishResult");
-                log.info("botId:{} query release status: {}", botId, releaseStatus);
-                botInfo.setBotStatus(Objects.equals(releaseStatus, "success") ? ShelfStatusEnum.ON_SHELF.getCode() : ShelfStatusEnum.OFF_SHELF.getCode());
+            if (StringUtils.isBlank(flowId)) {
+                return;
             }
 
-            String versionMax = versionResult.getJSONObject("data").getString("workflowMaxVersion");
-            botInfo.setWorkflowVersion(versionMax);
+            if (StringUtils.isNotBlank(workflowVersion)) {
+                workflowVersionLookupService.isPublishedVersion(flowId, workflowVersion)
+                        .ifPresent(published -> botInfo.setBotStatus(
+                                published ? ShelfStatusEnum.ON_SHELF.getCode() : ShelfStatusEnum.OFF_SHELF.getCode()));
+            }
+
+            workflowVersionLookupService.findLatestSuccessfulVersionName(botId)
+                    .ifPresentOrElse(
+                            botInfo::setWorkflowVersion,
+                            () -> {
+                                if (StringUtils.isNotBlank(workflowVersion)) {
+                                    botInfo.setWorkflowVersion(workflowVersion);
+                                }
+                            });
         } catch (Exception e) {
             log.error("botId:{} query release status exception", botId, e);
-            botInfo.setBotStatus(ShelfStatusEnum.OFF_SHELF.getCode());
         }
+    }
+
+    private String normalizeWorkflowVersion(String workflowVersion) {
+        if (StringUtils.isBlank(workflowVersion)
+                || "undefined".equalsIgnoreCase(workflowVersion)
+                || "null".equalsIgnoreCase(workflowVersion)) {
+            return null;
+        }
+        return workflowVersion;
     }
 
     @Override
@@ -777,35 +794,6 @@ public class BotServiceImpl implements BotService {
             log.error("Failed to get assistant background image: {}: {}, botId: {}, response: {}", e.getClass().getName(), e.getMessage(), botId, response);
         }
         return null;
-    }
-
-    private JSONObject getWorkflowApiResponse(String url) {
-        Request request = new Request.Builder()
-                .url(url)
-                .get()
-                .build();
-
-        try (Response okResponse = httpClient.newCall(request).execute()) {
-            if (!okResponse.isSuccessful()) {
-                log.error("Workflow API request failed: {}, URL: {}", okResponse.code(), url);
-                return new JSONObject();
-            }
-
-            ResponseBody responseBody = okResponse.body();
-            if (responseBody == null) {
-                return new JSONObject();
-            }
-
-            String response = responseBody.string();
-            if (StringUtils.isBlank(response)) {
-                return new JSONObject();
-            }
-
-            return JSONObject.parseObject(response);
-        } catch (Exception e) {
-            log.error("Workflow API call exception, URL: {}, error: {}", url, e.getMessage(), e);
-            return new JSONObject();
-        }
     }
 
     public void processPromptStruct(Integer botId, BotCreateForm bot) {

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/WorkflowVersionLookupService.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/WorkflowVersionLookupService.java
@@ -1,0 +1,10 @@
+package com.iflytek.astron.console.commons.service.workflow;
+
+import java.util.Optional;
+
+public interface WorkflowVersionLookupService {
+
+    Optional<String> findLatestSuccessfulVersionName(Integer botId);
+
+    Optional<Boolean> isPublishedVersion(String flowId, String versionName);
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImpl.java
@@ -25,6 +25,7 @@ import com.iflytek.astron.console.commons.entity.bot.UserLangChainInfo;
 import com.iflytek.astron.console.commons.enums.ShelfStatusEnum;
 import com.iflytek.astron.console.commons.service.workflow.WorkflowBotChatService;
 import com.iflytek.astron.console.commons.service.workflow.WorkflowBotParamService;
+import com.iflytek.astron.console.commons.service.workflow.WorkflowVersionLookupService;
 import com.iflytek.astron.console.commons.workflow.WorkflowClient;
 import com.iflytek.astron.console.commons.workflow.WorkflowListener;
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +68,9 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
 
     @Autowired
     private WssListenerService wssListenerService;
+
+    @Autowired
+    private WorkflowVersionLookupService workflowVersionLookupService;
 
     @Value("${workflow.chatUrl}")
     private String chatUrl;
@@ -111,6 +115,7 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
             throw new BusinessException(ResponseEnum.BOT_CHAIN_SUBMIT_ERROR);
         }
         String flowId = userLangChainInfo.getFlowId();
+        String effectiveWorkflowVersion = resolveWorkflowVersion(botId, flowId, workflowVersion);
         // Record current question
         ChatReqRecords chatReqRecords = new ChatReqRecords();
         chatReqRecords.setChatId(chatId);
@@ -137,7 +142,7 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
         List<ChatReqModelDto> reqList = chatDataService.getReqModelBotHistoryByChatId(uid, chatId);
         ChatRequestDtoList requestDtoList = chatHistoryService.getHistory(uid, chatId, reqList);
         filterContent(requestDtoList);
-        WorkflowApiRequest workflowApiRequest = new WorkflowApiRequest(flowId, uid, inputs, requestDtoList.getMessages(), workflowVersion);
+        WorkflowApiRequest workflowApiRequest = new WorkflowApiRequest(flowId, uid, inputs, requestDtoList.getMessages(), effectiveWorkflowVersion);
         log.info("workflowApiRequest:{}", workflowApiRequest);
         RequestBody body = RequestBody.create(JSON.toJSONString(workflowApiRequest), MediaType.parse("application/json; charset=utf-8"));
 
@@ -179,6 +184,21 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
         WorkflowClient client = new WorkflowClient(apiUsedUrl, appId, appKey, appSecret, body);
         WorkflowListener listener = new WorkflowListener(client, chatReqRecords, sseId, wssListenerService, isDebug, sseEmitter);
         client.createWebSocketConnect(listener);
+    }
+
+    private String resolveWorkflowVersion(Integer botId, String flowId, String workflowVersion) {
+        if (!StrUtil.isBlank(workflowVersion)
+                && !"undefined".equalsIgnoreCase(workflowVersion)
+                && !"null".equalsIgnoreCase(workflowVersion)) {
+            boolean published = workflowVersionLookupService.isPublishedVersion(flowId, workflowVersion).orElse(false);
+            if (published) {
+                return workflowVersion;
+            }
+            log.warn("Requested workflow version is not published, fallback to latest successful version: botId={}, flowId={}, version={}",
+                    botId, flowId, workflowVersion);
+        }
+        return workflowVersionLookupService.findLatestSuccessfulVersionName(botId)
+                .orElseThrow(() -> new BusinessException(ResponseEnum.WORKFLOW_VERSION_NOT_FOUND));
     }
 
     /**

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImplWorkflowVersionTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImplWorkflowVersionTest.java
@@ -1,0 +1,60 @@
+package com.iflytek.astron.console.commons.service.bot.impl;
+
+import com.iflytek.astron.console.commons.dto.bot.BotInfoDto;
+import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
+import com.iflytek.astron.console.commons.service.workflow.WorkflowVersionLookupService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BotServiceImplWorkflowVersionTest {
+
+    @Mock
+    private UserLangChainDataService userLangChainDataService;
+    @Mock
+    private WorkflowVersionLookupService workflowVersionLookupService;
+
+    private BotServiceImpl botService;
+
+    @BeforeEach
+    void setUp() {
+        botService = new BotServiceImpl();
+        ReflectionTestUtils.setField(botService, "userLangChainDataService", userLangChainDataService);
+        ReflectionTestUtils.setField(botService, "workflowVersionLookupService", workflowVersionLookupService);
+    }
+
+    @Test
+    void updateWorkflowStatusShouldUseLatestSuccessfulVersionWhenRequestedVersionIsBlank() {
+        BotInfoDto botInfo = new BotInfoDto();
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
+        when(workflowVersionLookupService.findLatestSuccessfulVersionName(25)).thenReturn(Optional.of("v1.0"));
+
+        ReflectionTestUtils.invokeMethod(
+                botService,
+                "updateWorkflowStatus",
+                botInfo,
+                25,
+                null);
+
+        assertThat(botInfo.getWorkflowVersion()).isEqualTo("v1.0");
+        verify(workflowVersionLookupService, never()).isPublishedVersion("flow-1", null);
+    }
+
+    @Test
+    void normalizeWorkflowVersionShouldTreatUndefinedAsBlank() {
+        String normalized = ReflectionTestUtils.invokeMethod(botService, "normalizeWorkflowVersion", "undefined");
+
+        assertThat(normalized).isNull();
+    }
+}

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImplTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImplTest.java
@@ -19,7 +19,10 @@ import com.iflytek.astron.console.commons.service.data.ChatDataService;
 import com.iflytek.astron.console.commons.service.data.ChatHistoryService;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.commons.service.workflow.WorkflowBotParamService;
+import com.iflytek.astron.console.commons.service.workflow.WorkflowVersionLookupService;
 import com.iflytek.astron.console.commons.workflow.WorkflowClient;
+import okhttp3.RequestBody;
+import okio.Buffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +37,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -62,6 +66,9 @@ class WorkflowBotChatServiceImplTest {
 
     @Mock
     private WssListenerService wssListenerService;
+
+    @Mock
+    private WorkflowVersionLookupService workflowVersionLookupService;
 
     @Mock
     private SseEmitter sseEmitter;
@@ -105,6 +112,8 @@ class WorkflowBotChatServiceImplTest {
         userLangChainInfo.setFlowId("test-flow-id");
         userLangChainInfo.setExtraInputs("{}");
         userLangChainInfo.setExtraInputsConfig("[]");
+        lenient().when(workflowVersionLookupService.isPublishedVersion(anyString(), anyString()))
+                .thenReturn(Optional.of(true));
 
         chatReqRecords = new ChatReqRecords();
         chatReqRecords.setId(789L);
@@ -177,6 +186,71 @@ class WorkflowBotChatServiceImplTest {
             List<WorkflowClient> constructed = mockWorkflowClient.constructed();
             assertEquals(1, constructed.size());
             verify(constructed.get(0)).createWebSocketConnect(any());
+        }
+    }
+
+    @Test
+    void chatWorkflowBotShouldFallbackToLatestSuccessfulVersionWhenRequestVersionIsBlank() throws Exception {
+        when(userLangChainDataService.findOneByBotId(456)).thenReturn(userLangChainInfo);
+        when(chatDataService.createRequest(any(ChatReqRecords.class))).thenReturn(chatReqRecords);
+        when(workflowBotParamService.handleMultiFileParam(anyString(), anyLong(), isNull(), any(), any(), anyLong())).thenReturn(false);
+
+        List<ChatReqModelDto> reqList = new ArrayList<>();
+        when(chatDataService.getReqModelBotHistoryByChatId("testUser", 123L)).thenReturn(reqList);
+
+        ChatRequestDtoList requestDtoList = new ChatRequestDtoList();
+        requestDtoList.setMessages(new LinkedList<>());
+        when(chatHistoryService.getHistory("testUser", 123L, reqList)).thenReturn(requestDtoList);
+        when(workflowVersionLookupService.findLatestSuccessfulVersionName(456)).thenReturn(Optional.of("v1.0"));
+
+        ChatBotMarket market = new ChatBotMarket();
+        market.setBotStatus(ShelfStatusEnum.ON_SHELF.getCode());
+        when(chatBotDataService.findMarketBotByBotId(456)).thenReturn(market);
+
+        List<List<?>> constructorArgs = new ArrayList<>();
+        try (MockedConstruction<WorkflowClient> mockWorkflowClient = mockConstruction(
+                WorkflowClient.class,
+                (mock, context) -> constructorArgs.add(context.arguments()))) {
+            workflowBotChatService.chatWorkflowBot(chatBotReqDto, sseEmitter, sseId, workflowOperation, "");
+
+            assertEquals(1, mockWorkflowClient.constructed().size());
+            RequestBody requestBody = (RequestBody) constructorArgs.get(0).get(4);
+            Buffer buffer = new Buffer();
+            requestBody.writeTo(buffer);
+            assertEquals("v1.0", JSON.parseObject(buffer.readUtf8()).getString("version"));
+        }
+    }
+
+    @Test
+    void chatWorkflowBotShouldFallbackToLatestSuccessfulVersionWhenRequestVersionIsNotPublished() throws Exception {
+        when(userLangChainDataService.findOneByBotId(456)).thenReturn(userLangChainInfo);
+        when(chatDataService.createRequest(any(ChatReqRecords.class))).thenReturn(chatReqRecords);
+        when(workflowBotParamService.handleMultiFileParam(anyString(), anyLong(), isNull(), any(), any(), anyLong())).thenReturn(false);
+
+        List<ChatReqModelDto> reqList = new ArrayList<>();
+        when(chatDataService.getReqModelBotHistoryByChatId("testUser", 123L)).thenReturn(reqList);
+
+        ChatRequestDtoList requestDtoList = new ChatRequestDtoList();
+        requestDtoList.setMessages(new LinkedList<>());
+        when(chatHistoryService.getHistory("testUser", 123L, reqList)).thenReturn(requestDtoList);
+        when(workflowVersionLookupService.isPublishedVersion("test-flow-id", "stale-version")).thenReturn(Optional.of(false));
+        when(workflowVersionLookupService.findLatestSuccessfulVersionName(456)).thenReturn(Optional.of("v1.0"));
+
+        ChatBotMarket market = new ChatBotMarket();
+        market.setBotStatus(ShelfStatusEnum.ON_SHELF.getCode());
+        when(chatBotDataService.findMarketBotByBotId(456)).thenReturn(market);
+
+        List<List<?>> constructorArgs = new ArrayList<>();
+        try (MockedConstruction<WorkflowClient> mockWorkflowClient = mockConstruction(
+                WorkflowClient.class,
+                (mock, context) -> constructorArgs.add(context.arguments()))) {
+            workflowBotChatService.chatWorkflowBot(chatBotReqDto, sseEmitter, sseId, workflowOperation, "stale-version");
+
+            assertEquals(1, mockWorkflowClient.constructed().size());
+            RequestBody requestBody = (RequestBody) constructorArgs.get(0).get(4);
+            Buffer buffer = new Buffer();
+            requestBody.writeTo(buffer);
+            assertEquals("v1.0", JSON.parseObject(buffer.readUtf8()).getString("version"));
         }
     }
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/listener/WorkflowBotPublishListener.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/listener/WorkflowBotPublishListener.java
@@ -1,9 +1,11 @@
 package com.iflytek.astron.console.hub.listener;
 
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.entity.bot.ChatBotBase;
 import com.iflytek.astron.console.commons.enums.ShelfStatusEnum;
 import com.iflytek.astron.console.commons.enums.bot.ReleaseTypeEnum;
 import com.iflytek.astron.console.commons.enums.bot.BotTypeEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.hub.dto.workflow.WorkflowReleaseResponseDto;
@@ -59,8 +61,8 @@ public class WorkflowBotPublishListener {
             // 3. Get flowId for workflow-specific operations
             String flowId = userLangChainDataService.findFlowIdByBotId(event.getBotId());
             if (flowId == null || flowId.trim().isEmpty()) {
-                log.warn("Workflow bot missing flowId, skipping workflow version creation: botId={}", event.getBotId());
-                return;
+                log.error("Workflow bot missing flowId, unable to create workflow version: botId={}", event.getBotId());
+                throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
             }
 
             // 4. Execute workflow publish logic (including version creation and API sync)
@@ -76,12 +78,17 @@ public class WorkflowBotPublishListener {
             } else {
                 log.error("Workflow bot publish failed: botId={}, error={}",
                         event.getBotId(), response.getErrorMessage());
+                throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
             }
 
-        } catch (Exception e) {
-            // Workflow publish failure should not affect the main process, just log the error
+        } catch (BusinessException e) {
             log.error("Exception occurred while handling workflow bot publish: botId={}, uid={}, spaceId={}",
                     event.getBotId(), event.getUid(), event.getSpaceId(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Exception occurred while handling workflow bot publish: botId={}, uid={}, spaceId={}",
+                    event.getBotId(), event.getUid(), event.getSpaceId(), e);
+            throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED, e);
         }
     }
 }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/PublishApiServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/PublishApiServiceImpl.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
@@ -115,17 +116,20 @@ public class PublishApiServiceImpl implements PublishApiService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public BotApiInfoDTO createBotApi(CreateBotApiVo createBotApiVo, HttpServletRequest request) {
         String uid = RequestContextUtil.getUID();
         return createBotApi(createBotApiVo, request, uid);
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public BotApiInfoDTO createBotApi(CreateBotApiVo createBotApiVo, HttpServletRequest request, String uid) {
         return createBotApi(createBotApiVo, request, uid, SpaceInfoUtil.getSpaceId());
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public BotApiInfoDTO createBotApi(CreateBotApiVo createBotApiVo, HttpServletRequest request, String uid, Long spaceId) {
         String uuid = UUID.randomUUID().toString();
 
@@ -199,9 +203,8 @@ public class PublishApiServiceImpl implements PublishApiService {
         String flowId = userLangChainInfo.getFlowId();
         // Synchronize with Maas service
         String versionName = releaseManageClientService.getVersionNameByBotId(Long.valueOf(botId), spaceId, request);
-        maasUtil.createApi(flowId, appMst.getAppId(), versionName);
-
         releaseManageClientService.releaseBotApi(botId, flowId, versionName, spaceId, request);
+        maasUtil.createApi(flowId, appMst.getAppId(), versionName);
 
         ChatBotApi chatBotApi = ChatBotApi.builder()
                 .uid(uid)

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImpl.java
@@ -1,250 +1,74 @@
 package com.iflytek.astron.console.hub.service.publish.impl;
 
 import cn.hutool.core.util.StrUtil;
-import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.enums.bot.ReleaseTypeEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.response.ApiResult;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
-import com.iflytek.astron.console.commons.util.I18nUtil;
-import com.iflytek.astron.console.commons.util.MaasUtil;
-import com.iflytek.astron.console.hub.dto.publish.ReleaseBotReqDto;
-import com.iflytek.astron.console.hub.dto.publish.ReleaseBotRespDto;
 import com.iflytek.astron.console.hub.service.publish.ReleaseManageClientService;
 import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
+import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
+import com.iflytek.astron.console.toolkit.service.workflow.VersionService;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author yun-zhi-ztl
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ReleaseManageClientServiceImpl implements ReleaseManageClientService {
 
-    // Basic URL configuration, read from config file
-    @Value("${maas.workflowVersion}")
-    private String baseUrl;
+    private final UserLangChainDataService userLangChainDataService;
+    private final VersionService versionService;
 
-    @Value("${maas.consumerId}")
-    private String consumerId;
-
-    @Value("${maas.consumerKey}")
-    private String consumerKey;
-
-    @Value("${maas.consumerSecret}")
-    private String consumerSecret;
-
-    // User language chain data service dependency injection
-    @Autowired
-    private UserLangChainDataService userLangChainDataService;
-
-    // Constant definition area
-    // API path for getting version name
-    private static final String GET_VERSION_NAME_URL = "/get-version-name";
-    // Success indicator for release
     private static final String RELEASE_SUCCESS = WorkflowConst.PublishResult.SUCCESS;
-    // API path for adding versions (currently empty)
-    private static final String ADD_VERSION_URL = "";
-    // Content-Type value in HTTP headers
-    private static final String APPLICATION_JSON = "application/json";
-    // HTTP header field name related to authentication
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    // HTTP header field name related to space ID
-    private static final String SPACE_ID_HEADER = "space-id";
-    private static final String X_CONSUMER_USERNAME_HEADER = "X-Consumer-Username";
-    private static final String LANG_CODE_HEADER = "Lang-Code";
-    private static final String X_AUTH_SOURCE_HEADER = "x-auth-source";
-    private static final String X_AUTH_SOURCE_VALUE = "xfyun";
-
-
-    // OkHttp client instance, configured with connection pool, timeouts and other parameters
-    private static final OkHttpClient HTTP_CLIENT = new OkHttpClient().newBuilder()
-            .connectionPool(new ConnectionPool(100, 5, TimeUnit.MINUTES))
-            .connectTimeout(60, TimeUnit.SECONDS)
-            .readTimeout(60, TimeUnit.SECONDS)
-            .writeTimeout(60, TimeUnit.SECONDS)
-            .build();
 
     @Override
     public String getVersionNameByBotId(Long botId, Long spaceId, HttpServletRequest request) {
-        // Query corresponding flow ID based on robot ID
         String flowId = userLangChainDataService.findFlowIdByBotId(botId.intValue());
         if (StrUtil.isBlank(flowId)) {
             log.error("getVersionNameByBotId - Failed to get flowId by botId, botId={}", botId);
-            return null;
+            throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_GET_NAME_FAILED);
         }
-        // Call private method to get version name
-        return getVersionName(flowId, spaceId, request);
+
+        WorkflowVersion query = new WorkflowVersion();
+        query.setFlowId(flowId);
+        ApiResult<JSONObject> response = versionService.getVersionNameForSpace(query, spaceId);
+        JSONObject data = response == null ? null : response.data();
+        String versionName = data == null ? null : data.getString("workflowVersionName");
+        if (response == null || response.code() != 0 || StrUtil.isBlank(versionName)) {
+            log.error("getVersionNameByBotId - Failed to get version name, botId={}, flowId={}, spaceId={}",
+                    botId, flowId, spaceId);
+            throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_GET_NAME_FAILED);
+        }
+        return versionName;
     }
 
     @Override
     public void releaseBotApi(Integer botId, String flowId, String versionName, Long spaceId, HttpServletRequest request) {
-        // Call private method to perform robot API publishing operation
-        releaseBot(botId.toString(), flowId, ReleaseTypeEnum.BOT_API.getCode(), RELEASE_SUCCESS, "", versionName, spaceId, request);
-    }
-
-    /**
-     * Core logic implementation for releasing robot versions
-     *
-     * @param botId Robot ID
-     * @param flowId Flow ID
-     * @param channel Channel type code
-     * @param result Result status string
-     * @param desc Description information
-     * @param versionName Version name
-     * @param spaceId Space ID
-     * @param request HTTP request object, used to obtain authentication info etc.
-     * @return Returns release result response object
-     */
-    private ReleaseBotRespDto releaseBot(String botId, String flowId, Integer channel, String result,
-            String desc, String versionName, Long spaceId, HttpServletRequest request) {
-        try {
-            // Build request data transfer object
-            ReleaseBotReqDto releaseBotDto = new ReleaseBotReqDto(botId, flowId, channel, result, desc, versionName);
-            // Create HTTP POST request with JSON formatted body
-            Request releaseBotRequest = buildRequest(ADD_VERSION_URL, spaceId, request)
-                    .post(RequestBody.create(MediaType.parse(APPLICATION_JSON), JSON.toJSONString(releaseBotDto)))
-                    .build();
-            // Execute request and process response result
-            return executeRequestForReleaseBot(releaseBotRequest, flowId);
-        } catch (Exception e) {
-            log.error("Failed to release bot for flowId: {}, botId: {}, error: {}", flowId, botId, e.getMessage(), e);
-            return null;
+        if (botId == null || StrUtil.isBlank(flowId) || StrUtil.isBlank(versionName)) {
+            throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
         }
-    }
 
-    /**
-     * Get version name for specified workflow
-     *
-     * @param flowId Flow ID
-     * @param spaceId Space ID
-     * @param request HTTP request object, used to obtain authentication info etc.
-     * @return Returns version name string
-     */
-    private String getVersionName(String flowId, Long spaceId, HttpServletRequest request) {
-        try {
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("flowId", flowId);
-            MediaType jsonMediaType = MediaType.get("application/json; charset=utf-8");
-            RequestBody requestBody = RequestBody.create(JSON.toJSONString(jsonObject), jsonMediaType);
-            // Create HTTP POST request
-            Request versionRequest = buildRequest(GET_VERSION_NAME_URL, spaceId, request)
-                    .addHeader("Content-Type", "application/json")
-                    .post(requestBody)
-                    .build();
-            // Execute request and parse version name
-            return executeRequestForVersionName(versionRequest, flowId);
-        } catch (Exception e) {
-            log.error("Failed to get version name for flowId: {}, error: {}", flowId, e.getMessage(), e);
-            return null;
-        }
-    }
+        WorkflowVersion workflowVersion = new WorkflowVersion();
+        workflowVersion.setBotId(botId.toString());
+        workflowVersion.setFlowId(flowId);
+        workflowVersion.setPublishChannel(Long.valueOf(ReleaseTypeEnum.BOT_API.getCode()));
+        workflowVersion.setPublishResult(RELEASE_SUCCESS);
+        workflowVersion.setDescription("");
+        workflowVersion.setName(versionName);
 
-    /**
-     * Build basic HTTP request builder
-     *
-     * @param url API relative path
-     * @param spaceId Space ID (optional)
-     * @param request HTTP request object, used to obtain authentication info etc.
-     * @return Returns configured Request.Builder instance
-     */
-    private Request.Builder buildRequest(String url, Long spaceId, HttpServletRequest request) {
-        String requestAuthorization = request == null ? "" : MaasUtil.getAuthorizationHeader(request);
-        boolean useServiceAuthorization = StrUtil.isBlank(requestAuthorization);
-        Request.Builder builder = new Request.Builder()
-                .url(baseUrl + url) // Concatenate complete URL
-                .addHeader(AUTHORIZATION_HEADER, useServiceAuthorization ? serviceAuthorizationHeader() : requestAuthorization)
-                .addHeader(X_AUTH_SOURCE_HEADER, X_AUTH_SOURCE_VALUE);
-        if (useServiceAuthorization) {
-            builder.addHeader(X_CONSUMER_USERNAME_HEADER, consumerId)
-                    .addHeader(LANG_CODE_HEADER, I18nUtil.getLanguage());
-        }
-        // If space ID exists, add it to request headers
-        if (spaceId != null) {
-            builder.addHeader(SPACE_ID_HEADER, spaceId.toString());
-            log.debug("Added space-id header: {}", spaceId);
-        }
-        return builder;
-    }
-
-    private String serviceAuthorizationHeader() {
-        return "Bearer %s:%s".formatted(consumerKey, consumerSecret);
-    }
-
-    /**
-     * Execute HTTP request for releasing robot versions and parse response into ReleaseBotRespDto
-     * object
-     *
-     * @param request HTTP request object
-     * @param flowId Flow ID (for logging purposes)
-     * @return Returns parsed response data object
-     */
-    private ReleaseBotRespDto executeRequestForReleaseBot(Request request, String flowId) {
-        try (Response response = HTTP_CLIENT.newCall(request).execute()) {
-            // Check if HTTP response was successful and has body content
-            ResponseBody body = response.body();
-            if (!response.isSuccessful() || body == null) {
-                log.error("HTTP request failed for flowId: {}, status: {}", flowId, response.code());
-                return null;
-            }
-            // Parse response JSON data
-            String responseBody = body.string();
-            if (responseBody == null) {
-                log.error("Response body string is null for flowId: {}", flowId);
-                return null;
-            }
-            JSONObject responseJson = JSONObject.parseObject(responseBody);
-            // Ensure response contains required 'data' field
-            if (!responseJson.containsKey("data")) {
-                log.error("Missing 'data' field in response for flowId: {}, response: {}", flowId, responseJson);
-                return null;
-            }
-            // Deserialize 'data' field content into ReleaseBotRespDto object
-            return JSON.parseObject(responseJson.getString("data"), ReleaseBotRespDto.class);
-        } catch (Exception e) {
-            log.error("IO exception occurred while executing request for flowId: {}, error: {}", flowId, e.getMessage(), e);
-            return null;
-        }
-    }
-
-    /**
-     * Execute HTTP request for getting version name and parse workflowVersionName field from response
-     *
-     * @param request HTTP request object
-     * @param flowId Flow ID (for logging purposes)
-     * @return Returns parsed version name string
-     */
-    private String executeRequestForVersionName(Request request, String flowId) {
-        try (Response response = HTTP_CLIENT.newCall(request).execute()) {
-            // Check if HTTP response was successful and has body content
-            ResponseBody body = response.body();
-            if (!response.isSuccessful() || body == null) {
-                log.error("HTTP request failed for flowId: {}, status: {}", flowId, response.code());
-                return null;
-            }
-            // Parse response JSON data
-            String responseBody = body.string();
-            if (responseBody == null) {
-                log.error("Response body string is null for flowId: {}", flowId);
-                return null;
-            }
-            JSONObject responseJson = JSONObject.parseObject(responseBody);
-            // Ensure response contains required 'data' and 'workflowVersionName' fields
-            if (!responseJson.containsKey("data") || !responseJson.getJSONObject("data").containsKey("workflowVersionName")) {
-                log.error("Missing required fields in response for flowId: {}, response: {}", flowId, responseJson);
-                return null;
-            }
-            // Extract and return workflowVersionName field value
-            return responseJson.getJSONObject("data").getString("workflowVersionName");
-        } catch (Exception e) {
-            log.error("Exception occurred while getting version name for flowId: {}, error: {}", flowId, e.getMessage(), e);
-            return null;
+        ApiResult<JSONObject> response = versionService.createForSpace(workflowVersion, spaceId);
+        if (response == null || response.code() != 0 || response.data() == null) {
+            log.error("releaseBotApi - Failed to create workflow version, botId={}, flowId={}, versionName={}, spaceId={}",
+                    botId, flowId, versionName, spaceId);
+            throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
         }
     }
 }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImpl.java
@@ -4,11 +4,11 @@ import com.iflytek.astron.console.commons.enums.bot.ReleaseTypeEnum;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.commons.mapper.bot.ChatBotApiMapper;
 import com.iflytek.astron.console.commons.dto.bot.ChatBotApi;
-import com.iflytek.astron.console.commons.util.I18nUtil;
 import com.iflytek.astron.console.commons.util.MaasUtil;
 import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
 import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
 import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowVersionMapper;
+import com.iflytek.astron.console.toolkit.service.workflow.VersionService;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.iflytek.astron.console.hub.dto.workflow.WorkflowReleaseRequestDto;
 import com.iflytek.astron.console.hub.dto.workflow.WorkflowReleaseResponseDto;
@@ -20,13 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
-import okhttp3.*;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-
-import java.util.Random;
-
-import java.time.Duration;
 
 /**
  * Workflow release service implementation Simplified version: no approval process, direct publish
@@ -41,52 +34,17 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
     private final WorkflowVersionMapper workflowVersionMapper;
     private final ChatBotApiMapper chatBotApiMapper;
     private final MaasUtil maasUtil;
-
-    // Workflow version management base URL
-    @Value("${maas.workflowVersion}")
-    private String baseUrl;
+    private final VersionService versionService;
 
     // MaaS appId configuration
     @Value("${maas.appId}")
     private String maasAppId;
-
-    @Value("${maas.consumerId}")
-    private String consumerId;
-
-    @Value("${maas.consumerKey}")
-    private String consumerKey;
-
-    @Value("${maas.consumerSecret}")
-    private String consumerSecret;
-
-    // API endpoints for workflow version management
-    private static final String ADD_VERSION_URL = ""; // Create new version
-    private static final String UPDATE_RESULT_URL = "/update-channel-result"; // Update audit result
-    private static final String GET_VERSION_NAME_URL = "/get-version-name"; // Get next version name
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String X_CONSUMER_USERNAME_HEADER = "X-Consumer-Username";
-    private static final String LANG_CODE_HEADER = "Lang-Code";
-    private static final String X_AUTH_SOURCE_HEADER = "x-auth-source";
-    private static final String X_AUTH_SOURCE_VALUE = "xfyun";
 
     // Release status constants (reserved for future use)
     @SuppressWarnings("unused")
     private static final String RELEASE_SUCCESS = WorkflowConst.PublishResult.SUCCESS;
     @SuppressWarnings("unused")
     private static final String RELEASE_FAIL = WorkflowConst.PublishResult.FAILED;
-
-    // HTTP client configuration
-    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
-    private final OkHttpClient okHttpClient = new OkHttpClient.Builder()
-            .connectTimeout(Duration.ofSeconds(30))
-            .readTimeout(Duration.ofSeconds(60))
-            .writeTimeout(Duration.ofSeconds(60))
-            .build();
-
-    // TODO: Inject actual workflow version management service and API sync service
-    // private final WorkflowVersionService workflowVersionService;
-    // private final ApiSyncService apiSyncService;
-    // private final WorkflowReleaseCallbackMapper workflowReleaseCallbackMapper;
 
     @Override
     public WorkflowReleaseResponseDto publishWorkflow(Integer botId, String uid, Long spaceId, String publishType) {
@@ -124,7 +82,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             request.setDescription("");
             request.setName(versionName);
 
-            WorkflowReleaseResponseDto response = createWorkflowVersion(request);
+            WorkflowReleaseResponseDto response = createWorkflowVersion(request, spaceId);
             if (!response.getSuccess()) {
                 return response;
             }
@@ -159,37 +117,15 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
     private String getNextVersionName(String flowId, Long spaceId) {
         log.info("Getting next workflow version name: flowId={}, spaceId={}", flowId, spaceId);
 
-        JSONObject requestBody = new JSONObject();
-        requestBody.put("flowId", flowId);
-
-        String jsonBody = requestBody.toJSONString();
-
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(baseUrl + GET_VERSION_NAME_URL)
-                .post(RequestBody.create(jsonBody, JSON_MEDIA_TYPE))
-                .addHeader("Content-Type", "application/json");
-        addAuthorizationHeaders(requestBuilder);
-
-        if (spaceId != null) {
-            requestBuilder.addHeader("space-id", spaceId.toString());
-        }
-
-        try (Response response = okHttpClient.newCall(requestBuilder.build()).execute()) {
-            ResponseBody body = response.body();
-            if (body != null && response.isSuccessful()) {
-                String responseStr = body.string();
-                log.debug("Version name API response: {}", responseStr);
-
-                JSONObject responseJson = JSON.parseObject(responseStr);
-                if (responseJson != null && responseJson.getInteger("code") == 0) {
-                    JSONObject data = responseJson.getJSONObject("data");
-                    if (data != null && data.containsKey("workflowVersionName")) {
-                        String versionName = data.getString("workflowVersionName");
-                        if (versionName != null && !versionName.trim().isEmpty()) {
-                            log.info("Got version name from API: {} for flowId: {}", versionName, flowId);
-                            return versionName;
-                        }
-                    }
+        try {
+            WorkflowVersion query = new WorkflowVersion();
+            query.setFlowId(flowId);
+            var response = versionService.getVersionNameForSpace(query, spaceId);
+            if (response != null && response.code() == 0 && response.data() != null) {
+                String versionName = response.data().getString("workflowVersionName");
+                if (StringUtils.hasText(versionName)) {
+                    log.info("Got version name from VersionService: {} for flowId: {}", versionName, flowId);
+                    return versionName;
                 }
             }
         } catch (Exception e) {
@@ -197,24 +133,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             return null;
         }
 
-        // If we reach here, API call failed - return null like old project
         return null;
-    }
-
-    /**
-     * Generate timestamp-based version number like old project
-     *
-     * @return Timestamp version number (e.g., "1760323182721")
-     */
-    private String generateTimestampVersionNumber() {
-        long timestamp = System.currentTimeMillis();
-        Random random = new Random();
-        int randomNumber = random.nextInt(900000) + 100000;
-        String versionNumber = String.valueOf(timestamp) + String.valueOf(randomNumber);
-        if (versionNumber.length() > 19) {
-            versionNumber = versionNumber.substring(0, 19);
-        }
-        return versionNumber;
     }
 
     /**
@@ -247,80 +166,35 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
         }
     }
 
-    private WorkflowReleaseResponseDto createWorkflowVersion(WorkflowReleaseRequestDto request) {
+    private WorkflowReleaseResponseDto createWorkflowVersion(WorkflowReleaseRequestDto request, Long spaceId) {
         log.info("Creating workflow version: request={}", request);
 
         try {
-            // Generate timestamp-based version number like old project
-            String timestampVersionNum = generateTimestampVersionNumber();
-            log.info("Generated timestamp version number: {}", timestampVersionNum);
+            WorkflowVersion workflowVersion = new WorkflowVersion();
+            workflowVersion.setBotId(request.getBotId());
+            workflowVersion.setFlowId(request.getFlowId());
+            workflowVersion.setPublishChannel(Long.valueOf(request.getPublishChannel()));
+            workflowVersion.setPublishResult(request.getPublishResult());
+            workflowVersion.setDescription(request.getDescription());
+            workflowVersion.setName(request.getName());
 
-            // Create a new request with timestamp version number
-            WorkflowReleaseRequestDto requestWithVersionNum = new WorkflowReleaseRequestDto();
-            requestWithVersionNum.setBotId(request.getBotId());
-            requestWithVersionNum.setFlowId(request.getFlowId());
-            requestWithVersionNum.setPublishChannel(request.getPublishChannel());
-            requestWithVersionNum.setPublishResult(request.getPublishResult());
-            requestWithVersionNum.setDescription(request.getDescription());
-            requestWithVersionNum.setName(request.getName());
-            requestWithVersionNum.setVersionNum(timestampVersionNum);
-
-            String jsonBody = JSON.toJSONString(requestWithVersionNum);
-
-            // Send request using OkHttp
-            Request.Builder requestBuilder = new Request.Builder()
-                    .url(baseUrl + ADD_VERSION_URL)
-                    .post(RequestBody.create(jsonBody, JSON_MEDIA_TYPE))
-                    .addHeader("Content-Type", "application/json");
-            addAuthorizationHeaders(requestBuilder);
-            Request httpRequest = requestBuilder.build();
-
-            try (Response response = okHttpClient.newCall(httpRequest).execute()) {
-                ResponseBody body = response.body();
-                String responseBody = body != null ? body.string() : null;
-
-                if (!response.isSuccessful()) {
-                    log.error("Failed to create workflow version: statusCode={}, response={}",
-                            response.code(), responseBody);
-                    return createErrorResponse("Failed to create version: HTTP " + response.code());
-                }
-
-                if (!StringUtils.hasText(responseBody)) {
-                    log.error("Empty response when creating workflow version");
-                    return createErrorResponse("Invalid response data format");
-                }
-
-                log.debug("Create workflow version response: {}", responseBody);
-
-                JSONObject responseJson = JSON.parseObject(responseBody);
-                if (responseJson == null) {
-                    log.error("Failed to parse workflow version response: {}", responseBody);
-                    return createErrorResponse("Invalid response data format");
-                }
-
-                JSONObject data = responseJson.getJSONObject("data");
-
-                if (data != null) {
-                    WorkflowReleaseResponseDto result = new WorkflowReleaseResponseDto();
-                    result.setSuccess(true);
-
-                    if (data.containsKey("workflowVersionId")) {
-                        result.setWorkflowVersionId(data.getLong("workflowVersionId"));
-                    }
-
-                    if (data.containsKey("workflowVersionName")) {
-                        result.setWorkflowVersionName(data.getString("workflowVersionName"));
-                    } else {
-                        result.setWorkflowVersionName(request.getName());
-                    }
-
-                    log.info("Successfully created workflow version: versionId={}, versionName={}",
-                            result.getWorkflowVersionId(), result.getWorkflowVersionName());
-                    return result;
-                }
-
+            var response = versionService.createForSpace(workflowVersion, spaceId);
+            JSONObject data = response == null ? null : response.data();
+            if (response == null || response.code() != 0 || data == null) {
                 return createErrorResponse("Invalid response data format");
             }
+
+            WorkflowReleaseResponseDto result = new WorkflowReleaseResponseDto();
+            result.setSuccess(true);
+            result.setWorkflowVersionId(data.getLong("workflowVersionId"));
+            result.setWorkflowVersionName(data.getString("workflowVersionName"));
+            if (!StringUtils.hasText(result.getWorkflowVersionName())) {
+                result.setWorkflowVersionName(request.getName());
+            }
+
+            log.info("Successfully created workflow version: versionId={}, versionName={}",
+                    result.getWorkflowVersionId(), result.getWorkflowVersionName());
+            return result;
 
         } catch (Exception e) {
             log.error("Exception occurred while creating workflow version: request={}", request, e);
@@ -337,7 +211,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             JSONObject versionData = getVersionSysData(botId, versionName);
             if (versionData == null) {
                 log.error("Failed to get version system data: botId={}, versionName={}", botId, versionName);
-                return;
+                throw new IllegalStateException("Failed to get version system data");
             }
 
             // 2. Use MaasUtil's createApi method to publish and bind
@@ -348,6 +222,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
         } catch (Exception e) {
             log.error("Exception occurred while syncing workflow to API system: botId={}, flowId={}, versionName={}, appId={}",
                     botId, flowId, versionName, appId, e);
+            throw e;
         }
     }
 
@@ -368,27 +243,28 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
 
             if (workflowVersion == null) {
                 log.warn("Workflow version not found in database: botId={}, versionName={}", botId, versionName);
-                return new JSONObject(); // Return empty object as fallback
+                return null;
             }
 
             String sysData = workflowVersion.getSysData();
             if (sysData != null && !sysData.trim().isEmpty()) {
                 try {
-                    return JSON.parseObject(sysData);
+                    JSONObject versionData = JSON.parseObject(sysData);
+                    return versionData == null || versionData.isEmpty() ? null : versionData;
                 } catch (Exception e) {
                     log.error("Failed to parse sysData JSON: botId={}, versionName={}, sysData={}",
                             botId, versionName, sysData, e);
-                    return new JSONObject(); // Return empty object as fallback
+                    return null;
                 }
             }
 
             log.warn("SysData is empty for version: botId={}, versionName={}", botId, versionName);
-            return new JSONObject(); // Return empty object as fallback
+            return null;
 
         } catch (Exception e) {
             log.error("Exception occurred while getting version system data: botId={}, versionName={}",
                     botId, versionName, e);
-            return new JSONObject(); // Return empty object as fallback
+            return null;
         }
     }
 
@@ -404,56 +280,16 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
         try {
             log.info("Updating audit result: versionId={}, auditResult={}", versionId, auditResult);
 
-            // Build request parameters
-            JSONObject requestBody = new JSONObject();
-            requestBody.put("id", versionId);
-            requestBody.put("publishResult", auditResult);
-
-            String jsonBody = requestBody.toJSONString();
-
-            // Send request using OkHttp
-            Request.Builder requestBuilder = new Request.Builder()
-                    .url(baseUrl + UPDATE_RESULT_URL)
-                    .post(RequestBody.create(jsonBody, JSON_MEDIA_TYPE))
-                    .addHeader("Content-Type", "application/json");
-            addAuthorizationHeaders(requestBuilder);
-            Request httpRequest = requestBuilder.build();
-
-            try (Response response = okHttpClient.newCall(httpRequest).execute()) {
-                ResponseBody body = response.body();
-                String responseBody = body != null ? body.string() : null;
-
-                if (!response.isSuccessful()) {
-                    log.error("Failed to update audit result: versionId={}, auditResult={}, responseCode={}, response={}",
-                            versionId, auditResult, response.code(), responseBody);
-                    return false;
-                }
-
-                if (!StringUtils.hasText(responseBody)) {
-                    log.error("Empty response when updating audit result: versionId={}, auditResult={}",
-                            versionId, auditResult);
-                    return false;
-                }
-
-                log.debug("Update audit result response: {}", responseBody);
-
-                JSONObject responseJson = JSON.parseObject(responseBody);
-                if (responseJson == null) {
-                    log.error("Failed to parse audit result response: versionId={}, response={}", versionId, responseBody);
-                    return false;
-                }
-
-                Integer code = responseJson.getInteger("code");
-
-                if (code != null && code.equals(0)) {
-                    log.info("Successfully updated audit result: versionId={}, auditResult={}", versionId, auditResult);
-                    return true;
-                } else {
-                    log.error("Failed to update audit result: versionId={}, auditResult={}, response={}",
-                            versionId, auditResult, responseBody);
-                    return false;
-                }
+            WorkflowVersion update = new WorkflowVersion();
+            update.setId(versionId);
+            update.setPublishResult(auditResult);
+            var response = versionService.update_channel_result(update);
+            if (response != null && response.code() == 0) {
+                log.info("Successfully updated audit result: versionId={}, auditResult={}", versionId, auditResult);
+                return true;
             }
+            log.error("Failed to update audit result: versionId={}, auditResult={}", versionId, auditResult);
+            return false;
 
         } catch (Exception e) {
             log.error("Exception occurred while updating audit result: versionId={}, auditResult={}",
@@ -471,8 +307,11 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             // Direct return since ReleaseTypeEnum code is the channel code
             return typeCode;
         } catch (NumberFormatException e) {
+            ReleaseTypeEnum releaseType = ReleaseTypeEnum.getByName(publishType);
+            if (releaseType != null) {
+                return releaseType.getCode();
+            }
             log.warn("Invalid publish type format: {}", publishType);
-            // Default to market
             return ReleaseTypeEnum.MARKET.getCode();
         }
     }
@@ -502,35 +341,6 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             log.error("Failed to get appId for botId: {}, using configured maas appId: {}", botId, maasAppId, e);
             return maasAppId;
         }
-    }
-
-    /**
-     * Add user authorization headers when available; otherwise fall back to service credentials for
-     * backend publish execution.
-     */
-    private void addAuthorizationHeaders(Request.Builder requestBuilder) {
-        String requestAuthorization = getRequestAuthorizationHeader();
-        boolean useServiceAuthorization = !StringUtils.hasText(requestAuthorization);
-        requestBuilder.addHeader(
-                AUTHORIZATION_HEADER,
-                useServiceAuthorization ? serviceAuthorizationHeader() : requestAuthorization);
-        requestBuilder.addHeader(X_AUTH_SOURCE_HEADER, X_AUTH_SOURCE_VALUE);
-        if (useServiceAuthorization) {
-            requestBuilder.addHeader(X_CONSUMER_USERNAME_HEADER, consumerId)
-                    .addHeader(LANG_CODE_HEADER, I18nUtil.getLanguage());
-        }
-    }
-
-    private String getRequestAuthorizationHeader() {
-        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        if (attributes == null) {
-            return "";
-        }
-        return MaasUtil.getAuthorizationHeader(attributes.getRequest());
-    }
-
-    private String serviceAuthorizationHeader() {
-        return "Bearer %s:%s".formatted(consumerKey, consumerSecret);
     }
 
     /**

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/strategy/publish/impl/MarketPublishStrategy.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/strategy/publish/impl/MarketPublishStrategy.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -37,6 +38,7 @@ public class MarketPublishStrategy implements PublishStrategy {
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public ApiResult<Object> publish(Integer botId, Object publishData, String currentUid, Long spaceId) {
         log.info("Publishing bot to market: botId={}, currentUid={}, spaceId={}", botId, currentUid, spaceId);
 
@@ -93,6 +95,7 @@ public class MarketPublishStrategy implements PublishStrategy {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public ApiResult<Object> offline(Integer botId, Object publishData, String currentUid, Long spaceId) {
         log.info("Offlining bot from market: botId={}, currentUid={}, spaceId={}", botId, currentUid, spaceId);
 
@@ -277,11 +280,11 @@ public class MarketPublishStrategy implements PublishStrategy {
         // Only update status and channels for offline operation
         int updateCount = chatBotMarketMapper.updatePublishStatus(botId, uid, spaceId, newStatus, newChannels);
         if (updateCount == 0) {
-            log.warn("Bot offline update failed, record not found: botId={}, uid={}, spaceId={}",
+            log.error("Bot offline update failed, record not found: botId={}, uid={}, spaceId={}",
                     botId, uid, spaceId);
-        } else {
-            log.info("Bot offline update successful: botId={}, status={}, channels={}",
-                    botId, newStatus, newChannels);
+            throw new BusinessException(ResponseEnum.BOT_UPDATE_FAILED);
         }
+        log.info("Bot offline update successful: botId={}, status={}, channels={}",
+                botId, newStatus, newChannels);
     }
 }

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/listener/WorkflowBotPublishListenerTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/listener/WorkflowBotPublishListenerTest.java
@@ -1,0 +1,92 @@
+package com.iflytek.astron.console.hub.listener;
+
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.entity.bot.ChatBotBase;
+import com.iflytek.astron.console.commons.enums.bot.BotTypeEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
+import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
+import com.iflytek.astron.console.hub.dto.workflow.WorkflowReleaseResponseDto;
+import com.iflytek.astron.console.hub.event.BotPublishStatusChangedEvent;
+import com.iflytek.astron.console.hub.service.workflow.WorkflowReleaseService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowBotPublishListenerTest {
+
+    @Mock
+    private ChatBotBaseMapper chatBotBaseMapper;
+    @Mock
+    private UserLangChainDataService userLangChainDataService;
+    @Mock
+    private WorkflowReleaseService workflowReleaseService;
+
+    private WorkflowBotPublishListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new WorkflowBotPublishListener(
+                chatBotBaseMapper,
+                userLangChainDataService,
+                workflowReleaseService);
+    }
+
+    @Test
+    void handleBotPublishStatusChangedShouldFailWhenWorkflowReleaseFails() {
+        ChatBotBase botBase = new ChatBotBase();
+        botBase.setId(25);
+        botBase.setVersion(BotTypeEnum.WORKFLOW_BOT.getType());
+        when(chatBotBaseMapper.selectById(25)).thenReturn(botBase);
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
+        WorkflowReleaseResponseDto failed = new WorkflowReleaseResponseDto();
+        failed.setSuccess(false);
+        failed.setErrorMessage("Unable to get version name");
+        when(workflowReleaseService.publishWorkflow(25, "requester-uid", 1L, "MARKET")).thenReturn(failed);
+
+        BotPublishStatusChangedEvent event = new BotPublishStatusChangedEvent(
+                this,
+                25,
+                "requester-uid",
+                1L,
+                "PUBLISH",
+                null,
+                1,
+                "MARKET");
+
+        assertThatThrownBy(() -> listener.handleBotPublishStatusChanged(event))
+                .isInstanceOf(BusinessException.class)
+                .extracting("responseEnum")
+                .isEqualTo(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
+    }
+
+    @Test
+    void handleBotPublishStatusChangedShouldFailWhenWorkflowBotHasNoFlowId() {
+        ChatBotBase botBase = new ChatBotBase();
+        botBase.setId(25);
+        botBase.setVersion(BotTypeEnum.WORKFLOW_BOT.getType());
+        when(chatBotBaseMapper.selectById(25)).thenReturn(botBase);
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("");
+
+        BotPublishStatusChangedEvent event = new BotPublishStatusChangedEvent(
+                this,
+                25,
+                "requester-uid",
+                1L,
+                "PUBLISH",
+                null,
+                1,
+                "MARKET");
+
+        assertThatThrownBy(() -> listener.handleBotPublishStatusChanged(event))
+                .isInstanceOf(BusinessException.class)
+                .extracting("responseEnum")
+                .isEqualTo(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
+    }
+}

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImplTest.java
@@ -1,0 +1,68 @@
+package com.iflytek.astron.console.hub.service.publish.impl;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.enums.bot.ReleaseTypeEnum;
+import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
+import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
+import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
+import com.iflytek.astron.console.toolkit.service.workflow.VersionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReleaseManageClientServiceImplTest {
+
+    @Mock
+    private UserLangChainDataService userLangChainDataService;
+    @Mock
+    private VersionService versionService;
+
+    private ReleaseManageClientServiceImpl releaseManageClientService;
+
+    @BeforeEach
+    void setUp() {
+        releaseManageClientService = new ReleaseManageClientServiceImpl(userLangChainDataService, versionService);
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void apiReleaseShouldUseVersionServiceWithExplicitSpaceWhenRequestContextIsCleared() {
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
+        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
+        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject()
+                        .fluentPut("workflowVersionId", 18L)
+                        .fluentPut("workflowVersionName", "v1.0")));
+
+        String versionName = releaseManageClientService.getVersionNameByBotId(25L, 1L, null);
+        releaseManageClientService.releaseBotApi(25, "flow-1", versionName, 1L, null);
+
+        assertThat(versionName).isEqualTo("v1.0");
+
+        ArgumentCaptor<WorkflowVersion> nameCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
+        verify(versionService).getVersionNameForSpace(nameCaptor.capture(), eq(1L));
+        assertThat(nameCaptor.getValue().getFlowId()).isEqualTo("flow-1");
+
+        ArgumentCaptor<WorkflowVersion> createCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
+        verify(versionService).createForSpace(createCaptor.capture(), eq(1L));
+        WorkflowVersion created = createCaptor.getValue();
+        assertThat(created.getBotId()).isEqualTo("25");
+        assertThat(created.getFlowId()).isEqualTo("flow-1");
+        assertThat(created.getName()).isEqualTo("v1.0");
+        assertThat(created.getPublishChannel()).isEqualTo(Long.valueOf(ReleaseTypeEnum.BOT_API.getCode()));
+        assertThat(created.getPublishResult()).isEqualTo(WorkflowConst.PublishResult.SUCCESS);
+    }
+}

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImplTest.java
@@ -1,0 +1,157 @@
+package com.iflytek.astron.console.hub.service.workflow.impl;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.dto.bot.ChatBotApi;
+import com.iflytek.astron.console.commons.enums.bot.ReleaseTypeEnum;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotApiMapper;
+import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
+import com.iflytek.astron.console.commons.util.MaasUtil;
+import com.iflytek.astron.console.hub.dto.workflow.WorkflowReleaseResponseDto;
+import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
+import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowVersionMapper;
+import com.iflytek.astron.console.toolkit.service.workflow.VersionService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowReleaseServiceImplTest {
+
+    @Mock
+    private UserLangChainDataService userLangChainDataService;
+    @Mock
+    private WorkflowVersionMapper workflowVersionMapper;
+    @Mock
+    private ChatBotApiMapper chatBotApiMapper;
+    @Mock
+    private MaasUtil maasUtil;
+    @Mock
+    private VersionService versionService;
+
+    private WorkflowReleaseServiceImpl workflowReleaseService;
+
+    @BeforeEach
+    void setUp() {
+        workflowReleaseService = new WorkflowReleaseServiceImpl(
+                userLangChainDataService,
+                workflowVersionMapper,
+                chatBotApiMapper,
+                maasUtil,
+                versionService);
+        ReflectionTestUtils.setField(workflowReleaseService, "maasAppId", "680ab54f");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void publishWorkflowShouldUseExplicitSpaceWhenRequestContextIsCleared() {
+        RequestContextHolder.resetRequestAttributes();
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
+        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
+        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject()
+                        .fluentPut("workflowVersionId", 18L)
+                        .fluentPut("workflowVersionName", "v1.0")));
+        when(versionService.update_channel_result(any(WorkflowVersion.class)))
+                .thenReturn(ApiResult.success(new JSONObject()));
+        WorkflowVersion storedVersion = new WorkflowVersion();
+        storedVersion.setSysData("{\"nodes\":[]}");
+        when(workflowVersionMapper.selectOne(any())).thenReturn(storedVersion);
+
+        WorkflowReleaseResponseDto response = workflowReleaseService.publishWorkflow(
+                25,
+                "requester-uid",
+                1L,
+                ReleaseTypeEnum.MARKET.name());
+
+        assertThat(response.getSuccess()).isTrue();
+        assertThat(response.getWorkflowVersionId()).isEqualTo(18L);
+        assertThat(response.getWorkflowVersionName()).isEqualTo("v1.0");
+        assertThat(RequestContextHolder.getRequestAttributes()).isNull();
+
+        ArgumentCaptor<WorkflowVersion> versionNameCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
+        verify(versionService).getVersionNameForSpace(versionNameCaptor.capture(), eq(1L));
+        assertThat(versionNameCaptor.getValue().getFlowId()).isEqualTo("flow-1");
+
+        ArgumentCaptor<WorkflowVersion> createCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
+        verify(versionService).createForSpace(createCaptor.capture(), eq(1L));
+        assertThat(createCaptor.getValue().getBotId()).isEqualTo("25");
+        assertThat(createCaptor.getValue().getFlowId()).isEqualTo("flow-1");
+        assertThat(createCaptor.getValue().getName()).isEqualTo("v1.0");
+        verify(maasUtil).createApi(eq("flow-1"), eq("680ab54f"), eq("v1.0"), any(JSONObject.class));
+    }
+
+    @Test
+    void apiPublishShouldUseBotBoundAppId() {
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
+        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
+        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject()
+                        .fluentPut("workflowVersionId", 18L)
+                        .fluentPut("workflowVersionName", "v1.0")));
+        when(versionService.update_channel_result(any(WorkflowVersion.class)))
+                .thenReturn(ApiResult.success(new JSONObject()));
+        WorkflowVersion storedVersion = new WorkflowVersion();
+        storedVersion.setSysData("{\"nodes\":[]}");
+        when(workflowVersionMapper.selectOne(any())).thenReturn(storedVersion);
+        ChatBotApi api = ChatBotApi.builder()
+                .appId("bound-app")
+                .build();
+        when(chatBotApiMapper.selectOne(any())).thenReturn(api);
+
+        WorkflowReleaseResponseDto response = workflowReleaseService.publishWorkflow(
+                25,
+                "requester-uid",
+                1L,
+                ReleaseTypeEnum.BOT_API.name());
+
+        assertThat(response.getSuccess()).isTrue();
+        ArgumentCaptor<WorkflowVersion> createCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
+        verify(versionService).createForSpace(createCaptor.capture(), eq(1L));
+        assertThat(createCaptor.getValue().getPublishChannel())
+                .isEqualTo(Long.valueOf(ReleaseTypeEnum.BOT_API.getCode()));
+        verify(maasUtil).createApi(eq("flow-1"), eq("bound-app"), eq("v1.0"), any(JSONObject.class));
+    }
+
+    @Test
+    void publishWorkflowShouldFailWhenVersionSysDataIsMissing() {
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
+        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
+        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+                .thenReturn(ApiResult.success(new JSONObject()
+                        .fluentPut("workflowVersionId", 18L)
+                        .fluentPut("workflowVersionName", "v1.0")));
+        WorkflowVersion storedVersion = new WorkflowVersion();
+        storedVersion.setSysData("{}");
+        when(workflowVersionMapper.selectOne(any())).thenReturn(storedVersion);
+
+        WorkflowReleaseResponseDto response = workflowReleaseService.publishWorkflow(
+                25,
+                "requester-uid",
+                1L,
+                ReleaseTypeEnum.MARKET.name());
+
+        assertThat(response.getSuccess()).isFalse();
+        verify(maasUtil, never()).createApi(any(), any(), any(), any(JSONObject.class));
+    }
+}

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/strategy/publish/impl/MarketPublishStrategyTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/strategy/publish/impl/MarketPublishStrategyTest.java
@@ -1,0 +1,65 @@
+package com.iflytek.astron.console.hub.strategy.publish.impl;
+
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.dto.bot.BotPublishQueryResult;
+import com.iflytek.astron.console.commons.enums.PublishChannelEnum;
+import com.iflytek.astron.console.commons.enums.ShelfStatusEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotMarketMapper;
+import com.iflytek.astron.console.hub.service.publish.PublishChannelService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MarketPublishStrategyTest {
+
+    @Mock
+    private ChatBotBaseMapper chatBotBaseMapper;
+    @Mock
+    private ChatBotMarketMapper chatBotMarketMapper;
+    @Mock
+    private PublishChannelService publishChannelService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private MarketPublishStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new MarketPublishStrategy(
+                chatBotBaseMapper,
+                chatBotMarketMapper,
+                publishChannelService,
+                eventPublisher);
+    }
+
+    @Test
+    void offlineShouldFailWhenPublishRecordCannotBeUpdated() {
+        when(chatBotBaseMapper.checkBotPermission(25, "owner-uid", 1L)).thenReturn(1);
+        BotPublishQueryResult queryResult = new BotPublishQueryResult();
+        queryResult.setBotStatus(ShelfStatusEnum.ON_SHELF.getCode());
+        queryResult.setPublishChannels(PublishChannelEnum.MARKET.getCode());
+        when(chatBotMarketMapper.selectBotDetail(25, "owner-uid", 1L)).thenReturn(queryResult);
+        when(publishChannelService.updatePublishChannels(
+                eq(PublishChannelEnum.MARKET.getCode()),
+                eq(PublishChannelEnum.MARKET.getCode()),
+                eq(false)))
+                .thenReturn("");
+        when(chatBotMarketMapper.updatePublishStatus(25, "owner-uid", 1L, ShelfStatusEnum.OFF_SHELF.getCode(), ""))
+                .thenReturn(0);
+
+        assertThatThrownBy(() -> strategy.offline(25, null, "owner-uid", 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("responseEnum")
+                .isEqualTo(ResponseEnum.BOT_UPDATE_FAILED);
+    }
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/VersionService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/VersionService.java
@@ -151,12 +151,17 @@ public class VersionService {
     // Exception database operation rollback
     @Transactional
     public ApiResult<JSONObject> create(WorkflowVersion createDto) {
+        return createForSpace(createDto, SpaceInfoUtil.getSpaceId());
+    }
+
+    @Transactional
+    public ApiResult<JSONObject> createForSpace(WorkflowVersion createDto, Long spaceId) {
         log.info("Starting to add version, input data: {}", createDto);
         Workflow workflow = workflowMapper.selectOne(Wrappers.lambdaQuery(Workflow.class).eq(Workflow::getFlowId, createDto.getFlowId()));
         if (workflow == null) {
             throw new BusinessException(ResponseEnum.WORKFLOW_NOT_EXIST);
         }
-        dataPermissionCheckTool.checkWorkflowBelong(workflow, SpaceInfoUtil.getSpaceId());
+        dataPermissionCheckTool.checkWorkflowBelong(workflow, spaceId);
 
         try {
             // Create workflow version
@@ -261,12 +266,16 @@ public class VersionService {
      * @return API result with suggested version name
      */
     public ApiResult<JSONObject> getVersionName(WorkflowVersion createDto) {
+        return getVersionNameForSpace(createDto, SpaceInfoUtil.getSpaceId());
+    }
+
+    public ApiResult<JSONObject> getVersionNameForSpace(WorkflowVersion createDto, Long spaceId) {
         log.info("Starting to get workflow version name, input data: {}", createDto);
         Workflow workflow = workflowMapper.selectOne(Wrappers.lambdaQuery(Workflow.class).eq(Workflow::getFlowId, createDto.getFlowId()));
         if (workflow == null) {
             throw new BusinessException(ResponseEnum.WORKFLOW_NOT_EXIST);
         }
-        dataPermissionCheckTool.checkWorkflowBelong(workflow, SpaceInfoUtil.getSpaceId());
+        dataPermissionCheckTool.checkWorkflowBelong(workflow, spaceId);
 
         try {
             // Get the maximum version integer

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowVersionLookupServiceImpl.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowVersionLookupServiceImpl.java
@@ -1,0 +1,54 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.iflytek.astron.console.commons.service.workflow.WorkflowVersionLookupService;
+import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
+import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
+import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowVersionMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkflowVersionLookupServiceImpl implements WorkflowVersionLookupService {
+
+    private final WorkflowVersionMapper workflowVersionMapper;
+
+    @Override
+    public Optional<String> findLatestSuccessfulVersionName(Integer botId) {
+        if (botId == null) {
+            return Optional.empty();
+        }
+        WorkflowVersion latestVersion = workflowVersionMapper.selectOne(
+                Wrappers.lambdaQuery(WorkflowVersion.class)
+                        .eq(WorkflowVersion::getBotId, String.valueOf(botId))
+                        .in(WorkflowVersion::getPublishResult,
+                                WorkflowConst.PublishResult.SUCCESS,
+                                WorkflowConst.PublishResult.LEGACY_SUCCESS,
+                                WorkflowConst.PublishResult.LEGACY_SUCCESS_UPPER)
+                        .orderByDesc(WorkflowVersion::getCreatedTime)
+                        .last("LIMIT 1"));
+        return latestVersion == null || StringUtils.isBlank(latestVersion.getName())
+                ? Optional.empty()
+                : Optional.of(latestVersion.getName());
+    }
+
+    @Override
+    public Optional<Boolean> isPublishedVersion(String flowId, String versionName) {
+        if (StringUtils.isBlank(flowId) || StringUtils.isBlank(versionName)) {
+            return Optional.empty();
+        }
+        WorkflowVersion workflowVersion = workflowVersionMapper.selectOne(
+                Wrappers.lambdaQuery(WorkflowVersion.class)
+                        .eq(WorkflowVersion::getFlowId, flowId)
+                        .eq(WorkflowVersion::getName, versionName)
+                        .orderByDesc(WorkflowVersion::getCreatedTime)
+                        .last("LIMIT 1"));
+        return workflowVersion == null
+                ? Optional.empty()
+                : Optional.of(WorkflowConst.PublishResult.isSuccess(workflowVersion.getPublishResult()));
+    }
+}

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowVersionLookupServiceImplTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowVersionLookupServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
+import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
+import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowVersionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowVersionLookupServiceImplTest {
+
+    @Mock
+    private WorkflowVersionMapper workflowVersionMapper;
+
+    private WorkflowVersionLookupServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkflowVersionLookupServiceImpl(workflowVersionMapper);
+    }
+
+    @Test
+    void findLatestSuccessfulVersionNameShouldReturnLatestVersionName() {
+        WorkflowVersion latest = new WorkflowVersion();
+        latest.setName("v1.0");
+        when(workflowVersionMapper.selectOne(any())).thenReturn(latest);
+
+        Optional<String> versionName = service.findLatestSuccessfulVersionName(25);
+
+        assertThat(versionName).contains("v1.0");
+    }
+
+    @Test
+    void isPublishedVersionShouldUnderstandSuccessPublishResult() {
+        WorkflowVersion version = new WorkflowVersion();
+        version.setPublishResult(WorkflowConst.PublishResult.SUCCESS);
+        when(workflowVersionMapper.selectOne(any())).thenReturn(version);
+
+        Optional<Boolean> published = service.isPublishedVersion("flow-1", "v1.0");
+
+        assertThat(published).contains(true);
+    }
+}

--- a/console/frontend/src/services/chat.ts
+++ b/console/frontend/src/services/chat.ts
@@ -22,9 +22,12 @@ export async function getBotInfoApi(
   botId: number,
   workflowVersion?: string
 ): Promise<BotInfoType> {
-  return http.get(
-    `/chat-list/v1/get-bot-info?botId=${botId}&workflowVersion=${workflowVersion}`
-  );
+  return http.get('/chat-list/v1/get-bot-info', {
+    params: {
+      botId,
+      ...(workflowVersion ? { workflowVersion } : {}),
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix team publish approval execution for market/API workflow bot publishing
- Replace request-context-dependent workflow version self-calls with direct version service calls using explicit spaceId
- Add workflow version lookup fallback for market chat and guard against empty/stale workflowVersion
- Tighten workflow publish failure propagation and market offline update failure handling

## Verification
- `mvn -pl hub -am "-Dtest=BotServiceImplWorkflowVersionTest,WorkflowBotChatServiceImplTest,WorkflowVersionLookupServiceImplTest,WorkflowReleaseServiceImplTest,WorkflowBotPublishListenerTest,MarketPublishStrategyTest,ReleaseManageClientServiceImplTest,BotApiPublishApprovalExecutorTest,PublishApprovalServiceImplTest,BotPublishControllerTest,UserBotServiceImplTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `git diff --check`
- `npx eslint src/services/chat.ts`