### PR TITLE
fix(frontend): improve skill resource file layout

### DIFF
--- a/console/frontend/_tests_/skill-page-layout.test.js
+++ b/console/frontend/_tests_/skill-page-layout.test.js
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const stylesheet = readFileSync(
+  resolve(
+    frontendRoot,
+    'src/pages/resource-management/skill-page/index.module.scss'
+  ),
+  'utf8'
+);
+const component = readFileSync(
+  resolve(frontendRoot, 'src/pages/resource-management/skill-page/index.tsx'),
+  'utf8'
+);
+
+function assertIncludes(source, expected, message) {
+  if (!source.includes(expected)) {
+    throw new Error(message);
+  }
+}
+
+function assertRuleContains(selector, expected, message) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rule = stylesheet.match(
+    new RegExp(`${escapedSelector}\\s*\\{[^}]*\\}`)
+  );
+  if (!rule?.[0].includes(expected)) {
+    throw new Error(message);
+  }
+}
+
+function assertRuleAfterContains(anchor, selector, expected, message) {
+  const anchorIndex = stylesheet.indexOf(anchor);
+  if (anchorIndex === -1) {
+    throw new Error(`missing stylesheet anchor: ${anchor}`);
+  }
+  const scopedStylesheet = stylesheet.slice(anchorIndex);
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rule = scopedStylesheet.match(
+    new RegExp(`${escapedSelector}\\s*\\{[^}]*\\}`)
+  );
+  if (!rule?.[0].includes(expected)) {
+    throw new Error(message);
+  }
+}
+
+assertIncludes(
+  component,
+  'styles.editorActions',
+  'file editor actions should use a dedicated non-shrinking action group'
+);
+
+assertIncludes(
+  component,
+  'styles.editorDescription',
+  'long skill descriptions should render in a bounded metadata row'
+);
+
+assertRuleContains(
+  '.editorHeader',
+  'align-items: flex-start',
+  'editor header should keep actions at the top instead of centered beside long text'
+);
+
+assertRuleContains(
+  '.editorActions',
+  'flex-shrink: 0',
+  'editor action group should not be squeezed by long descriptions'
+);
+
+assertRuleContains(
+  '.editorDescription',
+  'max-height:',
+  'skill descriptions should have a visible height boundary'
+);
+
+assertRuleContains(
+  '.editorCanvas',
+  'overflow: hidden',
+  'editor canvas should keep editor and preview scrolling inside the panel'
+);
+
+assertRuleContains(
+  '.preview',
+  'min-height: 100%',
+  'markdown preview should fill the available editor canvas height'
+);
+
+assertRuleAfterContains(
+  '@media (max-width: 1100px)',
+  '.editorActions',
+  'width: 100%',
+  'narrow editor actions should use full width so buttons can wrap cleanly'
+);

