### PR TITLE
feat: add team publish approval flow

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/data/impl/UserLangChainInfoDataServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/data/impl/UserLangChainInfoDataServiceImpl.java
@@ -68,12 +68,15 @@ public class UserLangChainInfoDataServiceImpl implements UserLangChainDataServic
 
     @Override
     public String findFlowIdByBotId(Integer botId) {
+        if (botId == null) {
+            return null;
+        }
         UserLangChainInfo userLangChainInfo = userLangChainInfoMapper.selectOne(
                 new LambdaQueryWrapper<UserLangChainInfo>()
                         .eq(UserLangChainInfo::getBotId, botId)
                         .orderByDesc(UserLangChainInfo::getUpdateTime)
                         .last("LIMIT 1"));
-        return userLangChainInfo.getFlowId();
+        return userLangChainInfo == null ? null : userLangChainInfo.getFlowId();
     }
 
     @Override

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/data/impl/UserLangChainInfoDataServiceImplTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/data/impl/UserLangChainInfoDataServiceImplTest.java
@@ -172,11 +172,22 @@ class UserLangChainInfoDataServiceImplTest {
         // Given
         when(userLangChainInfoMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
 
-        // When & Then
-        assertThrows(NullPointerException.class, () -> {
-            userLangChainInfoDataService.findFlowIdByBotId(botId);
-        });
+        // When
+        String result = userLangChainInfoDataService.findFlowIdByBotId(botId);
+
+        // Then
+        assertNull(result);
         verify(userLangChainInfoMapper).selectOne(any(LambdaQueryWrapper.class));
+    }
+
+    @Test
+    void testFindFlowIdByBotId_NullInput() {
+        // When
+        String result = userLangChainInfoDataService.findFlowIdByBotId(null);
+
+        // Then
+        assertNull(result);
+        verify(userLangChainInfoMapper, never()).selectOne(any(LambdaQueryWrapper.class));
     }
 
     @Test

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImpl.java
@@ -39,7 +39,7 @@ public class ReleaseManageClientServiceImpl implements ReleaseManageClientServic
 
         WorkflowVersion query = new WorkflowVersion();
         query.setFlowId(flowId);
-        ApiResult<JSONObject> response = versionService.getVersionNameForSpace(query, spaceId);
+        ApiResult<JSONObject> response = versionService.getVersionNameForBoundBotPublish(query);
         JSONObject data = response == null ? null : response.data();
         String versionName = data == null ? null : data.getString("workflowVersionName");
         if (response == null || response.code() != 0 || StrUtil.isBlank(versionName)) {
@@ -55,6 +55,12 @@ public class ReleaseManageClientServiceImpl implements ReleaseManageClientServic
         if (botId == null || StrUtil.isBlank(flowId) || StrUtil.isBlank(versionName)) {
             throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
         }
+        String boundFlowId = userLangChainDataService.findFlowIdByBotId(botId);
+        if (!StrUtil.equals(boundFlowId, flowId)) {
+            log.error("releaseBotApi - FlowId does not match bot binding, botId={}, flowId={}, boundFlowId={}",
+                    botId, flowId, boundFlowId);
+            throw new BusinessException(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
+        }
 
         WorkflowVersion workflowVersion = new WorkflowVersion();
         workflowVersion.setBotId(botId.toString());
@@ -64,7 +70,7 @@ public class ReleaseManageClientServiceImpl implements ReleaseManageClientServic
         workflowVersion.setDescription("");
         workflowVersion.setName(versionName);
 
-        ApiResult<JSONObject> response = versionService.createForSpace(workflowVersion, spaceId);
+        ApiResult<JSONObject> response = versionService.createForBoundBotPublish(workflowVersion);
         if (response == null || response.code() != 0 || response.data() == null) {
             log.error("releaseBotApi - Failed to create workflow version, botId={}, flowId={}, versionName={}, spaceId={}",
                     botId, flowId, versionName, spaceId);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImpl.java
@@ -60,7 +60,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             }
 
             // 2. Get version name for new release
-            String versionName = getNextVersionName(flowId, spaceId);
+            String versionName = getNextVersionName(flowId);
             if (!StringUtils.hasText(versionName)) {
                 log.error("Failed to get version name by flowId: flowId={}", flowId);
                 return createErrorResponse("Unable to get version name");
@@ -82,7 +82,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             request.setDescription("");
             request.setName(versionName);
 
-            WorkflowReleaseResponseDto response = createWorkflowVersion(request, spaceId);
+            WorkflowReleaseResponseDto response = createWorkflowVersion(request);
             if (!response.getSuccess()) {
                 return response;
             }
@@ -114,13 +114,13 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
      * Get next version name for workflow release Simplified to match old project logic exactly - no
      * fallback
      */
-    private String getNextVersionName(String flowId, Long spaceId) {
-        log.info("Getting next workflow version name: flowId={}, spaceId={}", flowId, spaceId);
+    private String getNextVersionName(String flowId) {
+        log.info("Getting next workflow version name for bound bot publish: flowId={}", flowId);
 
         try {
             WorkflowVersion query = new WorkflowVersion();
             query.setFlowId(flowId);
-            var response = versionService.getVersionNameForSpace(query, spaceId);
+            var response = versionService.getVersionNameForBoundBotPublish(query);
             if (response != null && response.code() == 0 && response.data() != null) {
                 String versionName = response.data().getString("workflowVersionName");
                 if (StringUtils.hasText(versionName)) {
@@ -166,7 +166,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
         }
     }
 
-    private WorkflowReleaseResponseDto createWorkflowVersion(WorkflowReleaseRequestDto request, Long spaceId) {
+    private WorkflowReleaseResponseDto createWorkflowVersion(WorkflowReleaseRequestDto request) {
         log.info("Creating workflow version: request={}", request);
 
         try {
@@ -178,7 +178,7 @@ public class WorkflowReleaseServiceImpl implements WorkflowReleaseService {
             workflowVersion.setDescription(request.getDescription());
             workflowVersion.setName(request.getName());
 
-            var response = versionService.createForSpace(workflowVersion, spaceId);
+            var response = versionService.createForBoundBotPublish(workflowVersion);
             JSONObject data = response == null ? null : response.data();
             if (response == null || response.code() != 0 || data == null) {
                 return createErrorResponse("Invalid response data format");

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/ReleaseManageClientServiceImplTest.java
@@ -1,7 +1,9 @@
 package com.iflytek.astron.console.hub.service.publish.impl;
 
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.enums.bot.ReleaseTypeEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.response.ApiResult;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
@@ -16,8 +18,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.context.request.RequestContextHolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,11 +41,11 @@ class ReleaseManageClientServiceImplTest {
     }
 
     @Test
-    void apiReleaseShouldUseVersionServiceWithExplicitSpaceWhenRequestContextIsCleared() {
+    void apiReleaseShouldUseBoundBotPublishVersionServiceWhenRequestContextIsCleared() {
         when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
-        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.getVersionNameForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
-        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.createForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject()
                         .fluentPut("workflowVersionId", 18L)
                         .fluentPut("workflowVersionName", "v1.0")));
@@ -53,16 +56,28 @@ class ReleaseManageClientServiceImplTest {
         assertThat(versionName).isEqualTo("v1.0");
 
         ArgumentCaptor<WorkflowVersion> nameCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
-        verify(versionService).getVersionNameForSpace(nameCaptor.capture(), eq(1L));
+        verify(versionService).getVersionNameForBoundBotPublish(nameCaptor.capture());
         assertThat(nameCaptor.getValue().getFlowId()).isEqualTo("flow-1");
 
         ArgumentCaptor<WorkflowVersion> createCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
-        verify(versionService).createForSpace(createCaptor.capture(), eq(1L));
+        verify(versionService).createForBoundBotPublish(createCaptor.capture());
         WorkflowVersion created = createCaptor.getValue();
         assertThat(created.getBotId()).isEqualTo("25");
         assertThat(created.getFlowId()).isEqualTo("flow-1");
         assertThat(created.getName()).isEqualTo("v1.0");
         assertThat(created.getPublishChannel()).isEqualTo(Long.valueOf(ReleaseTypeEnum.BOT_API.getCode()));
         assertThat(created.getPublishResult()).isEqualTo(WorkflowConst.PublishResult.SUCCESS);
+    }
+
+    @Test
+    void releaseBotApiShouldFailWhenFlowIdDoesNotMatchBotBinding() {
+        when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-actual");
+
+        assertThatThrownBy(() -> releaseManageClientService.releaseBotApi(25, "flow-other", "v1.0", 1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("responseEnum")
+                .isEqualTo(ResponseEnum.WORKFLOW_VERSION_PUBLISH_FAILED);
+
+        verify(versionService, never()).createForBoundBotPublish(any(WorkflowVersion.class));
     }
 }

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowReleaseServiceImplTest.java
@@ -61,12 +61,12 @@ class WorkflowReleaseServiceImplTest {
     }
 
     @Test
-    void publishWorkflowShouldUseExplicitSpaceWhenRequestContextIsCleared() {
+    void publishWorkflowShouldUseBoundBotPublishVersionServiceWhenRequestContextIsCleared() {
         RequestContextHolder.resetRequestAttributes();
         when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
-        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.getVersionNameForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
-        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.createForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject()
                         .fluentPut("workflowVersionId", 18L)
                         .fluentPut("workflowVersionName", "v1.0")));
@@ -88,11 +88,11 @@ class WorkflowReleaseServiceImplTest {
         assertThat(RequestContextHolder.getRequestAttributes()).isNull();
 
         ArgumentCaptor<WorkflowVersion> versionNameCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
-        verify(versionService).getVersionNameForSpace(versionNameCaptor.capture(), eq(1L));
+        verify(versionService).getVersionNameForBoundBotPublish(versionNameCaptor.capture());
         assertThat(versionNameCaptor.getValue().getFlowId()).isEqualTo("flow-1");
 
         ArgumentCaptor<WorkflowVersion> createCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
-        verify(versionService).createForSpace(createCaptor.capture(), eq(1L));
+        verify(versionService).createForBoundBotPublish(createCaptor.capture());
         assertThat(createCaptor.getValue().getBotId()).isEqualTo("25");
         assertThat(createCaptor.getValue().getFlowId()).isEqualTo("flow-1");
         assertThat(createCaptor.getValue().getName()).isEqualTo("v1.0");
@@ -102,9 +102,9 @@ class WorkflowReleaseServiceImplTest {
     @Test
     void apiPublishShouldUseBotBoundAppId() {
         when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
-        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.getVersionNameForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
-        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.createForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject()
                         .fluentPut("workflowVersionId", 18L)
                         .fluentPut("workflowVersionName", "v1.0")));
@@ -126,7 +126,7 @@ class WorkflowReleaseServiceImplTest {
 
         assertThat(response.getSuccess()).isTrue();
         ArgumentCaptor<WorkflowVersion> createCaptor = ArgumentCaptor.forClass(WorkflowVersion.class);
-        verify(versionService).createForSpace(createCaptor.capture(), eq(1L));
+        verify(versionService).createForBoundBotPublish(createCaptor.capture());
         assertThat(createCaptor.getValue().getPublishChannel())
                 .isEqualTo(Long.valueOf(ReleaseTypeEnum.BOT_API.getCode()));
         verify(maasUtil).createApi(eq("flow-1"), eq("bound-app"), eq("v1.0"), any(JSONObject.class));
@@ -135,9 +135,9 @@ class WorkflowReleaseServiceImplTest {
     @Test
     void publishWorkflowShouldFailWhenVersionSysDataIsMissing() {
         when(userLangChainDataService.findFlowIdByBotId(25)).thenReturn("flow-1");
-        when(versionService.getVersionNameForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.getVersionNameForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject().fluentPut("workflowVersionName", "v1.0")));
-        when(versionService.createForSpace(any(WorkflowVersion.class), eq(1L)))
+        when(versionService.createForBoundBotPublish(any(WorkflowVersion.class)))
                 .thenReturn(ApiResult.success(new JSONObject()
                         .fluentPut("workflowVersionId", 18L)
                         .fluentPut("workflowVersionName", "v1.0")));

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/VersionService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/VersionService.java
@@ -157,12 +157,23 @@ public class VersionService {
     @Transactional
     public ApiResult<JSONObject> createForSpace(WorkflowVersion createDto, Long spaceId) {
         log.info("Starting to add version, input data: {}", createDto);
-        Workflow workflow = workflowMapper.selectOne(Wrappers.lambdaQuery(Workflow.class).eq(Workflow::getFlowId, createDto.getFlowId()));
-        if (workflow == null) {
-            throw new BusinessException(ResponseEnum.WORKFLOW_NOT_EXIST);
-        }
+        Workflow workflow = requireWorkflow(createDto.getFlowId());
         dataPermissionCheckTool.checkWorkflowBelong(workflow, spaceId);
+        return createVersion(createDto, workflow);
+    }
 
+    /**
+     * Create a workflow version for a bot-bound publish flow after the caller has already verified
+     * bot publish permission and resolved the flowId from the bot binding.
+     */
+    @Transactional
+    public ApiResult<JSONObject> createForBoundBotPublish(WorkflowVersion createDto) {
+        log.info("Starting to add version for bound bot publish, input data: {}", createDto);
+        Workflow workflow = requireWorkflow(createDto.getFlowId());
+        return createVersion(createDto, workflow);
+    }
+
+    private ApiResult<JSONObject> createVersion(WorkflowVersion createDto, Workflow workflow) {
         try {
             // Create workflow version
             WorkflowVersion workflowVersion = new WorkflowVersion();
@@ -227,6 +238,14 @@ public class VersionService {
         //
     }
 
+    private Workflow requireWorkflow(String flowId) {
+        Workflow workflow = workflowMapper.selectOne(Wrappers.lambdaQuery(Workflow.class).eq(Workflow::getFlowId, flowId));
+        if (workflow == null) {
+            throw new BusinessException(ResponseEnum.WORKFLOW_NOT_EXIST);
+        }
+        return workflow;
+    }
+
     /**
      * Update isVersion flag for all versions of a specific flowId. Sets all versions' isVersion to 2
      * (inactive) for the given flowId.
@@ -271,12 +290,22 @@ public class VersionService {
 
     public ApiResult<JSONObject> getVersionNameForSpace(WorkflowVersion createDto, Long spaceId) {
         log.info("Starting to get workflow version name, input data: {}", createDto);
-        Workflow workflow = workflowMapper.selectOne(Wrappers.lambdaQuery(Workflow.class).eq(Workflow::getFlowId, createDto.getFlowId()));
-        if (workflow == null) {
-            throw new BusinessException(ResponseEnum.WORKFLOW_NOT_EXIST);
-        }
+        Workflow workflow = requireWorkflow(createDto.getFlowId());
         dataPermissionCheckTool.checkWorkflowBelong(workflow, spaceId);
+        return buildVersionName(createDto, workflow);
+    }
 
+    /**
+     * Get a workflow version name for a bot-bound publish flow after the caller has already verified
+     * bot publish permission and resolved the flowId from the bot binding.
+     */
+    public ApiResult<JSONObject> getVersionNameForBoundBotPublish(WorkflowVersion createDto) {
+        log.info("Starting to get workflow version name for bound bot publish, input data: {}", createDto);
+        Workflow workflow = requireWorkflow(createDto.getFlowId());
+        return buildVersionName(createDto, workflow);
+    }
+
+    private ApiResult<JSONObject> buildVersionName(WorkflowVersion createDto, Workflow workflow) {
         try {
             // Get the maximum version integer
             WorkflowVersion workflowVersion = workflowVersionMapper.selectOne(Wrappers.lambdaQuery(WorkflowVersion.class)

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/VersionServiceBoundBotPublishTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/VersionServiceBoundBotPublishTest.java
@@ -1,0 +1,67 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.entity.workflow.Workflow;
+import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowVersion;
+import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowMapper;
+import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowVersionMapper;
+import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VersionServiceBoundBotPublishTest {
+
+    @Mock
+    private WorkflowMapper workflowMapper;
+    @Mock
+    private WorkflowVersionMapper workflowVersionMapper;
+    @Mock
+    private DataPermissionCheckTool dataPermissionCheckTool;
+
+    private VersionService versionService;
+
+    @BeforeEach
+    void setUp() {
+        versionService = new VersionService();
+        versionService.workflowMapper = workflowMapper;
+        versionService.workflowVersionMapper = workflowVersionMapper;
+        versionService.dataPermissionCheckTool = dataPermissionCheckTool;
+    }
+
+    @Test
+    void getVersionNameForBoundBotPublishShouldNotCheckWorkflowSpaceBelong() {
+        when(workflowMapper.selectOne(any())).thenReturn(workflow());
+        when(workflowVersionMapper.selectOne(any())).thenReturn(null);
+
+        WorkflowVersion query = new WorkflowVersion();
+        query.setFlowId("flow-1");
+        ApiResult<JSONObject> result = versionService.getVersionNameForBoundBotPublish(query);
+
+        assertThat(result.code()).isZero();
+        assertThat(result.data().getString("workflowVersionName")).isEqualTo("v1.0");
+        verify(dataPermissionCheckTool, never()).checkWorkflowBelong(any(Workflow.class), any());
+    }
+
+    private Workflow workflow() {
+        Workflow workflow = new Workflow();
+        workflow.setId(7L);
+        workflow.setFlowId("flow-1");
+        workflow.setName("workflow");
+        workflow.setDescription("description");
+        workflow.setData("{}");
+        workflow.setSpaceId(99L);
+        workflow.setIsPublic(false);
+        return workflow;
+    }
+}


### PR DESCRIPTION
## Summary
- Add team-space publish approval for marketplace and API publishing while keeping personal-space publish direct.
- Restrict team publish review and offline operations to current-space OWNER/ADMIN.
- Fix workflow/bot publish approval execution to create versions through the bot-bound publish path instead of rechecking workflow space ownership with the approval space id.

## Verification
- `mvn -pl commons,toolkit,hub -am "-Dtest=UserLangChainInfoDataServiceImplTest,VersionServiceBoundBotPublishTest,ReleaseManageClientServiceImplTest,WorkflowReleaseServiceImplTest,WorkflowBotPublishListenerTest" -DfailIfNoTests=false test`
- `mvn -pl commons,toolkit,hub -am "-Dtest=!SparkChatServiceTest" -DfailIfNoTests=false test`

Note: the full unfiltered backend test run still fails in the pre-existing `SparkChatServiceTest.setUp:59` because the test reflects a removed `apiPassword` field.