### PR TITLE
fix(frontend): refine agent workbench interactions

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/index.module.scss
+++ b/console/frontend/src/components/config-page-component/config-base/index.module.scss
@@ -669,9 +669,13 @@
 
 .workbenchMainBody {
   min-height: 0;
-  overflow: hidden;
+  overflow: auto;
   padding: 22px 28px;
   background: #fbfdff;
+}
+
+.workbenchMainBodyChat {
+  overflow: hidden;
 }
 
 .workbenchChatWorkspace {
@@ -690,6 +694,32 @@
   border: 1px solid #e0e7ff;
   border-radius: 8px;
   background: #ffffff;
+}
+
+.workbenchInputModelSelect {
+  width: 180px;
+
+  :global(.ant-select-selector) {
+    height: 38px !important;
+    border-color: #d2dbe7 !important;
+    border-radius: 8px !important;
+    background: #ffffff !important;
+    box-shadow: none !important;
+  }
+
+  :global(.ant-select-selection-item) {
+    display: block;
+    overflow: hidden;
+    color: #475569;
+    font-size: 13px;
+    line-height: 36px !important;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.ant-select-arrow) {
+    color: #64748b;
+  }
 }
 
 .workbenchCompareGrid {
@@ -742,6 +772,7 @@
   border: 1px solid #e0e7ff;
   border-radius: 8px;
   background: #ffffff;
+  min-height: max-content;
 }
 
 .workbenchSectionTitle {

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -52,7 +52,6 @@ import { debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { getLanguageCode } from '@/utils/http';
 import {
-  AppstoreOutlined,
   BookOutlined,
   DatabaseOutlined,
   EditOutlined,
@@ -1388,11 +1387,6 @@ const BaseConfig: React.FC<ChatProps> = ({
       icon: <MessageOutlined />,
     },
     {
-      key: 'model',
-      label: t('configBase.modelSelection'),
-      icon: <AppstoreOutlined />,
-    },
-    {
       key: 'capability',
       label: t('configBase.CapabilityDevelopment.capability'),
       icon: <ThunderboltOutlined />,
@@ -1531,6 +1525,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     ? personalityData.personalityConfig
                     : null
                 }
+                showHeaderAndRecommend={false}
               />
             </div>
           ))}
@@ -1589,6 +1584,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     ? personalityData.personalityConfig
                     : null
                 }
+                showHeaderAndRecommend={false}
               />
             </div>
           ))}
@@ -1620,9 +1616,43 @@ const BaseConfig: React.FC<ChatProps> = ({
             ? personalityData.personalityConfig
             : null
         }
+        showHeaderAndRecommend={false}
       />
     );
   };
+
+  const renderChatModelSelector = () => (
+    <Select
+      value={model}
+      onChange={handleModelChange}
+      className={styles.workbenchInputModelSelect}
+      popupMatchSelectWidth={280}
+      placeholder={t('configBase.pleaseSelectModel')}
+      optionLabelProp="label"
+      showSearch
+      filterOption={(input, option) => {
+        const label = String(option?.label || '');
+        return label.toLowerCase().includes(input.toLowerCase());
+      }}
+    >
+      {modelOptions.map((option, index) => (
+        <Option
+          key={getModelUniqueKey(option, index)}
+          value={getModelUniqueKey(option, index)}
+          label={option.modelName}
+        >
+          <div className="flex items-center">
+            <img
+              className="w-[20px] h-[20px]"
+              src={option.modelIcon}
+              alt={option.modelName}
+            />
+            <span>{option.modelName}</span>
+          </div>
+        </Option>
+      ))}
+    </Select>
+  );
 
   const renderChatWorkspace = () => (
     <div className={styles.workbenchChatWorkspace}>
@@ -1635,6 +1665,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         value={askValue}
         onChange={setAskValue}
         isLoading={globalLoading}
+        footerExtra={renderChatModelSelector()}
       />
     </div>
   );
