### PR TITLE
fix: tighten code scanning security checks

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/config/SecurityConfig.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/config/SecurityConfig.java
@@ -3,17 +3,19 @@ package com.iflytek.astron.console.hub.config;
 import com.iflytek.astron.console.commons.config.JwtClaimsFilter;
 import com.iflytek.astron.console.hub.config.security.RestfulAccessDeniedHandler;
 import com.iflytek.astron.console.hub.config.security.RestfulAuthenticationEntryPoint;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -25,6 +27,8 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
     private final JwtClaimsFilter jwtClaimsFilter;
     private final RestfulAuthenticationEntryPoint restfulAuthenticationEntryPoint;
     private final RestfulAccessDeniedHandler restfulAccessDeniedHandler;
@@ -37,11 +41,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .anyRequest()
                         .permitAll())
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/internal/gateway/auth/**"))
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable());
 
         return http.build();
     }
@@ -60,20 +64,15 @@ public class SecurityConfig {
                 // Enable OAuth2 resource server support with JWT format tokens
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(Customizer.withDefaults()))
-                // CSRF protection disabled - Safe because:
-                // 1. Using OAuth2 Bearer token authentication (via Authorization header)
-                // 2. Stateless session management (no cookies)
-                // 3. CSRF attacks only affect cookie-based authentication
-                // 4. Bearer tokens cannot be automatically sent by browsers
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.ignoringRequestMatchers(this::shouldIgnoreCsrf))
                 .exceptionHandling(exceptions -> exceptions
                         .authenticationEntryPoint(restfulAuthenticationEntryPoint)
                         .accessDeniedHandler(restfulAccessDeniedHandler))
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 // Configure stateless session
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
 
         ;
 
@@ -98,5 +97,19 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    private boolean shouldIgnoreCsrf(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (StringUtils.startsWithIgnoreCase(authorization, "Bearer ")) {
+            return true;
+        }
+        String servletPath = request.getServletPath();
+        for (String pathPattern : WebMvcConfig.NO_AUTH_REQUIRED_APIS) {
+            if (PATH_MATCHER.match(pathPattern, servletPath)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/bot/impl/SpeakerTrainServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/bot/impl/SpeakerTrainServiceImpl.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.Set;
 import java.util.UUID;
 
@@ -81,8 +80,7 @@ public class SpeakerTrainServiceImpl implements SpeakerTrainService {
         // validate audio file
         AudioValidator.validateAudioFile(file);
 
-        String sanitizedFilename = sanitizeFilename(file.getOriginalFilename());
-        File tempFile = File.createTempFile(UUID.randomUUID().toString(), "_" + sanitizedFilename);
+        File tempFile = File.createTempFile(UUID.randomUUID().toString(), buildSafeTempFileSuffix(file.getOriginalFilename()));
         try {
             file.transferTo(tempFile);
             // Create task
@@ -160,26 +158,32 @@ public class SpeakerTrainServiceImpl implements SpeakerTrainService {
      * @param originalFilename original filename from user input
      * @return sanitized filename safe for use in file operations
      */