--- a/console/frontend/src/pages/resource-management/skill-page/index.module.scss
+++ b/console/frontend/src/pages/resource-management/skill-page/index.module.scss
@@ -1,6 +1,6 @@
 .page {
   --skill-surface: linear-gradient(180deg, #f6f8fb 0%, #eef3f7 100%);
-  --skill-panel: rgba(255, 255, 255, 0.86);
+  --skill-panel: rgba(255, 255, 255, 0.94);
   --skill-panel-border: rgba(15, 23, 42, 0.08);
   --skill-accent: #19a974;
   --skill-accent-soft: rgba(25, 169, 116, 0.12);
@@ -8,45 +8,36 @@
   --skill-subtle: #617080;
   position: relative;
   height: 100%;
-  padding: 20px 24px 24px;
-  background:
-    radial-gradient(
-      circle at top left,
-      rgba(25, 169, 116, 0.12),
-      transparent 28%
-    ),
-    radial-gradient(
-      circle at right 20%,
-      rgba(18, 92, 251, 0.08),
-      transparent 24%
-    ),
-    var(--skill-surface);
+  padding: 16px 18px 20px;
+  background: var(--skill-surface);
   color: var(--skill-ink);
 }
 
 .shell {
   display: grid;
-  grid-template-columns: 360px minmax(0, 1fr);
-  gap: 20px;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 16px;
   height: 100%;
+  min-height: 0;
 }
 
 .panel {
   border: 1px solid var(--skill-panel-border);
-  border-radius: 20px;
+  border-radius: 12px;
   background: var(--skill-panel);
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.06);
-  backdrop-filter: blur(16px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  backdrop-filter: blur(10px);
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   overflow: hidden;
 }
 
 .sidebarHeader {
-  padding: 20px 20px 14px;
+  padding: 16px 16px 12px;
   border-bottom: 1px solid rgba(15, 23, 42, 0.06);
 }
 
@@ -54,38 +45,39 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 10px;
-  border-radius: 999px;
+  padding: 4px 8px;
+  border-radius: 8px;
   background: rgba(15, 23, 42, 0.04);
   font-size: 12px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
 .title {
-  margin-top: 12px;
-  font-size: 24px;
+  margin-top: 10px;
+  font-size: 20px;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 
 .desc {
-  margin-top: 8px;
+  margin-top: 6px;
   color: var(--skill-subtle);
-  line-height: 1.6;
+  line-height: 1.55;
 }
 
 .toolbar {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
 }
 
 .treeWrap {
   flex: 1;
+  min-height: 0;
   overflow: auto;
-  padding: 12px 12px 20px;
+  padding: 10px 10px 14px;
 }
 
 .treeNode {
@@ -123,20 +115,22 @@
 .editorPanel {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   overflow: hidden;
 }
 
 .editorHeader {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  padding: 20px 22px 14px;
+  gap: 18px;
+  padding: 16px 18px 12px;
   border-bottom: 1px solid rgba(15, 23, 42, 0.06);
 }
 
 .editorMeta {
   min-width: 0;
+  flex: 1;
 }
 
 .editorTitleRow {
@@ -147,7 +141,7 @@
 }
 
 .editorTitle {
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 700;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -155,19 +149,40 @@
 }
 
 .editorSub {
-  margin-top: 8px;
+  margin-top: 6px;
   color: var(--skill-subtle);
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
+}
+
+.editorDescription {
+  max-height: 52px;
+  margin-top: 8px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  color: var(--skill-subtle);
+  font-size: 14px;
+  line-height: 1.55;
+  padding-right: 8px;
+}
+
+.editorActions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+  max-width: 46%;
 }
 
 .monoTag {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: 999px;
+  padding: 3px 8px;
+  border-radius: 8px;
   background: rgba(15, 23, 42, 0.06);
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
@@ -184,19 +199,22 @@
 .editorCanvas {
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 .preview {
   height: 100%;
+  min-height: 100%;
   overflow: auto;
-  padding: 24px 28px 36px;
+  padding: 20px 24px 32px;
 }
 
 .codePreview {
   height: 100%;
+  min-height: 100%;
   overflow: auto;
   margin: 0;
-  padding: 24px 28px 36px;
+  padding: 20px 24px 32px;
   background: #0f172a;
   color: #e2e8f0;
   font-family: 'JetBrains Mono', monospace;
@@ -207,21 +225,21 @@
 .empty {
   height: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 24px;
 }
 
 .emptyCard {
   max-width: 560px;
-  padding: 28px;
-  border-radius: 24px;
+  padding: 24px;
+  border-radius: 12px;
   border: 1px dashed rgba(15, 23, 42, 0.12);
   background: rgba(255, 255, 255, 0.72);
 }
 
 .emptyTitle {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 700;
 }
 
@@ -247,7 +265,31 @@
 }
 
 @media (max-width: 1100px) {
+  .page {
+    overflow: auto;
+  }
+
   .shell {
     grid-template-columns: 1fr;
+    height: auto;
+    min-height: 100%;
+  }
+
+  .sidebar {
+    min-height: 360px;
+  }
+
+  .editorPanel {
+    min-height: 560px;
+  }
+
+  .editorHeader {
+    flex-direction: column;
+  }
+
+  .editorActions {
+    max-width: none;
+    justify-content: flex-start;
+    width: 100%;
   }
 }

--- a/console/frontend/src/pages/resource-management/skill-page/index.tsx
+++ b/console/frontend/src/pages/resource-management/skill-page/index.tsx
@@ -744,15 +744,20 @@ function SkillPage(): React.ReactElement {
             {currentFile?.skillName ? (
               <span>技能名: {currentFile.skillName}</span>
             ) : null}
-            {currentFile?.skillDescription ? (
-              <span>{currentFile.skillDescription}</span>
-            ) : null}
             <span className={styles.monoTag}>
               .{currentFile?.fileExt || 'txt'}
             </span>
           </div>
+          {currentFile?.skillDescription ? (
+            <div
+              className={styles.editorDescription}
+              title={currentFile.skillDescription}
+            >
+              {currentFile.skillDescription}
+            </div>
+          ) : null}
         </div>
-        <div className="flex items-center gap-2">
+        <div className={styles.editorActions}>
           <Segmented
             value={mode}
             onChange={value => setMode(value as 'edit' | 'preview')}


### PR DESCRIPTION
## Summary
- Improve the skill resource file editor header and description layout.
- Tighten skill page panel spacing and responsive behavior.
- Add a layout guard test for the skill page.

## Files
- console/frontend/src/pages/resource-management/skill-page/index.tsx
- console/frontend/src/pages/resource-management/skill-page/index.module.scss
- console/frontend/_tests_/skill-page-layout.test.js