@@ -1976,7 +2007,11 @@ const BaseConfig: React.FC<ChatProps> = ({
             {renderWorkbenchActions()}
           </header>
 
-          <section className={styles.workbenchMainBody}>
+          <section
+            className={`${styles.workbenchMainBody} ${
+              activeWorkbenchView === 'chat' ? styles.workbenchMainBodyChat : ''
+            }`}
+          >
             {activeWorkbenchView === 'chat'
               ? renderChatWorkspace()
               : renderConfigWorkspace()}

--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -56,6 +56,7 @@ const PromptTry = forwardRef<
     debugSessionId?: string;
     initialMessages?: MessageListType[];
     onMessagesChange?: (messages: MessageListType[]) => void;
+    showHeaderAndRecommend?: boolean;
     choosedAlltool?: {
       [key: string]: boolean;
     };
@@ -83,6 +84,7 @@ const PromptTry = forwardRef<
       debugSessionId,
       initialMessages,
       onMessagesChange,
+      showHeaderAndRecommend = true,
       findModelOptionByUniqueKey,
       personalityConfig,
     },
@@ -347,6 +349,7 @@ const PromptTry = forwardRef<
             isLoading={isLoading}
             isCompleted={isCompleted}
             stopAnswer={stopAnswer}
+            showHeaderAndRecommend={showHeaderAndRecommend}
           />
         </div>
       </div>

--- a/console/frontend/src/components/prompt-try/input-box.tsx
+++ b/console/frontend/src/components/prompt-try/input-box.tsx
@@ -5,11 +5,13 @@ import { useTranslation } from 'react-i18next';
 
 interface InputBoxProps {
   onSend: (text: string) => void;
-  onClear: () => void;
+  onClear?: () => void;
   isLoading?: boolean;
   placeholder?: string;
   value?: string;
   onChange?: (value: string) => void;
+  footerExtra?: React.ReactNode;
+  showClear?: boolean;
 }
 
 const InputBox = ({
@@ -19,6 +21,8 @@ const InputBox = ({
   placeholder,
   value,
   onChange,
+  footerExtra,
+  showClear = false,
 }: InputBoxProps) => {
   const { t } = useTranslation();
   const [internalValue, setInternalValue] = useState('');
@@ -62,20 +66,23 @@ const InputBox = ({
       message.warning(t('configBase.promptTry.answerPleaseTryAgainLater'));
       return;
     }
-    onClear();
+    onClear?.();
   };
 
   return (
     <div className="relative w-full rounded-md h-[95px] flex">
-      <div
-        className="w-[107px] h-[26px] absolute top-[-34px] left-0 bg-white border border-[#e4ebf9] rounded-[13px] flex items-center justify-center text-[12px] text-[#535875] z-[40] cursor-pointer hover:text-[#6b89ff]"
-        onClick={handleClear}
-      >
-        <DeleteIcon style={{ pointerEvents: 'none', marginRight: '6px' }} />
-        {t('configBase.promptTry.clearHistory')}
-      </div>
+      {showClear && onClear && (
+        <div
+          className="w-[107px] h-[26px] absolute top-[-34px] left-0 bg-white border border-[#e4ebf9] rounded-[13px] flex items-center justify-center text-[12px] text-[#535875] z-[40] cursor-pointer hover:text-[#6b89ff]"
+          onClick={handleClear}
+        >
+          <DeleteIcon style={{ pointerEvents: 'none', marginRight: '6px' }} />
+          {t('configBase.promptTry.clearHistory')}
+        </div>
+      )}
       <textarea
-        className="rounded-[8px] absolute left-[2px] bottom-[2px] w-[calc(100%-4px)] leading-[25px] min-h-[95px] max-h-[180px] resize-none outline-none border border-[#d2dbe7] text-[14px] py-[10px] pr-[100px] pl-[16px] text-[#07133e] z-[32] placeholder:text-[#d0d0da]"
+        className="rounded-[8px] absolute left-[2px] bottom-[2px] w-[calc(100%-4px)] leading-[25px] min-h-[95px] max-h-[180px] resize-none outline-none border border-[#d2dbe7] text-[14px] py-[10px] pl-[16px] text-[#07133e] z-[32] placeholder:text-[#d0d0da]"
+        style={{ paddingRight: footerExtra ? 280 : 100 }}
         placeholder={placeholder || t('chatPage.chatWindow.defaultPlaceholder')}
         onKeyDown={handleKeyDown}
         value={inputValue}
@@ -85,6 +92,11 @@ const InputBox = ({
         onCompositionStart={() => setIsComposing(true)}
         onCompositionEnd={() => setIsComposing(false)}
       />
+      {footerExtra && (
+        <div className="absolute bottom-[10px] right-[92px] h-[38px] z-[36] flex items-center">
+          {footerExtra}
+        </div>
+      )}
       <div
         className="absolute bottom-[10px] right-[10px] w-[70px] h-[38px] rounded-[8px] text-white text-center leading-[38px] text-[14px] cursor-pointer transition-all duration-300 z-[35] hover:bg-[#257eff] hover:opacity-100"
         style={{

--- a/console/frontend/src/components/prompt-try/message-list.tsx
+++ b/console/frontend/src/components/prompt-try/message-list.tsx
@@ -21,6 +21,7 @@ const MessageList = (props: {
   isLoading: boolean;
   isCompleted: boolean;
   stopAnswer: () => void;
+  showHeaderAndRecommend?: boolean;
 }): ReactElement => {
   const {
     messageList,
@@ -30,6 +31,7 @@ const MessageList = (props: {
     isLoading,
     isCompleted,
     stopAnswer,
+    showHeaderAndRecommend = true,
   } = props;
   const scrollAnchorRef = useRef<HTMLDivElement>(null);
   const { user } = useUserStore();
@@ -185,7 +187,7 @@ const MessageList = (props: {
               </div>
             );
           })}
-        {renderHeaderAndRecommend()}
+        {showHeaderAndRecommend && renderHeaderAndRecommend()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Hide the empty chat agent preview block in the agent workbench
- Remove the clear-history action and keep new chat as the reset entry point
- Move model selection into the chat input footer and remove it from the sidebar
- Allow configuration content, including capability settings, to scroll in the main pane

## Verification
- npm run build:test
- focused ESLint on changed frontend files
- focused type-check filtering changed paths
- git diff --check