-    private String sanitizeFilename(String originalFilename) {
+    private String buildSafeTempFileSuffix(String originalFilename) {
         if (StringUtils.isBlank(originalFilename)) {
-            return "audio";
+            return ".tmp";
         }
-        // Extract just the filename part (not the path) to prevent path traversal
-        java.nio.file.Path fileNamePath = Paths.get(originalFilename).getFileName();
-        // getFileName() can return null for root paths (e.g., "/", "C:\")
-        if (fileNamePath == null) {
-            return "audio";
+        String normalized = originalFilename.replace('\\', '/');
+        int separatorIndex = normalized.lastIndexOf('/');
+        String filename = separatorIndex >= 0 ? normalized.substring(separatorIndex + 1) : normalized;
+        int dotIndex = filename.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == filename.length() - 1) {
+            return ".tmp";
         }
-        String filename = fileNamePath.toString();
-        // Remove dangerous characters: path separators, wildcards, and other special chars
-        // Keep only alphanumeric, dots, dashes, and underscores
-        String sanitized = filename.replaceAll("[^a-zA-Z0-9._-]", "_");
-        // Prevent empty result or just dots
-        if (sanitized.isEmpty() || sanitized.matches("^\\.+$")) {
-            return "audio";
+        StringBuilder extension = new StringBuilder();
+        for (int i = dotIndex + 1; i < filename.length() && extension.length() < 10; i++) {
+            char current = filename.charAt(i);
+            if ((current >= 'a' && current <= 'z')
+                    || (current >= 'A' && current <= 'Z')
+                    || (current >= '0' && current <= '9')) {
+                extension.append(Character.toLowerCase(current));
+            } else {
+                break;
+            }
         }
-        // Limit length to prevent excessively long filenames
-        return sanitized.length() > 255 ? sanitized.substring(0, 255) : sanitized;
+        if (extension.isEmpty()) {
+            return ".tmp";
+        }
+        return "." + extension;
     }
 
     /**

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowSkillExportServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/workflow/impl/WorkflowSkillExportServiceImpl.java
@@ -192,16 +192,35 @@ public class WorkflowSkillExportServiceImpl implements WorkflowSkillExportServic
     }
 
     private String toSkillName(String workflowName, Long workflowId) {
-        String normalized = Normalizer.normalize(StringUtils.defaultString(workflowName), Normalizer.Form.NFKD)
-                .replaceAll("\\p{M}", "")
-                .toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9]+", "-")
-                .replaceAll("(^-+|-+$)", "");
+        String normalizedText = Normalizer.normalize(
+                StringUtils.defaultString(workflowName),
+                Normalizer.Form.NFKD);
+        StringBuilder normalizedBuilder = new StringBuilder(normalizedText.length());
+        boolean previousHyphen = false;
+        for (int i = 0; i < normalizedText.length(); i++) {
+            char current = normalizedText.charAt(i);
+            int charType = Character.getType(current);
+            if (charType == Character.NON_SPACING_MARK
+                    || charType == Character.COMBINING_SPACING_MARK
+                    || charType == Character.ENCLOSING_MARK) {
+                continue;
+            }
+            if (isAsciiAlphaNumeric(current)) {
+                normalizedBuilder.append(Character.toLowerCase(current));
+                previousHyphen = false;
+                continue;
+            }
+            if (!previousHyphen && !normalizedBuilder.isEmpty()) {
+                normalizedBuilder.append('-');
+                previousHyphen = true;
+            }
+        }
+        String normalized = trimEdgeHyphen(normalizedBuilder.toString());
         if (StringUtils.isBlank(normalized)) {
             normalized = "workflow-" + workflowId;
         }
         if (normalized.length() > SKILL_NAME_MAX_LENGTH) {
-            normalized = normalized.substring(0, SKILL_NAME_MAX_LENGTH).replaceAll("-+$", "");
+            normalized = trimEdgeHyphen(normalized.substring(0, SKILL_NAME_MAX_LENGTH));
         }
         return StringUtils.defaultIfBlank(normalized, "workflow-" + workflowId);
     }
@@ -369,6 +388,27 @@ public class WorkflowSkillExportServiceImpl implements WorkflowSkillExportServic
 
     private String shellSingleQuote(String value) {
         return StringUtils.defaultString(value).replace("'", "'\"'\"'");
+    }
+
+    private boolean isAsciiAlphaNumeric(char value) {
+        return (value >= 'a' && value <= 'z')
+                || (value >= 'A' && value <= 'Z')
+                || (value >= '0' && value <= '9');
+    }
+
+    private String trimEdgeHyphen(String value) {
+        if (StringUtils.isBlank(value)) {
+            return "";
+        }
+        int start = 0;
+        int end = value.length();
+        while (start < end && value.charAt(start) == '-') {
+            start++;
+        }
+        while (end > start && value.charAt(end - 1) == '-') {
+            end--;
+        }
+        return value.substring(start, end);
     }
 
     private record SkillMetadata(String name, String description, boolean aiGenerated) {}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/skill/SkillFileService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/skill/SkillFileService.java
@@ -41,8 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -68,8 +66,6 @@ public class SkillFileService extends ServiceImpl<SkillFileMapper, SkillFile> {
     private static final String ENTRY_TYPE_FOLDER = "folder";
     private static final String ENTRY_TYPE_FILE = "file";
     private static final String SKILL_FILE_NAME = "SKILL.md";
-    private static final Pattern FRONTMATTER_PATTERN =
-            Pattern.compile("(?s)^---\\s*(.*?)\\s*---\\s*(.*)$");
 
     @Resource
     private S3Util s3Util;
@@ -780,12 +776,10 @@ public class SkillFileService extends ServiceImpl<SkillFileMapper, SkillFile> {
     private SkillMetadata extractSkillMetadata(String content, String fallbackName) {
         String name = null;
         String description = null;
-        Matcher matcher = FRONTMATTER_PATTERN.matcher(StringUtils.defaultString(content));
-        String body = content;
-        if (matcher.find()) {
-            String frontmatter = matcher.group(1);
-            body = matcher.group(2);
-            for (String line : frontmatter.split("\\r?\\n")) {
+        ParsedSkillContent parsedContent = parseSkillContent(StringUtils.defaultString(content));
+        String body = parsedContent.getBody();
+        if (StringUtils.isNotBlank(parsedContent.getFrontmatter())) {
+            for (String line : parsedContent.getFrontmatterLines()) {
                 String trimmed = StringUtils.trimToEmpty(line);
                 if (trimmed.startsWith("name:")) {
                     name = cleanupYamlValue(StringUtils.substringAfter(trimmed, "name:"));
@@ -827,6 +821,57 @@ public class SkillFileService extends ServiceImpl<SkillFileMapper, SkillFile> {
             cleaned = cleaned.substring(1, cleaned.length() - 1);
         }
         return cleaned;
+    }
+
+    private ParsedSkillContent parseSkillContent(String content) {
+        if (!startsWithFrontmatter(content)) {
+            return new ParsedSkillContent("", content);
+        }
+        int frontmatterStart = skipLineBreak(content, findLineBreakIndex(content, 0));
+        int lineStart = frontmatterStart;
+        while (lineStart >= 0 && lineStart < content.length()) {
+            int lineEnd = findLineBreakIndex(content, lineStart);
+            String currentLine = trimLineEnding(content.substring(lineStart, lineEnd));
+            if ("---".equals(currentLine)) {
+                int bodyStart = skipLineBreak(content, lineEnd);
+                return new ParsedSkillContent(content.substring(frontmatterStart, lineStart), content.substring(bodyStart));
+            }
+            int nextLineStart = skipLineBreak(content, lineEnd);
+            lineStart = nextLineStart > lineEnd ? nextLineStart : -1;
+        }
+        return new ParsedSkillContent("", content);
+    }
+
+    private boolean startsWithFrontmatter(String content) {
+        return "---\n".equals(content)
+                || content.startsWith("---\n")
+                || content.startsWith("---\r\n");
+    }
+
+    private int findLineBreakIndex(String content, int lineStart) {
+        int index = lineStart;
+        while (index < content.length()) {
+            char current = content.charAt(index);
+            if (current == '\n' || current == '\r') {
+                break;
+            }
+            index++;
+        }
+        return index;
+    }
+
+    private int skipLineBreak(String content, int index) {
+        if (index < content.length() && content.charAt(index) == '\r') {
+            index++;
+        }
+        if (index < content.length() && content.charAt(index) == '\n') {
+            index++;
+        }
+        return index;
+    }
+
+    private String trimLineEnding(String line) {
+        return StringUtils.removeEnd(line, "\r");
     }
 
     private boolean matchesSkillKeyword(SkillFile file, String keyword) {
@@ -888,5 +933,19 @@ public class SkillFileService extends ServiceImpl<SkillFileMapper, SkillFile> {
     private static class SkillMetadata {
         private String name;
         private String description;
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class ParsedSkillContent {
+        private String frontmatter;
+        private String body;
+
+        private List<String> getFrontmatterLines() {
+            if (StringUtils.isBlank(frontmatter)) {
+                return Collections.emptyList();
+            }
+            return frontmatter.lines().toList();
+        }
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -95,7 +95,8 @@ public class UrlCheckTool {
     private RedirectLookupResult lookupRedirect(String url) throws IOException {
         HttpURLConnection conn = null;
         try {
-            URL u = new URL(url);
+            URL u = toSafeHttpUrl(url);
+            ensurePublicAddresses(u.getHost());
             URLConnection urlConnection = u.openConnection();
             if (!(urlConnection instanceof HttpURLConnection httpURLConnection)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_HTTP_HTTPS_ONLY);
@@ -235,19 +236,27 @@ public class UrlCheckTool {
             }
         }
 
-        InetAddress inet = InetAddress.getByName(asciiHost);
-        String ip = inet.getHostAddress();
-
-        // IPv4 blacklist
-        if (ipBlackList.stream().map(String::trim).anyMatch(ip::equals)) {
-            throw new BusinessException(ResponseEnum.TOOLBOX_IP_IN_BLACKLIST);
+        InetAddress[] addresses = InetAddress.getAllByName(asciiHost);
+        if (addresses.length == 0) {
+            throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
         }
+        for (InetAddress inet : addresses) {
+            if (isRestrictedAddress(inet)) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
+            }
+            String ip = inet.getHostAddress();
 
-        // Network segment blacklist (only effective for IPv4; IPv6 can be extended)
-        if (inet instanceof Inet4Address) {
-            for (String segment : segmentBlackList) {
-                if (isIpInRange(ip, segment)) {
-                    throw new BusinessException(ResponseEnum.TOOLBOX_IP_IN_BLACKLIST);
+            // IPv4 blacklist
+            if (ipBlackList.stream().map(String::trim).anyMatch(ip::equals)) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_IP_IN_BLACKLIST);
+            }
+
+            // Network segment blacklist (only effective for IPv4; IPv6 can be extended)
+            if (inet instanceof Inet4Address) {
+                for (String segment : segmentBlackList) {
+                    if (isIpInRange(ip, segment)) {
+                        throw new BusinessException(ResponseEnum.TOOLBOX_IP_IN_BLACKLIST);
+                    }
                 }
             }
         }
@@ -460,5 +469,55 @@ public class UrlCheckTool {
     }
 
     private record RedirectLookupResult(int statusCode, String location) {
+    }
+
+    private URL toSafeHttpUrl(String url) throws IOException {
+        try {
+            URI uri = new URI(url);
+            String scheme = StringUtils.lowerCase(uri.getScheme(), Locale.ROOT);
+            if (!"http".equals(scheme) && !"https".equals(scheme)) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_URL_HTTP_HTTPS_ONLY);
+            }
+            if (StringUtils.isNotBlank(uri.getUserInfo())) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
+            }
+            String host = uri.getHost();
+            if (StringUtils.isBlank(host)) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
+            }
+            String asciiHost = IDN.toASCII(host);
+            String path = StringUtils.defaultIfBlank(uri.getRawPath(), "/");
+            return new URI(
+                    scheme,
+                    null,
+                    asciiHost,
+                    uri.getPort(),
+                    path,
+                    uri.getRawQuery(),
+                    null).toURL();
+        } catch (URISyntaxException e) {
+            throw new IOException("Illegal URL", e);
+        }
+    }
+
+    private void ensurePublicAddresses(String host) throws UnknownHostException {
+        for (InetAddress address : InetAddress.getAllByName(host)) {
+            if (isRestrictedAddress(address)) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
+            }
+        }
+    }
+
+    private boolean isRestrictedAddress(InetAddress address) {
+        return address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()
+                || address.isMCGlobal()
+                || address.isMCLinkLocal()
+                || address.isMCNodeLocal()
+                || address.isMCOrgLocal()
+                || address.isMCSiteLocal();
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
@@ -74,6 +74,14 @@ class UrlCheckToolTest {
         assertThrows(BusinessException.class, () -> tool.checkUrl("http://example.com/start"));
     }
 
+    @Test
+    void checkUrlRejectsLoopbackAddressDirectly() {
+        ConfigInfoMapper mapper = mockConfigMapper("", "");
+        UrlCheckTool tool = new UrlCheckTool(mapper);
+
+        assertThrows(BusinessException.class, () -> tool.checkUrl("http://127.0.0.1/internal"));
+    }
+
     private static ConfigInfoMapper mockConfigMapper(String ipBlackList, String segmentBlackList) {
         ConfigInfoMapper mapper = mock(ConfigInfoMapper.class);
         when(mapper.getListByCategory("IP_BLACK_LIST")).thenReturn(List.of(config(ipBlackList)));

--- a/core/memory/database/repository/middleware/adapters/mysql_adapter.py
+++ b/core/memory/database/repository/middleware/adapters/mysql_adapter.py
@@ -154,6 +154,7 @@ class MySQLAdapter(DatabaseAdapter):
         return {}
 
     async def create_database_if_not_exists(self, base_url: str, db_name: str) -> None:
+        safe_db_name = self._validate_mysql_identifier(db_name)
         engine = create_async_engine(
             f"{base_url}/information_schema", isolation_level="AUTOCOMMIT"
         )
@@ -170,13 +171,13 @@ class MySQLAdapter(DatabaseAdapter):
                 if not exists:
                     await conn.execute(
                         text(
-                            f"CREATE DATABASE `{db_name}` "
+                            f"CREATE DATABASE `{safe_db_name}` "
                             f"CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
                         )
                     )
-                    logger.info(f"Database '{db_name}' created successfully")
+                    logger.info(f"Database '{safe_db_name}' created successfully")
         except RuntimeError as e:
-            logger.error(f"Failed to create database '{db_name}': {e}")
+            logger.error(f"Failed to create database '{safe_db_name}': {e}")
         finally:
             await engine.dispose()
 
@@ -202,14 +203,14 @@ class MySQLAdapter(DatabaseAdapter):
             await engine.dispose()
 
     def safe_create_schema_sql(self, schema_name: str) -> Any:
-        safe_name = quoted_name(schema_name, quote=True)
+        safe_name = quoted_name(self._validate_mysql_identifier(schema_name), quote=True)
         return text(
             f"CREATE DATABASE IF NOT EXISTS `{safe_name}` "
             f"CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
         )
 
     def safe_drop_schema_sql(self, schema_name: str) -> Any:
-        safe_name = quoted_name(schema_name, quote=True)
+        safe_name = quoted_name(self._validate_mysql_identifier(schema_name), quote=True)
         return text(f"DROP DATABASE IF EXISTS `{safe_name}`")
 
     def list_tables_sql(self) -> str:
@@ -243,9 +244,10 @@ class MySQLAdapter(DatabaseAdapter):
         current_schema = getattr(session, "_current_schema", None)
         if current_schema:
             try:
-                await session.execute(text(f"USE `{current_schema}`"))
+                safe_name = self._validate_mysql_identifier(current_schema)
+                await session.execute(text(f"USE `{safe_name}`"))
                 logger.debug(
-                    f"Restored active database to {current_schema} after cache clearing"
+                    f"Restored active database to {safe_name} after cache clearing"
                 )
             except Exception as restore_error:
                 logger.warning(
@@ -254,7 +256,7 @@ class MySQLAdapter(DatabaseAdapter):
                 )
 
     def set_search_path_sql(self, schema_name: str) -> str:
-        safe_name = quoted_name(schema_name, quote=True)
+        safe_name = quoted_name(self._validate_mysql_identifier(schema_name), quote=True)
         return f"USE `{safe_name}`"
 
     def get_alembic_version_table_schema(self) -> Optional[str]:
@@ -273,3 +275,11 @@ class MySQLAdapter(DatabaseAdapter):
 
     def get_default_port(self) -> int:
         return 3306
+
+    def _validate_mysql_identifier(self, identifier: str) -> str:
+        if not identifier:
+            raise ValueError("MySQL identifier must not be empty")
+        for char in identifier:
+            if not (char.isalnum() or char == "_"):
+                raise ValueError(f"Invalid MySQL identifier: {identifier}")
+        return identifier

--- a/core/memory/database/tests/test_adapters.py
+++ b/core/memory/database/tests/test_adapters.py
@@ -316,6 +316,11 @@ class TestMySQLAdapter:
         result = self.adapter.set_search_path_sql("my_schema")
         assert "USE" in result
 
+    def test_set_search_path_sql_rejects_invalid_identifier(self) -> None:
+        """set_search_path_sql rejects identifiers containing unsafe characters."""
+        with pytest.raises(ValueError):
+            self.adapter.set_search_path_sql("my-schema")
+
     def test_alembic_version_table_schema(self) -> None:
         """Alembic version table schema is None for MySQL."""
         assert self.adapter.get_alembic_version_table_schema() is None


### PR DESCRIPTION
## 背景
处理 GitHub code scanning 中已定位的部分高优先级告警，优先收敛 Java 与 MySQL 相关的可安全落地修复。

## 本次变更
- 收紧 Spring Security 的 CSRF 策略，避免全局 disable
- 收紧 URL 校验与重定向校验，阻断回环、内网、链路本地与多播地址访问
- 将高复杂度正则解析替换为确定性字符串解析，降低 ReDoS 风险
- 限制临时文件后缀来源，避免用户输入进入潜在路径表达式
- 为 MySQL schema/database 标识符增加白名单校验，阻断注入路径
- 补充 URL 校验与 MySQL 标识符校验回归测试

## 验证
- 已完成静态诊断检查
- 当前执行环境缺少 mvn 与 Python/uv 运行时，未在本机实际跑通单测
- 建议在 CI 或具备完整构建环境的机器补跑相关测试

## 说明
- `core/common/utils/hmac_auth.py` 与 `core/knowledge/utils/spark_signature.py` 的弱哈希告警本次未改动
- 两处看起来更像第三方协议约束，需单独做兼容性评估或按误报处理