### PR TITLE
fix: prevent debug history restore from clearing messages

### DIFF
--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -96,7 +96,7 @@ const PromptTry = forwardRef<
     const [messageList, setMessageList] = useState<MessageListType[]>([]); // 消息列表
     const controllerRef = useRef<AbortController>(new AbortController()); //sse请求ref
     const currentSid = useRef<string>(''); // 当前sid
-    const syncingInitialMessagesRef = useRef(false);
+    const pendingInitialMessagesRef = useRef<MessageListType[] | null>(null);
 
     // 使用useImperativeHandle暴露组件方法
     useImperativeHandle(ref, () => ({
@@ -124,14 +124,22 @@ const PromptTry = forwardRef<
 
     useEffect(() => {
       if (initialMessages) {
-        syncingInitialMessagesRef.current = true;
-        setMessageList(initialMessages);
+        pendingInitialMessagesRef.current = initialMessages;
+        setMessageList(current => {
+          if (current === initialMessages) {
+            pendingInitialMessagesRef.current = null;
+            return current;
+          }
+          return initialMessages;
+        });
       }
     }, [initialMessages]);
 
     useEffect(() => {
-      if (syncingInitialMessagesRef.current) {
-        syncingInitialMessagesRef.current = false;
+      if (pendingInitialMessagesRef.current) {
+        if (pendingInitialMessagesRef.current === messageList) {
+          pendingInitialMessagesRef.current = null;
+        }
         return;
       }
       onMessagesChange?.(messageList);


### PR DESCRIPTION
## Summary
- prevent PromptTry initial/history message sync from firing parent persistence callbacks
- keep real user message changes notifying persistence after sync completes

## Verification
- npx eslint src/components/prompt-try/index.tsx src/components/config-page-component/config-base/index.tsx src/services/agent-debug.ts
- npm run build
- one-off Node simulation for initial sync suppression
- independent code review: no blocking issues