### PR TITLE
fix: align agent tool calling boundaries

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/CurrentTimeTool.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/CurrentTimeTool.java
@@ -1,0 +1,40 @@
+package com.iflytek.astron.console.hub.service;
+
+import com.alibaba.fastjson2.JSONObject;
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+final class CurrentTimeTool {
+
+    static final String TOOL_NAME = "current_time";
+    static final String DEFAULT_TIMEZONE = "Asia/Shanghai";
+
+    private CurrentTimeTool() {}
+
+    static String execute(String requestedTimezone) {
+        ZoneId zoneId = resolveZoneId(requestedTimezone);
+        ZonedDateTime now = ZonedDateTime.now(zoneId);
+        JSONObject result = new JSONObject();
+        result.put("timezone", zoneId.getId());
+        result.put("date", now.toLocalDate().toString());
+        result.put("time", now.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm:ss")));
+        result.put("weekday", now.getDayOfWeek().getDisplayName(java.time.format.TextStyle.FULL, Locale.ENGLISH));
+        result.put("weekday_zh", now.getDayOfWeek().getDisplayName(java.time.format.TextStyle.FULL, Locale.CHINA));
+        result.put("iso", now.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        return result.toJSONString();
+    }
+
+    private static ZoneId resolveZoneId(String requestedTimezone) {
+        String timezone = StringUtils.defaultIfBlank(requestedTimezone, DEFAULT_TIMEZONE);
+        try {
+            return ZoneId.of(timezone);
+        } catch (DateTimeException e) {
+            return ZoneId.of(DEFAULT_TIMEZONE);
+        }
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/PromptChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/PromptChatService.java
@@ -18,8 +18,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author mingsuiyongheng
@@ -32,10 +36,24 @@ public class PromptChatService {
     private static final String PROVIDER_ANTHROPIC = "anthropic";
     private static final String OPENAI_SEARCH_TOOL_NAME = "web_search";
     private static final String LEGACY_OPENAI_SEARCH_TOOL_NAME = "ifly_search";
+    private static final String CURRENT_TIME_TOOL_NAME = CurrentTimeTool.TOOL_NAME;
+    private static final int MAX_OPENAI_TOOL_ROUNDS = 15;
+    private static final int MAX_OPENAI_TOOL_CALLS = 15;
     private static final String WEB_SEARCH_DECISION_INSTRUCTION = """
             You have access to a web_search tool. Decide whether to call it.
-            Use web_search for questions that require current or recently changed information, including current date, weekday, time-sensitive facts, latest news, prices, policies, schedules, releases, rankings, or status.
+            Use web_search for questions that require current or recently changed external information, including latest news, prices, policies, schedules, releases, rankings, or status.
             For static knowledge that does not need real-time information, answer directly without using the tool.
+            """;
+    private static final String CURRENT_TIME_DECISION_INSTRUCTION = """
+            You have access to a current_time tool. Decide whether to call it.
+            Use current_time for questions about the current date, weekday, time, or timezone.
+            For static knowledge that does not need the current time, answer directly without using a tool.
+            """;
+    private static final String OPENAI_TOOL_DECISION_INSTRUCTION = """
+            You have access to current_time and web_search tools. Decide whether to call them.
+            Use current_time for questions about the current date, weekday, time, or timezone.
+            Use web_search for questions that require current or recently changed external information, including latest news, prices, policies, schedules, releases, rankings, or status.
+            For static knowledge that does not need tools, answer directly without using a tool.
             """;
     private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
 
@@ -85,15 +103,17 @@ public class PromptChatService {
      */
     private void performChatRequest(JSONObject request, SseEmitter emitter, String streamId, ChatReqRecords chatReqRecords, boolean edit, boolean isDebug) throws IOException {
         String provider = normalizeProvider(request.getString("provider"));
-        if (hasWebSearchCapability(request)) {
+        ensureManagedToolsForOpenAiCompatibleProvider(provider, request);
+        boolean shouldHandleOpenAiFunctionTools = shouldHandleOpenAiFunctionToolCall(provider, request);
+        JSONObject fallbackRequest = null;
+        if (shouldHandleOpenAiFunctionTools) {
+            fallbackRequest = JSON.parseObject(request.toJSONString());
+            applyToolDecisionInstruction(request);
+        } else if (hasWebSearchCapability(request)) {
             applyWebSearchDecisionInstruction(request);
         }
-        // Handle managed web search directly (when managedWebSearch=true without tools array)
-        if (request.getBooleanValue("managedWebSearch") && !hasOpenAiSearchTool(request.getJSONArray("tools"))) {
-            applyManagedWebSearch(request, chatReqRecords);
-        }
-        if (shouldHandleOpenAiFunctionToolCall(provider, request)
-                && handleOpenAiFunctionToolCall(request, emitter, streamId, chatReqRecords, edit, isDebug, provider)) {
+        if (shouldHandleOpenAiFunctionTools
+                && handleOpenAiFunctionToolCall(request, fallbackRequest, emitter, streamId, chatReqRecords, edit, isDebug, provider)) {
             return;
         }
         PreparedRequest preparedRequest = buildPreparedRequest(request, provider);
@@ -241,7 +261,21 @@ public class PromptChatService {
         if (PROVIDER_GOOGLE.equals(provider) || PROVIDER_ANTHROPIC.equals(provider)) {
             return false;
         }
-        return hasOpenAiSearchTool(request.getJSONArray("tools"));
+        return hasOpenAiManagedTool(request.getJSONArray("tools"));
+    }
+
+    private boolean hasOpenAiManagedTool(JSONArray tools) {
+        if (tools == null || tools.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < tools.size(); i++) {
+            JSONObject tool = tools.getJSONObject(i);
+            JSONObject function = tool == null ? null : tool.getJSONObject("function");
+            if (function != null && isManagedToolName(function.getString("name"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean hasOpenAiSearchTool(JSONArray tools) {
@@ -256,6 +290,83 @@ public class PromptChatService {
             }
         }
         return false;
+    }
+
+    private boolean hasOpenAiCurrentTimeTool(JSONArray tools) {
+        if (tools == null || tools.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < tools.size(); i++) {
+            JSONObject tool = tools.getJSONObject(i);
+            JSONObject function = tool == null ? null : tool.getJSONObject("function");
+            if (function != null && isCurrentTimeToolName(function.getString("name"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void ensureManagedToolsForOpenAiCompatibleProvider(String provider, JSONObject request) {
+        if (!request.getBooleanValue("managedWebSearch")
+                || PROVIDER_GOOGLE.equals(provider)
+                || PROVIDER_ANTHROPIC.equals(provider)) {
+            return;
+        }
+        JSONArray tools = request.getJSONArray("tools");
+        if (tools == null) {
+            tools = new JSONArray();
+            request.put("tools", tools);
+        }
+        if (!hasOpenAiSearchTool(tools)) {
+            tools.add(buildOpenAiSearchFunctionTool());
+        }
+        if (!hasOpenAiCurrentTimeTool(tools)) {
+            tools.add(buildOpenAiCurrentTimeFunctionTool());
+        }
+        if (StringUtils.isBlank(request.getString("tool_choice"))
+                && StringUtils.isBlank(request.getString("toolChoice"))) {
+            request.put("tool_choice", "auto");
+        }
+    }
+
+    private JSONObject buildOpenAiSearchFunctionTool() {
+        JSONObject properties = new JSONObject()
+                .fluentPut("query", new JSONObject()
+                        .fluentPut("type", "string")
+                        .fluentPut("description", "A precise web search query based on the user's request."));
+        JSONArray required = new JSONArray();
+        required.add("query");
+        return buildOpenAiFunctionTool(
+                OPENAI_SEARCH_TOOL_NAME,
+                "Search the live web for up-to-date external information. Use this for recent events, latest facts, prices, policies, schedules, releases, rankings, or status.",
+                properties,
+                required);
+    }
+
+    private JSONObject buildOpenAiCurrentTimeFunctionTool() {
+        JSONObject properties = new JSONObject()
+                .fluentPut("timezone", new JSONObject()
+                        .fluentPut("type", "string")
+                        .fluentPut("description", "IANA timezone name. Defaults to Asia/Shanghai."));
+        return buildOpenAiFunctionTool(
+                CURRENT_TIME_TOOL_NAME,
+                "Get the current date, time, weekday, timezone, and ISO timestamp. Use this for questions about today, now, the current date, or the current weekday.",
+                properties,
+                new JSONArray());
+    }
+
+    private JSONObject buildOpenAiFunctionTool(String name, String description, JSONObject properties, JSONArray requiredFields) {
+        JSONObject parameters = new JSONObject()
+                .fluentPut("type", "object")
+                .fluentPut("properties", properties)
+                .fluentPut("required", requiredFields)
+                .fluentPut("additionalProperties", false);
+        return new JSONObject()
+                .fluentPut("type", "function")
+                .fluentPut("function", new JSONObject()
+                        .fluentPut("name", name)
+                        .fluentPut("description", description)
+                        .fluentPut("parameters", parameters));
     }
 
     private boolean hasWebSearchCapability(JSONObject request) {
@@ -292,7 +403,32 @@ public class PromptChatService {
                 || StringUtils.equals(name, LEGACY_OPENAI_SEARCH_TOOL_NAME);
     }
 
+    private boolean isCurrentTimeToolName(String name) {
+        return StringUtils.equals(name, CURRENT_TIME_TOOL_NAME);
+    }
+
+    private boolean isManagedToolName(String name) {
+        return isSearchToolName(name) || isCurrentTimeToolName(name);
+    }
+
+    private void applyToolDecisionInstruction(JSONObject request) {
+        JSONArray tools = request.getJSONArray("tools");
+        boolean hasSearchTool = hasOpenAiSearchTool(tools);
+        boolean hasCurrentTimeTool = hasOpenAiCurrentTimeTool(tools);
+        if (hasSearchTool && hasCurrentTimeTool) {
+            applyDecisionInstruction(request, OPENAI_TOOL_DECISION_INSTRUCTION, "current_time and web_search tools");
+        } else if (hasCurrentTimeTool) {
+            applyDecisionInstruction(request, CURRENT_TIME_DECISION_INSTRUCTION, "current_time tool");
+        } else if (hasSearchTool) {
+            applyDecisionInstruction(request, WEB_SEARCH_DECISION_INSTRUCTION, "web_search tool");
+        }
+    }
+
     private void applyWebSearchDecisionInstruction(JSONObject request) {
+        applyDecisionInstruction(request, WEB_SEARCH_DECISION_INSTRUCTION, "web_search tool");
+    }
+
+    private void applyDecisionInstruction(JSONObject request, String instruction, String marker) {
         JSONArray messages = request.getJSONArray("messages");
         if (messages == null || messages.isEmpty()) {
             return;
@@ -310,58 +446,102 @@ public class PromptChatService {
         if (firstSystemMessage == null) {
             messages.add(0, new JSONObject()
                     .fluentPut("role", "system")
-                    .fluentPut("content", WEB_SEARCH_DECISION_INSTRUCTION));
+                    .fluentPut("content", instruction));
         } else {
             String content = StringUtils.defaultString(firstSystemMessage.getString("content"));
-            if (!StringUtils.contains(content, "web_search tool")) {
-                firstSystemMessage.put("content", WEB_SEARCH_DECISION_INSTRUCTION + "\n" + content);
+            if (!StringUtils.contains(content, marker)) {
+                firstSystemMessage.put("content", instruction + "\n" + content);
             }
         }
         request.put("messages", messages);
     }
 
-    private boolean handleOpenAiFunctionToolCall(JSONObject request, SseEmitter emitter, String streamId,
+    private boolean handleOpenAiFunctionToolCall(JSONObject request, JSONObject fallbackRequest, SseEmitter emitter, String streamId,
             ChatReqRecords chatReqRecords, boolean edit, boolean isDebug, String provider) throws IOException {
-        JSONObject planningRequest = JSON.parseObject(request.toJSONString());
-        planningRequest.put("stream", false);
+        JSONObject loopRequest = JSON.parseObject(request.toJSONString());
+        JSONArray managedSearchTrace = new JSONArray();
+        Set<String> seenToolCalls = new HashSet<>();
+        int executedToolCalls = 0;
+        boolean toolExecuted = false;
 
-        JSONObject planningResponse;
-        try {
-            planningResponse = executeJsonRequest(planningRequest, provider);
-        } catch (Exception e) {
-            log.warn("OpenAI-compatible tool planning failed, fallback to normal request, streamId: {}, error: {}", streamId, e.getMessage());
-            request.remove("tools");
-            request.remove("toolChoice");
-            request.remove("tool_choice");
-            return false;
-        }
+        for (int round = 0; round < MAX_OPENAI_TOOL_ROUNDS; round++) {
+            loopRequest.put("stream", false);
 
-        JSONArray toolCalls = extractAssistantToolCalls(planningResponse);
-        if (toolCalls == null || toolCalls.isEmpty()) {
-            JSONObject normalizedData = normalizeSynchronousOpenAiResponse(planningResponse);
-            StringBuffer finalResult = new StringBuffer(extractAssistantContent(planningResponse));
-            StringBuffer thinkingResult = new StringBuffer();
-            StringBuffer sid = new StringBuffer(StringUtils.defaultString(planningResponse.getString("id")));
-            StringBuffer traceResult = new StringBuffer();
-            if (normalizedData != null) {
-                tryServeSSEData(emitter, normalizedData, streamId);
+            JSONObject planningResponse;
+            try {
+                planningResponse = executeJsonRequest(loopRequest, provider);
+            } catch (Exception e) {
+                if (!toolExecuted) {
+                    log.warn("OpenAI-compatible tool planning failed, fallback to normal request, streamId: {}, error: {}", streamId, e.getMessage());
+                    if (fallbackRequest != null) {
+                        request.clear();
+                        request.putAll(fallbackRequest);
+                    }
+                    stripToolFields(request);
+                    return false;
+                }
+                log.warn("OpenAI-compatible tool loop failed after tool execution, streamId: {}, error: {}", streamId, e.getMessage());
+                SseEmitterUtil.completeWithError(emitter, "Tool call failed: " + e.getMessage());
+                return true;
             }
-            handleStreamComplete(emitter, streamId, finalResult, thinkingResult, chatReqRecords, sid, traceResult, edit, isDebug, false);
-            return true;
+
+            JSONArray toolCalls = extractAssistantToolCalls(planningResponse);
+            if (toolCalls == null || toolCalls.isEmpty()) {
+                emitSynchronousOpenAiResponse(planningResponse, emitter, streamId, chatReqRecords, edit, isDebug, managedSearchTrace);
+                return true;
+            }
+
+            ManagedToolBatchResult batchResult = executeManagedTools(
+                    toolCalls,
+                    loopRequest,
+                    chatReqRecords,
+                    seenToolCalls,
+                    MAX_OPENAI_TOOL_CALLS - executedToolCalls,
+                    resolveAllowedManagedToolNames(loopRequest.getJSONArray("tools")));
+            appendTraceEntries(managedSearchTrace, batchResult.traceEntries());
+            appendToolMessages(loopRequest, extractAssistantMessage(planningResponse), toolCalls, batchResult.outputs());
+            executedToolCalls += batchResult.executedToolCalls();
+            toolExecuted = toolExecuted || batchResult.executedToolCalls() > 0;
+
+            if (batchResult.limitExceeded()) {
+                return completeToolLoopStopped(
+                        loopRequest,
+                        emitter,
+                        streamId,
+                        chatReqRecords,
+                        edit,
+                        isDebug,
+                        provider,
+                        managedSearchTrace,
+                        "TOOL_CALL_LIMIT_EXCEEDED",
+                        "The tool call budget for this user message has been exhausted after " + MAX_OPENAI_TOOL_CALLS + " tool calls.");
+            }
+            if (batchResult.duplicateDetected()) {
+                return completeToolLoopStopped(
+                        loopRequest,
+                        emitter,
+                        streamId,
+                        chatReqRecords,
+                        edit,
+                        isDebug,
+                        provider,
+                        managedSearchTrace,
+                        "DUPLICATE_TOOL_CALL",
+                        "A duplicate tool call was detected and skipped to prevent a loop.");
+            }
         }
 
-        ManagedToolResult toolResult = executeSearchTool(toolCalls, request, chatReqRecords);
-        if (StringUtils.isNotBlank(toolResult.traceJson())) {
-            request.put("managedSearchTrace", toolResult.traceJson());
-        } else {
-            request.remove("managedSearchTrace");
-        }
-        appendToolMessages(request, extractAssistantMessage(planningResponse), toolCalls, toolResult.content());
-        request.remove("tools");
-        request.remove("toolChoice");
-        request.remove("tool_choice");
-        request.put("stream", true);
-        return false;
+        return completeToolLoopStopped(
+                loopRequest,
+                emitter,
+                streamId,
+                chatReqRecords,
+                edit,
+                isDebug,
+                provider,
+                managedSearchTrace,
+                "TOOL_ROUND_LIMIT_EXCEEDED",
+                "The tool round budget for this user message has been exhausted after " + MAX_OPENAI_TOOL_ROUNDS + " rounds.");
     }
 
     private JSONObject executeJsonRequest(JSONObject request, String provider) throws IOException {
@@ -444,80 +624,204 @@ public class PromptChatService {
         return normalized;
     }
 
-    private ManagedToolResult executeSearchTool(JSONArray toolCalls, JSONObject request, ChatReqRecords chatReqRecords) {
-        String query = resolveSearchQueryFromToolCalls(toolCalls, request);
+    private void emitSynchronousOpenAiResponse(JSONObject response, SseEmitter emitter, String streamId,
+            ChatReqRecords chatReqRecords, boolean edit, boolean isDebug, JSONArray managedSearchTrace) {
+        String traceJson = managedSearchTrace == null || managedSearchTrace.isEmpty() ? "" : managedSearchTrace.toJSONString();
+        if (StringUtils.isNotBlank(traceJson)) {
+            emitManagedSearchToolCalls(emitter, streamId, traceJson);
+        }
+        JSONObject normalizedData = normalizeSynchronousOpenAiResponse(response);
+        StringBuffer finalResult = new StringBuffer(extractAssistantContent(response));
+        StringBuffer thinkingResult = new StringBuffer();
+        StringBuffer sid = new StringBuffer(StringUtils.defaultString(response == null ? null : response.getString("id")));
+        StringBuffer traceResult = new StringBuffer(traceJson);
+        if (normalizedData != null) {
+            tryServeSSEData(emitter, normalizedData, streamId);
+        }
+        handleStreamComplete(emitter, streamId, finalResult, thinkingResult, chatReqRecords, sid, traceResult, edit, isDebug,
+                StringUtils.isNotBlank(traceJson));
+    }
+
+    private boolean completeToolLoopStopped(JSONObject loopRequest, SseEmitter emitter, String streamId,
+            ChatReqRecords chatReqRecords, boolean edit, boolean isDebug, String provider, JSONArray managedSearchTrace,
+            String code, String message) throws IOException {
+        appendToolLoopStopInstruction(loopRequest, code, message);
+        stripToolFields(loopRequest);
+        loopRequest.put("stream", false);
+        try {
+            JSONObject finalResponse = executeJsonRequest(loopRequest, provider);
+            emitSynchronousOpenAiResponse(finalResponse, emitter, streamId, chatReqRecords, edit, isDebug, managedSearchTrace);
+        } catch (Exception e) {
+            log.warn("OpenAI-compatible final answer after tool loop stop failed, streamId: {}, code: {}, error: {}",
+                    streamId, code, e.getMessage());
+            SseEmitterUtil.completeWithError(emitter, code + ": " + e.getMessage());
+        }
+        return true;
+    }
+
+    private void appendToolLoopStopInstruction(JSONObject request, String code, String message) {
+        JSONArray messages = request.getJSONArray("messages");
+        if (messages == null) {
+            messages = new JSONArray();
+            request.put("messages", messages);
+        }
+        String instruction = """
+                Tool execution stopped with code %s.
+                %s
+                Use only the available tool results already present in the conversation. If the available results are insufficient, say that the answer is incomplete.
+                """.formatted(code, message);
+        for (int i = 0; i < messages.size(); i++) {
+            JSONObject messageObj = messages.getJSONObject(i);
+            if (messageObj != null && "system".equals(normalizeMessageRole(messageObj.getString("role")))) {
+                messageObj.put("content", appendPrompt(messageObj.getString("content"), instruction));
+                return;
+            }
+        }
+        messages.add(0, new JSONObject()
+                .fluentPut("role", "system")
+                .fluentPut("content", instruction));
+    }
+
+    private void stripToolFields(JSONObject request) {
+        request.remove("tools");
+        request.remove("toolChoice");
+        request.remove("tool_choice");
+    }
+
+    private ManagedToolBatchResult executeManagedTools(JSONArray toolCalls, JSONObject request, ChatReqRecords chatReqRecords,
+            Set<String> seenToolCalls, int remainingToolCallBudget, Set<String> allowedToolNames) {
+        List<ManagedToolOutput> outputs = new ArrayList<>();
+        JSONArray traceEntries = new JSONArray();
+        boolean limitExceeded = false;
+        boolean duplicateDetected = false;
+        int executedToolCalls = 0;
+
+        for (int i = 0; i < toolCalls.size(); i++) {
+            JSONObject toolCall = toolCalls.getJSONObject(i);
+            JSONObject function = toolCall == null ? null : toolCall.getJSONObject("function");
+            if (function == null) {
+                continue;
+            }
+            String toolCallId = toolCall.getString("id");
+            String toolName = function.getString("name");
+            JSONObject arguments = parseToolArguments(function.getString("arguments"));
+
+            if (allowedToolNames == null || !allowedToolNames.contains(toolName)) {
+                outputs.add(new ManagedToolOutput(toolCallId, buildToolErrorContent("TOOL_NOT_AVAILABLE", "Tool was not provided for this request: " + toolName)));
+                continue;
+            }
+
+            if (!isManagedToolName(toolName)) {
+                outputs.add(new ManagedToolOutput(toolCallId, buildToolErrorContent("UNSUPPORTED_TOOL", "Unsupported tool: " + toolName)));
+                continue;
+            }
+
+            String signature = toolName + ":" + arguments.toJSONString();
+            if (seenToolCalls.contains(signature)) {
+                duplicateDetected = true;
+                outputs.add(new ManagedToolOutput(toolCallId, buildToolErrorContent("DUPLICATE_TOOL_CALL", "Duplicate tool call skipped: " + toolName)));
+                continue;
+            }
+
+            if (remainingToolCallBudget <= 0) {
+                limitExceeded = true;
+                outputs.add(new ManagedToolOutput(toolCallId, buildToolErrorContent(
+                        "TOOL_CALL_LIMIT_EXCEEDED",
+                        "Tool call budget exhausted for this user message.")));
+                continue;
+            }
+
+            seenToolCalls.add(signature);
+            remainingToolCallBudget--;
+            executedToolCalls++;
+
+            if (isSearchToolName(toolName)) {
+                ManagedToolOutput output = executeSearchTool(toolCallId, arguments, request, chatReqRecords, traceEntries);
+                outputs.add(output);
+            } else if (isCurrentTimeToolName(toolName)) {
+                outputs.add(new ManagedToolOutput(toolCallId, CurrentTimeTool.execute(arguments.getString("timezone"))));
+            }
+        }
+
+        return new ManagedToolBatchResult(outputs, traceEntries, executedToolCalls, limitExceeded, duplicateDetected);
+    }
+
+    private Set<String> resolveAllowedManagedToolNames(JSONArray tools) {
+        Set<String> allowedToolNames = new HashSet<>();
+        if (tools == null || tools.isEmpty()) {
+            return allowedToolNames;
+        }
+        for (int i = 0; i < tools.size(); i++) {
+            JSONObject tool = tools.getJSONObject(i);
+            JSONObject function = tool == null ? null : tool.getJSONObject("function");
+            if (function == null) {
+                continue;
+            }
+            String name = function.getString("name");
+            if (isManagedToolName(name)) {
+                allowedToolNames.add(name);
+            }
+        }
+        return allowedToolNames;
+    }
+
+    private ManagedToolOutput executeSearchTool(String toolCallId, JSONObject arguments, JSONObject request,
+            ChatReqRecords chatReqRecords, JSONArray traceEntries) {
+        String query = StringUtils.defaultIfBlank(arguments.getString("query"), resolveLatestUserQuery(request.getJSONArray("messages")));
         String userId = StringUtils.defaultIfBlank(
                 chatReqRecords == null ? request.getString("userId") : chatReqRecords.getUid(),
                 "managed-web-search");
         ManagedWebSearchService.SearchAugmentation augmentation = managedWebSearchService.search(query, userId);
         if (augmentation.failed()) {
             String errorMessage = StringUtils.defaultIfBlank(augmentation.errorMessage(), "real-time web search unavailable");
-            return new ManagedToolResult("实时联网搜索失败：" + errorMessage, "");
+            return new ManagedToolOutput(toolCallId, "实时联网搜索失败：" + errorMessage);
         }
-        return new ManagedToolResult(augmentation.summary(), augmentation.traceJson());
+        appendTraceEntries(traceEntries, augmentation.traceJson());
+        return new ManagedToolOutput(toolCallId, augmentation.summary());
     }
 
-    /**
-     * Apply managed web search directly when managedWebSearch=true without tools array. Executes search
-     * and injects results into system message, then removes the flag.
-     */
-    private void applyManagedWebSearch(JSONObject request, ChatReqRecords chatReqRecords) {
-        String query = request.getString("managedSearchQuery");
-        if (StringUtils.isBlank(query)) {
-            request.remove("managedWebSearch");
+    private JSONObject parseToolArguments(String arguments) {
+        if (StringUtils.isBlank(arguments)) {
+            return new JSONObject();
+        }
+        try {
+            JSONObject parsedArguments = JSON.parseObject(arguments);
+            return parsedArguments == null ? new JSONObject() : parsedArguments;
+        } catch (Exception e) {
+            log.warn("Failed to parse tool arguments: {}", arguments, e);
+            return new JSONObject();
+        }
+    }
+
+    private String buildToolErrorContent(String code, String message) {
+        return new JSONObject()
+                .fluentPut("error", code)
+                .fluentPut("message", message)
+                .toJSONString();
+    }
+
+    private void appendTraceEntries(JSONArray target, JSONArray traceEntries) {
+        if (target == null || traceEntries == null || traceEntries.isEmpty()) {
             return;
         }
-        String userId = StringUtils.defaultIfBlank(
-                chatReqRecords == null ? request.getString("userId") : chatReqRecords.getUid(),
-                "managed-web-search");
-        ManagedWebSearchService.SearchAugmentation augmentation = managedWebSearchService.search(query, userId);
-        if (augmentation.failed()) {
-            request.remove("managedWebSearch");
+        target.addAll(traceEntries);
+    }
+
+    private void appendTraceEntries(JSONArray target, String traceJson) {
+        if (target == null || StringUtils.isBlank(traceJson)) {
             return;
         }
-        // Inject search summary into first message's content
-        JSONArray messages = request.getJSONArray("messages");
-        if (messages != null && !messages.isEmpty()) {
-            JSONObject firstMessage = messages.getJSONObject(0);
-            if (firstMessage != null) {
-                String existingContent = firstMessage.getString("content");
-                String augmentedContent = "[managed real-time web search results: " + augmentation.summary() + "]\n" + StringUtils.defaultString(existingContent);
-                firstMessage.put("content", augmentedContent);
+        try {
+            JSONArray parsedTrace = JSON.parseArray(traceJson);
+            if (parsedTrace != null && !parsedTrace.isEmpty()) {
+                target.addAll(parsedTrace);
             }
-        }
-        // Remove managed web search fields so they don't trigger function tool call flow
-        request.remove("managedWebSearch");
-        request.remove("managedSearchQuery");
-        if (StringUtils.isNotBlank(augmentation.traceJson())) {
-            request.put("managedSearchTrace", augmentation.traceJson());
+        } catch (Exception e) {
+            log.warn("Failed to parse managed search trace: {}", traceJson, e);
         }
     }
 
-    private String resolveSearchQueryFromToolCalls(JSONArray toolCalls, JSONObject request) {
-        for (int i = 0; i < toolCalls.size(); i++) {
-            JSONObject toolCall = toolCalls.getJSONObject(i);
-            JSONObject function = toolCall == null ? null : toolCall.getJSONObject("function");
-            if (function == null || !isSearchToolName(function.getString("name"))) {
-                continue;
-            }
-            String arguments = function.getString("arguments");
-            if (StringUtils.isBlank(arguments)) {
-                continue;
-            }
-            try {
-                JSONObject argumentJson = JSON.parseObject(arguments);
-                String query = argumentJson == null ? null : argumentJson.getString("query");
-                if (StringUtils.isNotBlank(query)) {
-                    return query;
-                }
-            } catch (Exception e) {
-                log.warn("Failed to parse tool arguments: {}", arguments, e);
-            }
-        }
-        return resolveLatestUserQuery(request.getJSONArray("messages"));
-    }
-
-    private void appendToolMessages(JSONObject request, JSONObject assistantMessage, JSONArray toolCalls, String toolContent) {
+    private void appendToolMessages(JSONObject request, JSONObject assistantMessage, JSONArray toolCalls, List<ManagedToolOutput> outputs) {
         JSONArray messages = request.getJSONArray("messages");
         if (messages == null) {
             messages = new JSONArray();
@@ -527,16 +831,14 @@ public class PromptChatService {
                 .fluentPut("role", "assistant")
                 .fluentPut("content", assistantMessage == null ? "" : StringUtils.defaultString(assistantMessage.getString("content")))
                 .fluentPut("tool_calls", toolCalls));
-        for (int i = 0; i < toolCalls.size(); i++) {
-            JSONObject toolCall = toolCalls.getJSONObject(i);
-            JSONObject function = toolCall == null ? null : toolCall.getJSONObject("function");
-            if (function == null || !isSearchToolName(function.getString("name"))) {
+        for (ManagedToolOutput output : outputs) {
+            if (output == null || StringUtils.isBlank(output.toolCallId())) {
                 continue;
             }
             messages.add(new JSONObject()
                     .fluentPut("role", "tool")
-                    .fluentPut("tool_call_id", toolCall.getString("id"))
-                    .fluentPut("content", toolContent));
+                    .fluentPut("tool_call_id", output.toolCallId())
+                    .fluentPut("content", output.content()));
         }
     }
 
@@ -1076,7 +1378,10 @@ public class PromptChatService {
         return value;
     }
 
-    private record ManagedToolResult(String content, String traceJson) {}
+    private record ManagedToolOutput(String toolCallId, String content) {}
+
+    private record ManagedToolBatchResult(List<ManagedToolOutput> outputs, JSONArray traceEntries, int executedToolCalls,
+            boolean limitExceeded, boolean duplicateDetected) {}
 
     private record PreparedRequest(String url, String body, String accept) {}
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/SparkChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/SparkChatService.java
@@ -136,8 +136,12 @@ public class SparkChatService {
             return SparkModel.SPARK_X1;
         }
 
-        return switch (model.toLowerCase()) {
-            case "spark" -> SparkModel.SPARK_4_0_ULTRA;
+        return switch (model.trim().toLowerCase()) {
+            case "spark", "4.0ultra", "bm4" -> SparkModel.SPARK_4_0_ULTRA;
+            case "generalv3.5", "bm3.5", "spark-max", "max" -> SparkModel.SPARK_MAX;
+            case "generalv3", "bm3", "spark-pro", "pro" -> SparkModel.SPARK_PRO;
+            case "general", "cbm", "spark-lite", "lite" -> SparkModel.SPARK_LITE;
+            case "spark-x1", "x1" -> SparkModel.SPARK_X1;
             default -> SparkModel.SPARK_X1;
         };
     }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
@@ -142,7 +142,7 @@ public class BotChatServiceImpl implements BotChatService {
                 } else {
                     List<SparkChatRequest.MessageDto> messages = buildMessageList(chatBotReqDto, botConfig.supportContext, botConfig.supportDocument, botConfig.prompt, modelConfig.maxInputTokens(), chatReqRecords.getId());
                     ProviderToolOrchestrator.ToolExecutionPlan toolPlan =
-                            ProviderToolOrchestrator.resolve(modelConfig.llmInfoVo().getProvider(), botConfig.openedTool);
+                            ProviderToolOrchestrator.resolvePromptProvider(modelConfig.llmInfoVo().getProvider(), botConfig.openedTool);
                     JSONObject jsonObject = buildPromptChatRequest(
                             modelConfig.llmInfoVo(),
                             messages,
@@ -190,7 +190,7 @@ public class BotChatServiceImpl implements BotChatService {
             } else {
                 List<SparkChatRequest.MessageDto> messages = buildMessageList(chatBotReqDto, botConfig.supportContext, botConfig.supportDocument, botConfig.prompt, modelConfig.maxInputTokens(), chatReqRecords.getId());
                 ProviderToolOrchestrator.ToolExecutionPlan toolPlan =
-                        ProviderToolOrchestrator.resolve(modelConfig.llmInfoVo().getProvider(), botConfig.openedTool);
+                        ProviderToolOrchestrator.resolvePromptProvider(modelConfig.llmInfoVo().getProvider(), botConfig.openedTool);
                 JSONObject jsonObject = buildPromptChatRequest(
                         modelConfig.llmInfoVo(),
                         messages,
@@ -241,7 +241,7 @@ public class BotChatServiceImpl implements BotChatService {
                     throw new BusinessException(ResponseEnum.MODEL_CHECK_FAILED);
                 }
                 ProviderToolOrchestrator.ToolExecutionPlan toolPlan =
-                        ProviderToolOrchestrator.resolve(modelConfig.llmInfoVo().getProvider(), request.getOpenedTool());
+                        ProviderToolOrchestrator.resolvePromptProvider(modelConfig.llmInfoVo().getProvider(), request.getOpenedTool());
                 JSONObject jsonObject = buildPromptChatRequest(
                         modelConfig.llmInfoVo(),
                         messageList,
@@ -370,8 +370,16 @@ public class BotChatServiceImpl implements BotChatService {
             return true;
         }
         return "spark".equalsIgnoreCase(model)
+                || "spark-x1".equalsIgnoreCase(model)
                 || "x1".equalsIgnoreCase(model)
-                || "generalv3.5".equalsIgnoreCase(model);
+                || "general".equalsIgnoreCase(model)
+                || "generalv3".equalsIgnoreCase(model)
+                || "generalv3.5".equalsIgnoreCase(model)
+                || "4.0Ultra".equalsIgnoreCase(model)
+                || "cbm".equalsIgnoreCase(model)
+                || "bm3".equalsIgnoreCase(model)
+                || "bm3.5".equalsIgnoreCase(model)
+                || "bm4".equalsIgnoreCase(model);
     }
 
     private ModelConfigResult buildModelConfigResult(LLMInfoVo llmInfoVo) {
@@ -708,7 +716,7 @@ public class BotChatServiceImpl implements BotChatService {
      * Utility method to build SparkChatRequest object
      *
      * @param chatBotReqDto Chat bot request data transfer object
-     * @param botConfig Bot configuration
+     * @param model Spark model name
      * @param messages List of message data transfer objects
      * @return Built SparkChatRequest object
      */

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ProviderToolOrchestrator.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ProviderToolOrchestrator.java
@@ -14,16 +14,17 @@ import java.util.Set;
 /**
  * Shared tool orchestration for bot debug and formal chat.
  *
- * Current provider capability matrix for enabled web search: - spark: native support via
- * SparkChatRequest.enableWebSearch - google: native support via Gemini tools.google_search -
- * anthropic: native support via Anthropic web_search tool + beta header - other OpenAI-compatible
- * providers: model-driven function tool calling via web_search
+ * Current provider capability matrix for enabled tools: spark uses native Spark web search;
+ * OpenAI-compatible providers use model-driven function tool calling via web_search and
+ * current_time; google and anthropic use their native web search tools.
  */
 final class ProviderToolOrchestrator {
 
     static final String TOOL_WEB_SEARCH = "web_search";
     static final String TOOL_IFLY_SEARCH_LEGACY = "ifly_search";
+    static final String TOOL_CURRENT_TIME = "current_time";
     static final String OPENAI_SEARCH_TOOL_NAME = "web_search";
+    static final String OPENAI_CURRENT_TIME_TOOL_NAME = "current_time";
     static final String PROVIDER_SPARK = "spark";
     static final String PROVIDER_GOOGLE = "google";
     static final String PROVIDER_ANTHROPIC = "anthropic";
@@ -31,21 +32,31 @@ final class ProviderToolOrchestrator {
     private ProviderToolOrchestrator() {}
 
     static ToolExecutionPlan resolve(String provider, String openedTool) {
-        Set<String> enabledTools = parseEnabledTools(openedTool);
-        boolean webSearchEnabled = enabledTools.contains(TOOL_WEB_SEARCH)
-                || enabledTools.contains(TOOL_IFLY_SEARCH_LEGACY);
+        Set<String> configuredTools = parseEnabledTools(openedTool);
         String normalizedProvider = normalizeProvider(provider);
 
-        if (!webSearchEnabled) {
-            return new ToolExecutionPlan(normalizedProvider, enabledTools, WebSearchMode.DISABLED);
-        }
-
         return switch (normalizedProvider) {
-            case PROVIDER_SPARK -> new ToolExecutionPlan(normalizedProvider, enabledTools, WebSearchMode.SPARK_NATIVE);
-            case PROVIDER_GOOGLE -> new ToolExecutionPlan(normalizedProvider, enabledTools, WebSearchMode.GOOGLE_NATIVE);
-            case PROVIDER_ANTHROPIC -> new ToolExecutionPlan(normalizedProvider, enabledTools, WebSearchMode.ANTHROPIC_NATIVE);
-            default -> new ToolExecutionPlan(normalizedProvider, enabledTools, WebSearchMode.OPENAI_FUNCTION);
+            case PROVIDER_SPARK -> new ToolExecutionPlan(
+                    normalizedProvider,
+                    configuredTools,
+                    hasSearchTool(configuredTools) ? WebSearchMode.SPARK_NATIVE : WebSearchMode.DISABLED);
+            case PROVIDER_GOOGLE -> new ToolExecutionPlan(
+                    normalizedProvider,
+                    configuredTools,
+                    hasSearchTool(configuredTools) ? WebSearchMode.GOOGLE_NATIVE : WebSearchMode.DISABLED);
+            case PROVIDER_ANTHROPIC -> new ToolExecutionPlan(
+                    normalizedProvider,
+                    configuredTools,
+                    hasSearchTool(configuredTools) ? WebSearchMode.ANTHROPIC_NATIVE : WebSearchMode.DISABLED);
+            default -> new ToolExecutionPlan(
+                    normalizedProvider,
+                    withDefaultBuiltInTools(configuredTools),
+                    WebSearchMode.OPENAI_FUNCTION);
         };
+    }
+
+    static ToolExecutionPlan resolvePromptProvider(String provider, String openedTool) {
+        return resolve(provider, openedTool);
     }
 
     static void applyToSparkRequest(SparkChatRequest request, ToolExecutionPlan plan) {
@@ -63,8 +74,13 @@ final class ProviderToolOrchestrator {
                 request.put("anthropicBeta", "web-search-2025-03-05");
             }
             case OPENAI_FUNCTION -> {
-                request.put("managedWebSearch", true);
-                request.put("tools", buildOpenAiCompatibleSearchTools());
+                boolean webSearchEnabled = plan.enabledTools().contains(TOOL_WEB_SEARCH)
+                        || plan.enabledTools().contains(TOOL_IFLY_SEARCH_LEGACY);
+                boolean currentTimeEnabled = plan.enabledTools().contains(TOOL_CURRENT_TIME);
+                if (webSearchEnabled) {
+                    request.put("managedWebSearch", true);
+                }
+                request.put("tools", buildOpenAiCompatibleTools(webSearchEnabled, currentTimeEnabled));
                 request.put("tool_choice", "auto");
             }
             case SPARK_NATIVE -> {
@@ -92,6 +108,18 @@ final class ProviderToolOrchestrator {
         return new LinkedHashSet<>(tools);
     }
 
+    private static Set<String> withDefaultBuiltInTools(Set<String> openedTools) {
+        LinkedHashSet<String> enabledTools = new LinkedHashSet<>(openedTools);
+        enabledTools.remove(TOOL_IFLY_SEARCH_LEGACY);
+        enabledTools.add(TOOL_WEB_SEARCH);
+        enabledTools.add(TOOL_CURRENT_TIME);
+        return enabledTools;
+    }
+
+    private static boolean hasSearchTool(Set<String> enabledTools) {
+        return enabledTools.contains(TOOL_WEB_SEARCH) || enabledTools.contains(TOOL_IFLY_SEARCH_LEGACY);
+    }
+
     private static JSONArray buildGoogleTools() {
         JSONArray tools = new JSONArray();
         tools.add(new JSONObject().fluentPut("google_search", new JSONObject()));
@@ -107,30 +135,48 @@ final class ProviderToolOrchestrator {
         return tools;
     }
 
-    private static JSONArray buildOpenAiCompatibleSearchTools() {
+    private static JSONArray buildOpenAiCompatibleTools(boolean includeWebSearch, boolean includeCurrentTime) {
         JSONArray tools = new JSONArray();
+        if (includeWebSearch) {
+            tools.add(buildOpenAiFunctionTool(
+                    OPENAI_SEARCH_TOOL_NAME,
+                    "Search the live web for up-to-date external information. Use this for recent events, latest facts, prices, policies, schedules, releases, rankings, or status.",
+                    new JSONObject()
+                            .fluentPut("query", new JSONObject()
+                                    .fluentPut("type", "string")
+                                    .fluentPut("description", "A precise web search query based on the user's request.")),
+                    List.of("query")));
+        }
+        if (includeCurrentTime) {
+            tools.add(buildOpenAiFunctionTool(
+                    OPENAI_CURRENT_TIME_TOOL_NAME,
+                    "Get the current date, time, weekday, timezone, and ISO timestamp. Use this for questions about today, now, the current date, or the current weekday.",
+                    new JSONObject()
+                            .fluentPut("timezone", new JSONObject()
+                                    .fluentPut("type", "string")
+                                    .fluentPut("description", "IANA timezone name. Defaults to Asia/Shanghai.")),
+                    List.of()));
+        }
+        return tools;
+    }
+
+    private static JSONObject buildOpenAiFunctionTool(String name, String description, JSONObject properties, List<String> requiredFields) {
         JSONObject function = new JSONObject();
-        function.put("name", OPENAI_SEARCH_TOOL_NAME);
-        function.put("description", "Search the live web for up-to-date information. Use this for current dates, weekdays, recent events, latest facts, prices, policies, schedules, or anything that may have changed recently.");
+        function.put("name", name);
+        function.put("description", description);
 
         JSONObject parameters = new JSONObject();
         parameters.put("type", "object");
-        JSONObject properties = new JSONObject();
-        properties.put("query", new JSONObject()
-                .fluentPut("type", "string")
-                .fluentPut("description", "A precise web search query based on the user's request."));
         parameters.put("properties", properties);
         JSONArray required = new JSONArray();
-        required.add("query");
+        required.addAll(requiredFields);
         parameters.put("required", required);
         parameters.put("additionalProperties", false);
 
         function.put("parameters", parameters);
-
-        tools.add(new JSONObject()
+        return new JSONObject()
                 .fluentPut("type", "function")
-                .fluentPut("function", function));
-        return tools;
+                .fluentPut("function", function);
     }
 
     record ToolExecutionPlan(String provider, Set<String> enabledTools, WebSearchMode webSearchMode) {}

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.hub.service;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.commons.entity.chat.ChatReqRecords;
 import com.iflytek.astron.console.commons.service.ChatRecordModelService;
@@ -18,6 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -168,7 +170,76 @@ class PromptChatServiceTest {
     }
 
     @Test
-    void testChatStream_OpenAiManagedSearch_InjectsSearchSummaryIntoMessages() {
+    void testChatStream_GoogleNativeSearch_KeepsWebSearchDecisionInstruction() {
+        request.put("provider", "google");
+        request.put("model", "gemini-3.1-pro");
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天热点新闻"}
+                ]
+                """));
+        request.put("tools", JSON.parseArray("""
+                [{"google_search": {}}]
+                """));
+        request.put("url", "https://example.com/v1beta/models/gemini-3.1-pro:generateContent");
+
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        doNothing().when(call).enqueue(any(Callback.class));
+
+        promptChatService.chatStream(request, emitter, streamId, chatReqRecords, false, false);
+
+        verify(httpClient).newCall(argThat(req -> {
+            try {
+                JSONObject body = parseRequestBody(req);
+                String systemInstruction = body.getJSONObject("systemInstruction")
+                        .getJSONArray("parts")
+                        .getJSONObject(0)
+                        .getString("text");
+                assertTrue(systemInstruction.contains("You have access to a web_search tool"));
+                assertFalse(systemInstruction.contains("current_time and web_search tools"));
+            } catch (IOException e) {
+                fail(e);
+            }
+            return true;
+        }));
+    }
+
+    @Test
+    void testChatStream_AnthropicNativeSearch_KeepsWebSearchDecisionInstruction() {
+        request.put("provider", "anthropic");
+        request.put("model", "claude-sonnet");
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天热点新闻"}
+                ]
+                """));
+        request.put("tools", JSON.parseArray("""
+                [{"type":"web_search_20250305","name":"web_search"}]
+                """));
+        request.put("url", "https://example.com/v1/messages");
+
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        doNothing().when(call).enqueue(any(Callback.class));
+
+        promptChatService.chatStream(request, emitter, streamId, chatReqRecords, false, false);
+
+        verify(httpClient).newCall(argThat(req -> {
+            try {
+                JSONObject body = parseRequestBody(req);
+                String system = body.getString("system");
+                assertTrue(system.contains("You have access to a web_search tool"));
+                assertFalse(system.contains("current_time and web_search tools"));
+            } catch (IOException e) {
+                fail(e);
+            }
+            return true;
+        }));
+    }
+
+    @Test
+    void testChatStream_OpenAiManagedSearchWithoutTools_AddsDefaultToolsAndDoesNotPreSearch() throws Exception {
         request.put("provider", "openai");
         request.put("model", "deepseek-chat");
         request.put("managedWebSearch", true);
@@ -180,14 +251,12 @@ class PromptChatServiceTest {
                   {"role":"user","content":"<wrapped prompt with knowledge> Help me search today's news"}
                 ]
                 """));
-        when(managedWebSearchService.search(eq("today's news"), eq("test-uid")))
-                .thenReturn(new ManagedWebSearchService.SearchAugmentation(
-                        "Search summary with [1]",
-                        "[{\"type\":\"web_search\",\"deskToolName\":\"Web Search\",\"web_search\":{\"outputs\":[{\"index\":1,\"url\":\"https://example.com\",\"title\":\"Example\"}]}}]",
-                        false,
-                        null));
         when(httpClient.newCall(any(Request.class))).thenReturn(call);
-        doNothing().when(call).enqueue(any(Callback.class));
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(ResponseBody.create(
+                "{\"id\":\"plan-id\",\"choices\":[{\"message\":{\"content\":\"no tool call\"}}]}",
+                MediaType.get("application/json; charset=utf-8")));
 
         promptChatService.chatStream(request, emitter, streamId, chatReqRecords, false, false);
 
@@ -196,23 +265,30 @@ class PromptChatServiceTest {
                 JSONObject body = parseRequestBody(req);
                 assertFalse(body.containsKey("managedSearchQuery"));
                 assertFalse(body.containsKey("userId"));
-                assertTrue(body.getJSONArray("messages")
+                assertEquals("auto", body.getString("tool_choice"));
+                assertEquals("web_search", body.getJSONArray("tools")
+                        .getJSONObject(0)
+                        .getJSONObject("function")
+                        .getString("name"));
+                assertEquals("current_time", body.getJSONArray("tools")
+                        .getJSONObject(1)
+                        .getJSONObject("function")
+                        .getString("name"));
+                assertFalse(body.getJSONArray("messages")
                         .getJSONObject(0)
                         .getString("content")
                         .contains("managed real-time web search"));
-                assertTrue(body.getJSONArray("messages")
-                        .getJSONObject(0)
-                        .getString("content")
-                        .contains("Search summary with [1]"));
             } catch (IOException e) {
                 fail(e);
             }
             return true;
         }));
+        verify(call).execute();
+        verify(managedWebSearchService, never()).search(anyString(), anyString());
     }
 
     @Test
-    void testChatStream_DebugManagedSearch_UsesRequestUserIdWhenRecordsMissing() {
+    void testChatStream_DebugManagedSearch_UsesRequestUserIdWhenToolIsCalled() throws Exception {
         request.put("provider", "openai");
         request.put("model", "deepseek-chat");
         request.put("managedWebSearch", true);
@@ -224,13 +300,31 @@ class PromptChatServiceTest {
                   {"role":"user","content":"wrapped prompt"}
                 ]
                 """));
+        Call planningCall = mock(Call.class);
+        Call finalCall = mock(Call.class);
+        Response planningResponse = mock(Response.class);
+        Response finalResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalCall);
+        when(planningCall.execute()).thenReturn(planningResponse);
+        when(finalCall.execute()).thenReturn(finalResponse);
+        when(planningResponse.isSuccessful()).thenReturn(true);
+        when(finalResponse.isSuccessful()).thenReturn(true);
+        when(planningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-id","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_search","type":"function","function":{"name":"web_search","arguments":"{\\"query\\":\\"latest headlines\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(finalResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"final-id","choices":[{"message":{"role":"assistant","content":"summary"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
         when(managedWebSearchService.search(eq("latest headlines"), eq("debug-user")))
                 .thenReturn(new ManagedWebSearchService.SearchAugmentation("summary", "[]", false, null));
-        when(httpClient.newCall(any(Request.class))).thenReturn(call);
-        doNothing().when(call).enqueue(any(Callback.class));
 
         promptChatService.chatStream(request, emitter, streamId, null, false, true);
 
+        verify(httpClient, times(2)).newCall(any(Request.class));
         verify(managedWebSearchService).search("latest headlines", "debug-user");
     }
 
@@ -249,6 +343,14 @@ class PromptChatServiceTest {
                       "name": "web_search",
                       "description": "Search the live web.",
                       "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }
+                  },
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {}}
                     }
                   }
                 ]
@@ -270,7 +372,7 @@ class PromptChatServiceTest {
                 assertTrue(body.getJSONArray("messages")
                         .getJSONObject(0)
                         .getString("content")
-                        .contains("Use web_search for questions that require current"));
+                        .contains("Use current_time for questions about the current date"));
                 assertFalse(body.containsKey("managedWebSearch"));
                 assertFalse(body.containsKey("managedSearchQuery"));
             } catch (IOException e) {
@@ -291,11 +393,61 @@ class PromptChatServiceTest {
     }
 
     @Test
+    void testChatStream_OpenAiToolPlanningFailure_FallbackDoesNotKeepToolInstruction() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天是周几"}
+                ]
+                """));
+
+        Call planningCall = mock(Call.class);
+        Call fallbackCall = mock(Call.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, fallbackCall);
+        when(planningCall.execute()).thenThrow(new IOException("planning failed"));
+        doNothing().when(fallbackCall).enqueue(any(Callback.class));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).newCall(requestCaptor.capture());
+        JSONObject fallbackBody = parseRequestBody(requestCaptor.getAllValues().get(1));
+        assertFalse(fallbackBody.containsKey("tools"));
+        assertFalse(fallbackBody.containsKey("tool_choice"));
+        assertFalse(fallbackBody.getJSONArray("messages")
+                .getJSONObject(0)
+                .getString("content")
+                .contains("current_time and web_search tools"));
+        assertFalse(fallbackBody.getJSONArray("messages")
+                .getJSONObject(0)
+                .getString("content")
+                .contains("current_time tool"));
+        assertFalse(fallbackBody.getJSONArray("messages")
+                .getJSONObject(0)
+                .getString("content")
+                .contains("Use current_time for questions"));
+    }
+
+    @Test
     void testChatStream_OpenAiSearchToolCall_ExecutesSearchAndAppendsToolMessages() throws Exception {
         request.put("provider", "openai");
         request.put("model", "deepseek-chat");
-        request.put("managedWebSearch", true);
-        request.put("managedSearchQuery", "今天是周几");
         request.put("userId", "debug-user");
         request.put("tool_choice", "auto");
         request.put("tools", JSON.parseArray("""
@@ -318,11 +470,14 @@ class PromptChatServiceTest {
                 """));
 
         Call planningCall = mock(Call.class);
-        Call finalCall = mock(Call.class);
+        Call finalPlanningCall = mock(Call.class);
         Response planningResponse = mock(Response.class);
-        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalCall);
+        Response finalPlanningResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalPlanningCall);
         when(planningCall.execute()).thenReturn(planningResponse);
+        when(finalPlanningCall.execute()).thenReturn(finalPlanningResponse);
         when(planningResponse.isSuccessful()).thenReturn(true);
+        when(finalPlanningResponse.isSuccessful()).thenReturn(true);
         when(planningResponse.body()).thenReturn(ResponseBody.create(
                 """
                 {
@@ -348,13 +503,27 @@ class PromptChatServiceTest {
                 }
                 """,
                 MediaType.get("application/json; charset=utf-8")));
+        when(finalPlanningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "id": "final-id",
+                  "choices": [
+                    {
+                      "message": {
+                        "role": "assistant",
+                        "content": "今天是星期一。"
+                      }
+                    }
+                  ]
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
         when(managedWebSearchService.search(eq("今天是周几"), eq("debug-user")))
                 .thenReturn(new ManagedWebSearchService.SearchAugmentation(
                         "今天是星期一。",
                         "[{\"type\":\"web_search\",\"deskToolName\":\"Web Search\"}]",
                         false,
                         null));
-        doNothing().when(finalCall).enqueue(any(Callback.class));
 
         promptChatService.chatStream(request, emitter, streamId, null, false, true);
 
@@ -369,8 +538,11 @@ class PromptChatServiceTest {
                 .getString("name"));
         assertFalse(planningBody.containsKey("managedWebSearch"));
         assertFalse(planningBody.containsKey("managedSearchQuery"));
-        assertFalse(finalBody.containsKey("tools"));
-        assertFalse(finalBody.containsKey("tool_choice"));
+        assertEquals("web_search", finalBody.getJSONArray("tools")
+                .getJSONObject(0)
+                .getJSONObject("function")
+                .getString("name"));
+        assertEquals("auto", finalBody.getString("tool_choice"));
         assertFalse(finalBody.containsKey("managedWebSearch"));
         assertFalse(finalBody.containsKey("managedSearchQuery"));
         assertEquals("assistant", finalBody.getJSONArray("messages").getJSONObject(2).getString("role"));
@@ -378,7 +550,450 @@ class PromptChatServiceTest {
         assertEquals("call_1", finalBody.getJSONArray("messages").getJSONObject(3).getString("tool_call_id"));
         assertTrue(finalBody.getJSONArray("messages").getJSONObject(3).getString("content").contains("星期一"));
         verify(managedWebSearchService).search("今天是周几", "debug-user");
-        verify(finalCall).enqueue(any(Callback.class));
+        verify(finalPlanningCall).execute();
+    }
+
+    @Test
+    void testChatStream_OpenAiToolLoop_ExecutesMultipleToolRoundsBeforeFinalAnswer() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("managedWebSearch", true);
+        request.put("managedSearchQuery", "今天热点新闻");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}}
+                    }
+                  },
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "web_search",
+                      "description": "Search the live web.",
+                      "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天热点新闻"}
+                ]
+                """));
+
+        Call timeCall = mock(Call.class);
+        Call searchCall = mock(Call.class);
+        Response timeResponse = mock(Response.class);
+        Response searchResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(timeCall, searchCall);
+        when(timeCall.execute()).thenReturn(timeResponse);
+        when(searchCall.execute()).thenReturn(searchResponse);
+        when(timeResponse.isSuccessful()).thenReturn(true);
+        when(searchResponse.isSuccessful()).thenReturn(true);
+        when(timeResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "id": "plan-time",
+                  "choices": [
+                    {
+                      "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                          {
+                            "id": "call_time",
+                            "type": "function",
+                            "function": {
+                              "name": "current_time",
+                              "arguments": "{\\"timezone\\":\\"Asia/Shanghai\\"}"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(searchResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "id": "plan-final",
+                  "choices": [
+                    {
+                      "message": {
+                        "role": "assistant",
+                        "content": "今天是2026年6月9日，热点新闻如下。"
+                      }
+                    }
+                  ]
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).newCall(requestCaptor.capture());
+        JSONObject secondRoundBody = parseRequestBody(requestCaptor.getAllValues().get(1));
+        assertEquals("assistant", secondRoundBody.getJSONArray("messages").getJSONObject(2).getString("role"));
+        assertEquals("tool", secondRoundBody.getJSONArray("messages").getJSONObject(3).getString("role"));
+        assertEquals("call_time", secondRoundBody.getJSONArray("messages").getJSONObject(3).getString("tool_call_id"));
+        assertTrue(secondRoundBody.getJSONArray("messages").getJSONObject(3).getString("content").contains("Asia/Shanghai"));
+        assertTrue(secondRoundBody.getJSONArray("messages").getJSONObject(3).getString("content").contains("weekday"));
+        verify(managedWebSearchService, never()).search(anyString(), anyString());
+        verify(timeCall).execute();
+        verify(searchCall).execute();
+    }
+
+    @Test
+    void testChatStream_OpenAiToolLoop_DoesNotExecuteUnadvertisedSearchTool() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天是周几"}
+                ]
+                """));
+
+        Call planningCall = mock(Call.class);
+        Call finalPlanningCall = mock(Call.class);
+        Response planningResponse = mock(Response.class);
+        Response finalPlanningResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalPlanningCall);
+        when(planningCall.execute()).thenReturn(planningResponse);
+        when(finalPlanningCall.execute()).thenReturn(finalPlanningResponse);
+        when(planningResponse.isSuccessful()).thenReturn(true);
+        when(finalPlanningResponse.isSuccessful()).thenReturn(true);
+        when(planningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-search","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_search","type":"function","function":{"name":"web_search","arguments":"{\\"query\\":\\"今天热点新闻\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(finalPlanningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"final-id","choices":[{"message":{"role":"assistant","content":"当前请求没有启用联网搜索。"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).newCall(requestCaptor.capture());
+        JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(1));
+        JSONObject toolMessage = finalBody.getJSONArray("messages").getJSONObject(3);
+        assertEquals("tool", toolMessage.getString("role"));
+        assertEquals("call_search", toolMessage.getString("tool_call_id"));
+        assertTrue(toolMessage.getString("content").contains("TOOL_NOT_AVAILABLE"));
+        verify(managedWebSearchService, never()).search(anyString(), anyString());
+    }
+
+    @Test
+    void testChatStream_OpenAiToolLoop_SearchesAfterCurrentTimeTool() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("managedWebSearch", true);
+        request.put("managedSearchQuery", "今天热点新闻");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}}
+                    }
+                  },
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "web_search",
+                      "description": "Search the live web.",
+                      "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天热点新闻"}
+                ]
+                """));
+
+        Call timeCall = mock(Call.class);
+        Call searchPlanningCall = mock(Call.class);
+        Call finalPlanningCall = mock(Call.class);
+        Response timeResponse = mock(Response.class);
+        Response searchPlanningResponse = mock(Response.class);
+        Response finalPlanningResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(timeCall, searchPlanningCall, finalPlanningCall);
+        when(timeCall.execute()).thenReturn(timeResponse);
+        when(searchPlanningCall.execute()).thenReturn(searchPlanningResponse);
+        when(finalPlanningCall.execute()).thenReturn(finalPlanningResponse);
+        when(timeResponse.isSuccessful()).thenReturn(true);
+        when(searchPlanningResponse.isSuccessful()).thenReturn(true);
+        when(finalPlanningResponse.isSuccessful()).thenReturn(true);
+        when(timeResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-time","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_time","type":"function","function":{"name":"current_time","arguments":"{\\"timezone\\":\\"Asia/Shanghai\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(searchPlanningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-search","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_search","type":"function","function":{"name":"web_search","arguments":"{\\"query\\":\\"2026年6月9日 今日热点新闻\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(finalPlanningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-final","choices":[{"message":{"role":"assistant","content":"今天热点新闻总结。"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(managedWebSearchService.search(eq("2026年6月9日 今日热点新闻"), eq("debug-user")))
+                .thenReturn(new ManagedWebSearchService.SearchAugmentation(
+                        "搜索结果摘要",
+                        "[{\"type\":\"web_search\",\"deskToolName\":\"Web Search\"}]",
+                        false,
+                        null));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        verify(httpClient, times(3)).newCall(any(Request.class));
+        verify(managedWebSearchService).search("2026年6月9日 今日热点新闻", "debug-user");
+    }
+
+    @Test
+    void testChatStream_OpenAiToolLoop_StopsOnDuplicateToolCall() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天是周几"}
+                ]
+                """));
+
+        Call firstCall = mock(Call.class);
+        Call duplicateCall = mock(Call.class);
+        Call finalCall = mock(Call.class);
+        Response firstResponse = mock(Response.class);
+        Response duplicateResponse = mock(Response.class);
+        Response finalResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(firstCall, duplicateCall, finalCall);
+        when(firstCall.execute()).thenReturn(firstResponse);
+        when(duplicateCall.execute()).thenReturn(duplicateResponse);
+        when(finalCall.execute()).thenReturn(finalResponse);
+        when(firstResponse.isSuccessful()).thenReturn(true);
+        when(duplicateResponse.isSuccessful()).thenReturn(true);
+        when(finalResponse.isSuccessful()).thenReturn(true);
+        when(firstResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-1","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_time_1","type":"function","function":{"name":"current_time","arguments":"{\\"timezone\\":\\"Asia/Shanghai\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(duplicateResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-2","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_time_2","type":"function","function":{"name":"current_time","arguments":"{\\"timezone\\":\\"Asia/Shanghai\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(finalResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"final-id","choices":[{"message":{"role":"assistant","content":"今天是星期二。"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(3)).newCall(requestCaptor.capture());
+        JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(2));
+        assertFalse(finalBody.containsKey("tools"));
+        assertFalse(finalBody.containsKey("tool_choice"));
+        assertTrue(finalBody.getJSONArray("messages")
+                .getJSONObject(0)
+                .getString("content")
+                .contains("DUPLICATE_TOOL_CALL"));
+        assertTrue(finalBody.getJSONArray("messages")
+                .getJSONObject(5)
+                .getString("content")
+                .contains("Duplicate tool call skipped"));
+    }
+
+    @Test
+    void testChatStream_OpenAiToolLoop_StopsWhenToolCallLimitExceeded() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"请连续检查很多城市的当前时间"}
+                ]
+                """));
+
+        JSONArray toolCalls = new JSONArray();
+        for (int i = 0; i < 16; i++) {
+            toolCalls.add(new JSONObject()
+                    .fluentPut("id", "call_time_" + i)
+                    .fluentPut("type", "function")
+                    .fluentPut("function", new JSONObject()
+                            .fluentPut("name", "current_time")
+                            .fluentPut("arguments", "{\"timezone\":\"Asia/Shanghai\",\"round\":" + i + "}")));
+        }
+        JSONObject planningBody = new JSONObject()
+                .fluentPut("id", "plan-limit")
+                .fluentPut("choices", new JSONArray().fluentAdd(new JSONObject()
+                        .fluentPut("message", new JSONObject()
+                                .fluentPut("role", "assistant")
+                                .fluentPut("content", "")
+                                .fluentPut("tool_calls", toolCalls))));
+
+        Call planningCall = mock(Call.class);
+        Call finalCall = mock(Call.class);
+        Response planningResponse = mock(Response.class);
+        Response finalResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalCall);
+        when(planningCall.execute()).thenReturn(planningResponse);
+        when(finalCall.execute()).thenReturn(finalResponse);
+        when(planningResponse.isSuccessful()).thenReturn(true);
+        when(finalResponse.isSuccessful()).thenReturn(true);
+        when(planningResponse.body()).thenReturn(ResponseBody.create(
+                planningBody.toJSONString(),
+                MediaType.get("application/json; charset=utf-8")));
+        when(finalResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"final-id","choices":[{"message":{"role":"assistant","content":"工具调用次数过多，以下是已得到的结果。"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(2)).newCall(requestCaptor.capture());
+        JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(1));
+        assertFalse(finalBody.containsKey("tools"));
+        assertFalse(finalBody.containsKey("tool_choice"));
+        assertTrue(finalBody.getJSONArray("messages")
+                .getJSONObject(0)
+                .getString("content")
+                .contains("TOOL_CALL_LIMIT_EXCEEDED"));
+        assertTrue(finalBody.getJSONArray("messages")
+                .toJSONString()
+                .contains("Tool call budget exhausted"));
+    }
+
+    @Test
+    void testChatStream_OpenAiToolLoop_StopsWhenToolRoundLimitExceeded() throws Exception {
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("userId", "debug-user");
+        request.put("tool_choice", "auto");
+        request.put("tools", JSON.parseArray("""
+                [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "current_time",
+                      "description": "Get current time.",
+                      "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}}
+                    }
+                  }
+                ]
+                """));
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"今天是周几"}
+                ]
+                """));
+
+        Call[] calls = new Call[16];
+        Response[] responses = new Response[16];
+        for (int i = 0; i < calls.length; i++) {
+            calls[i] = mock(Call.class);
+            responses[i] = mock(Response.class);
+            when(calls[i].execute()).thenReturn(responses[i]);
+            when(responses[i].isSuccessful()).thenReturn(true);
+        }
+        for (int i = 0; i < 15; i++) {
+            String responseBody = """
+                    {"id":"plan-%d","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_time_%d","type":"function","function":{"name":"current_time","arguments":"{\\"timezone\\":\\"Asia/Shanghai\\",\\"round\\":%d}"}}]}}]}
+                    """.formatted(i, i, i);
+            when(responses[i].body()).thenReturn(ResponseBody.create(
+                    responseBody,
+                    MediaType.get("application/json; charset=utf-8")));
+        }
+        when(responses[15].body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"final-id","choices":[{"message":{"role":"assistant","content":"工具轮次过多，以下是已得到的结果。"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        AtomicInteger callIndex = new AtomicInteger();
+        when(httpClient.newCall(any(Request.class))).thenAnswer(invocation -> calls[callIndex.getAndIncrement()]);
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(16)).newCall(requestCaptor.capture());
+        JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(15));
+        assertFalse(finalBody.containsKey("tools"));
+        assertFalse(finalBody.containsKey("tool_choice"));
+        assertTrue(finalBody.getJSONArray("messages")
+                .getJSONObject(0)
+                .getString("content")
+                .contains("TOOL_ROUND_LIMIT_EXCEEDED"));
+        assertEquals(32, finalBody.getJSONArray("messages").size());
     }
 
     @Test

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/SparkChatServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/SparkChatServiceTest.java
@@ -1,12 +1,15 @@
 package com.iflytek.astron.console.hub.service;
 
 import cn.xfyun.api.SparkChatClient;
+import cn.xfyun.config.SparkModel;
 import cn.xfyun.model.sparkmodel.SparkChatParam;
 import com.iflytek.astron.console.commons.dto.llm.SparkChatRequest;
 import com.iflytek.astron.console.commons.entity.chat.ChatReqRecords;
 import com.iflytek.astron.console.commons.service.ChatRecordModelService;
 import com.iflytek.astron.console.commons.service.data.ChatDataService;
 import com.iflytek.astron.console.commons.util.SseEmitterUtil;
+import com.iflytek.astron.console.toolkit.entity.platform.PlatformAccountConfigDto;
+import com.iflytek.astron.console.toolkit.service.platform.PlatformAccountService;
 import okhttp3.*;
 import okio.Buffer;
 import okio.BufferedSource;
@@ -36,6 +39,9 @@ class SparkChatServiceTest {
     private ChatRecordModelService chatRecordModelService;
 
     @Mock
+    private PlatformAccountService platformAccountService;
+
+    @Mock
     private SseEmitter emitter;
 
     @Mock
@@ -56,9 +62,13 @@ class SparkChatServiceTest {
     @BeforeEach
     void setUp() {
         sparkChatService = new SparkChatService();
-        ReflectionTestUtils.setField(sparkChatService, "apiPassword", "test-api-password");
         ReflectionTestUtils.setField(sparkChatService, "chatDataService", chatDataService);
         ReflectionTestUtils.setField(sparkChatService, "chatRecordModelService", chatRecordModelService);
+        ReflectionTestUtils.setField(sparkChatService, "platformAccountService", platformAccountService);
+        PlatformAccountConfigDto.IflytekOpenPlatformConfig config =
+                new PlatformAccountConfigDto.IflytekOpenPlatformConfig();
+        config.setSparkApiPassword("test-api-password");
+        lenient().when(platformAccountService.requireIflytekOpenPlatform()).thenReturn(config);
 
         streamId = "test-stream-id";
 
@@ -172,6 +182,22 @@ class SparkChatServiceTest {
     }
 
     @Test
+    void testChatStream_DoesNotInjectCurrentTimeContextIntoSparkMessages() {
+        try (MockedConstruction<SparkChatClient> clientMock = mockConstruction(SparkChatClient.class,
+                (mock, context) -> doNothing().when(mock).send(any(SparkChatParam.class), any(Callback.class)))) {
+
+            sparkChatService.chatStream(sparkChatRequest, emitter, streamId, chatReqRecords, false, true);
+
+            ArgumentCaptor<SparkChatParam> paramCaptor = ArgumentCaptor.forClass(SparkChatParam.class);
+            verify(clientMock.constructed().get(0)).send(paramCaptor.capture(), any(Callback.class));
+            SparkChatParam capturedParam = paramCaptor.getValue();
+            assertEquals(1, capturedParam.getMessages().size());
+            assertEquals("user", capturedParam.getMessages().get(0).getRole());
+            assertEquals("Hello", capturedParam.getMessages().get(0).getContent());
+        }
+    }
+
+    @Test
     void testChatStream_Exception_HandledGracefully() {
         try (MockedStatic<SseEmitterUtil> sseUtilMock = mockStatic(SseEmitterUtil.class);
                 MockedConstruction<SparkChatClient> clientMock = mockConstruction(SparkChatClient.class,
@@ -208,6 +234,20 @@ class SparkChatServiceTest {
 
             assertEquals(1, clientMock.constructed().size());
         }
+    }
+
+    @Test
+    void testGetSparkModel_KnownSparkAliases_ReturnMatchingSdkModels() {
+        assertEquals(SparkModel.SPARK_X1, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "x1"));
+        assertEquals(SparkModel.SPARK_X1, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "spark-x1"));
+        assertEquals(SparkModel.SPARK_4_0_ULTRA, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "4.0Ultra"));
+        assertEquals(SparkModel.SPARK_4_0_ULTRA, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "bm4"));
+        assertEquals(SparkModel.SPARK_MAX, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "generalv3.5"));
+        assertEquals(SparkModel.SPARK_MAX, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "bm3.5"));
+        assertEquals(SparkModel.SPARK_PRO, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "generalv3"));
+        assertEquals(SparkModel.SPARK_PRO, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "bm3"));
+        assertEquals(SparkModel.SPARK_LITE, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "general"));
+        assertEquals(SparkModel.SPARK_LITE, ReflectionTestUtils.invokeMethod(sparkChatService, "getSparkModel", "cbm"));
     }
 
     @Test

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
@@ -119,7 +119,7 @@ class BotChatServiceImplUnitTest {
     }
 
     @Test
-    void testChatMessageBot_SparkChat_Success() {
+    void testChatMessageBot_DefaultSparkUsesOriginalSparkChatService() {
         // Given
         ChatBotReqDto chatBotReqDto = createChatBotReqDto();
         SseEmitter sseEmitter = new SseEmitter();
@@ -144,14 +144,116 @@ class BotChatServiceImplUnitTest {
         lenient().when(knowledgeService.getChuncksByBotId(anyInt(), anyString(), anyInt())).thenReturn(knowledgeList);
         when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
         lenient().when(reqKnowledgeRecordsDataService.create(any())).thenReturn(null);
-        doNothing().when(sparkChatService).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
 
         // When
         botChatService.chatMessageBot(chatBotReqDto, sseEmitter, sseId, null, null);
 
         // Then
         verify(chatDataService).createRequest(any(ChatReqRecords.class));
-        verify(sparkChatService).chatStream(argThat(req -> req.getEnableWebSearch()),
+        verify(sparkChatService).chatStream(
+                argThat(request -> "x1".equals(request.getModel()) &&
+                        "1".equals(request.getChatId()) &&
+                        "test-uid".equals(request.getUserId()) &&
+                        Boolean.TRUE.equals(request.getEnableWebSearch()) &&
+                        "deep".equals(request.getSearchMode()) &&
+                        Boolean.TRUE.equals(request.getShowRefLabel()) &&
+                        request.getMessages() != null &&
+                        !request.getMessages().isEmpty() &&
+                        "test question".equals(request.getMessages().getLast().getContent())),
+                eq(sseEmitter), eq(sseId), any(ChatReqRecords.class), eq(false), eq(false));
+        verify(promptChatService, never()).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    void testChatMessageBot_ModelIdWithSparkDomainUsesConfiguredPromptEndpoint() {
+        ChatBotReqDto chatBotReqDto = createChatBotReqDto();
+        SseEmitter sseEmitter = new SseEmitter();
+        String sseId = "test-sse-id";
+
+        ChatBotMarket chatBotMarket = createChatBotMarket();
+        chatBotMarket.setModelId(9L);
+        chatBotMarket.setVersion(1);
+        chatBotMarket.setSupportDocument(0);
+
+        ChatReqRecords createdRecord = createChatReqRecords();
+        List<SparkChatRequest.MessageDto> historyMessages = new ArrayList<>();
+        SparkChatRequest.MessageDto currentAskMessage = new SparkChatRequest.MessageDto();
+        currentAskMessage.setRole("user");
+        currentAskMessage.setContent("test question");
+        historyMessages.add(currentAskMessage);
+
+        LLMInfoVo llmInfoVo = createLLMInfoVo();
+        llmInfoVo.setProvider(null);
+        llmInfoVo.setDomain("4.0Ultra");
+        llmInfoVo.setServiceId("bm4");
+        llmInfoVo.setUrl("https://old-spark.example.com/v1");
+        llmInfoVo.setApiKey("old-spark-api-key");
+
+        when(chatBotDataService.findMarketBotByBotId(anyInt())).thenReturn(chatBotMarket);
+        when(chatDataService.createRequest(any())).thenReturn(createdRecord);
+        when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
+        lenient().when(knowledgeService.getChuncksByBotId(anyInt(), anyString(), anyInt())).thenReturn(new ArrayList<>());
+        lenient().when(reqKnowledgeRecordsDataService.create(any())).thenReturn(null);
+        when(modelService.getDetail(anyInt(), anyLong(), any())).thenReturn(new ApiResult<>(0, "success", llmInfoVo, 1L));
+        doNothing().when(promptChatService).chatStream(any(JSONObject.class), any(SseEmitter.class), anyString(), any(), anyBoolean(), anyBoolean());
+
+        botChatService.chatMessageBot(chatBotReqDto, sseEmitter, sseId, null, null);
+
+        verify(modelService).getDetail(eq(0), eq(9L), isNull());
+        verify(promptChatService).chatStream(
+                argThat(json -> "openai".equals(json.getString("provider")) &&
+                        "https://old-spark.example.com/v1".equals(json.getString("url")) &&
+                        "old-spark-api-key".equals(json.getString("apiKey")) &&
+                        "4.0Ultra".equals(json.getString("model")) &&
+                        json.getBooleanValue("managedWebSearch") &&
+                        "auto".equals(json.getString("tool_choice")) &&
+                        json.getJSONArray("tools") != null &&
+                        json.getJSONArray("tools").size() == 2 &&
+                        "web_search".equals(json.getJSONArray("tools").getJSONObject(0).getJSONObject("function").getString("name")) &&
+                        "current_time".equals(json.getJSONArray("tools").getJSONObject(1).getJSONObject("function").getString("name"))),
+                eq(sseEmitter), eq(sseId), any(), eq(false), eq(false));
+        verify(sparkChatService, never()).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    void testChatMessageBot_NonSparkProviderWithSparkLikeDomainUsesConfiguredEndpoint() {
+        ChatBotReqDto chatBotReqDto = createChatBotReqDto();
+        SseEmitter sseEmitter = new SseEmitter();
+        String sseId = "test-sse-id";
+
+        ChatBotMarket chatBotMarket = createChatBotMarket();
+        chatBotMarket.setModelId(10L);
+        chatBotMarket.setVersion(1);
+        chatBotMarket.setSupportDocument(0);
+
+        ChatReqRecords createdRecord = createChatReqRecords();
+        List<SparkChatRequest.MessageDto> historyMessages = new ArrayList<>();
+        SparkChatRequest.MessageDto currentAskMessage = new SparkChatRequest.MessageDto();
+        currentAskMessage.setRole("user");
+        currentAskMessage.setContent("test question");
+        historyMessages.add(currentAskMessage);
+
+        LLMInfoVo llmInfoVo = createLLMInfoVo();
+        llmInfoVo.setProvider("openai");
+        llmInfoVo.setDomain("4.0Ultra");
+        llmInfoVo.setUrl("https://custom-openai.example.com/v1/chat/completions");
+        llmInfoVo.setApiKey("custom-api-key");
+
+        when(chatBotDataService.findMarketBotByBotId(anyInt())).thenReturn(chatBotMarket);
+        when(chatDataService.createRequest(any())).thenReturn(createdRecord);
+        when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
+        lenient().when(knowledgeService.getChuncksByBotId(anyInt(), anyString(), anyInt())).thenReturn(new ArrayList<>());
+        lenient().when(reqKnowledgeRecordsDataService.create(any())).thenReturn(null);
+        when(modelService.getDetail(anyInt(), anyLong(), any())).thenReturn(new ApiResult<>(0, "success", llmInfoVo, 1L));
+        doNothing().when(promptChatService).chatStream(any(JSONObject.class), any(SseEmitter.class), anyString(), any(), anyBoolean(), anyBoolean());
+
+        botChatService.chatMessageBot(chatBotReqDto, sseEmitter, sseId, null, null);
+
+        verify(promptChatService).chatStream(
+                argThat(json -> "openai".equals(json.getString("provider")) &&
+                        "https://custom-openai.example.com/v1/chat/completions".equals(json.getString("url")) &&
+                        "custom-api-key".equals(json.getString("apiKey")) &&
+                        "4.0Ultra".equals(json.getString("model"))),
                 eq(sseEmitter), eq(sseId), any(), eq(false), eq(false));
     }
 
@@ -245,7 +347,6 @@ class BotChatServiceImplUnitTest {
         lenient().when(knowledgeService.getChuncksByBotId(anyInt(), anyString(), anyInt())).thenReturn(knowledgeList);
         lenient().when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
         lenient().when(reqKnowledgeRecordsDataService.create(any())).thenReturn(null);
-        doNothing().when(sparkChatService).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
 
         // When
         botChatService.chatMessageBot(chatBotReqDto, sseEmitter, sseId, null, null);
@@ -254,6 +355,7 @@ class BotChatServiceImplUnitTest {
         verify(chatBotDataService).findMarketBotByBotId(eq(chatBotReqDto.getBotId()));
         verify(chatBotDataService).findById(eq(chatBotReqDto.getBotId()));
         verify(sparkChatService).chatStream(any(SparkChatRequest.class), eq(sseEmitter), eq(sseId), any(), eq(false), eq(false));
+        verify(promptChatService, never()).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
     }
 
     @Test
@@ -301,14 +403,22 @@ class BotChatServiceImplUnitTest {
         lenient().when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
         lenient().when(knowledgeService.getChuncksByBotId(anyInt(), anyString(), anyInt())).thenReturn(Arrays.asList("knowledge"));
         lenient().when(reqKnowledgeRecordsDataService.create(any())).thenReturn(null);
-        doNothing().when(sparkChatService).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
 
         // When
         botChatService.reAnswerMessageBot(requestId, botId, sseEmitter, sseId);
 
         // Then
         verify(chatDataService).findRequestById(requestId);
-        verify(sparkChatService).chatStream(any(SparkChatRequest.class), eq(sseEmitter), eq(sseId), eq(chatReqRecords), eq(true), eq(false));
+        verify(sparkChatService).chatStream(
+                argThat(request -> "x1".equals(request.getModel()) &&
+                        "1".equals(request.getChatId()) &&
+                        "test-uid".equals(request.getUserId()) &&
+                        Boolean.TRUE.equals(request.getEnableWebSearch()) &&
+                        request.getMessages() != null &&
+                        !request.getMessages().isEmpty() &&
+                        "test question".equals(request.getMessages().getLast().getContent())),
+                eq(sseEmitter), eq(sseId), eq(chatReqRecords), eq(true), eq(false));
+        verify(promptChatService, never()).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
     }
 
     @Test
@@ -330,13 +440,19 @@ class BotChatServiceImplUnitTest {
 
         when(personalityConfigService.getChatPrompt(isNull(), eq("test prompt"))).thenReturn("test prompt");
         when(knowledgeService.getChuncks(any(), anyString(), anyInt(), anyBoolean())).thenReturn(Arrays.asList("knowledge"));
-        doNothing().when(sparkChatService).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
 
         // When
         botChatService.debugChatMessageBot(request, sseEmitter, sseId);
 
         // Then
-        verify(sparkChatService).chatStream(argThat(req -> req.getEnableWebSearch()),
+        verify(sparkChatService).chatStream(
+                argThat(sparkRequest -> "x1".equals(sparkRequest.getModel()) &&
+                        sparkRequest.getChatId() == null &&
+                        "test-uid".equals(sparkRequest.getUserId()) &&
+                        Boolean.TRUE.equals(sparkRequest.getEnableWebSearch()) &&
+                        sparkRequest.getMessages() != null &&
+                        !sparkRequest.getMessages().isEmpty() &&
+                        sparkRequest.getMessages().getLast().getContent().contains("test message")),
                 eq(sseEmitter), eq(sseId), isNull(), eq(false), eq(true));
         verify(promptChatService, never()).chatStream(any(), any(), any(), any(), anyBoolean(), anyBoolean());
     }
@@ -378,6 +494,7 @@ class BotChatServiceImplUnitTest {
                     json.getBooleanValue("managedWebSearch") &&
                     "auto".equals(json.getString("tool_choice")) &&
                     "web_search".equals(json.getJSONArray("tools").getJSONObject(0).getJSONObject("function").getString("name")) &&
+                    "current_time".equals(json.getJSONArray("tools").getJSONObject(1).getJSONObject("function").getString("name")) &&
                     "test message".equals(json.getString("managedSearchQuery")) &&
                     "test-uid".equals(json.getString("userId"))),
                     eq(sseEmitter),
@@ -509,6 +626,54 @@ class BotChatServiceImplUnitTest {
                         json.getBooleanValue("managedWebSearch") &&
                         "auto".equals(json.getString("tool_choice")) &&
                         "web_search".equals(json.getJSONArray("tools").getJSONObject(0).getJSONObject("function").getString("name")) &&
+                        "current_time".equals(json.getJSONArray("tools").getJSONObject(1).getJSONObject("function").getString("name")) &&
+                        "test question".equals(json.getString("managedSearchQuery")) &&
+                        "test-uid".equals(json.getString("userId"))),
+                eq(sseEmitter),
+                eq(sseId),
+                any(),
+                eq(false),
+                eq(false));
+    }
+
+    @Test
+    void testChatMessageBot_PromptChat_OpenAiDefaultsBuiltInTools() {
+        ChatBotReqDto chatBotReqDto = createChatBotReqDto();
+        SseEmitter sseEmitter = new SseEmitter();
+        String sseId = "test-sse-id";
+
+        ChatBotMarket chatBotMarket = createChatBotMarket();
+        chatBotMarket.setModelId(3L);
+        chatBotMarket.setVersion(1);
+        chatBotMarket.setOpenedTool("");
+
+        ChatReqRecords createdRecord = createChatReqRecords();
+        LLMInfoVo llmInfoVo = createLLMInfoVo();
+        llmInfoVo.setProvider("openai");
+
+        when(chatBotDataService.findMarketBotByBotId(anyInt())).thenReturn(chatBotMarket);
+        when(chatDataService.createRequest(any())).thenReturn(createdRecord);
+        lenient().when(knowledgeService.getChuncksByBotId(anyInt(), anyString(), anyInt())).thenReturn(new ArrayList<>());
+        List<SparkChatRequest.MessageDto> historyMessages = new ArrayList<>();
+        SparkChatRequest.MessageDto msg = new SparkChatRequest.MessageDto();
+        msg.setRole("user");
+        msg.setContent("test question");
+        historyMessages.add(msg);
+        when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
+        lenient().when(reqKnowledgeRecordsDataService.create(any())).thenReturn(null);
+        when(modelService.getDetail(anyInt(), anyLong(), any())).thenReturn(new ApiResult<>(0, "success", llmInfoVo, 1L));
+        doNothing().when(promptChatService).chatStream(any(JSONObject.class), any(SseEmitter.class), anyString(), any(), anyBoolean(), anyBoolean());
+
+        botChatService.chatMessageBot(chatBotReqDto, sseEmitter, sseId, null, null);
+
+        verify(promptChatService).chatStream(
+                argThat(json -> "openai".equals(json.getString("provider")) &&
+                        json.getBooleanValue("managedWebSearch") &&
+                        "auto".equals(json.getString("tool_choice")) &&
+                        json.getJSONArray("tools") != null &&
+                        json.getJSONArray("tools").size() == 2 &&
+                        "web_search".equals(json.getJSONArray("tools").getJSONObject(0).getJSONObject("function").getString("name")) &&
+                        "current_time".equals(json.getJSONArray("tools").getJSONObject(1).getJSONObject("function").getString("name")) &&
                         "test question".equals(json.getString("managedSearchQuery")) &&
                         "test-uid".equals(json.getString("userId"))),
                 eq(sseEmitter),

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ProviderToolOrchestratorTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ProviderToolOrchestratorTest.java
@@ -1,0 +1,105 @@
+package com.iflytek.astron.console.hub.service.chat.impl;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.dto.llm.SparkChatRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProviderToolOrchestratorTest {
+
+    @Test
+    void testApplyToPromptRequest_OpenAiDefaultsWebSearchAndCurrentTimeTools() {
+        ProviderToolOrchestrator.ToolExecutionPlan plan = ProviderToolOrchestrator.resolve("openai", "");
+        JSONObject request = new JSONObject();
+
+        ProviderToolOrchestrator.applyToPromptRequest(request, plan);
+
+        assertTrue(request.getBooleanValue("managedWebSearch"));
+        assertEquals("auto", request.getString("tool_choice"));
+        JSONArray tools = request.getJSONArray("tools");
+        assertNotNull(tools);
+        assertEquals(2, tools.size());
+        assertEquals("web_search", tools.getJSONObject(0)
+                .getJSONObject("function")
+                .getString("name"));
+        assertEquals("current_time", tools.getJSONObject(1)
+                .getJSONObject("function")
+                .getString("name"));
+    }
+
+    @Test
+    void testApplyToPromptRequest_OpenAiIgnoresSavedToolTogglesForDefaultBuiltIns() {
+        ProviderToolOrchestrator.ToolExecutionPlan plan = ProviderToolOrchestrator.resolve("openai", "current_time");
+        JSONObject request = new JSONObject();
+
+        ProviderToolOrchestrator.applyToPromptRequest(request, plan);
+
+        assertTrue(request.getBooleanValue("managedWebSearch"));
+        assertEquals("auto", request.getString("tool_choice"));
+        JSONArray tools = request.getJSONArray("tools");
+        assertNotNull(tools);
+        assertEquals(2, tools.size());
+        assertEquals("web_search", tools.getJSONObject(0)
+                .getJSONObject("function")
+                .getString("name"));
+        assertEquals("current_time", tools.getJSONObject(1)
+                .getJSONObject("function")
+                .getString("name"));
+    }
+
+    @Test
+    void testApplyToPromptRequest_SparkDoesNotUseOpenAiCompatibleBuiltInTools() {
+        ProviderToolOrchestrator.ToolExecutionPlan plan = ProviderToolOrchestrator.resolve("spark", "");
+        JSONObject request = new JSONObject();
+
+        ProviderToolOrchestrator.applyToPromptRequest(request, plan);
+
+        assertEquals("spark", plan.provider());
+        assertEquals(ProviderToolOrchestrator.WebSearchMode.DISABLED, plan.webSearchMode());
+        assertFalse(request.containsKey("managedWebSearch"));
+        assertFalse(request.containsKey("tool_choice"));
+        assertFalse(request.containsKey("tools"));
+    }
+
+    @Test
+    void testApplyToSparkRequest_ExplicitSearchUsesNativeSparkWebSearch() {
+        ProviderToolOrchestrator.ToolExecutionPlan plan = ProviderToolOrchestrator.resolve("spark", "ifly_search");
+        SparkChatRequest request = new SparkChatRequest();
+
+        ProviderToolOrchestrator.applyToSparkRequest(request, plan);
+
+        assertEquals("spark", plan.provider());
+        assertEquals(ProviderToolOrchestrator.WebSearchMode.SPARK_NATIVE, plan.webSearchMode());
+        assertTrue(request.getEnableWebSearch());
+        assertEquals("deep", request.getSearchMode());
+        assertTrue(request.getShowRefLabel());
+    }
+
+    @Test
+    void testApplyToPromptRequest_GoogleWithoutExplicitSearchKeepsNativeToolsDisabled() {
+        ProviderToolOrchestrator.ToolExecutionPlan plan = ProviderToolOrchestrator.resolve("google", "");
+        JSONObject request = new JSONObject();
+
+        ProviderToolOrchestrator.applyToPromptRequest(request, plan);
+
+        assertEquals("google", plan.provider());
+        assertEquals(ProviderToolOrchestrator.WebSearchMode.DISABLED, plan.webSearchMode());
+        assertFalse(request.containsKey("tools"));
+        assertFalse(request.containsKey("managedWebSearch"));
+    }
+
+    @Test
+    void testApplyToPromptRequest_AnthropicWithoutExplicitSearchKeepsNativeToolsDisabled() {
+        ProviderToolOrchestrator.ToolExecutionPlan plan = ProviderToolOrchestrator.resolve("anthropic", "");
+        JSONObject request = new JSONObject();
+
+        ProviderToolOrchestrator.applyToPromptRequest(request, plan);
+
+        assertEquals("anthropic", plan.provider());
+        assertEquals(ProviderToolOrchestrator.WebSearchMode.DISABLED, plan.webSearchMode());
+        assertFalse(request.containsKey("tools"));
+        assertFalse(request.containsKey("anthropicBeta"));
+    }
+}

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -35,10 +35,8 @@ import fileImg from '@/assets/imgs/bot-center/file.svg';
 import closeImg from '@/assets/imgs/bot-center/close.svg';
 import autoInputExamplesLoadingIcon from '@/assets/imgs/bot-center/autoInputExamplesLoadingIcon.svg';
 import codeIcon from '@/assets/imgs/plugin/code.svg'; // 代码图标
-import netIcon from '@/assets/imgs/plugin/network.svg'; // 网络图标
 import genPicIcon from '@/assets/imgs/plugin/gen-pic.svg'; // 图片图标
 import { useTranslation } from 'react-i18next';
-import { hasWebSearchTool } from '../tool-config';
 
 import styles from './CapabilityDevelopment.module.scss';
 import cls from 'classnames';
@@ -368,30 +366,6 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
                 <span className="ml-2 text-[#D84516] font-medium">
                   {t('configBase.CapabilityDevelopment.capability')}
                 </span>
-              </div>
-              <div
-                className="flex justify-between items-center border-b border-[#E9EFF6]"
-                style={{
-                  padding: '8px 20px 12px 20px',
-                }}
-              >
-                <div className="flex gap-2 items-center">
-                  <img src={netIcon} alt="" className="w-[16px] h-[16px]" />
-                  <span className="text-sm font-medium">
-                    {t('configBase.CapabilityDevelopment.internetSearch')}
-                  </span>
-                </div>
-                <Switch
-                  className="list-switch config-switch"
-                  defaultChecked={hasWebSearchTool(detailInfo.openedTool)}
-                  onChange={checked => {
-                    setChoosedAlltool({
-                      ...choosedAlltool,
-                      web_search: checked,
-                      ifly_search: false,
-                    });
-                  }}
-                />
               </div>
               <div
                 className="flex justify-between items-center border-b border-[#E9EFF6]"

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -77,11 +77,7 @@ import {
   KnowledgeLeaf,
   Knowledge,
 } from './types';
-import {
-  getEffectiveToolConfig,
-  hasWebSearchTool,
-  serializeOpenedTool,
-} from './tool-config';
+import { getEffectiveToolConfig, serializeOpenedTool } from './tool-config';
 import { VcnItem } from '@/components/speaker-modal';
 import { getVcnList } from '@/services/chat';
 import type { MessageListType } from '@/types/chat';
@@ -225,8 +221,6 @@ const BaseConfig: React.FC<ChatProps> = ({
     { prompt: prompt, promptAnswerCompleted: true },
   ]);
   const [choosedAlltool, setChoosedAlltool] = useState<any>({
-    web_search: true,
-    ifly_search: false,
     text_to_image: false,
     codeinterpreter: false,
   });
@@ -681,8 +675,6 @@ const BaseConfig: React.FC<ChatProps> = ({
     setSupportContextFlag(true);
     setChoosedAlltool((currentTools: any) => ({
       ...currentTools,
-      web_search: true,
-      ifly_search: false,
       text_to_image: false,
       codeinterpreter: false,
     }));
@@ -761,15 +753,6 @@ const BaseConfig: React.FC<ChatProps> = ({
             cn: save == 'true' ? configPageData?.vcnCn : res.vcnCn,
           });
           const obj: any = {};
-          const openedToolValue =
-            save == 'true' ? configPageData?.openedTool : res.openedTool;
-          obj.web_search = hasWebSearchTool(openedToolValue);
-          obj.ifly_search =
-            typeof openedToolValue === 'string' &&
-            openedToolValue
-              .split(',')
-              .map((tool: string) => tool.trim())
-              .includes('ifly_search');
           if (
             save == 'true'
               ? typeof configPageData?.openedTool === 'string' &&

--- a/console/frontend/src/components/config-page-component/config-base/tool-config.ts
+++ b/console/frontend/src/components/config-page-component/config-base/tool-config.ts
@@ -1,11 +1,8 @@
 export type ToolConfig = Record<string, boolean>;
 
-const WEB_SEARCH_TOOL = 'web_search';
-const LEGACY_WEB_SEARCH_TOOL = 'ifly_search';
+const BUILT_IN_TOOL_KEYS = new Set(['web_search', 'ifly_search', 'current_time']);
 
 const NEW_WORKBENCH_TOOL_OVERRIDES: ToolConfig = {
-  [WEB_SEARCH_TOOL]: true,
-  [LEGACY_WEB_SEARCH_TOOL]: false,
   text_to_image: false,
   codeinterpreter: false,
 };
@@ -36,19 +33,6 @@ export const serializeOpenedTool = (
 
 const normalizeToolConfig = (toolConfig: ToolConfig | undefined): ToolConfig => {
   const normalized = { ...(toolConfig ?? {}) };
-  if (normalized[LEGACY_WEB_SEARCH_TOOL]) {
-    normalized[WEB_SEARCH_TOOL] = true;
-    delete normalized[LEGACY_WEB_SEARCH_TOOL];
-  }
+  BUILT_IN_TOOL_KEYS.forEach(toolKey => delete normalized[toolKey]);
   return normalized;
-};
-
-export const hasWebSearchTool = (openedTool?: string): boolean => {
-  if (!openedTool) {
-    return false;
-  }
-  return openedTool
-    .split(',')
-    .map(tool => tool.trim())
-    .some(tool => tool === WEB_SEARCH_TOOL || tool === LEGACY_WEB_SEARCH_TOOL);
 };

--- a/console/frontend/src/components/config-page-component/config-base/types.ts
+++ b/console/frontend/src/components/config-page-component/config-base/types.ts
@@ -98,8 +98,6 @@ export interface PromptListItem {
 
 // 选择的工具配置接口
 export interface ChoosedAlltool {
-  web_search: boolean;
-  ifly_search: boolean;
   text_to_image: boolean;
   codeinterpreter: boolean;
 }

--- a/console/frontend/src/pages/chat-page/components/chat-side.tsx
+++ b/console/frontend/src/pages/chat-page/components/chat-side.tsx
@@ -3,7 +3,6 @@ import { Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { BotInfoType } from '@/types/chat';
 import codeIcon from '@/assets/imgs/chat/plugin/code.svg';
-import netIcon from '@/assets/imgs/chat/plugin/network.svg';
 import genPicIcon from '@/assets/imgs/chat/plugin/gen-pic.svg';
 import sparkIcon from '@/assets/imgs/chat/plugin/spark-logo.png';
 
@@ -29,11 +28,7 @@ type ModelConfig =
   | 'flow';
 
 // 工具类型
-type ToolType =
-  | 'web_search'
-  | 'ifly_search'
-  | 'text_to_image'
-  | 'codeinterpreter';
+type ToolType = 'text_to_image' | 'codeinterpreter';
 
 // 模型信息接口
 interface ModelInfo {
@@ -373,22 +368,8 @@ const ChatSide: React.FC<ChatSideProps> = ({ botInfo }) => {
             </>
           ) : (
             /* 兼容旧版工具配置 */
-            toolList.map((tool: ToolType, index: number) => (
+            toolList.map((tool: string, index: number) => (
               <div key={`${tool}-${index}`}>
-                {(tool === 'web_search' || tool === 'ifly_search') && (
-                  <Tooltip
-                    title={t('chatPage.chatSide.webSearch')}
-                    placement="top"
-                    overlayClassName="black-tooltip"
-                  >
-                    <img
-                      src={netIcon}
-                      alt="网络搜索"
-                      className="w-5 h-5 mr-2"
-                    />
-                  </Tooltip>
-                )}
-
                 {tool === 'text_to_image' && (
                   <Tooltip
                     title={t('chatPage.chatSide.aiImage')}


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible multi-round tool-call handling with default web_search and current_time tools.
- Keep default Spark Agent chat on the original SparkChatService path and restore Spark-native web search behavior.
- Hide built-in managed tools from frontend configuration surfaces.
- Add regression coverage for provider tool orchestration, Spark routing, Spark model aliases, and prompt chat tool loops.

## Verification
- mvn -pl hub -Dtest=BotChatServiceImplUnitTest,ProviderToolOrchestratorTest,PromptChatServiceTest,SparkChatServiceTest test
- git diff --check