### PR TITLE
fix: improve web search tool orchestration

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
@@ -102,7 +102,7 @@ public class BotCreateForm {
      */
     private int isSentence;
 
-    @Schema(description = "Enabled tools, joined by comma, e.g.: ifly_search,text_to_image,codeinterpreter")
+    @Schema(description = "Enabled tools, joined by comma, e.g.: web_search,text_to_image,codeinterpreter")
     private String openedTool;
 
     @Schema(description = "Background image color scheme: 0 Light, 1 Dark")

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/PromptChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/PromptChatService.java
@@ -30,7 +30,13 @@ import java.util.Objects;
 public class PromptChatService {
     private static final String PROVIDER_GOOGLE = "google";
     private static final String PROVIDER_ANTHROPIC = "anthropic";
-    private static final String OPENAI_SEARCH_TOOL_NAME = "ifly_search";
+    private static final String OPENAI_SEARCH_TOOL_NAME = "web_search";
+    private static final String LEGACY_OPENAI_SEARCH_TOOL_NAME = "ifly_search";
+    private static final String WEB_SEARCH_DECISION_INSTRUCTION = """
+            You have access to a web_search tool. Decide whether to call it.
+            Use web_search for questions that require current or recently changed information, including current date, weekday, time-sensitive facts, latest news, prices, policies, schedules, releases, rankings, or status.
+            For static knowledge that does not need real-time information, answer directly without using the tool.
+            """;
     private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
 
     private final OkHttpClient httpClient;
@@ -79,6 +85,9 @@ public class PromptChatService {
      */
     private void performChatRequest(JSONObject request, SseEmitter emitter, String streamId, ChatReqRecords chatReqRecords, boolean edit, boolean isDebug) throws IOException {
         String provider = normalizeProvider(request.getString("provider"));
+        if (hasWebSearchCapability(request)) {
+            applyWebSearchDecisionInstruction(request);
+        }
         // Handle managed web search directly (when managedWebSearch=true without tools array)
         if (request.getBooleanValue("managedWebSearch") && !hasOpenAiSearchTool(request.getJSONArray("tools"))) {
             applyManagedWebSearch(request, chatReqRecords);
@@ -242,11 +251,73 @@ public class PromptChatService {
         for (int i = 0; i < tools.size(); i++) {
             JSONObject tool = tools.getJSONObject(i);
             JSONObject function = tool == null ? null : tool.getJSONObject("function");
-            if (function != null && StringUtils.equals(function.getString("name"), OPENAI_SEARCH_TOOL_NAME)) {
+            if (function != null && isSearchToolName(function.getString("name"))) {
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean hasWebSearchCapability(JSONObject request) {
+        if (request.getBooleanValue("managedWebSearch")) {
+            return true;
+        }
+        JSONArray tools = request.getJSONArray("tools");
+        if (tools == null || tools.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < tools.size(); i++) {
+            JSONObject tool = tools.getJSONObject(i);
+            if (tool == null) {
+                continue;
+            }
+            if (tool.containsKey("google_search")) {
+                return true;
+            }
+            String type = tool.getString("type");
+            String name = tool.getString("name");
+            if (StringUtils.containsIgnoreCase(type, "web_search") || isSearchToolName(name)) {
+                return true;
+            }
+            JSONObject function = tool.getJSONObject("function");
+            if (function != null && isSearchToolName(function.getString("name"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSearchToolName(String name) {
+        return StringUtils.equals(name, OPENAI_SEARCH_TOOL_NAME)
+                || StringUtils.equals(name, LEGACY_OPENAI_SEARCH_TOOL_NAME);
+    }
+
+    private void applyWebSearchDecisionInstruction(JSONObject request) {
+        JSONArray messages = request.getJSONArray("messages");
+        if (messages == null || messages.isEmpty()) {
+            return;
+        }
+
+        JSONObject firstSystemMessage = null;
+        for (int i = 0; i < messages.size(); i++) {
+            JSONObject message = messages.getJSONObject(i);
+            if (message != null && "system".equals(normalizeMessageRole(message.getString("role")))) {
+                firstSystemMessage = message;
+                break;
+            }
+        }
+
+        if (firstSystemMessage == null) {
+            messages.add(0, new JSONObject()
+                    .fluentPut("role", "system")
+                    .fluentPut("content", WEB_SEARCH_DECISION_INSTRUCTION));
+        } else {
+            String content = StringUtils.defaultString(firstSystemMessage.getString("content"));
+            if (!StringUtils.contains(content, "web_search tool")) {
+                firstSystemMessage.put("content", WEB_SEARCH_DECISION_INSTRUCTION + "\n" + content);
+            }
+        }
+        request.put("messages", messages);
     }
 
     private boolean handleOpenAiFunctionToolCall(JSONObject request, SseEmitter emitter, String streamId,
@@ -261,6 +332,7 @@ public class PromptChatService {
             log.warn("OpenAI-compatible tool planning failed, fallback to normal request, streamId: {}, error: {}", streamId, e.getMessage());
             request.remove("tools");
             request.remove("toolChoice");
+            request.remove("tool_choice");
             return false;
         }
 
@@ -287,6 +359,7 @@ public class PromptChatService {
         appendToolMessages(request, extractAssistantMessage(planningResponse), toolCalls, toolResult.content());
         request.remove("tools");
         request.remove("toolChoice");
+        request.remove("tool_choice");
         request.put("stream", true);
         return false;
     }
@@ -424,7 +497,7 @@ public class PromptChatService {
         for (int i = 0; i < toolCalls.size(); i++) {
             JSONObject toolCall = toolCalls.getJSONObject(i);
             JSONObject function = toolCall == null ? null : toolCall.getJSONObject("function");
-            if (function == null || !StringUtils.equals(function.getString("name"), OPENAI_SEARCH_TOOL_NAME)) {
+            if (function == null || !isSearchToolName(function.getString("name"))) {
                 continue;
             }
             String arguments = function.getString("arguments");
@@ -457,7 +530,7 @@ public class PromptChatService {
         for (int i = 0; i < toolCalls.size(); i++) {
             JSONObject toolCall = toolCalls.getJSONObject(i);
             JSONObject function = toolCall == null ? null : toolCall.getJSONObject("function");
-            if (function == null || !StringUtils.equals(function.getString("name"), OPENAI_SEARCH_TOOL_NAME)) {
+            if (function == null || !isSearchToolName(function.getString("name"))) {
                 continue;
             }
             messages.add(new JSONObject()

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ProviderToolOrchestrator.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ProviderToolOrchestrator.java
@@ -17,12 +17,13 @@ import java.util.Set;
  * Current provider capability matrix for enabled web search: - spark: native support via
  * SparkChatRequest.enableWebSearch - google: native support via Gemini tools.google_search -
  * anthropic: native support via Anthropic web_search tool + beta header - other OpenAI-compatible
- * providers: model-driven function tool calling via ifly_search
+ * providers: model-driven function tool calling via web_search
  */
 final class ProviderToolOrchestrator {
 
-    static final String TOOL_IFLY_SEARCH = "ifly_search";
-    static final String OPENAI_SEARCH_TOOL_NAME = "ifly_search";
+    static final String TOOL_WEB_SEARCH = "web_search";
+    static final String TOOL_IFLY_SEARCH_LEGACY = "ifly_search";
+    static final String OPENAI_SEARCH_TOOL_NAME = "web_search";
     static final String PROVIDER_SPARK = "spark";
     static final String PROVIDER_GOOGLE = "google";
     static final String PROVIDER_ANTHROPIC = "anthropic";
@@ -31,7 +32,8 @@ final class ProviderToolOrchestrator {
 
     static ToolExecutionPlan resolve(String provider, String openedTool) {
         Set<String> enabledTools = parseEnabledTools(openedTool);
-        boolean webSearchEnabled = enabledTools.contains(TOOL_IFLY_SEARCH);
+        boolean webSearchEnabled = enabledTools.contains(TOOL_WEB_SEARCH)
+                || enabledTools.contains(TOOL_IFLY_SEARCH_LEGACY);
         String normalizedProvider = normalizeProvider(provider);
 
         if (!webSearchEnabled) {
@@ -63,6 +65,7 @@ final class ProviderToolOrchestrator {
             case OPENAI_FUNCTION -> {
                 request.put("managedWebSearch", true);
                 request.put("tools", buildOpenAiCompatibleSearchTools());
+                request.put("tool_choice", "auto");
             }
             case SPARK_NATIVE -> {
             }
@@ -108,7 +111,7 @@ final class ProviderToolOrchestrator {
         JSONArray tools = new JSONArray();
         JSONObject function = new JSONObject();
         function.put("name", OPENAI_SEARCH_TOOL_NAME);
-        function.put("description", "Search the live web for up-to-date information when the user asks about current events, recent facts, or anything that requires real-time information.");
+        function.put("description", "Search the live web for up-to-date information. Use this for current dates, weekdays, recent events, latest facts, prices, policies, schedules, or anything that may have changed recently.");
 
         JSONObject parameters = new JSONObject();
         parameters.put("type", "object");

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
@@ -235,6 +235,153 @@ class PromptChatServiceTest {
     }
 
     @Test
+    void testChatStream_OpenAiSearchTool_AddsDecisionInstructionToPlanningRequest() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("managedWebSearch", true);
+        request.put("managedSearchQuery", "今天是周几");
+        request.put("userId", "debug-user");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "web_search",
+                      "description": "Search the live web.",
+                      "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天是周几"}
+                ]
+                """));
+
+        when(httpClient.newCall(argThat(req -> {
+            try {
+                JSONObject body = parseRequestBody(req);
+                assertEquals("web_search", body.getJSONArray("tools")
+                        .getJSONObject(0)
+                        .getJSONObject("function")
+                        .getString("name"));
+                assertTrue(body.getJSONArray("messages")
+                        .getJSONObject(0)
+                        .getString("content")
+                        .contains("Use web_search for questions that require current"));
+                assertFalse(body.containsKey("managedWebSearch"));
+                assertFalse(body.containsKey("managedSearchQuery"));
+            } catch (IOException e) {
+                fail(e);
+            }
+            return true;
+        }))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(ResponseBody.create(
+                "{\"id\":\"plan-id\",\"choices\":[{\"message\":{\"content\":\"no tool call\"}}]}",
+                MediaType.get("application/json; charset=utf-8")));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        verify(call).execute();
+        verify(managedWebSearchService, never()).search(anyString(), anyString());
+    }
+
+    @Test
+    void testChatStream_OpenAiSearchToolCall_ExecutesSearchAndAppendsToolMessages() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("managedWebSearch", true);
+        request.put("managedSearchQuery", "今天是周几");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "web_search",
+                      "description": "Search the live web.",
+                      "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天是周几"}
+                ]
+                """));
+
+        Call planningCall = mock(Call.class);
+        Call finalCall = mock(Call.class);
+        Response planningResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalCall);
+        when(planningCall.execute()).thenReturn(planningResponse);
+        when(planningResponse.isSuccessful()).thenReturn(true);
+        when(planningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "id": "plan-id",
+                  "choices": [
+                    {
+                      "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                          {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                              "name": "web_search",
+                              "arguments": "{\\"query\\":\\"今天是周几\\"}"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(managedWebSearchService.search(eq("今天是周几"), eq("debug-user")))
+                .thenReturn(new ManagedWebSearchService.SearchAugmentation(
+                        "今天是星期一。",
+                        "[{\"type\":\"web_search\",\"deskToolName\":\"Web Search\"}]",
+                        false,
+                        null));
+        doNothing().when(finalCall).enqueue(any(Callback.class));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).newCall(requestCaptor.capture());
+        JSONObject planningBody = parseRequestBody(requestCaptor.getAllValues().get(0));
+        JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(1));
+
+        assertEquals("web_search", planningBody.getJSONArray("tools")
+                .getJSONObject(0)
+                .getJSONObject("function")
+                .getString("name"));
+        assertFalse(planningBody.containsKey("managedWebSearch"));
+        assertFalse(planningBody.containsKey("managedSearchQuery"));
+        assertFalse(finalBody.containsKey("tools"));
+        assertFalse(finalBody.containsKey("tool_choice"));
+        assertFalse(finalBody.containsKey("managedWebSearch"));
+        assertFalse(finalBody.containsKey("managedSearchQuery"));
+        assertEquals("assistant", finalBody.getJSONArray("messages").getJSONObject(2).getString("role"));
+        assertEquals("tool", finalBody.getJSONArray("messages").getJSONObject(3).getString("role"));
+        assertEquals("call_1", finalBody.getJSONArray("messages").getJSONObject(3).getString("tool_call_id"));
+        assertTrue(finalBody.getJSONArray("messages").getJSONObject(3).getString("content").contains("星期一"));
+        verify(managedWebSearchService).search("今天是周几", "debug-user");
+        verify(finalCall).enqueue(any(Callback.class));
+    }
+
+    @Test
     void testChatStream_Exception_HandledGracefully() {
         try (MockedStatic<SseEmitterUtil> sseUtilMock = mockStatic(SseEmitterUtil.class)) {
             when(httpClient.newCall(any(Request.class))).thenThrow(new RuntimeException("HTTP error"));

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
@@ -319,7 +319,7 @@ class BotChatServiceImplUnitTest {
         request.setPrompt("test prompt");
         request.setMessages(Arrays.asList("message1", "message2"));
         request.setUid("test-uid");
-        request.setOpenedTool("ifly_search");
+        request.setOpenedTool("web_search");
         request.setModel("x1");
         request.setModelId(null);
         request.setMaasDatasetList(Arrays.asList("dataset1"));
@@ -349,7 +349,7 @@ class BotChatServiceImplUnitTest {
         request.setPrompt("test prompt");
         request.setMessages(Arrays.asList("message1", "message2"));
         request.setUid("test-uid");
-        request.setOpenedTool("ifly_search");
+        request.setOpenedTool("web_search");
         request.setModel("test-model");
         request.setModelId(1L);
         request.setMaasDatasetList(Arrays.asList("dataset1"));
@@ -376,6 +376,8 @@ class BotChatServiceImplUnitTest {
             verify(modelService).getDetail(eq(0), eq(1L), isNull());
             verify(promptChatService).chatStream(argThat(json -> "openai".equals(json.getString("provider")) &&
                     json.getBooleanValue("managedWebSearch") &&
+                    "auto".equals(json.getString("tool_choice")) &&
+                    "web_search".equals(json.getJSONArray("tools").getJSONObject(0).getJSONObject("function").getString("name")) &&
                     "test message".equals(json.getString("managedSearchQuery")) &&
                     "test-uid".equals(json.getString("userId"))),
                     eq(sseEmitter),
@@ -505,6 +507,8 @@ class BotChatServiceImplUnitTest {
         verify(promptChatService).chatStream(
                 argThat(json -> "openai".equals(json.getString("provider")) &&
                         json.getBooleanValue("managedWebSearch") &&
+                        "auto".equals(json.getString("tool_choice")) &&
+                        "web_search".equals(json.getJSONArray("tools").getJSONObject(0).getJSONObject("function").getString("name")) &&
                         "test question".equals(json.getString("managedSearchQuery")) &&
                         "test-uid".equals(json.getString("userId"))),
                 eq(sseEmitter),

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -38,6 +38,7 @@ import codeIcon from '@/assets/imgs/plugin/code.svg'; // 代码图标
 import netIcon from '@/assets/imgs/plugin/network.svg'; // 网络图标
 import genPicIcon from '@/assets/imgs/plugin/gen-pic.svg'; // 图片图标
 import { useTranslation } from 'react-i18next';
+import { hasWebSearchTool } from '../tool-config';
 
 import styles from './CapabilityDevelopment.module.scss';
 import cls from 'classnames';
@@ -382,12 +383,13 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
                 </div>
                 <Switch
                   className="list-switch config-switch"
-                  defaultChecked={
-                    detailInfo.openedTool?.indexOf('ifly_search') !== -1
-                  }
+                  defaultChecked={hasWebSearchTool(detailInfo.openedTool)}
                   onChange={checked => {
-                    choosedAlltool.ifly_search = checked;
-                    setChoosedAlltool(choosedAlltool);
+                    setChoosedAlltool({
+                      ...choosedAlltool,
+                      web_search: checked,
+                      ifly_search: false,
+                    });
                   }}
                 />
               </div>

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -77,6 +77,11 @@ import {
   KnowledgeLeaf,
   Knowledge,
 } from './types';
+import {
+  getEffectiveToolConfig,
+  hasWebSearchTool,
+  serializeOpenedTool,
+} from './tool-config';
 import { VcnItem } from '@/components/speaker-modal';
 import { getVcnList } from '@/services/chat';
 import type { MessageListType } from '@/types/chat';
@@ -220,10 +225,19 @@ const BaseConfig: React.FC<ChatProps> = ({
     { prompt: prompt, promptAnswerCompleted: true },
   ]);
   const [choosedAlltool, setChoosedAlltool] = useState<any>({
-    ifly_search: true,
+    web_search: true,
+    ifly_search: false,
     text_to_image: false,
     codeinterpreter: false,
   });
+  const effectiveToolConfig = useMemo(
+    () => getEffectiveToolConfig(choosedAlltool, isNewWorkbench),
+    [choosedAlltool, isNewWorkbench]
+  );
+  const effectiveOpenedTool = useMemo(
+    () => serializeOpenedTool(effectiveToolConfig),
+    [effectiveToolConfig]
+  );
   const [supportSystemFlag, setSupportSystemFlag] = useState(false);
   const [supportContextFlag, setSupportContextFlag] = useState(true);
   const [promptNow, setPromptNow] = useState();
@@ -472,15 +486,6 @@ const BaseConfig: React.FC<ChatProps> = ({
       : baseinfo.botTemplate ||
         detailInfo.botTemplate ||
         botTemplateInfoValue.botTemplate;
-    const normalizedToolConfig = isNewWorkbench
-      ? {
-          ...choosedAlltool,
-          ifly_search: true,
-          text_to_image: false,
-          codeinterpreter: false,
-        }
-      : choosedAlltool;
-
     return {
       ...(backgroundImgApp && {
         appBackground:
@@ -507,9 +512,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       avatar: coverUrl,
       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
       isSentence: 0,
-      openedTool: Object.keys(normalizedToolConfig)
-        .filter((key: any) => normalizedToolConfig[key])
-        .join(','),
+      openedTool: effectiveOpenedTool,
       prologue: prologue,
       ...getModelConfig(model),
       prompt: prompt,
@@ -678,7 +681,8 @@ const BaseConfig: React.FC<ChatProps> = ({
     setSupportContextFlag(true);
     setChoosedAlltool((currentTools: any) => ({
       ...currentTools,
-      ifly_search: true,
+      web_search: true,
+      ifly_search: false,
       text_to_image: false,
       codeinterpreter: false,
     }));
@@ -757,17 +761,15 @@ const BaseConfig: React.FC<ChatProps> = ({
             cn: save == 'true' ? configPageData?.vcnCn : res.vcnCn,
           });
           const obj: any = {};
-          if (
-            save == 'true'
-              ? typeof configPageData?.openedTool === 'string' &&
-                configPageData.openedTool.indexOf('ifly_search') !== -1
-              : typeof res.openedTool === 'string' &&
-                res.openedTool.indexOf('ifly_search') !== -1
-          ) {
-            obj.ifly_search = true;
-          } else {
-            obj.ifly_search = false;
-          }
+          const openedToolValue =
+            save == 'true' ? configPageData?.openedTool : res.openedTool;
+          obj.web_search = hasWebSearchTool(openedToolValue);
+          obj.ifly_search =
+            typeof openedToolValue === 'string' &&
+            openedToolValue
+              .split(',')
+              .map((tool: string) => tool.trim())
+              .includes('ifly_search');
           if (
             save == 'true'
               ? typeof configPageData?.openedTool === 'string' &&
@@ -1363,6 +1365,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     prompt,
     sentence,
     choosedAlltool,
+    effectiveOpenedTool,
   ]);
 
   /** 提示词对比 */
@@ -1610,7 +1613,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 model={item.model}
                 promptText={promptNow}
                 supportContext={supportContextFlag ? 1 : 0}
-                choosedAlltool={choosedAlltool}
+                choosedAlltool={effectiveToolConfig}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1669,7 +1672,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 model={model}
                 promptText={promptNow}
                 supportContext={supportContextFlag ? 1 : 0}
-                choosedAlltool={choosedAlltool}
+                choosedAlltool={effectiveToolConfig}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1701,7 +1704,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         model={model}
         promptText={promptNow}
         supportContext={supportContextFlag ? 1 : 0}
-        choosedAlltool={choosedAlltool}
+        choosedAlltool={effectiveToolConfig}
         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
         personalityConfig={
           personalityData.enablePersonality
@@ -2171,9 +2174,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       avatar: coverUrl,
                       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                       isSentence: 0,
-                      openedTool: Object.keys(choosedAlltool)
-                        .filter((key: any) => choosedAlltool[key])
-                        .join(','),
+                      openedTool: effectiveOpenedTool,
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2221,9 +2222,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       avatar: coverUrl,
                       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                       isSentence: 0,
-                      openedTool: Object.keys(choosedAlltool)
-                        .filter((key: any) => choosedAlltool[key])
-                        .join(','),
+                      openedTool: effectiveOpenedTool,
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2301,9 +2300,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     avatar: coverUrl,
                     vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                     isSentence: sentence,
-                    openedTool: Object.keys(choosedAlltool)
-                      .filter((key: any) => choosedAlltool[key])
-                      .join(','),
+                    openedTool: effectiveOpenedTool,
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2350,9 +2347,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     avatar: coverUrl,
                     vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                     isSentence: sentence,
-                    openedTool: Object.keys(choosedAlltool)
-                      .filter((key: any) => choosedAlltool[key])
-                      .join(','),
+                    openedTool: effectiveOpenedTool,
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2798,7 +2793,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       model={model}
                       promptText={promptNow}
                       supportContext={supportContextFlag ? 1 : 0}
-                      choosedAlltool={choosedAlltool}
+                      choosedAlltool={effectiveToolConfig}
                       findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                       personalityConfig={
                         personalityData.enablePersonality
@@ -2841,7 +2836,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                           model={model}
                           promptText={promptNow}
                           supportContext={supportContextFlag ? 1 : 0}
-                          choosedAlltool={choosedAlltool}
+                          choosedAlltool={effectiveToolConfig}
                           findModelOptionByUniqueKey={
                             findModelOptionByUniqueKey
                           }
@@ -2914,7 +2909,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                         model={item.model}
                         promptText={promptNow}
                         supportContext={supportContextFlag ? 1 : 0}
-                        choosedAlltool={choosedAlltool}
+                        choosedAlltool={effectiveToolConfig}
                         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                         personalityConfig={
                           personalityData.enablePersonality

--- a/console/frontend/src/components/config-page-component/config-base/tool-config.ts
+++ b/console/frontend/src/components/config-page-component/config-base/tool-config.ts
@@ -1,0 +1,54 @@
+export type ToolConfig = Record<string, boolean>;
+
+const WEB_SEARCH_TOOL = 'web_search';
+const LEGACY_WEB_SEARCH_TOOL = 'ifly_search';
+
+const NEW_WORKBENCH_TOOL_OVERRIDES: ToolConfig = {
+  [WEB_SEARCH_TOOL]: true,
+  [LEGACY_WEB_SEARCH_TOOL]: false,
+  text_to_image: false,
+  codeinterpreter: false,
+};
+
+export const getEffectiveToolConfig = (
+  toolConfig: ToolConfig | undefined,
+  isNewWorkbench: boolean
+): ToolConfig => {
+  const baseConfig = normalizeToolConfig(toolConfig);
+  if (!isNewWorkbench) {
+    return baseConfig;
+  }
+
+  return {
+    ...baseConfig,
+    ...NEW_WORKBENCH_TOOL_OVERRIDES,
+  };
+};
+
+export const serializeOpenedTool = (
+  toolConfig: ToolConfig | undefined
+): string => {
+  const normalized = normalizeToolConfig(toolConfig);
+  return Object.keys(normalized)
+    .filter(key => normalized[key])
+    .join(',');
+};
+
+const normalizeToolConfig = (toolConfig: ToolConfig | undefined): ToolConfig => {
+  const normalized = { ...(toolConfig ?? {}) };
+  if (normalized[LEGACY_WEB_SEARCH_TOOL]) {
+    normalized[WEB_SEARCH_TOOL] = true;
+    delete normalized[LEGACY_WEB_SEARCH_TOOL];
+  }
+  return normalized;
+};
+
+export const hasWebSearchTool = (openedTool?: string): boolean => {
+  if (!openedTool) {
+    return false;
+  }
+  return openedTool
+    .split(',')
+    .map(tool => tool.trim())
+    .some(tool => tool === WEB_SEARCH_TOOL || tool === LEGACY_WEB_SEARCH_TOOL);
+};

--- a/console/frontend/src/components/config-page-component/config-base/types.ts
+++ b/console/frontend/src/components/config-page-component/config-base/types.ts
@@ -98,6 +98,7 @@ export interface PromptListItem {
 
 // 选择的工具配置接口
 export interface ChoosedAlltool {
+  web_search: boolean;
   ifly_search: boolean;
   text_to_image: boolean;
   codeinterpreter: boolean;

--- a/console/frontend/src/pages/chat-page/components/chat-side.tsx
+++ b/console/frontend/src/pages/chat-page/components/chat-side.tsx
@@ -29,7 +29,11 @@ type ModelConfig =
   | 'flow';
 
 // 工具类型
-type ToolType = 'ifly_search' | 'text_to_image' | 'codeinterpreter';
+type ToolType =
+  | 'web_search'
+  | 'ifly_search'
+  | 'text_to_image'
+  | 'codeinterpreter';
 
 // 模型信息接口
 interface ModelInfo {
@@ -371,7 +375,7 @@ const ChatSide: React.FC<ChatSideProps> = ({ botInfo }) => {
             /* 兼容旧版工具配置 */
             toolList.map((tool: ToolType, index: number) => (
               <div key={`${tool}-${index}`}>
-                {tool === 'ifly_search' && (
+                {(tool === 'web_search' || tool === 'ifly_search') && (
                   <Tooltip
                     title={t('chatPage.chatSide.webSearch')}
                     placement="top"


### PR DESCRIPTION
## Summary
- expose generic web_search tool while keeping legacy ifly_search compatibility
- let non-Spark models decide whether to call web search via provider-native tools or OpenAI-compatible function calling
- add regression tests for planning and executed web_search tool calls

## Verification
- mvn -pl hub -Dtest=PromptChatServiceTest#testChatStream_OpenAiSearchToolCall_ExecutesSearchAndAppendsToolMessages+testChatStream_OpenAiSearchTool_AddsDecisionInstructionToPlanningRequest+testChatStream_OpenAiManagedSearch_InjectsSearchSummaryIntoMessages+testChatStream_DebugManagedSearch_UsesRequestUserIdWhenRecordsMissing test
- mvn -pl hub -Dtest=BotChatServiceImplUnitTest#testDebugChatMessageBot_WithNullModelId+testDebugChatMessageBot_WithModelId+testDebugChatMessageBot_WithGoogleModelId_PropagatesProvider+testChatMessageBot_PromptChat_AnthropicAddsNativeWebSearch+testChatMessageBot_PromptChat_OpenAiUsesManagedWebSearch test
- npx eslint src/components/config-page-component/config-base/index.tsx src/components/config-page-component/config-base/tool-config.ts src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx src/components/config-page-component/config-base/types.ts src/pages/chat-page/components/chat-side.tsx
- npm run build