### PR TITLE
fix(frontend): remove prompt comparison action

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -1782,9 +1782,6 @@ const BaseConfig: React.FC<ChatProps> = ({
       <div className={styles.workbenchSectionTitle}>
         <span>{personalizationTitle}</span>
         <div className={styles.workbenchInlineActions}>
-          <Button onClick={() => handleShowTipPk('show')}>
-            {t('configBase.promptComparison')}
-          </Button>
           <Button onClick={aiGen} loading={loadingPrompt}>
             {t('configBase.AIoptimization')}
           </Button>


### PR DESCRIPTION
## Summary
- remove the prompt comparison action from the personalization settings toolbar
- keep the AI optimization action available

## Verification
- npx prettier --write src\components\config-page-component\config-base\index.tsx
- git diff --check -- console/frontend/src/components/config-page-component/config-base/index.tsx
- npx eslint src\components\config-page-component\config-base\index.tsx
- npm run build:test