### PR TITLE
fix(frontend): simplify agent workbench settings

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -46,6 +46,7 @@ import { CheckboxChangeEvent } from 'antd/es/checkbox';
 const { TextArea } = Input;
 
 interface CapabilityDevelopmentProps {
+  viewMode?: 'full' | 'personalization' | 'knowledge';
   botCreateActiveV: any;
   setBotCreateActiveV: (v: any) => void;
   baseinfo: any;
@@ -79,6 +80,7 @@ interface CapabilityDevelopmentProps {
 
 const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
   const {
+    viewMode = 'full',
     botCreateActiveV,
     setBotCreateActiveV,
     baseinfo,
@@ -322,838 +324,869 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
     setDisList(arr);
   }, [dataSource]);
 
+  const showCapabilitySection = viewMode === 'full';
+  const showKnowledgeSection = viewMode === 'full' || viewMode === 'knowledge';
+  const showPersonalizationSection =
+    viewMode === 'full' || viewMode === 'personalization';
+  const showSupportContextSwitch = viewMode === 'full';
+  const isScopedMode = viewMode !== 'full';
+
   return (
     <div
-      className="flex-1  overflow-auto pr-6"
+      className={cls('flex-1 overflow-auto', !isScopedMode && 'pr-6')}
       ref={containerRef}
       style={{
-        padding: multiModelDebugging ? '' : '0 24px',
-        borderLeft: multiModelDebugging ? '' : '1px solid #E2E8FF',
+        padding: multiModelDebugging ? '' : isScopedMode ? '0' : '0 24px',
+        borderLeft:
+          multiModelDebugging || isScopedMode ? '' : '1px solid #E2E8FF',
         marginTop: multiModelDebugging ? 24 : 0,
       }}
     >
-      <div className="flex items-center justify-between mt-6">
-        <div className=" w-full">
-          <div className="flex items-center" style={{ marginBottom: '20px' }}>
-            {multiModelDebugging && (
-              <img
-                src={growOrShrinkConfig?.tools ? arrowDown : arrowUp}
-                className="w-[16px] h-[16px] mr-2 cursor-pointer"
-                alt=""
-                onClick={() =>
-                  setGrowOrShrinkConfig({
-                    ...growOrShrinkConfig,
-                    tools: !growOrShrinkConfig.tools,
-                  })
-                }
-              />
-            )}
-            <img src={plugin} className="w-6 h-6" alt="" />
-            <span className="ml-2 text-[#D84516] font-medium">
-              {t('configBase.CapabilityDevelopment.capability')}
-            </span>
-          </div>
-          <div
-            className="flex justify-between items-center border-b border-[#E9EFF6]"
-            style={{
-              padding: '8px 20px 12px 20px',
-            }}
-          >
-            <div className="flex gap-2 items-center">
-              <img src={netIcon} alt="" className="w-[16px] h-[16px]" />
-              <span className="text-sm font-medium">
-                {t('configBase.CapabilityDevelopment.internetSearch')}
-              </span>
-            </div>
-            <Switch
-              className="list-switch config-switch"
-              defaultChecked={
-                detailInfo.openedTool?.indexOf('ifly_search') !== -1
-              }
-              onChange={checked => {
-                choosedAlltool.ifly_search = checked;
-                setChoosedAlltool(choosedAlltool);
-              }}
-            />
-          </div>
-          <div
-            className="flex justify-between items-center border-b border-[#E9EFF6]"
-            style={{
-              padding: '8px 20px 12px 20px',
-            }}
-          >
-            <div className="flex gap-2 items-center">
-              <img src={genPicIcon} alt="" className="w-[16px] h-[16px]" />
-              <span className="text-sm font-medium">
-                {t('configBase.CapabilityDevelopment.AIDraw')}
-              </span>
-            </div>
-            <Switch
-              className="list-switch config-switch"
-              defaultChecked={
-                detailInfo.openedTool?.indexOf('text_to_image') !== -1
-              }
-              onChange={checked => {
-                choosedAlltool.text_to_image = checked;
-                setChoosedAlltool(choosedAlltool);
-              }}
-            />
-          </div>
-          <div
-            className="flex justify-between items-center border-b border-[#E9EFF6]"
-            style={{
-              padding: '8px 20px 12px 20px',
-            }}
-          >
-            <div className="flex gap-2 items-center">
-              <img src={codeIcon} alt="" className="w-[16px] h-[16px]" />
-              <span className="text-sm font-medium">
-                {t('configBase.CapabilityDevelopment.codeGeneration')}
-              </span>
-            </div>
-            <Switch
-              className="list-switch config-switch"
-              defaultChecked={
-                detailInfo.openedTool?.indexOf('codeinterpreter') !== -1
-              }
-              onChange={checked => {
-                choosedAlltool.codeinterpreter = checked;
-                setChoosedAlltool(choosedAlltool);
-              }}
-            />
-          </div>
-        </div>
-      </div>
-      {growOrShrinkConfig.tools && tools.length > 0 && (
-        <div className="mt-1.5 w-full overflow-auto max-h-[300px]">
-          {tools.map((item: any, index: number) => (
-            <div
-              key={index}
-              className="flex items-center px-5 py-3 border-b border-[#E2E8FF]"
-            >
-              <Tooltip
-                title={
-                  item.isPublic
-                    ? t('configBase.CapabilityDevelopment.officialPlugin')
-                    : t('configBase.CapabilityDevelopment.personalPlugin')
-                }
-                overlayClassName="black-tooltip config-secret"
-              ></Tooltip>
-              <span
-                className="w-[200px] text-overflow ml-2 text-sm"
-                title={item.name}
+      {showCapabilitySection && (
+        <>
+          <div className="flex items-center justify-between mt-6">
+            <div className=" w-full">
+              <div
+                className="flex items-center"
+                style={{ marginBottom: '20px' }}
               >
-                {item.name}
-              </span>
-              <span
-                className="ml-5 flex-1 text-overflow text-[#757575] text-xs font-medium"
-                title={item.description}
-              >
-                {item.description}
-              </span>
-              <img
-                src={del}
-                className="ml-6 w-4 h-4 cursor-pointer"
-                onClick={() => deleteTool(item.toolId)}
-                alt=""
-              />
-            </div>
-          ))}
-        </div>
-      )}
-      <div className="mt-[52px]">
-        <div className="w-full font-medium text-second">
-          <div
-            className="flex items-center"
-            style={{ marginBottom: '20px', justifyContent: 'space-between' }}
-          >
-            {multiModelDebugging && (
-              <img
-                src={growOrShrinkConfig?.knowledges ? arrowDown : arrowUp}
-                className="w-[16px] h-[16px] mr-2 cursor-pointer"
-                alt=""
-                onClick={() =>
-                  setGrowOrShrinkConfig({
-                    ...growOrShrinkConfig,
-                    knowledges: !growOrShrinkConfig.knowledges,
-                  })
-                }
-              />
-            )}
-            <div style={{ display: 'flex' }}>
-              <img src={settingFile} className="w-6 h-6" alt="" />
-              <span className="text-[#13A10E] font-medium ml-2">
-                {t('configBase.CapabilityDevelopment.knowledgeBase')}
-              </span>
-            </div>
-            <div
-              onClick={() => {
-                setVisible(true);
-              }}
-              style={{ color: '#6356EA', cursor: 'pointer' }}
-            >
-              + {t('configBase.CapabilityDevelopment.addKnowledgeBase')}
-            </div>
-          </div>
-          <Modal
-            wrapClassName={styles.datasetModalWrap}
-            open={visible}
-            centered
-            footer={null}
-            closable={false}
-            // width={461}
-            forceRender
-            maskClosable={false}
-          >
-            <div
-              style={{ display: 'flex', justifyContent: ' space-between' }}
-              className={styles.title}
-            >
-              <div>
-                {t(
-                  'configBase.CapabilityDevelopment.selectToAssociateTheDataset'
+                {multiModelDebugging && (
+                  <img
+                    src={growOrShrinkConfig?.tools ? arrowDown : arrowUp}
+                    className="w-[16px] h-[16px] mr-2 cursor-pointer"
+                    alt=""
+                    onClick={() =>
+                      setGrowOrShrinkConfig({
+                        ...growOrShrinkConfig,
+                        tools: !growOrShrinkConfig.tools,
+                      })
+                    }
+                  />
                 )}
-                <span
-                  style={{ display: 'inline-block' }}
-                  className={styles.refresh}
-                  onClick={() => {
-                    setIsFresh(true);
-                    setTimeout(() => {
-                      setIsFresh(false);
-                    }, 500);
-                    listRepos().then((res: any) => {
-                      setDataSource(res?.pageData);
-                    });
-                  }}
-                >
-                  <img
-                    src={
-                      'https://aixfyun-cn-bj.xfyun.cn/bbs/88573.51517541305/%E5%88%B7%E6%96%B0.svg'
-                    }
-                    style={
-                      isFresh
-                        ? {
-                            display: 'inline-block',
-                            transform: 'rotate(360deg)',
-                            transformOrigin: 'center',
-                            transition: 'all 0.5s linear',
-                          }
-                        : {
-                            display: 'inline-block',
-                          }
-                    }
-                    alt=""
-                  />
-                  {t('configBase.CapabilityDevelopment.refresh')}
-                </span>
-              </div>
-              <img
-                alt=""
-                className={styles.close}
-                src={closeImg}
-                onClick={() => setVisible(false)}
-              />
-            </div>
-            <div
-              style={{ position: 'relative' }}
-              className={styles.data_content}
-            >
-              {dataSource?.length > 0 ? (
-                (dataSource || []).map((item: any, index: number) => {
-                  return (
-                    <div
-                      style={{
-                        cursor:
-                          disList.length == 0 || disList[0]?.tag == item.tag
-                            ? 'pointer'
-                            : 'not-allowed',
-                      }}
-                      key={item.id}
-                      className={`${item.checked ? styles.checked : ''} ${
-                        styles.cardlist
-                      }`}
-                      onClick={() => {
-                        if (
-                          disList.length == 0 ||
-                          disList[0]?.tag == item.tag
-                        ) {
-                          item.checked = !item.checked;
-                          setDataSource([...dataSource]);
-                        }
-                      }}
-                    >
-                      <div
-                        style={{
-                          position: 'absolute',
-                          right: 0,
-                          top: 0,
-                          background:
-                            item.tag == 'SparkDesk-RAG'
-                              ? '#13A10e'
-                              : item.tag == 'AIUI-RAG2'
-                                ? 'linear-gradient(215deg, #6F8AF5 18%, #0458FF 82%)'
-                                : 'linear-gradient(34deg, #6B23FF 19%, rgba(153, 98, 255, 0.9281) 83%)',
-                          width: '58px',
-                          height: '28px',
-                          fontFamily: '苹方',
-                          fontSize: '14px',
-                          fontWeight: 500,
-                          lineHeight: '28px',
-                          letterSpacing: 'normal',
-                          color: '#FFFFFF',
-                          textAlign: 'center',
-                          borderRadius: '0px 17px 0px 8px',
-                        }}
-                      >
-                        {item.tag == 'SparkDesk-RAG'
-                          ? t(
-                              'configBase.CapabilityDevelopment.personalVersion'
-                            )
-                          : item.tag == 'AIUI-RAG2'
-                            ? t('configBase.CapabilityDevelopment.stardust')
-                            : t('configBase.CapabilityDevelopment.spark')}
-                      </div>
-                      <div className={styles.img}>
-                        <img src={fileImg} alt="" />
-                      </div>
-                      <div className={styles.info}>
-                        <div className={styles.name}>{item.name}</div>
-                        <div className={styles.detail}>
-                          <span title={item.charCount}>
-                            {t('configBase.CapabilityDevelopment.character')}{' '}
-                            {item.charCount ? item.charCount : 0}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })
-              ) : (
-                <div className={styles.empty_card}>
-                  <img
-                    src="https://aixfyun-cn-bj.xfyun.cn/bbs/84929.66416893165/%E4%B8%8A%E4%BC%A0%E6%96%87%E4%BB%B6%E5%A4%87%E4%BB%BD%202.svg"
-                    alt=""
-                  />
-                  <div className={styles.tips}>
-                    {t(
-                      'configBase.CapabilityDevelopment.youHaveNotCreatedAnyDatasets'
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-            {dataSource?.length > 0 && (
-              <div
-                style={{ display: 'flex' }}
-                className={styles.go_create}
-                onClick={() => window.open('/resource/knowledge')}
-              >
-                <img
-                  src="https://aixfyun-cn-bj.xfyun.cn/bbs/27965.529211835106/%E6%96%B0%E5%A2%9E.svg"
-                  style={{ height: 12, marginRight: 2, marginTop: '3px' }}
-                  alt=""
-                />
-                <div>
-                  {t('configBase.CapabilityDevelopment.createNewDataset')}
-                </div>
-              </div>
-            )}
-            <div className={styles.button_list}>
-              <Button
-                onClick={() => {
-                  setVisible(false);
-                  (dataSource || []).forEach((item: any) => {
-                    if (selectSource.includes(item)) {
-                      item.checked = true;
-                    } else {
-                      item.checked = false;
-                    }
-                  });
-                }}
-              >
-                {t('configBase.CapabilityDevelopment.cancel')}
-              </Button>
-              <Button
-                type="primary"
-                onClick={() => {
-                  if (dataSource?.length > 0) {
-                    setVisible(false);
-                    const filterSource = (dataSource || []).filter(
-                      (item: any) => item.checked
-                    );
-                    setSelectSource(filterSource);
-                  } else window.open('/resource/knowledge');
-                }}
-              >
-                {dataSource?.length > 0
-                  ? t('configBase.CapabilityDevelopment.confirm')
-                  : t('configBase.CapabilityDevelopment.goCreate')}
-              </Button>
-            </div>
-          </Modal>
-          {selectSource?.length > 0 && (
-            <div className="flex items-center">
-              <div className={styles.selectDataset}>
-                {
-                  <div className={styles.selectDatasetBox}>
-                    <div
-                      className={styles.selectDatasetBoxBtn}
-                      onClick={() => {
-                        setVisible(true);
-                      }}
-                    >
-                      <img src="https://openres.xfyun.cn/xfyundoc/2024-01-22/47883fae-7d3e-46e2-bde0-e46b4753351b/1705888336589/addDatasetIcon.svg" />
-                      {t('configBase.CapabilityDevelopment.addDataset')}
-                    </div>
-                    <div className={styles.datasetList}>
-                      {(selectSource || []).map((item: any) => {
-                        return (
-                          <div key={item.id} className={styles.dataset}>
-                            <div className={styles.datasetNameBox}>
-                              <span className={styles.datasetName}>
-                                <img src="https://openres.xfyun.cn/xfyundoc/2024-01-19/79de3a69-71e9-4e5a-b3cb-188df402f443/1705654589331/selectDatasetBtnIcon.svg" />
-                                {item.name}
-                              </span>
-                              <img
-                                onClick={() => {
-                                  const filterSource = (
-                                    selectSource || []
-                                  ).filter((fs: any) => item.id !== fs.id);
-                                  if (selectSource?.length == 1) {
-                                    setDisList([]);
-                                  }
-                                  // 去掉chekced
-                                  if (dataSource?.length > 0) {
-                                    (dataSource || []).forEach((da: any) => {
-                                      if (da.id === item.id) {
-                                        da.checked = false;
-                                      }
-                                    });
-                                    setSelectSource(filterSource);
-                                  }
-                                }}
-                                src="https://openres.xfyun.cn/xfyundoc/2024-01-22/83a641b6-1132-4105-88f9-1d11b5f2d376/1705889402708/deleteDatasetIcon.svg"
-                              />
-                            </div>
-                            <div className={styles.datasetInfo}>
-                              {t('configBase.CapabilityDevelopment.character')}{' '}
-                              {item.charCount ? item.charCount : 0}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                }
-              </div>
-            </div>
-          )}
-        </div>
-        {growOrShrinkConfig.knowledges && files.length > 0 && (
-          <div className="mt-1.5 w-full overflow-auto max-h-[300px]">
-            {files.map((item: any) => (
-              <div
-                key={item.id}
-                className="flex items-center px-6 py-3 border-b border-[#E2E8FF]"
-              >
-                <img src={typeList.get(item.type)} className="w-5 h-5" alt="" />
-                <span className="flex-1 text-overflow ml-2 text-sm">
-                  {item.fullName}
-                </span>
-                <img
-                  src={del}
-                  className="ml-6 w-4 h-4 cursor-pointer"
-                  onClick={() => deleteFile(item)}
-                  alt=""
-                />
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-      <div className="mt-[52px]">
-        <div className="flex items-center">
-          {multiModelDebugging && (
-            <img
-              src={growOrShrinkConfig?.chatStrong ? arrowDown : arrowUp}
-              className="w-[16px] h-[16px] mr-2 cursor-pointer"
-              alt=""
-              onClick={() =>
-                setGrowOrShrinkConfig({
-                  ...growOrShrinkConfig,
-                  chatStrong: !growOrShrinkConfig.chatStrong,
-                })
-              }
-            />
-          )}
-          <img src={settingKaichangbai} className="w-6 h-6" alt="" />
-          <span className="text-[#6407FD] font-medium ml-2">
-            {t('configBase.CapabilityDevelopment.conversationEnhancement')}
-          </span>
-        </div>
-        {growOrShrinkConfig.chatStrong && (
-          <div className="flex flex-col gap-4 mt-5">
-            <div
-              className="border-b border-[#E9EFF6]"
-              style={{
-                padding: '8px 20px 12px 20px',
-              }}
-            >
-              <div className="flex justify-between items-center">
-                <div className="flex flex-col gap-2">
-                  <span className="text-sm font-medium">
-                    {t('configBase.CapabilityDevelopment.openingStatement')}
-                  </span>
-                </div>
-                <Switch
-                  className="list-switch config-switch"
-                  checked={conversation}
-                  onChange={checked => setConversation(checked)}
-                />
-              </div>
-              {conversation && (
-                <>
-                  <div className="relative">
-                    <div
-                      className="absolute bottom-2 right-2.5 inline-flex items-center rounded-lg gap-1 cursor-pointer border border-[#6356EA] py-1 px-2.5 text-[#6356EA] text-sm bg-[#eff1f9] z-20"
-                      onClick={() => setOpeningRemarksModal(true)}
-                    >
-                      <img src={aiGenerate} className="w-4 h-4" alt="" />
-                      <span
-                        onClick={() => {
-                          if (!baseinfo.botName && !baseinfo.botDesc) {
-                            return message.warning(
-                              t(
-                                'configBase.CapabilityDevelopment.pleaseFillInIntroductionAndName'
-                              )
-                            );
-                          }
-                          setShiliLoading(true);
-                          generatePrologue({
-                            name: baseinfo.botName,
-                            botDesc: baseinfo.botDesc,
-                          }).then(res => {
-                            setPrologue(res);
-                            setShiliLoading(false);
-                          });
-                          return;
-                        }}
-                      >
-                        {t('configBase.CapabilityDevelopment.aiGenerated')}
-                      </span>
-                    </div>
-                    <Spin
-                      spinning={shiliLoading}
-                      tip={t('configBase.CapabilityDevelopment.generating')}
-                    >
-                      <TextArea
-                        className="mt-1.5 global-textarea pr-6"
-                        placeholder={t(
-                          'configBase.CapabilityDevelopment.pleaseEnterOpeningStatement'
-                        )}
-                        style={{ height: 96, resize: 'none' }}
-                        value={prologue}
-                        onChange={event => setPrologue(event.target.value)}
-                      />
-                    </Spin>
-                  </div>
-                </>
-              )}
-            </div>
-            <div
-              className="border-b border-[#E9EFF6]"
-              style={{
-                padding: '8px 20px 12px 20px',
-              }}
-            >
-              <div className="flex justify-between items-center">
-                <div className="flex  gap-2">
-                  <div className="flex text-sm font-medium">
-                    {t('configBase.CapabilityDevelopment.inputExample')}
-                  </div>
-                  {inputExampFlag && (
-                    <div
-                      onClick={
-                        inputExampleLoading ? () => null : getInputExamples
-                      }
-                      className={cls(
-                        styles.autoInputExampleBtn,
-                        inputExampleLoading && styles.inputExampleLoading
-                      )}
-                      style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
-                    >
-                      <img
-                        src="https://aixfyun-cn-bj.xfyun.cn/bbs/28921.014458559814/%E7%A7%91%E6%8A%80.svg"
-                        alt=""
-                      />
-                      <span>
-                        {t('configBase.CapabilityDevelopment.aiGenerated')}
-                      </span>
-                    </div>
-                  )}
-                  <p className={styles.threeLabelBox}>
-                    <>
-                      {inputExampleLoading && (
-                        <img
-                          className={styles.autoInputExamplesLoadingIcon}
-                          src={autoInputExamplesLoadingIcon}
-                        />
-                      )}
-                    </>
-                  </p>
-                </div>
-
-                <Switch
-                  className="list-switch config-switch"
-                  checked={inputExampFlag}
-                  onChange={checked => setInputExampFlag(checked)}
-                />
-              </div>
-              {inputExampFlag && (
-                <>
-                  <div className={styles.inputExamples}>
-                    <Input
-                      className={styles.inputField}
-                      maxLength={50}
-                      placeholder={
-                        placeholderText[botTypeValue]?.example1 ||
-                        t(
-                          'configBase.CapabilityDevelopment.femaleBabyWithSurnameZhang'
-                        )
-                      }
-                      value={inputExample[0]}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>
-                      ) => {
-                        inputExample[0] = event.target.value;
-                        setInputExample([...inputExample]);
-                      }}
-                    />
-                    <Input
-                      className={styles.inputField}
-                      maxLength={50}
-                      placeholder={
-                        placeholderText[botTypeValue]?.example2 ||
-                        t(
-                          'configBase.CapabilityDevelopment.nameWithSurnameSong'
-                        )
-                      }
-                      value={inputExample[1]}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>
-                      ) => {
-                        inputExample[1] = event.target.value;
-                        setInputExample([...inputExample]);
-                      }}
-                    />
-                    <Input
-                      className={styles.inputField}
-                      maxLength={50}
-                      placeholder={
-                        placeholderText[botTypeValue]?.example3 ||
-                        t('configBase.CapabilityDevelopment.liNameWithSurname')
-                      }
-                      value={inputExample[2]}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>
-                      ) => {
-                        inputExample[2] = event.target.value;
-                        setInputExample([...inputExample]);
-                      }}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
-
-            <Personality
-              enablePersonality={personalityData.enablePersonality}
-              personalityConfig={personalityData.personalityConfig}
-              onPersonalityChange={setPersonalityData}
-              botName={baseinfo.botName}
-              botType={baseinfo.botType}
-              botDesc={baseinfo.botDesc}
-              prompt={prompt}
-            />
-
-            <div
-              className="flex justify-between items-center border-b border-[#E9EFF6]"
-              style={{
-                padding: '8px 20px 12px 20px',
-              }}
-            >
-              <div className="flex flex-col gap-2">
-                <span className="text-sm font-medium">
-                  {t('configBase.CapabilityDevelopment.roleSound')}
+                <img src={plugin} className="w-6 h-6" alt="" />
+                <span className="ml-2 text-[#D84516] font-medium">
+                  {t('configBase.CapabilityDevelopment.capability')}
                 </span>
               </div>
               <div
-                style={{
-                  display: 'flex',
-                  borderRadius: '22px',
-                  background: '#F2F5FE',
-                  height: '44px',
-                  justifyContent: 'center',
-                  padding: '10px 16px',
-                  cursor: 'pointer',
-                }}
-                className={`${styles.vcn_choose} ${styles.vcn_choose_banned}`}
-                onClick={() => {
-                  setShowSpeakerModal(true);
-                }}
-              >
-                {renderBotVcn()}
-              </div>
-            </div>
-            <div
-              className="flex justify-between items-center border-b border-[#E9EFF6]"
-              style={{
-                padding: '8px 20px 12px 20px',
-              }}
-            >
-              <div className="flex flex-col gap-2">
-                <span className="text-sm font-medium">
-                  {t(
-                    'configBase.CapabilityDevelopment.supportMultiRoundConversation'
-                  )}
-                </span>
-              </div>
-              <Switch
-                className="list-switch config-switch"
-                checked={supportContextFlag}
-                onChange={checked => setSupportContextFlag(checked)}
-              />
-            </div>
-
-            <div className="border-b border-[#E9EFF6]">
-              <div
-                className="flex justify-between items-center"
+                className="flex justify-between items-center border-b border-[#E9EFF6]"
                 style={{
                   padding: '8px 20px 12px 20px',
                 }}
               >
-                <div className="flex">
+                <div className="flex gap-2 items-center">
+                  <img src={netIcon} alt="" className="w-[16px] h-[16px]" />
                   <span className="text-sm font-medium">
-                    {t('configBase.CapabilityDevelopment.backgroundImage')}
+                    {t('configBase.CapabilityDevelopment.internetSearch')}
                   </span>
-                  <Tooltip
-                    title={t(
-                      'configBase.CapabilityDevelopment.viewActualVerticalScreenEffect'
-                    )}
-                    overlayClassName="black-tooltip config-secret"
-                  >
-                    <QuestionCircleOutlined
-                      style={{ marginLeft: '5px', cursor: 'pointer' }}
-                    />
-                  </Tooltip>
                 </div>
-                <Button
-                  className={styles.uploadButton}
-                  type="primary"
-                  onClick={() => setUploadBackgroundModalVisible(true)}
-                >
-                  {backgroundImg
-                    ? t('configBase.CapabilityDevelopment.modify')
-                    : t('configBase.CapabilityDevelopment.upload')}
-                </Button>
+                <Switch
+                  className="list-switch config-switch"
+                  defaultChecked={
+                    detailInfo.openedTool?.indexOf('ifly_search') !== -1
+                  }
+                  onChange={checked => {
+                    choosedAlltool.ifly_search = checked;
+                    setChoosedAlltool(choosedAlltool);
+                  }}
+                />
               </div>
-              {backgroundImg && (
-                <div className={styles.backgroundImgBox}>
-                  <div className={styles.backgroundPc}>
+              <div
+                className="flex justify-between items-center border-b border-[#E9EFF6]"
+                style={{
+                  padding: '8px 20px 12px 20px',
+                }}
+              >
+                <div className="flex gap-2 items-center">
+                  <img src={genPicIcon} alt="" className="w-[16px] h-[16px]" />
+                  <span className="text-sm font-medium">
+                    {t('configBase.CapabilityDevelopment.AIDraw')}
+                  </span>
+                </div>
+                <Switch
+                  className="list-switch config-switch"
+                  defaultChecked={
+                    detailInfo.openedTool?.indexOf('text_to_image') !== -1
+                  }
+                  onChange={checked => {
+                    choosedAlltool.text_to_image = checked;
+                    setChoosedAlltool(choosedAlltool);
+                  }}
+                />
+              </div>
+              <div
+                className="flex justify-between items-center border-b border-[#E9EFF6]"
+                style={{
+                  padding: '8px 20px 12px 20px',
+                }}
+              >
+                <div className="flex gap-2 items-center">
+                  <img src={codeIcon} alt="" className="w-[16px] h-[16px]" />
+                  <span className="text-sm font-medium">
+                    {t('configBase.CapabilityDevelopment.codeGeneration')}
+                  </span>
+                </div>
+                <Switch
+                  className="list-switch config-switch"
+                  defaultChecked={
+                    detailInfo.openedTool?.indexOf('codeinterpreter') !== -1
+                  }
+                  onChange={checked => {
+                    choosedAlltool.codeinterpreter = checked;
+                    setChoosedAlltool(choosedAlltool);
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+          {growOrShrinkConfig.tools && tools.length > 0 && (
+            <div className="mt-1.5 w-full overflow-auto max-h-[300px]">
+              {tools.map((item: any, index: number) => (
+                <div
+                  key={index}
+                  className="flex items-center px-5 py-3 border-b border-[#E2E8FF]"
+                >
+                  <Tooltip
+                    title={
+                      item.isPublic
+                        ? t('configBase.CapabilityDevelopment.officialPlugin')
+                        : t('configBase.CapabilityDevelopment.personalPlugin')
+                    }
+                    overlayClassName="black-tooltip config-secret"
+                  ></Tooltip>
+                  <span
+                    className="w-[200px] text-overflow ml-2 text-sm"
+                    title={item.name}
+                  >
+                    {item.name}
+                  </span>
+                  <span
+                    className="ml-5 flex-1 text-overflow text-[#757575] text-xs font-medium"
+                    title={item.description}
+                  >
+                    {item.description}
+                  </span>
+                  <img
+                    src={del}
+                    className="ml-6 w-4 h-4 cursor-pointer"
+                    onClick={() => deleteTool(item.toolId)}
+                    alt=""
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+      {showKnowledgeSection && (
+        <div className={showCapabilitySection ? 'mt-[52px]' : ''}>
+          <div className="w-full font-medium text-second">
+            <div
+              className="flex items-center"
+              style={{ marginBottom: '20px', justifyContent: 'space-between' }}
+            >
+              {multiModelDebugging && (
+                <img
+                  src={growOrShrinkConfig?.knowledges ? arrowDown : arrowUp}
+                  className="w-[16px] h-[16px] mr-2 cursor-pointer"
+                  alt=""
+                  onClick={() =>
+                    setGrowOrShrinkConfig({
+                      ...growOrShrinkConfig,
+                      knowledges: !growOrShrinkConfig.knowledges,
+                    })
+                  }
+                />
+              )}
+              <div style={{ display: 'flex' }}>
+                <img src={settingFile} className="w-6 h-6" alt="" />
+                <span className="text-[#13A10E] font-medium ml-2">
+                  {t('configBase.CapabilityDevelopment.knowledgeBase')}
+                </span>
+              </div>
+              <div
+                onClick={() => {
+                  setVisible(true);
+                }}
+                style={{ color: '#6356EA', cursor: 'pointer' }}
+              >
+                + {t('configBase.CapabilityDevelopment.addKnowledgeBase')}
+              </div>
+            </div>
+            <Modal
+              wrapClassName={styles.datasetModalWrap}
+              open={visible}
+              centered
+              footer={null}
+              closable={false}
+              // width={461}
+              forceRender
+              maskClosable={false}
+            >
+              <div
+                style={{ display: 'flex', justifyContent: ' space-between' }}
+                className={styles.title}
+              >
+                <div>
+                  {t(
+                    'configBase.CapabilityDevelopment.selectToAssociateTheDataset'
+                  )}
+                  <span
+                    style={{ display: 'inline-block' }}
+                    className={styles.refresh}
+                    onClick={() => {
+                      setIsFresh(true);
+                      setTimeout(() => {
+                        setIsFresh(false);
+                      }, 500);
+                      listRepos().then((res: any) => {
+                        setDataSource(res?.pageData);
+                      });
+                    }}
+                  >
                     <img
-                      className={styles.backgroundImg}
-                      src={backgroundImg}
+                      src={
+                        'https://aixfyun-cn-bj.xfyun.cn/bbs/88573.51517541305/%E5%88%B7%E6%96%B0.svg'
+                      }
+                      style={
+                        isFresh
+                          ? {
+                              display: 'inline-block',
+                              transform: 'rotate(360deg)',
+                              transformOrigin: 'center',
+                              transition: 'all 0.5s linear',
+                            }
+                          : {
+                              display: 'inline-block',
+                            }
+                      }
                       alt=""
                     />
-                    <div className={styles.hengping}>
-                      <div className={styles.hengpingText}>
-                        {t(
-                          'configBase.CapabilityDevelopment.horizontalScreenDisplay'
-                        )}
+                    {t('configBase.CapabilityDevelopment.refresh')}
+                  </span>
+                </div>
+                <img
+                  alt=""
+                  className={styles.close}
+                  src={closeImg}
+                  onClick={() => setVisible(false)}
+                />
+              </div>
+              <div
+                style={{ position: 'relative' }}
+                className={styles.data_content}
+              >
+                {dataSource?.length > 0 ? (
+                  (dataSource || []).map((item: any, index: number) => {
+                    return (
+                      <div
+                        style={{
+                          cursor:
+                            disList.length == 0 || disList[0]?.tag == item.tag
+                              ? 'pointer'
+                              : 'not-allowed',
+                        }}
+                        key={item.id}
+                        className={`${item.checked ? styles.checked : ''} ${
+                          styles.cardlist
+                        }`}
+                        onClick={() => {
+                          if (
+                            disList.length == 0 ||
+                            disList[0]?.tag == item.tag
+                          ) {
+                            item.checked = !item.checked;
+                            setDataSource([...dataSource]);
+                          }
+                        }}
+                      >
+                        <div
+                          style={{
+                            position: 'absolute',
+                            right: 0,
+                            top: 0,
+                            background:
+                              item.tag == 'SparkDesk-RAG'
+                                ? '#13A10e'
+                                : item.tag == 'AIUI-RAG2'
+                                  ? 'linear-gradient(215deg, #6F8AF5 18%, #0458FF 82%)'
+                                  : 'linear-gradient(34deg, #6B23FF 19%, rgba(153, 98, 255, 0.9281) 83%)',
+                            width: '58px',
+                            height: '28px',
+                            fontFamily: '苹方',
+                            fontSize: '14px',
+                            fontWeight: 500,
+                            lineHeight: '28px',
+                            letterSpacing: 'normal',
+                            color: '#FFFFFF',
+                            textAlign: 'center',
+                            borderRadius: '0px 17px 0px 8px',
+                          }}
+                        >
+                          {item.tag == 'SparkDesk-RAG'
+                            ? t(
+                                'configBase.CapabilityDevelopment.personalVersion'
+                              )
+                            : item.tag == 'AIUI-RAG2'
+                              ? t('configBase.CapabilityDevelopment.stardust')
+                              : t('configBase.CapabilityDevelopment.spark')}
+                        </div>
+                        <div className={styles.img}>
+                          <img src={fileImg} alt="" />
+                        </div>
+                        <div className={styles.info}>
+                          <div className={styles.name}>{item.name}</div>
+                          <div className={styles.detail}>
+                            <span title={item.charCount}>
+                              {t('configBase.CapabilityDevelopment.character')}{' '}
+                              {item.charCount ? item.charCount : 0}
+                            </span>
+                          </div>
+                        </div>
                       </div>
-                      <div className={styles.shang}>
-                        <div className={styles.left} />
-                        <div className={styles.right} />
-                      </div>
-                      <div className={styles.zhong}>
-                        <div className={styles.left} />
-                        <div className={styles.right} />
-                      </div>
-                      <div className={styles.xia}>
-                        <div className={styles.left} />
-                        <div className={styles.right} />
-                      </div>
+                    );
+                  })
+                ) : (
+                  <div className={styles.empty_card}>
+                    <img
+                      src="https://aixfyun-cn-bj.xfyun.cn/bbs/84929.66416893165/%E4%B8%8A%E4%BC%A0%E6%96%87%E4%BB%B6%E5%A4%87%E4%BB%BD%202.svg"
+                      alt=""
+                    />
+                    <div className={styles.tips}>
+                      {t(
+                        'configBase.CapabilityDevelopment.youHaveNotCreatedAnyDatasets'
+                      )}
                     </div>
                   </div>
-                  <div className={styles.backgroundApp}>
-                    <img
-                      className={styles.backgroundImgApp}
-                      src={backgroundImgApp}
-                      alt=""
-                    />
-                    <div className={styles.shuping}>
-                      <div className={styles.shupingText}>
-                        {t(
-                          'configBase.CapabilityDevelopment.verticalScreenDisplay'
-                        )}
-                      </div>
-                      <div className={styles.shang}>
-                        <div className={styles.left} />
-                      </div>
-                      <div className={styles.zhong}>
-                        <div className={styles.left} />
-                      </div>
-                      <div className={styles.xia}>
-                        <div className={styles.left} />
-                      </div>
-                    </div>
+                )}
+              </div>
+              {dataSource?.length > 0 && (
+                <div
+                  style={{ display: 'flex' }}
+                  className={styles.go_create}
+                  onClick={() => window.open('/resource/knowledge')}
+                >
+                  <img
+                    src="https://aixfyun-cn-bj.xfyun.cn/bbs/27965.529211835106/%E6%96%B0%E5%A2%9E.svg"
+                    style={{ height: 12, marginRight: 2, marginTop: '3px' }}
+                    alt=""
+                  />
+                  <div>
+                    {t('configBase.CapabilityDevelopment.createNewDataset')}
                   </div>
                 </div>
               )}
-            </div>
-            <UploadBackgroundModal
-              visible={uploadBackgroundModalVisible}
-              onCancel={async () =>
-                await setUploadBackgroundModalVisible(false)
-              }
-            />
-          </div>
-        )}
-        <Checkbox
-          style={{ marginTop: '20px' }}
-          onChange={onChecked}
-          checked={xieyi}
-          className={styles.customCheckbox}
-        >
-          {t('configBase.CapabilityDevelopment.iHaveAgreed')}
-          <a
-            href="https://www.xfyun.cn/doc/policy/agreement.html"
-            rel="noreferrer"
-            target="_blank"
-          >
-            {t(
-              'configBase.CapabilityDevelopment.xunfeiOpenPlatformServiceAgreement'
+              <div className={styles.button_list}>
+                <Button
+                  onClick={() => {
+                    setVisible(false);
+                    (dataSource || []).forEach((item: any) => {
+                      if (selectSource.includes(item)) {
+                        item.checked = true;
+                      } else {
+                        item.checked = false;
+                      }
+                    });
+                  }}
+                >
+                  {t('configBase.CapabilityDevelopment.cancel')}
+                </Button>
+                <Button
+                  type="primary"
+                  onClick={() => {
+                    if (dataSource?.length > 0) {
+                      setVisible(false);
+                      const filterSource = (dataSource || []).filter(
+                        (item: any) => item.checked
+                      );
+                      setSelectSource(filterSource);
+                    } else window.open('/resource/knowledge');
+                  }}
+                >
+                  {dataSource?.length > 0
+                    ? t('configBase.CapabilityDevelopment.confirm')
+                    : t('configBase.CapabilityDevelopment.goCreate')}
+                </Button>
+              </div>
+            </Modal>
+            {selectSource?.length > 0 && (
+              <div className="flex items-center">
+                <div className={styles.selectDataset}>
+                  {
+                    <div className={styles.selectDatasetBox}>
+                      <div
+                        className={styles.selectDatasetBoxBtn}
+                        onClick={() => {
+                          setVisible(true);
+                        }}
+                      >
+                        <img src="https://openres.xfyun.cn/xfyundoc/2024-01-22/47883fae-7d3e-46e2-bde0-e46b4753351b/1705888336589/addDatasetIcon.svg" />
+                        {t('configBase.CapabilityDevelopment.addDataset')}
+                      </div>
+                      <div className={styles.datasetList}>
+                        {(selectSource || []).map((item: any) => {
+                          return (
+                            <div key={item.id} className={styles.dataset}>
+                              <div className={styles.datasetNameBox}>
+                                <span className={styles.datasetName}>
+                                  <img src="https://openres.xfyun.cn/xfyundoc/2024-01-19/79de3a69-71e9-4e5a-b3cb-188df402f443/1705654589331/selectDatasetBtnIcon.svg" />
+                                  {item.name}
+                                </span>
+                                <img
+                                  onClick={() => {
+                                    const filterSource = (
+                                      selectSource || []
+                                    ).filter((fs: any) => item.id !== fs.id);
+                                    if (selectSource?.length == 1) {
+                                      setDisList([]);
+                                    }
+                                    // 去掉chekced
+                                    if (dataSource?.length > 0) {
+                                      (dataSource || []).forEach((da: any) => {
+                                        if (da.id === item.id) {
+                                          da.checked = false;
+                                        }
+                                      });
+                                      setSelectSource(filterSource);
+                                    }
+                                  }}
+                                  src="https://openres.xfyun.cn/xfyundoc/2024-01-22/83a641b6-1132-4105-88f9-1d11b5f2d376/1705889402708/deleteDatasetIcon.svg"
+                                />
+                              </div>
+                              <div className={styles.datasetInfo}>
+                                {t(
+                                  'configBase.CapabilityDevelopment.character'
+                                )}{' '}
+                                {item.charCount ? item.charCount : 0}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
             )}
-          </a>
-          与
-          <a
-            href="https://www.xfyun.cn/doc/policy/privacy.html"
-            rel="noreferrer"
-            target="_blank"
+          </div>
+          {growOrShrinkConfig.knowledges && files.length > 0 && (
+            <div className="mt-1.5 w-full overflow-auto max-h-[300px]">
+              {files.map((item: any) => (
+                <div
+                  key={item.id}
+                  className="flex items-center px-6 py-3 border-b border-[#E2E8FF]"
+                >
+                  <img
+                    src={typeList.get(item.type)}
+                    className="w-5 h-5"
+                    alt=""
+                  />
+                  <span className="flex-1 text-overflow ml-2 text-sm">
+                    {item.fullName}
+                  </span>
+                  <img
+                    src={del}
+                    className="ml-6 w-4 h-4 cursor-pointer"
+                    onClick={() => deleteFile(item)}
+                    alt=""
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      {showPersonalizationSection && (
+        <div className={showKnowledgeSection ? 'mt-[52px]' : ''}>
+          <div className="flex items-center">
+            {multiModelDebugging && (
+              <img
+                src={growOrShrinkConfig?.chatStrong ? arrowDown : arrowUp}
+                className="w-[16px] h-[16px] mr-2 cursor-pointer"
+                alt=""
+                onClick={() =>
+                  setGrowOrShrinkConfig({
+                    ...growOrShrinkConfig,
+                    chatStrong: !growOrShrinkConfig.chatStrong,
+                  })
+                }
+              />
+            )}
+            <img src={settingKaichangbai} className="w-6 h-6" alt="" />
+            <span className="text-[#6407FD] font-medium ml-2">
+              {t('configBase.CapabilityDevelopment.conversationEnhancement')}
+            </span>
+          </div>
+          {growOrShrinkConfig.chatStrong && (
+            <div className="flex flex-col gap-4 mt-5">
+              <div
+                className="border-b border-[#E9EFF6]"
+                style={{
+                  padding: '8px 20px 12px 20px',
+                }}
+              >
+                <div className="flex justify-between items-center">
+                  <div className="flex flex-col gap-2">
+                    <span className="text-sm font-medium">
+                      {t('configBase.CapabilityDevelopment.openingStatement')}
+                    </span>
+                  </div>
+                  <Switch
+                    className="list-switch config-switch"
+                    checked={conversation}
+                    onChange={checked => setConversation(checked)}
+                  />
+                </div>
+                {conversation && (
+                  <>
+                    <div className="relative">
+                      <div
+                        className="absolute bottom-2 right-2.5 inline-flex items-center rounded-lg gap-1 cursor-pointer border border-[#6356EA] py-1 px-2.5 text-[#6356EA] text-sm bg-[#eff1f9] z-20"
+                        onClick={() => setOpeningRemarksModal(true)}
+                      >
+                        <img src={aiGenerate} className="w-4 h-4" alt="" />
+                        <span
+                          onClick={() => {
+                            if (!baseinfo.botName && !baseinfo.botDesc) {
+                              return message.warning(
+                                t(
+                                  'configBase.CapabilityDevelopment.pleaseFillInIntroductionAndName'
+                                )
+                              );
+                            }
+                            setShiliLoading(true);
+                            generatePrologue({
+                              name: baseinfo.botName,
+                              botDesc: baseinfo.botDesc,
+                            }).then(res => {
+                              setPrologue(res);
+                              setShiliLoading(false);
+                            });
+                            return;
+                          }}
+                        >
+                          {t('configBase.CapabilityDevelopment.aiGenerated')}
+                        </span>
+                      </div>
+                      <Spin
+                        spinning={shiliLoading}
+                        tip={t('configBase.CapabilityDevelopment.generating')}
+                      >
+                        <TextArea
+                          className="mt-1.5 global-textarea pr-6"
+                          placeholder={t(
+                            'configBase.CapabilityDevelopment.pleaseEnterOpeningStatement'
+                          )}
+                          style={{ height: 96, resize: 'none' }}
+                          value={prologue}
+                          onChange={event => setPrologue(event.target.value)}
+                        />
+                      </Spin>
+                    </div>
+                  </>
+                )}
+              </div>
+              <div
+                className="border-b border-[#E9EFF6]"
+                style={{
+                  padding: '8px 20px 12px 20px',
+                }}
+              >
+                <div className="flex justify-between items-center">
+                  <div className="flex  gap-2">
+                    <div className="flex text-sm font-medium">
+                      {t('configBase.CapabilityDevelopment.inputExample')}
+                    </div>
+                    {inputExampFlag && (
+                      <div
+                        onClick={
+                          inputExampleLoading ? () => null : getInputExamples
+                        }
+                        className={cls(
+                          styles.autoInputExampleBtn,
+                          inputExampleLoading && styles.inputExampleLoading
+                        )}
+                        style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
+                      >
+                        <img
+                          src="https://aixfyun-cn-bj.xfyun.cn/bbs/28921.014458559814/%E7%A7%91%E6%8A%80.svg"
+                          alt=""
+                        />
+                        <span>
+                          {t('configBase.CapabilityDevelopment.aiGenerated')}
+                        </span>
+                      </div>
+                    )}
+                    <p className={styles.threeLabelBox}>
+                      <>
+                        {inputExampleLoading && (
+                          <img
+                            className={styles.autoInputExamplesLoadingIcon}
+                            src={autoInputExamplesLoadingIcon}
+                          />
+                        )}
+                      </>
+                    </p>
+                  </div>
+
+                  <Switch
+                    className="list-switch config-switch"
+                    checked={inputExampFlag}
+                    onChange={checked => setInputExampFlag(checked)}
+                  />
+                </div>
+                {inputExampFlag && (
+                  <>
+                    <div className={styles.inputExamples}>
+                      <Input
+                        className={styles.inputField}
+                        maxLength={50}
+                        placeholder={
+                          placeholderText[botTypeValue]?.example1 ||
+                          t(
+                            'configBase.CapabilityDevelopment.femaleBabyWithSurnameZhang'
+                          )
+                        }
+                        value={inputExample[0]}
+                        onChange={(
+                          event: React.ChangeEvent<HTMLInputElement>
+                        ) => {
+                          inputExample[0] = event.target.value;
+                          setInputExample([...inputExample]);
+                        }}
+                      />
+                      <Input
+                        className={styles.inputField}
+                        maxLength={50}
+                        placeholder={
+                          placeholderText[botTypeValue]?.example2 ||
+                          t(
+                            'configBase.CapabilityDevelopment.nameWithSurnameSong'
+                          )
+                        }
+                        value={inputExample[1]}
+                        onChange={(
+                          event: React.ChangeEvent<HTMLInputElement>
+                        ) => {
+                          inputExample[1] = event.target.value;
+                          setInputExample([...inputExample]);
+                        }}
+                      />
+                      <Input
+                        className={styles.inputField}
+                        maxLength={50}
+                        placeholder={
+                          placeholderText[botTypeValue]?.example3 ||
+                          t(
+                            'configBase.CapabilityDevelopment.liNameWithSurname'
+                          )
+                        }
+                        value={inputExample[2]}
+                        onChange={(
+                          event: React.ChangeEvent<HTMLInputElement>
+                        ) => {
+                          inputExample[2] = event.target.value;
+                          setInputExample([...inputExample]);
+                        }}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+
+              <Personality
+                enablePersonality={personalityData.enablePersonality}
+                personalityConfig={personalityData.personalityConfig}
+                onPersonalityChange={setPersonalityData}
+                botName={baseinfo.botName}
+                botType={baseinfo.botType}
+                botDesc={baseinfo.botDesc}
+                prompt={prompt}
+              />
+
+              <div
+                className="flex justify-between items-center border-b border-[#E9EFF6]"
+                style={{
+                  padding: '8px 20px 12px 20px',
+                }}
+              >
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm font-medium">
+                    {t('configBase.CapabilityDevelopment.roleSound')}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    borderRadius: '22px',
+                    background: '#F2F5FE',
+                    height: '44px',
+                    justifyContent: 'center',
+                    padding: '10px 16px',
+                    cursor: 'pointer',
+                  }}
+                  className={`${styles.vcn_choose} ${styles.vcn_choose_banned}`}
+                  onClick={() => {
+                    setShowSpeakerModal(true);
+                  }}
+                >
+                  {renderBotVcn()}
+                </div>
+              </div>
+              {showSupportContextSwitch && (
+                <div
+                  className="flex justify-between items-center border-b border-[#E9EFF6]"
+                  style={{
+                    padding: '8px 20px 12px 20px',
+                  }}
+                >
+                  <div className="flex flex-col gap-2">
+                    <span className="text-sm font-medium">
+                      {t(
+                        'configBase.CapabilityDevelopment.supportMultiRoundConversation'
+                      )}
+                    </span>
+                  </div>
+                  <Switch
+                    className="list-switch config-switch"
+                    checked={supportContextFlag}
+                    onChange={checked => setSupportContextFlag(checked)}
+                  />
+                </div>
+              )}
+
+              <div className="border-b border-[#E9EFF6]">
+                <div
+                  className="flex justify-between items-center"
+                  style={{
+                    padding: '8px 20px 12px 20px',
+                  }}
+                >
+                  <div className="flex">
+                    <span className="text-sm font-medium">
+                      {t('configBase.CapabilityDevelopment.backgroundImage')}
+                    </span>
+                    <Tooltip
+                      title={t(
+                        'configBase.CapabilityDevelopment.viewActualVerticalScreenEffect'
+                      )}
+                      overlayClassName="black-tooltip config-secret"
+                    >
+                      <QuestionCircleOutlined
+                        style={{ marginLeft: '5px', cursor: 'pointer' }}
+                      />
+                    </Tooltip>
+                  </div>
+                  <Button
+                    className={styles.uploadButton}
+                    type="primary"
+                    onClick={() => setUploadBackgroundModalVisible(true)}
+                  >
+                    {backgroundImg
+                      ? t('configBase.CapabilityDevelopment.modify')
+                      : t('configBase.CapabilityDevelopment.upload')}
+                  </Button>
+                </div>
+                {backgroundImg && (
+                  <div className={styles.backgroundImgBox}>
+                    <div className={styles.backgroundPc}>
+                      <img
+                        className={styles.backgroundImg}
+                        src={backgroundImg}
+                        alt=""
+                      />
+                      <div className={styles.hengping}>
+                        <div className={styles.hengpingText}>
+                          {t(
+                            'configBase.CapabilityDevelopment.horizontalScreenDisplay'
+                          )}
+                        </div>
+                        <div className={styles.shang}>
+                          <div className={styles.left} />
+                          <div className={styles.right} />
+                        </div>
+                        <div className={styles.zhong}>
+                          <div className={styles.left} />
+                          <div className={styles.right} />
+                        </div>
+                        <div className={styles.xia}>
+                          <div className={styles.left} />
+                          <div className={styles.right} />
+                        </div>
+                      </div>
+                    </div>
+                    <div className={styles.backgroundApp}>
+                      <img
+                        className={styles.backgroundImgApp}
+                        src={backgroundImgApp}
+                        alt=""
+                      />
+                      <div className={styles.shuping}>
+                        <div className={styles.shupingText}>
+                          {t(
+                            'configBase.CapabilityDevelopment.verticalScreenDisplay'
+                          )}
+                        </div>
+                        <div className={styles.shang}>
+                          <div className={styles.left} />
+                        </div>
+                        <div className={styles.zhong}>
+                          <div className={styles.left} />
+                        </div>
+                        <div className={styles.xia}>
+                          <div className={styles.left} />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+              <UploadBackgroundModal
+                visible={uploadBackgroundModalVisible}
+                onCancel={async () =>
+                  await setUploadBackgroundModalVisible(false)
+                }
+              />
+            </div>
+          )}
+          <Checkbox
+            style={{ marginTop: '20px' }}
+            onChange={onChecked}
+            checked={xieyi}
+            className={styles.customCheckbox}
           >
-            {t('configBase.CapabilityDevelopment.privacyAgreement')}
-          </a>
-        </Checkbox>
-      </div>
-      <SpeakerModal
-        vcnList={vcnList}
-        changeSpeakerModal={setShowSpeakerModal}
-        botCreateCallback={setBotCreateVcn}
-        setBotCreateActiveV={setBotCreateActiveV}
-        botCreateActiveV={botCreateActiveV}
-        showSpeakerModal={showSpeakerModal}
-        onMySpeakerChange={setMySpeaker}
-      />
+            {t('configBase.CapabilityDevelopment.iHaveAgreed')}
+            <a
+              href="https://www.xfyun.cn/doc/policy/agreement.html"
+              rel="noreferrer"
+              target="_blank"
+            >
+              {t(
+                'configBase.CapabilityDevelopment.xunfeiOpenPlatformServiceAgreement'
+              )}
+            </a>
+            与
+            <a
+              href="https://www.xfyun.cn/doc/policy/privacy.html"
+              rel="noreferrer"
+              target="_blank"
+            >
+              {t('configBase.CapabilityDevelopment.privacyAgreement')}
+            </a>
+          </Checkbox>
+        </div>
+      )}
+      {showPersonalizationSection && (
+        <SpeakerModal
+          vcnList={vcnList}
+          changeSpeakerModal={setShowSpeakerModal}
+          botCreateCallback={setBotCreateVcn}
+          setBotCreateActiveV={setBotCreateActiveV}
+          botCreateActiveV={botCreateActiveV}
+          showSpeakerModal={showSpeakerModal}
+          onMySpeakerChange={setMySpeaker}
+        />
+      )}
     </div>
   );
 };

--- a/console/frontend/src/components/config-page-component/config-base/index.module.scss
+++ b/console/frontend/src/components/config-page-component/config-base/index.module.scss
@@ -766,6 +766,13 @@
   width: 100%;
 }
 
+.workbenchBasicWorkspace {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 18px;
+}
+
 .workbenchFormSection,
 .workbenchCapabilityShell {
   padding: 18px;

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -52,14 +52,11 @@ import { debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { getLanguageCode } from '@/utils/http';
 import {
-  BookOutlined,
-  DatabaseOutlined,
   EditOutlined,
   LeftOutlined,
   MessageOutlined,
   PlusSquareOutlined,
   SearchOutlined,
-  SoundOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
 
@@ -94,16 +91,7 @@ import {
 
 const { Option } = Select;
 
-type WorkbenchView =
-  | 'chat'
-  | 'search'
-  | 'basic'
-  | 'prompt'
-  | 'model'
-  | 'capability'
-  | 'knowledge'
-  | 'opening'
-  | 'appearance';
+type WorkbenchView = 'chat' | 'search' | 'basic' | 'prompt' | 'capability';
 
 const baseModelConfig: BaseModelConfig = {
   visible: false,
@@ -214,6 +202,7 @@ const BaseConfig: React.FC<ChatProps> = ({
   const [inputExample, setInputExample] = useState<string[]>([]);
   const [bottypeList, setBottypeList] = useState<any>([]);
   const [searchParams] = useSearchParams();
+  const isNewWorkbench = searchParams.get('legacy') !== 'true';
   const [selectSource, setSelectSource] = useState<any>([]);
   const [prompt, setPrompt] = useState(t('configBase.prompt'));
   const [promptList, setPromptList]: any = useState([
@@ -222,11 +211,11 @@ const BaseConfig: React.FC<ChatProps> = ({
   ]);
   const [choosedAlltool, setChoosedAlltool] = useState<any>({
     ifly_search: true,
-    text_to_image: true,
-    codeinterpreter: true,
+    text_to_image: false,
+    codeinterpreter: false,
   });
   const [supportSystemFlag, setSupportSystemFlag] = useState(false);
-  const [supportContextFlag, setSupportContextFlag] = useState(false);
+  const [supportContextFlag, setSupportContextFlag] = useState(true);
   const [promptNow, setPromptNow] = useState();
   const [coverUrl, setCoverUrl] = useState<string>(''); // 助手封面图
   const isMounted = useRef(false);
@@ -466,6 +455,14 @@ const BaseConfig: React.FC<ChatProps> = ({
       : baseinfo.botTemplate ||
         detailInfo.botTemplate ||
         botTemplateInfoValue.botTemplate;
+    const normalizedToolConfig = isNewWorkbench
+      ? {
+          ...choosedAlltool,
+          ifly_search: true,
+          text_to_image: false,
+          codeinterpreter: false,
+        }
+      : choosedAlltool;
 
     return {
       ...(backgroundImgApp && {
@@ -485,7 +482,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       botType: botType,
       botDesc: botDesc,
       botTemplate,
-      supportContext: supportContextFlag ? 1 : 0,
+      supportContext: isNewWorkbench ? 1 : supportContextFlag ? 1 : 0,
       supportSystem: supportSystemFlag ? 1 : 0,
       promptType: 0,
       inputExample: inputExample,
@@ -493,8 +490,8 @@ const BaseConfig: React.FC<ChatProps> = ({
       avatar: coverUrl,
       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
       isSentence: 0,
-      openedTool: Object.keys(choosedAlltool)
-        .filter((key: any) => choosedAlltool[key])
+      openedTool: Object.keys(normalizedToolConfig)
+        .filter((key: any) => normalizedToolConfig[key])
         .join(','),
       prologue: prologue,
       ...getModelConfig(model),
@@ -657,6 +654,18 @@ const BaseConfig: React.FC<ChatProps> = ({
       setVcnList(res);
     });
   }, []);
+
+  useEffect(() => {
+    if (!isNewWorkbench) return;
+
+    setSupportContextFlag(true);
+    setChoosedAlltool((currentTools: any) => ({
+      ...currentTools,
+      ifly_search: true,
+      text_to_image: false,
+      codeinterpreter: false,
+    }));
+  }, [isNewWorkbench, detailInfo?.openedTool]);
 
   // 监听 modelOptions 加载完成，处理待回显的模型数据
   useEffect(() => {
@@ -1371,6 +1380,8 @@ const BaseConfig: React.FC<ChatProps> = ({
     setInputExampleModel('');
   };
 
+  const personalizationTitle = '个性化设置';
+
   const configNavItems: Array<{
     key: WorkbenchView;
     label: string;
@@ -1383,7 +1394,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     },
     {
       key: 'prompt',
-      label: t('configBase.promptEdit'),
+      label: personalizationTitle,
       icon: <MessageOutlined />,
     },
     {
@@ -1391,33 +1402,14 @@ const BaseConfig: React.FC<ChatProps> = ({
       label: t('configBase.CapabilityDevelopment.capability'),
       icon: <ThunderboltOutlined />,
     },
-    {
-      key: 'knowledge',
-      label: t('configBase.CapabilityDevelopment.knowledgeBase'),
-      icon: <DatabaseOutlined />,
-    },
-    {
-      key: 'opening',
-      label: t('configBase.CapabilityDevelopment.openingStatement'),
-      icon: <BookOutlined />,
-    },
-    {
-      key: 'appearance',
-      label: t('configBase.agentAppearanceVoice') || '外观声音',
-      icon: <SoundOutlined />,
-    },
   ];
 
   const workbenchTitleMap: Record<WorkbenchView, string> = {
     chat: t('chatPage.chatWindow.newChat'),
     search: t('configBase.search') || '搜索',
     basic: t('configBase.agentBaseInfo') || '基础信息',
-    prompt: t('configBase.promptEdit'),
-    model: t('configBase.modelSelection'),
+    prompt: personalizationTitle,
     capability: t('configBase.CapabilityDevelopment.capability'),
-    knowledge: t('configBase.CapabilityDevelopment.knowledgeBase'),
-    opening: t('configBase.CapabilityDevelopment.openingStatement'),
-    appearance: t('configBase.agentAppearanceVoice') || '外观声音',
   };
 
   const renderWorkbenchActions = () => (
@@ -1670,83 +1662,125 @@ const BaseConfig: React.FC<ChatProps> = ({
     </div>
   );
 
+  const renderCapabilityDevelopment = (
+    viewMode: 'full' | 'personalization' | 'knowledge' = 'full'
+  ) => (
+    <CapabilityDevelopment
+      viewMode={viewMode}
+      botCreateActiveV={botCreateActiveV}
+      setBotCreateActiveV={setBotCreateActiveV}
+      baseinfo={baseinfo}
+      detailInfo={detailInfo}
+      prompt={prompt}
+      prologue={prologue}
+      setPrologue={setPrologue}
+      inputExample={inputExample}
+      setInputExample={setInputExample}
+      choosedAlltool={choosedAlltool}
+      setChoosedAlltool={setChoosedAlltool}
+      supportContextFlag={supportContextFlag}
+      setSupportContextFlag={setSupportContextFlag}
+      selectSource={selectSource}
+      setSelectSource={setSelectSource}
+      files={files}
+      tree={tree}
+      setTree={setTree}
+      tools={tools}
+      setTools={setTools}
+      conversation={conversation}
+      setConversation={setConversation}
+      multiModelDebugging={multiModelDebugging}
+      growOrShrinkConfig={growOrShrinkConfig}
+      setGrowOrShrinkConfig={setGrowOrShrinkConfig}
+      personalityData={personalityData}
+      setPersonalityData={handlePersonalityChange}
+      model={model}
+      vcnList={vcnList}
+    />
+  );
+
   const renderBasicInfoWorkspace = () => (
-    <Form
-      form={form}
-      name="botEditWorkbench"
-      className={styles.workbenchForm}
-      onValuesChange={val => {
-        setBaseinfo({ ...baseinfo, ...val });
-      }}
-    >
-      <div className={styles.workbenchFormSection}>
-        <div className={styles.workbenchSectionTitle}>
-          <span>{t('configBase.agentBaseInfo') || '基础信息'}</span>
-        </div>
-        <div className={styles.workbenchBaseInfoGrid}>
-          <Form.Item label="" name="cover" required colon={false}>
-            <UploadCover
-              name={form.getFieldsValue().botName}
-              botDesc={form.getFieldsValue().botDesc}
-              setCoverUrl={setCoverUrl}
-              coverUrl={coverUrl}
-            />
-          </Form.Item>
-          <div className={styles.workbenchBaseInfoFields}>
-            <Form.Item
-              label={t('configBase.agentName')}
-              name="botName"
-              rules={[{ required: true, message: '' }]}
-              colon={false}
-            >
-              <Input
-                disabled={
-                  detailInfo.botStatus == 1 ||
-                  detailInfo.botStatus == 2 ||
-                  detailInfo.botStatus == 4
-                }
-                maxLength={20}
+    <div className={styles.workbenchBasicWorkspace}>
+      <Form
+        form={form}
+        name="botEditWorkbench"
+        className={styles.workbenchForm}
+        onValuesChange={val => {
+          setBaseinfo({ ...baseinfo, ...val });
+        }}
+      >
+        <div className={styles.workbenchFormSection}>
+          <div className={styles.workbenchSectionTitle}>
+            <span>{t('configBase.agentBaseInfo') || '基础信息'}</span>
+          </div>
+          <div className={styles.workbenchBaseInfoGrid}>
+            <Form.Item label="" name="cover" required colon={false}>
+              <UploadCover
+                name={form.getFieldsValue().botName}
+                botDesc={form.getFieldsValue().botDesc}
+                setCoverUrl={setCoverUrl}
+                coverUrl={coverUrl}
               />
             </Form.Item>
-            <Form.Item
-              name="botType"
-              rules={[{ required: true, message: '' }]}
-              colon={false}
-              label={t('configBase.agentCategory')}
-            >
-              <Select
-                disabled={
-                  detailInfo.botStatus == 1 ||
-                  detailInfo.botStatus == 2 ||
-                  detailInfo.botStatus == 4
-                }
-                options={bottypeList}
-              />
-            </Form.Item>
-            <Form.Item
-              label={t('configBase.agentIntroduction')}
-              name="botDesc"
-              rules={[{ required: true, message: '' }]}
-              colon={false}
-              className={styles.workbenchDescField}
-            >
-              <Input.TextArea
-                className="xingchen-textarea"
-                maxLength={100}
-                showCount
-                autoSize={{ minRows: 4, maxRows: 4 }}
-              />
-            </Form.Item>
+            <div className={styles.workbenchBaseInfoFields}>
+              <Form.Item
+                label={t('configBase.agentName')}
+                name="botName"
+                rules={[{ required: true, message: '' }]}
+                colon={false}
+              >
+                <Input
+                  disabled={
+                    detailInfo.botStatus == 1 ||
+                    detailInfo.botStatus == 2 ||
+                    detailInfo.botStatus == 4
+                  }
+                  maxLength={20}
+                />
+              </Form.Item>
+              <Form.Item
+                name="botType"
+                rules={[{ required: true, message: '' }]}
+                colon={false}
+                label={t('configBase.agentCategory')}
+              >
+                <Select
+                  disabled={
+                    detailInfo.botStatus == 1 ||
+                    detailInfo.botStatus == 2 ||
+                    detailInfo.botStatus == 4
+                  }
+                  options={bottypeList}
+                />
+              </Form.Item>
+              <Form.Item
+                label={t('configBase.agentIntroduction')}
+                name="botDesc"
+                rules={[{ required: true, message: '' }]}
+                colon={false}
+                className={styles.workbenchDescField}
+              >
+                <Input.TextArea
+                  className="xingchen-textarea"
+                  maxLength={100}
+                  showCount
+                  autoSize={{ minRows: 4, maxRows: 4 }}
+                />
+              </Form.Item>
+            </div>
           </div>
         </div>
+      </Form>
+      <div className={styles.workbenchFormSection}>
+        {renderCapabilityDevelopment('personalization')}
       </div>
-    </Form>
+    </div>
   );
 
   const renderPromptWorkspace = () => (
     <div className={styles.workbenchFormSection}>
       <div className={styles.workbenchSectionTitle}>
-        <span>{t('configBase.promptEdit')}</span>
+        <span>{personalizationTitle}</span>
         <div className={styles.workbenchInlineActions}>
           <Button onClick={() => handleShowTipPk('show')}>
             {t('configBase.promptComparison')}
@@ -1767,72 +1801,9 @@ const BaseConfig: React.FC<ChatProps> = ({
     </div>
   );
 
-  const renderModelWorkspace = () => (
-    <div className={styles.workbenchFormSection}>
-      <div className={styles.workbenchSectionTitle}>
-        <span>{t('configBase.modelSelection')}</span>
-        <Button onClick={() => setShowModelPk(2)}>
-          {t('configBase.modelComparison')}
-        </Button>
-      </div>
-      <Select
-        value={model}
-        onChange={handleModelChange}
-        className={styles.workbenchFullWidth}
-        placeholder={t('configBase.pleaseSelectModel')}
-      >
-        {modelOptions.map((option, index) => (
-          <Option
-            key={getModelUniqueKey(option, index)}
-            value={getModelUniqueKey(option, index)}
-          >
-            <div className="flex items-center">
-              <img
-                className="w-[20px] h-[20px]"
-                src={option.modelIcon}
-                alt={option.modelName}
-              />
-              <span>{option.modelName}</span>
-            </div>
-          </Option>
-        ))}
-      </Select>
-    </div>
-  );
-
   const renderCapabilityWorkspace = () => (
     <div className={styles.workbenchCapabilityShell}>
-      <CapabilityDevelopment
-        botCreateActiveV={botCreateActiveV}
-        setBotCreateActiveV={setBotCreateActiveV}
-        baseinfo={baseinfo}
-        detailInfo={detailInfo}
-        prompt={prompt}
-        prologue={prologue}
-        setPrologue={setPrologue}
-        inputExample={inputExample}
-        setInputExample={setInputExample}
-        choosedAlltool={choosedAlltool}
-        setChoosedAlltool={setChoosedAlltool}
-        supportContextFlag={supportContextFlag}
-        setSupportContextFlag={setSupportContextFlag}
-        selectSource={selectSource}
-        setSelectSource={setSelectSource}
-        files={files}
-        tree={tree}
-        setTree={setTree}
-        tools={tools}
-        setTools={setTools}
-        conversation={conversation}
-        setConversation={setConversation}
-        multiModelDebugging={multiModelDebugging}
-        growOrShrinkConfig={growOrShrinkConfig}
-        setGrowOrShrinkConfig={setGrowOrShrinkConfig}
-        personalityData={personalityData}
-        setPersonalityData={handlePersonalityChange}
-        model={model}
-        vcnList={vcnList}
-      />
+      {renderCapabilityDevelopment('knowledge')}
     </div>
   );
 
@@ -1853,7 +1824,6 @@ const BaseConfig: React.FC<ChatProps> = ({
     if (activeWorkbenchView === 'search') return renderSearchWorkspace();
     if (activeWorkbenchView === 'basic') return renderBasicInfoWorkspace();
     if (activeWorkbenchView === 'prompt') return renderPromptWorkspace();
-    if (activeWorkbenchView === 'model') return renderModelWorkspace();
     return renderCapabilityWorkspace();
   };
 


### PR DESCRIPTION
## Summary
- rename prompt editing entry to personalization settings
- keep ability navigation focused on knowledge base only
- move personalization controls into basic info while defaulting web search and multi-turn conversation on

## Verification
- npx prettier --write src\components\config-page-component\config-base\index.tsx src\components\config-page-component\config-base\index.module.scss src\components\config-page-component\config-base\components\CapabilityDevelopment.tsx
- git diff --check
- npx eslint src\components\config-page-component\config-base\index.tsx src\components\config-page-component\config-base\components\CapabilityDevelopment.tsx
- npm run build:test