### PR TITLE
feat: add agent debug conversation history

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/agentdebug/AgentDebugMessage.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/agentdebug/AgentDebugMessage.java
@@ -1,0 +1,33 @@
+package com.iflytek.astron.console.commons.entity.agentdebug;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@TableName("agent_debug_message")
+@Schema(name = "AgentDebugMessage", description = "Agent debug message")
+public class AgentDebugMessage {
+
+    @TableId(type = IdType.AUTO)
+    @Schema(description = "Primary key")
+    private Long id;
+
+    @Schema(description = "Session ID")
+    private String sessionId;
+
+    @Schema(description = "Message order in session")
+    private Integer messageIndex;
+
+    @Schema(description = "Serialized message JSON")
+    private String messageJson;
+
+    @Schema(description = "Create time")
+    private LocalDateTime createTime;
+
+    @Schema(description = "Modify time")
+    private LocalDateTime updateTime;
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/agentdebug/AgentDebugSession.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/agentdebug/AgentDebugSession.java
@@ -1,0 +1,42 @@
+package com.iflytek.astron.console.commons.entity.agentdebug;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@TableName("agent_debug_session")
+@Schema(name = "AgentDebugSession", description = "Agent debug session")
+public class AgentDebugSession {
+
+    @TableId(type = IdType.INPUT)
+    @Schema(description = "Session ID")
+    private String id;
+
+    @Schema(description = "Bot ID")
+    private Integer botId;
+
+    @Schema(description = "User ID")
+    private String uid;
+
+    @Schema(description = "Space ID")
+    private Long spaceId;
+
+    @Schema(description = "Session title")
+    private String title;
+
+    @Schema(description = "Message count")
+    private Integer messageCount;
+
+    @Schema(description = "Deletion status: 0 Not delete, 1 Delete")
+    private Integer isDelete;
+
+    @Schema(description = "Create time")
+    private LocalDateTime createTime;
+
+    @Schema(description = "Modify time")
+    private LocalDateTime updateTime;
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/mapper/agentdebug/AgentDebugMessageMapper.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/mapper/agentdebug/AgentDebugMessageMapper.java
@@ -1,0 +1,9 @@
+package com.iflytek.astron.console.commons.mapper.agentdebug;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.iflytek.astron.console.commons.entity.agentdebug.AgentDebugMessage;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AgentDebugMessageMapper extends BaseMapper<AgentDebugMessage> {
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/mapper/agentdebug/AgentDebugSessionMapper.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/mapper/agentdebug/AgentDebugSessionMapper.java
@@ -1,0 +1,9 @@
+package com.iflytek.astron.console.commons.mapper.agentdebug;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.iflytek.astron.console.commons.entity.agentdebug.AgentDebugSession;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AgentDebugSessionMapper extends BaseMapper<AgentDebugSession> {
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/agentdebug/AgentDebugController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/agentdebug/AgentDebugController.java
@@ -1,0 +1,72 @@
+package com.iflytek.astron.console.hub.controller.agentdebug;
+
+import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.util.RequestContextUtil;
+import com.iflytek.astron.console.commons.util.space.SpaceInfoUtil;
+import com.iflytek.astron.console.hub.dto.agentdebug.AgentDebugSessionDto;
+import com.iflytek.astron.console.hub.dto.agentdebug.CreateAgentDebugSessionRequest;
+import com.iflytek.astron.console.hub.dto.agentdebug.SaveAgentDebugMessagesRequest;
+import com.iflytek.astron.console.hub.service.agentdebug.AgentDebugService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/agent-debug")
+@Tag(name = "Agent Debug History", description = "Agent debug session history")
+@RequiredArgsConstructor
+public class AgentDebugController {
+
+    private final AgentDebugService agentDebugService;
+
+    @GetMapping("/sessions")
+    @Operation(summary = "List agent debug sessions")
+    public ApiResult<List<AgentDebugSessionDto>> listSessions(@RequestParam Integer botId) {
+        return ApiResult.success(
+                agentDebugService.listSessions(RequestContextUtil.getUID(), SpaceInfoUtil.getSpaceId(), botId));
+    }
+
+    @PostMapping("/sessions")
+    @Operation(summary = "Create agent debug session")
+    public ApiResult<AgentDebugSessionDto> createSession(
+            @Valid @RequestBody CreateAgentDebugSessionRequest request) {
+        return ApiResult.success(
+                agentDebugService.createSession(RequestContextUtil.getUID(), SpaceInfoUtil.getSpaceId(), request));
+    }
+
+    @GetMapping("/sessions/{sessionId}/messages")
+    @Operation(summary = "Get agent debug session messages")
+    public ApiResult<List<Map<String, Object>>> getMessages(@PathVariable String sessionId) {
+        return ApiResult.success(
+                agentDebugService.getMessages(RequestContextUtil.getUID(), SpaceInfoUtil.getSpaceId(), sessionId));
+    }
+
+    @PutMapping("/sessions/{sessionId}/messages")
+    @Operation(summary = "Save agent debug session messages")
+    public ApiResult<Void> saveMessages(
+            @PathVariable String sessionId,
+            @Valid @RequestBody SaveAgentDebugMessagesRequest request) {
+        agentDebugService.saveMessages(
+                RequestContextUtil.getUID(), SpaceInfoUtil.getSpaceId(), sessionId, request.getMessages());
+        return ApiResult.success();
+    }
+
+    @DeleteMapping("/sessions/{sessionId}")
+    @Operation(summary = "Delete agent debug session")
+    public ApiResult<Void> deleteSession(@PathVariable String sessionId) {
+        agentDebugService.deleteSession(RequestContextUtil.getUID(), SpaceInfoUtil.getSpaceId(), sessionId);
+        return ApiResult.success();
+    }
+
+    @DeleteMapping("/sessions")
+    @Operation(summary = "Clear agent debug sessions")
+    public ApiResult<Void> clearSessions(@RequestParam Integer botId) {
+        agentDebugService.clearSessions(RequestContextUtil.getUID(), SpaceInfoUtil.getSpaceId(), botId);
+        return ApiResult.success();
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/agentdebug/AgentDebugSessionDto.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/agentdebug/AgentDebugSessionDto.java
@@ -1,0 +1,28 @@
+package com.iflytek.astron.console.hub.dto.agentdebug;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@Schema(name = "AgentDebugSessionDto", description = "Agent debug session response")
+public class AgentDebugSessionDto {
+
+    @Schema(description = "Session ID")
+    private String id;
+
+    @Schema(description = "Bot ID")
+    private Integer botId;
+
+    @Schema(description = "Session title")
+    private String title;
+
+    @Schema(description = "Create time")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "Modify time")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "Message count")
+    private Integer messageCount;
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/agentdebug/CreateAgentDebugSessionRequest.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/agentdebug/CreateAgentDebugSessionRequest.java
@@ -1,0 +1,17 @@
+package com.iflytek.astron.console.hub.dto.agentdebug;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@Schema(name = "CreateAgentDebugSessionRequest", description = "Create agent debug session request")
+public class CreateAgentDebugSessionRequest {
+
+    @NotNull
+    @Schema(description = "Bot ID", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer botId;
+
+    @Schema(description = "Session title")
+    private String title;
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/agentdebug/SaveAgentDebugMessagesRequest.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/agentdebug/SaveAgentDebugMessagesRequest.java
@@ -1,0 +1,16 @@
+package com.iflytek.astron.console.hub.dto.agentdebug;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+@Schema(name = "SaveAgentDebugMessagesRequest", description = "Save agent debug messages request")
+public class SaveAgentDebugMessagesRequest {
+
+    @NotNull
+    @Schema(description = "Messages", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<Map<String, Object>> messages;
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/agentdebug/AgentDebugService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/agentdebug/AgentDebugService.java
@@ -1,0 +1,45 @@
+package com.iflytek.astron.console.hub.service.agentdebug;
+
+import com.iflytek.astron.console.hub.dto.agentdebug.AgentDebugSessionDto;
+import com.iflytek.astron.console.hub.dto.agentdebug.CreateAgentDebugSessionRequest;
+import java.util.List;
+import java.util.Map;
+
+public interface AgentDebugService {
+
+    default List<AgentDebugSessionDto> listSessions(String uid, Integer botId) {
+        return listSessions(uid, null, botId);
+    }
+
+    List<AgentDebugSessionDto> listSessions(String uid, Long spaceId, Integer botId);
+
+    default AgentDebugSessionDto createSession(String uid, CreateAgentDebugSessionRequest request) {
+        return createSession(uid, null, request);
+    }
+
+    AgentDebugSessionDto createSession(String uid, Long spaceId, CreateAgentDebugSessionRequest request);
+
+    default List<Map<String, Object>> getMessages(String uid, String sessionId) {
+        return getMessages(uid, null, sessionId);
+    }
+
+    List<Map<String, Object>> getMessages(String uid, Long spaceId, String sessionId);
+
+    default void saveMessages(String uid, String sessionId, List<Map<String, Object>> messages) {
+        saveMessages(uid, null, sessionId, messages);
+    }
+
+    void saveMessages(String uid, Long spaceId, String sessionId, List<Map<String, Object>> messages);
+
+    default void deleteSession(String uid, String sessionId) {
+        deleteSession(uid, null, sessionId);
+    }
+
+    void deleteSession(String uid, Long spaceId, String sessionId);
+
+    default void clearSessions(String uid, Integer botId) {
+        clearSessions(uid, null, botId);
+    }
+
+    void clearSessions(String uid, Long spaceId, Integer botId);
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/agentdebug/impl/AgentDebugServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/agentdebug/impl/AgentDebugServiceImpl.java
@@ -1,0 +1,251 @@
+package com.iflytek.astron.console.hub.service.agentdebug.impl;
+
+import com.alibaba.fastjson2.JSON;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.entity.agentdebug.AgentDebugMessage;
+import com.iflytek.astron.console.commons.entity.agentdebug.AgentDebugSession;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.mapper.agentdebug.AgentDebugMessageMapper;
+import com.iflytek.astron.console.commons.mapper.agentdebug.AgentDebugSessionMapper;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
+import com.iflytek.astron.console.hub.dto.agentdebug.AgentDebugSessionDto;
+import com.iflytek.astron.console.hub.dto.agentdebug.CreateAgentDebugSessionRequest;
+import com.iflytek.astron.console.hub.service.agentdebug.AgentDebugService;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AgentDebugServiceImpl implements AgentDebugService {
+
+    private static final String DEFAULT_TITLE = "全新对话";
+    private static final int MAX_TITLE_LENGTH = 30;
+    private static final int MAX_SESSION_SIZE = 50;
+
+    private final AgentDebugSessionMapper sessionMapper;
+    private final AgentDebugMessageMapper messageMapper;
+    private final ChatBotBaseMapper chatBotBaseMapper;
+
+    @Override
+    public List<AgentDebugSessionDto> listSessions(String uid, Long spaceId, Integer botId) {
+        validateUser(uid);
+        checkBotPermission(uid, spaceId, botId);
+        LambdaQueryWrapper<AgentDebugSession> query = Wrappers.lambdaQuery(AgentDebugSession.class)
+                .eq(AgentDebugSession::getBotId, botId)
+                .eq(AgentDebugSession::getUid, uid)
+                .eq(AgentDebugSession::getIsDelete, 0)
+                .orderByDesc(AgentDebugSession::getUpdateTime)
+                .last("LIMIT " + MAX_SESSION_SIZE);
+        addSpaceCondition(query, spaceId);
+        return sessionMapper.selectList(query)
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Override
+    public AgentDebugSessionDto createSession(String uid, Long spaceId, CreateAgentDebugSessionRequest request) {
+        validateUser(uid);
+        if (request == null || request.getBotId() == null) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+        checkBotPermission(uid, spaceId, request.getBotId());
+
+        LocalDateTime now = LocalDateTime.now();
+        AgentDebugSession session = new AgentDebugSession();
+        session.setId(UUID.randomUUID().toString().replace("-", ""));
+        session.setBotId(request.getBotId());
+        session.setUid(uid);
+        session.setSpaceId(spaceId);
+        session.setTitle(normalizeTitle(request.getTitle(), DEFAULT_TITLE));
+        session.setMessageCount(0);
+        session.setIsDelete(0);
+        session.setCreateTime(now);
+        session.setUpdateTime(now);
+        sessionMapper.insert(session);
+        return toDto(session);
+    }
+
+    @Override
+    public List<Map<String, Object>> getMessages(String uid, Long spaceId, String sessionId) {
+        validateUser(uid);
+        findAccessibleSession(uid, spaceId, sessionId);
+        return messageMapper.selectList(Wrappers.lambdaQuery(AgentDebugMessage.class)
+                .eq(AgentDebugMessage::getSessionId, sessionId)
+                .orderByAsc(AgentDebugMessage::getMessageIndex))
+                .stream()
+                .map(this::parseMessage)
+                .toList();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void saveMessages(String uid, Long spaceId, String sessionId, List<Map<String, Object>> messages) {
+        validateUser(uid);
+        AgentDebugSession existing = findAccessibleSession(uid, spaceId, sessionId);
+        List<Map<String, Object>> safeMessages = messages == null ? Collections.emptyList() : messages;
+        LocalDateTime now = LocalDateTime.now();
+
+        messageMapper.delete(Wrappers.lambdaQuery(AgentDebugMessage.class)
+                .eq(AgentDebugMessage::getSessionId, sessionId));
+        for (int index = 0; index < safeMessages.size(); index++) {
+            AgentDebugMessage message = new AgentDebugMessage();
+            message.setSessionId(sessionId);
+            message.setMessageIndex(index);
+            message.setMessageJson(JSON.toJSONString(safeMessages.get(index)));
+            message.setCreateTime(now);
+            message.setUpdateTime(now);
+            messageMapper.insert(message);
+        }
+
+        AgentDebugSession update = new AgentDebugSession();
+        update.setId(existing.getId());
+        update.setTitle(deriveTitle(safeMessages, existing.getTitle()));
+        update.setMessageCount(safeMessages.size());
+        update.setUpdateTime(now);
+        sessionMapper.updateById(update);
+    }
+
+    @Override
+    public void deleteSession(String uid, Long spaceId, String sessionId) {
+        validateUser(uid);
+        AgentDebugSession existing = findAccessibleSession(uid, spaceId, sessionId);
+        AgentDebugSession update = new AgentDebugSession();
+        update.setId(existing.getId());
+        update.setIsDelete(1);
+        update.setUpdateTime(LocalDateTime.now());
+        sessionMapper.updateById(update);
+    }
+
+    @Override
+    public void clearSessions(String uid, Long spaceId, Integer botId) {
+        validateUser(uid);
+        checkBotPermission(uid, spaceId, botId);
+        AgentDebugSession update = new AgentDebugSession();
+        update.setIsDelete(1);
+        update.setUpdateTime(LocalDateTime.now());
+        LambdaUpdateWrapper<AgentDebugSession> updateWrapper = Wrappers.lambdaUpdate(AgentDebugSession.class)
+                .eq(AgentDebugSession::getBotId, botId)
+                .eq(AgentDebugSession::getUid, uid)
+                .eq(AgentDebugSession::getIsDelete, 0);
+        addSpaceCondition(updateWrapper, spaceId);
+        sessionMapper.update(update, updateWrapper);
+    }
+
+    private void validateUser(String uid) {
+        if (StringUtils.isBlank(uid)) {
+            throw new BusinessException(ResponseEnum.UNAUTHORIZED);
+        }
+    }
+
+    private void checkBotPermission(String uid, Long spaceId, Integer botId) {
+        if (botId == null || chatBotBaseMapper.checkBotPermission(botId, uid, spaceId) <= 0) {
+            throw new BusinessException(ResponseEnum.INSUFFICIENT_PERMISSIONS);
+        }
+    }
+
+    private AgentDebugSession findAccessibleSession(String uid, Long spaceId, String sessionId) {
+        AgentDebugSession session = findSession(uid, sessionId);
+        if (!isSameSpace(session.getSpaceId(), spaceId)) {
+            throw new BusinessException(ResponseEnum.DATA_NOT_FOUND);
+        }
+        checkBotPermission(uid, spaceId, session.getBotId());
+        return session;
+    }
+
+    private boolean isSameSpace(Long sessionSpaceId, Long currentSpaceId) {
+        if (sessionSpaceId == null || currentSpaceId == null) {
+            return sessionSpaceId == null && currentSpaceId == null;
+        }
+        return sessionSpaceId.equals(currentSpaceId);
+    }
+
+    private void addSpaceCondition(LambdaQueryWrapper<AgentDebugSession> queryWrapper, Long spaceId) {
+        if (spaceId == null) {
+            queryWrapper.isNull(AgentDebugSession::getSpaceId);
+        } else {
+            queryWrapper.eq(AgentDebugSession::getSpaceId, spaceId);
+        }
+    }
+
+    private void addSpaceCondition(LambdaUpdateWrapper<AgentDebugSession> updateWrapper, Long spaceId) {
+        if (spaceId == null) {
+            updateWrapper.isNull(AgentDebugSession::getSpaceId);
+        } else {
+            updateWrapper.eq(AgentDebugSession::getSpaceId, spaceId);
+        }
+    }
+
+    private AgentDebugSession findSession(String uid, String sessionId) {
+        if (StringUtils.isBlank(sessionId)) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+        AgentDebugSession session = sessionMapper.selectOne(Wrappers.lambdaQuery(AgentDebugSession.class)
+                .eq(AgentDebugSession::getId, sessionId)
+                .eq(AgentDebugSession::getUid, uid)
+                .eq(AgentDebugSession::getIsDelete, 0)
+                .last("LIMIT 1"));
+        if (session == null) {
+            throw new BusinessException(ResponseEnum.DATA_NOT_FOUND);
+        }
+        return session;
+    }
+
+    private AgentDebugSessionDto toDto(AgentDebugSession session) {
+        AgentDebugSessionDto dto = new AgentDebugSessionDto();
+        dto.setId(session.getId());
+        dto.setBotId(session.getBotId());
+        dto.setTitle(session.getTitle());
+        dto.setCreatedAt(session.getCreateTime());
+        dto.setUpdatedAt(session.getUpdateTime());
+        dto.setMessageCount(session.getMessageCount() == null ? 0 : session.getMessageCount());
+        return dto;
+    }
+
+    private String deriveTitle(List<Map<String, Object>> messages, String fallback) {
+        for (Map<String, Object> message : messages) {
+            if ("USER".equalsIgnoreCase(String.valueOf(message.get("reqType")))) {
+                Object rawTitle = message.get("message");
+                if (rawTitle == null) {
+                    rawTitle = message.get("content");
+                }
+                String title = normalizeTitle(rawTitle == null ? null : rawTitle.toString(), null);
+                if (StringUtils.isNotBlank(title)) {
+                    return title;
+                }
+            }
+        }
+        return normalizeTitle(fallback, DEFAULT_TITLE);
+    }
+
+    private String normalizeTitle(String title, String fallback) {
+        String normalized = StringUtils.normalizeSpace(title);
+        if (StringUtils.isBlank(normalized)) {
+            normalized = fallback;
+        }
+        if (StringUtils.isBlank(normalized)) {
+            return null;
+        }
+        return normalized.substring(0, Math.min(normalized.length(), MAX_TITLE_LENGTH));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseMessage(AgentDebugMessage message) {
+        if (StringUtils.isBlank(message.getMessageJson())) {
+            return new LinkedHashMap<>();
+        }
+        return JSON.parseObject(message.getMessageJson(), LinkedHashMap.class);
+    }
+}

--- a/console/backend/hub/src/main/resources/db/migration/V1.36__add_agent_debug_history.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.36__add_agent_debug_history.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS `agent_debug_session` (
+  `id` varchar(64) NOT NULL COMMENT 'Session ID',
+  `bot_id` int NOT NULL COMMENT 'Bot ID',
+  `uid` varchar(128) NOT NULL COMMENT 'User ID',
+  `space_id` bigint DEFAULT NULL COMMENT 'Space ID',
+  `title` varchar(255) DEFAULT NULL COMMENT 'Session title',
+  `message_count` int NOT NULL DEFAULT 0 COMMENT 'Message count',
+  `is_delete` tinyint NOT NULL DEFAULT 0 COMMENT 'Deletion status: 0 not deleted, 1 deleted',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+  PRIMARY KEY (`id`),
+  KEY `idx_agent_debug_session_bot_uid` (`bot_id`, `uid`, `is_delete`, `update_time`),
+  KEY `idx_agent_debug_session_space` (`space_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Agent debug sessions';
+
+CREATE TABLE IF NOT EXISTS `agent_debug_message` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT 'Primary key',
+  `session_id` varchar(64) NOT NULL COMMENT 'Session ID',
+  `message_index` int NOT NULL COMMENT 'Message order in session',
+  `message_json` longtext NOT NULL COMMENT 'Serialized message JSON',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_agent_debug_message_order` (`session_id`, `message_index`),
+  KEY `idx_agent_debug_message_session` (`session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Agent debug messages';

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/agentdebug/impl/AgentDebugServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/agentdebug/impl/AgentDebugServiceImplTest.java
@@ -1,0 +1,175 @@
+package com.iflytek.astron.console.hub.service.agentdebug.impl;
+
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.entity.agentdebug.AgentDebugMessage;
+import com.iflytek.astron.console.commons.entity.agentdebug.AgentDebugSession;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.mapper.agentdebug.AgentDebugMessageMapper;
+import com.iflytek.astron.console.commons.mapper.agentdebug.AgentDebugSessionMapper;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
+import com.iflytek.astron.console.hub.dto.agentdebug.AgentDebugSessionDto;
+import com.iflytek.astron.console.hub.dto.agentdebug.CreateAgentDebugSessionRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AgentDebugServiceImplTest {
+
+    private static final String UID = "test-user";
+    private static final int BOT_ID = 7;
+
+    @Mock
+    private AgentDebugSessionMapper sessionMapper;
+
+    @Mock
+    private AgentDebugMessageMapper messageMapper;
+
+    @Mock
+    private ChatBotBaseMapper chatBotBaseMapper;
+
+    @InjectMocks
+    private AgentDebugServiceImpl agentDebugService;
+
+    @Test
+    void createSession_WithBotPermission_ShouldInsertNewSession() {
+        when(chatBotBaseMapper.checkBotPermission(BOT_ID, UID, null)).thenReturn(1);
+        when(sessionMapper.insert(any(AgentDebugSession.class))).thenReturn(1);
+
+        CreateAgentDebugSessionRequest request = new CreateAgentDebugSessionRequest();
+        request.setBotId(BOT_ID);
+        request.setTitle("  ");
+
+        AgentDebugSessionDto result = agentDebugService.createSession(UID, request);
+
+        assertNotNull(result.getId());
+        assertEquals(BOT_ID, result.getBotId());
+        assertEquals("全新对话", result.getTitle());
+        assertEquals(0, result.getMessageCount());
+
+        ArgumentCaptor<AgentDebugSession> captor = ArgumentCaptor.forClass(AgentDebugSession.class);
+        verify(sessionMapper).insert(captor.capture());
+        AgentDebugSession inserted = captor.getValue();
+        assertEquals(result.getId(), inserted.getId());
+        assertEquals(UID, inserted.getUid());
+        assertEquals(BOT_ID, inserted.getBotId());
+        assertEquals("全新对话", inserted.getTitle());
+    }
+
+    @Test
+    void createSession_WithoutBotPermission_ShouldThrow() {
+        when(chatBotBaseMapper.checkBotPermission(BOT_ID, UID, null)).thenReturn(0);
+
+        CreateAgentDebugSessionRequest request = new CreateAgentDebugSessionRequest();
+        request.setBotId(BOT_ID);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> agentDebugService.createSession(UID, request));
+
+        assertEquals(ResponseEnum.INSUFFICIENT_PERMISSIONS, exception.getResponseEnum());
+        verify(sessionMapper, never()).insert(any(AgentDebugSession.class));
+    }
+
+    @Test
+    void saveAndLoadMessages_ShouldPreserveMessageOrderAndUpdateTitle() {
+        AgentDebugSession session = new AgentDebugSession();
+        session.setId("session-1");
+        session.setUid(UID);
+        session.setBotId(BOT_ID);
+        session.setTitle("全新对话");
+        when(sessionMapper.selectOne(any())).thenReturn(session);
+        when(chatBotBaseMapper.checkBotPermission(BOT_ID, UID, null)).thenReturn(1);
+        when(messageMapper.insert(any(AgentDebugMessage.class))).thenReturn(1);
+
+        List<Map<String, Object>> messages = List.of(
+                message("USER", "帮我写一篇小红书文案"),
+                message("BOT", "好的，我来帮你写。"));
+
+        agentDebugService.saveMessages(UID, "session-1", messages);
+
+        verify(messageMapper).delete(any());
+        ArgumentCaptor<AgentDebugMessage> messageCaptor = ArgumentCaptor.forClass(AgentDebugMessage.class);
+        verify(messageMapper, times(2)).insert(messageCaptor.capture());
+        List<AgentDebugMessage> savedMessages = messageCaptor.getAllValues();
+        assertEquals(0, savedMessages.get(0).getMessageIndex());
+        assertTrue(savedMessages.get(0).getMessageJson().contains("帮我写一篇小红书文案"));
+        assertEquals(1, savedMessages.get(1).getMessageIndex());
+
+        ArgumentCaptor<AgentDebugSession> sessionCaptor = ArgumentCaptor.forClass(AgentDebugSession.class);
+        verify(sessionMapper).updateById(sessionCaptor.capture());
+        assertEquals("帮我写一篇小红书文案", sessionCaptor.getValue().getTitle());
+        assertEquals(2, sessionCaptor.getValue().getMessageCount());
+
+        AgentDebugMessage first = storedMessage(0, "{\"reqType\":\"USER\",\"message\":\"帮我写一篇小红书文案\"}");
+        AgentDebugMessage second = storedMessage(1, "{\"reqType\":\"BOT\",\"message\":\"好的，我来帮你写。\"}");
+        when(messageMapper.selectList(any())).thenReturn(List.of(first, second));
+
+        List<Map<String, Object>> result = agentDebugService.getMessages(UID, "session-1");
+
+        assertEquals(2, result.size());
+        assertEquals("帮我写一篇小红书文案", result.get(0).get("message"));
+        assertEquals("好的，我来帮你写。", result.get(1).get("message"));
+    }
+
+    @Test
+    void getMessages_WithDifferentSpace_ShouldThrowDataNotFound() {
+        AgentDebugSession session = new AgentDebugSession();
+        session.setId("session-1");
+        session.setUid(UID);
+        session.setBotId(BOT_ID);
+        session.setSpaceId(1L);
+        when(sessionMapper.selectOne(any())).thenReturn(session);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> agentDebugService.getMessages(UID, 2L, "session-1"));
+
+        assertEquals(ResponseEnum.DATA_NOT_FOUND, exception.getResponseEnum());
+        verify(messageMapper, never()).selectList(any());
+    }
+
+    @Test
+    void saveMessages_WithoutCurrentBotPermission_ShouldThrow() {
+        AgentDebugSession session = new AgentDebugSession();
+        session.setId("session-1");
+        session.setUid(UID);
+        session.setBotId(BOT_ID);
+        session.setSpaceId(1L);
+        when(sessionMapper.selectOne(any())).thenReturn(session);
+        when(chatBotBaseMapper.checkBotPermission(BOT_ID, UID, 1L)).thenReturn(0);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> agentDebugService.saveMessages(UID, 1L, "session-1", List.of()));
+
+        assertEquals(ResponseEnum.INSUFFICIENT_PERMISSIONS, exception.getResponseEnum());
+        verify(messageMapper, never()).delete(any());
+    }
+
+    private static Map<String, Object> message(String reqType, String content) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("reqType", reqType);
+        message.put("message", content);
+        return message;
+    }
+
+    private static AgentDebugMessage storedMessage(Integer index, String json) {
+        AgentDebugMessage message = new AgentDebugMessage();
+        message.setSessionId("session-1");
+        message.setMessageIndex(index);
+        message.setMessageJson(json);
+        return message;
+    }
+}

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -84,6 +84,7 @@ import {
   AgentDebugSession,
   buildDebugSessionTitle,
   createAgentDebugSession,
+  deleteAgentDebugSession,
   getAgentDebugMessages,
   getAgentDebugSessions,
   saveAgentDebugMessages,
@@ -92,6 +93,15 @@ import {
 const { Option } = Select;
 
 type WorkbenchView = 'chat' | 'search' | 'basic' | 'prompt' | 'capability';
+
+const getDebugSessionTitleFromMessages = (
+  messages: MessageListType[]
+): string => {
+  const userMessage = messages.find(
+    item => item.reqType === 'USER' && item.message?.trim()
+  );
+  return userMessage?.message?.trim().slice(0, 30) || '';
+};
 
 const baseModelConfig: BaseModelConfig = {
   visible: false,
@@ -236,6 +246,13 @@ const BaseConfig: React.FC<ChatProps> = ({
   >([]);
   const [debugSessionKey, setDebugSessionKey] = useState(0);
   const [debugHistoryLoading, setDebugHistoryLoading] = useState(false);
+  const activeDebugSessionIdRef = useRef('');
+  const debugSessionScopeRef = useRef(0);
+  const debugMessageRevisionRef = useRef(0);
+  const creatingDebugSessionRef = useRef<{
+    scope: number;
+    promise: Promise<AgentDebugSession | null>;
+  } | null>(null);
 
   // 人设相关状态
   const [personalityData, setPersonalityData] = useState({
@@ -1067,44 +1084,116 @@ const BaseConfig: React.FC<ChatProps> = ({
     loadDebugSessions();
   }, [loadDebugSessions]);
 
-  const handleStartDebugSession = useCallback(async () => {
+  useEffect(() => {
+    activeDebugSessionIdRef.current = activeDebugSessionId;
+  }, [activeDebugSessionId]);
+
+  const updateDebugSessionSummary = useCallback(
+    (sessionId: string, messages: MessageListType[]) => {
+      const title = getDebugSessionTitleFromMessages(messages);
+      setDebugSessions(prev =>
+        prev.map(session =>
+          session.id === sessionId
+            ? {
+                ...session,
+                title: title || session.title,
+                messageCount: messages.length,
+                updatedAt: new Date().toISOString(),
+              }
+            : session
+        )
+      );
+    },
+    []
+  );
+
+  const ensureDebugSession = useCallback(
+    async (scope: number) => {
+      if (scope !== debugSessionScopeRef.current) return null;
+      if (activeDebugSessionIdRef.current) return null;
+      if (!currentBotId) return null;
+      if (creatingDebugSessionRef.current?.scope === scope) {
+        return creatingDebugSessionRef.current.promise;
+      }
+
+      const creation = createAgentDebugSession({
+        botId: currentBotId,
+        title: t('chatPage.chatWindow.newChat'),
+      })
+        .then(session => {
+          if (
+            scope !== debugSessionScopeRef.current ||
+            activeDebugSessionIdRef.current
+          ) {
+            deleteAgentDebugSession(session.id).catch(() => {});
+            return null;
+          }
+          activeDebugSessionIdRef.current = session.id;
+          setActiveDebugSessionId(session.id);
+          setDebugSessions(prev => [
+            session,
+            ...prev.filter(item => item.id !== session.id),
+          ]);
+          return session;
+        })
+        .catch(() => null)
+        .finally(() => {
+          if (creatingDebugSessionRef.current?.promise === creation) {
+            creatingDebugSessionRef.current = null;
+          }
+        });
+
+      creatingDebugSessionRef.current = {
+        scope,
+        promise: creation,
+      };
+      return creation;
+    },
+    [currentBotId, t]
+  );
+
+  const handleStartDebugSession = useCallback(() => {
+    debugSessionScopeRef.current += 1;
+    debugMessageRevisionRef.current += 1;
     setActiveWorkbenchView('chat');
     setShowTipPk(false);
     setShowModelPk(0);
     setAskValue('');
     setDebugInitialMessages([]);
+    activeDebugSessionIdRef.current = '';
     setActiveDebugSessionId('');
     setDebugSessionKey(key => key + 1);
-
-    if (!currentBotId) {
-      return;
-    }
-
-    try {
-      const session = await createAgentDebugSession({
-        botId: currentBotId,
-        title: t('chatPage.chatWindow.newChat'),
-      });
-      setActiveDebugSessionId(session.id);
-      setDebugSessions(prev => [session, ...prev]);
-    } catch (err) {
-      setActiveDebugSessionId('');
-    }
-  }, [currentBotId, t]);
+  }, []);
 
   const handleSelectDebugSession = useCallback(
     async (session: AgentDebugSession) => {
+      debugSessionScopeRef.current += 1;
+      const scope = debugSessionScopeRef.current;
+      const revision = debugMessageRevisionRef.current;
       setActiveWorkbenchView('chat');
       setShowTipPk(false);
       setShowModelPk(0);
+      activeDebugSessionIdRef.current = session.id;
       setActiveDebugSessionId(session.id);
+      setDebugInitialMessages([]);
       setDebugSessionKey(key => key + 1);
 
       try {
         const messages = await getAgentDebugMessages(session.id);
-        setDebugInitialMessages(messages || []);
+        if (
+          scope === debugSessionScopeRef.current &&
+          revision === debugMessageRevisionRef.current &&
+          activeDebugSessionIdRef.current === session.id
+        ) {
+          setDebugInitialMessages(messages || []);
+        }
       } catch (err) {
-        setDebugInitialMessages([]);
+        if (
+          scope === debugSessionScopeRef.current &&
+          activeDebugSessionIdRef.current === session.id
+        ) {
+          setDebugInitialMessages([]);
+        }
       }
     },
     []
@@ -1125,11 +1214,22 @@ const BaseConfig: React.FC<ChatProps> = ({
   }, [persistDebugMessages]);
 
   const handleDebugMessagesChange = useCallback(
-    (messages: MessageListType[]) => {
-      if (!activeDebugSessionId || messages.length === 0) return;
-      persistDebugMessages(activeDebugSessionId, messages);
+    async (messages: MessageListType[]) => {
+      const scope = debugSessionScopeRef.current;
+      const existingSession = activeDebugSessionIdRef.current;
+      if (messages.length === 0 && !existingSession) return;
+
+      debugMessageRevisionRef.current += 1;
+
+      const activeSession =
+        existingSession || (await ensureDebugSession(scope))?.id;
+      if (!activeSession) return;
+      if (scope !== debugSessionScopeRef.current) return;
+
+      updateDebugSessionSummary(activeSession, messages);
+      persistDebugMessages(activeSession, messages);
     },
-    [activeDebugSessionId, persistDebugMessages]
+    [ensureDebugSession, persistDebugMessages, updateDebugSessionSummary]
   );
 
   useEffect(() => {
@@ -1587,7 +1687,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     return (
       <PromptTry
         ref={defaultPromptTryRef}
-        key={activeDebugSessionId || `debug-session-${debugSessionKey}`}
+        key={`debug-session-${debugSessionKey}`}
         debugSessionId={
           activeDebugSessionId || `debug-session-${debugSessionKey}`
         }

--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -81,7 +81,6 @@ const PromptTry = forwardRef<
       model,
       supportContext,
       choosedAlltool,
-      debugSessionId,
       initialMessages,
       onMessagesChange,
       showHeaderAndRecommend = true,
@@ -97,6 +96,7 @@ const PromptTry = forwardRef<
     const [messageList, setMessageList] = useState<MessageListType[]>([]); // 消息列表
     const controllerRef = useRef<AbortController>(new AbortController()); //sse请求ref
     const currentSid = useRef<string>(''); // 当前sid
+    const syncingInitialMessagesRef = useRef(false);
 
     // 使用useImperativeHandle暴露组件方法
     useImperativeHandle(ref, () => ({
@@ -124,11 +124,16 @@ const PromptTry = forwardRef<
 
     useEffect(() => {
       if (initialMessages) {
+        syncingInitialMessagesRef.current = true;
         setMessageList(initialMessages);
       }
-    }, [debugSessionId]);
+    }, [initialMessages]);
 
     useEffect(() => {
+      if (syncingInitialMessagesRef.current) {
+        syncingInitialMessagesRef.current = false;
+        return;
+      }
       onMessagesChange?.(messageList);
     }, [messageList, onMessagesChange]);
 


### PR DESCRIPTION
## Summary
- add persisted agent debug sessions and ordered message history APIs
- wire the workbench debug chat sidebar to real session history
- guard async history loading/session creation races and clean stale empty sessions

## Verification
- mvn -pl hub -Dtest=AgentDebugServiceImplTest test
- npx eslint src/components/config-page-component/config-base/index.tsx src/components/prompt-try/index.tsx src/services/agent-debug.ts
- npm run build

## Review
- independent reviewer found no push-blocking issues after fixes