### PR TITLE
feat: enable custom MCP runtime tools for agents

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
@@ -105,6 +105,9 @@ public class BotCreateForm {
     @Schema(description = "Enabled tools, joined by comma, e.g.: web_search,text_to_image,codeinterpreter")
     private String openedTool;
 
+    @Schema(description = "Custom MCP server URL list")
+    private List<String> mcpServerUrls;
+
     @Schema(description = "Background image color scheme: 0 Light, 1 Dark")
     private Integer backgroundColor;
 

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotDetail.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotDetail.java
@@ -35,6 +35,7 @@ public class BotDetail {
     private Integer vcnSpeed;
     private Integer version;
     private String openedTool;
+    private String mcpServerUrls;
     private Integer hotNum;
     private String marketBotId;
     private Integer supportSystem;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotInfoDto.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotInfoDto.java
@@ -109,6 +109,8 @@ public class BotInfoDto {
 
     private Long modelId;
 
+    private String mcpServerUrls;
+
     private String vcnCn;
 
     private String vcnEn;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/DebugChatBotReqDto.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/DebugChatBotReqDto.java
@@ -42,6 +42,11 @@ public class DebugChatBotReqDto {
     private String openedTool;
 
     /**
+     * Custom MCP server URL list
+     */
+    private String mcpServerUrls;
+
+    /**
      * Model name
      */
     private String model;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/bot/ChatBotBase.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/bot/ChatBotBase.java
@@ -118,6 +118,9 @@ public class ChatBotBase {
     @Schema(description = "Enabled tools, separated by commas")
     private String openedTool;
 
+    @Schema(description = "Custom MCP server URL list")
+    private String mcpServerUrls;
+
     @Schema(description = "Hidden on certain clients")
     private String clientHide;
 

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -44,6 +44,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -355,6 +356,7 @@ public class BotServiceImpl implements BotService {
         botBase.setModel(bot.getModel());
         botBase.setIsSentence(bot.getIsSentence());
         botBase.setOpenedTool(bot.getOpenedTool());
+        botBase.setMcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()));
         botBase.setClientType(bot.getClientType());
         botBase.setSpaceId(spaceId);
         setInputExamples(botBase, bot.getInputExample(), null);
@@ -389,6 +391,7 @@ public class BotServiceImpl implements BotService {
         botBase.setVcnSpeed(bot.getVcnSpeed());
         botBase.setIsSentence(bot.getIsSentence());
         botBase.setOpenedTool(bot.getOpenedTool());
+        botBase.setMcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()));
         botBase.setClientType(bot.getClientType());
         botBase.setBotNameEn(bot.getBotNameEn());
         botBase.setBotDescEn(bot.getBotDescEn());
@@ -414,6 +417,30 @@ public class BotServiceImpl implements BotService {
         }
         if (inputExampleEn != null && !inputExampleEn.isEmpty()) {
             botBase.setInputExampleEn(String.join(BOT_INPUT_EXAMPLE_SPLIT, inputExampleEn));
+        }
+    }
+
+    private String serializeMcpServerUrls(List<String> mcpServerUrls) {
+        if (mcpServerUrls == null) {
+            return null;
+        }
+        List<String> normalizedUrls = mcpServerUrls.stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .filter(this::isValidMcpServerUrl)
+                .distinct()
+                .collect(Collectors.toList());
+        return JSON.toJSONString(normalizedUrls);
+    }
+
+    private boolean isValidMcpServerUrl(String mcpServerUrl) {
+        try {
+            URI uri = URI.create(mcpServerUrl);
+            String scheme = uri.getScheme();
+            return StringUtils.isNotBlank(uri.getHost())
+                    && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
+        } catch (IllegalArgumentException e) {
+            return false;
         }
     }
 
@@ -455,6 +482,7 @@ public class BotServiceImpl implements BotService {
                     .model(bot.getModel())
                     .isSentence(bot.getIsSentence())
                     .openedTool(bot.getOpenedTool())
+                    .mcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()))
                     .clientType(bot.getClientType())
                     .inputExample(bot.getInputExample() != null && bot.getInputExample().size() > 0 ? String.join(BOT_INPUT_EXAMPLE_SPLIT, bot.getInputExample()) : null)
                     .modelId(bot.getModelId())
@@ -519,6 +547,7 @@ public class BotServiceImpl implements BotService {
                 .vcnSpeed(bot.getVcnSpeed())
                 .isSentence(bot.getIsSentence())
                 .openedTool(bot.getOpenedTool())
+                .mcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()))
                 .clientType(bot.getClientType())
                 .botNameEn(bot.getBotNameEn())
                 .botDescEn(bot.getBotDescEn())

--- a/console/backend/commons/src/main/resources/mapper/ChatBotBaseMapper.xml
+++ b/console/backend/commons/src/main/resources/mapper/ChatBotBaseMapper.xml
@@ -27,6 +27,7 @@
         a.vcn_speed AS vcnSpeed,
         a.version,
         a.opened_tool AS openedTool,
+        a.mcp_server_urls AS mcpServerUrls,
         a.client_hide as clientHide,
         b.hot_num as hotNum,
         b.id as marketBotId,

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
@@ -396,6 +396,7 @@ public class ChatMessageController {
         debugChatReqDto.setMessages(messageList);
         debugChatReqDto.setUid(uid);
         debugChatReqDto.setOpenedTool(debugRequest.getOpenedTool());
+        debugChatReqDto.setMcpServerUrls(debugRequest.getMcpServerUrls());
         debugChatReqDto.setModel(debugRequest.getModel());
         debugChatReqDto.setModelId(debugRequest.getModelId());
         debugChatReqDto.setMaasDatasetList(maasDatasetList);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/chat/BotDebugRequest.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/chat/BotDebugRequest.java
@@ -47,6 +47,11 @@ public class BotDebugRequest {
     private String openedTool;
 
     /**
+     * Custom MCP server URL list
+     */
+    private String mcpServerUrls;
+
+    /**
      * Model name
      */
     private String model = "spark";

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/McpRuntimeToolService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/McpRuntimeToolService.java
@@ -1,0 +1,262 @@
+package com.iflytek.astron.console.hub.service;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.CRC32;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class McpRuntimeToolService {
+
+    private static final String MCP_TOOL_LIST_PATH = "/api/v1/mcp/tool_list";
+    private static final String MCP_CALL_TOOL_PATH = "/api/v1/mcp/call_tool";
+    private static final int MAX_FUNCTION_NAME_LENGTH = 64;
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+
+    private final OkHttpClient httpClient;
+    private final ApiUrl apiUrl;
+
+    public List<McpRuntimeTool> listTools(List<String> serverUrls) throws IOException {
+        List<String> normalizedUrls = normalizeUrls(serverUrls);
+        if (normalizedUrls.isEmpty()) {
+            return List.of();
+        }
+
+        JSONObject requestBody = new JSONObject()
+                .fluentPut("mcp_server_ids", new JSONArray())
+                .fluentPut("mcp_server_urls", new JSONArray(normalizedUrls));
+        JSONObject response = post(MCP_TOOL_LIST_PATH, requestBody);
+        if (response.getIntValue("code") != 0) {
+            throw new IOException("MCP tool list failed: " + response.getString("message"));
+        }
+
+        JSONObject data = response.getJSONObject("data");
+        JSONArray servers = data == null ? null : data.getJSONArray("servers");
+        if (servers == null || servers.isEmpty()) {
+            return List.of();
+        }
+
+        List<McpRuntimeTool> tools = new ArrayList<>();
+        Set<String> usedFunctionNames = new LinkedHashSet<>();
+        for (int i = 0; i < servers.size(); i++) {
+            JSONObject server = servers.getJSONObject(i);
+            if (server == null) {
+                continue;
+            }
+            int status = server.getIntValue("server_status");
+            String serverId = StringUtils.defaultString(server.getString("server_id"));
+            String serverUrl = StringUtils.defaultString(server.getString("server_url"));
+            if (status != 0) {
+                log.warn("MCP server skipped, serverId: {}, serverUrl: {}, status: {}, message: {}",
+                        serverId, serverUrl, status, server.getString("server_message"));
+                continue;
+            }
+            JSONArray serverTools = server.getJSONArray("tools");
+            if (serverTools == null || serverTools.isEmpty()) {
+                continue;
+            }
+            for (int j = 0; j < serverTools.size(); j++) {
+                JSONObject tool = serverTools.getJSONObject(j);
+                if (tool == null || StringUtils.isBlank(tool.getString("name"))) {
+                    continue;
+                }
+                String toolName = tool.getString("name");
+                tools.add(new McpRuntimeTool(
+                        buildFunctionName(serverId, serverUrl, toolName, usedFunctionNames),
+                        serverId,
+                        serverUrl,
+                        toolName,
+                        StringUtils.defaultIfBlank(tool.getString("description"), "Call MCP tool " + toolName + "."),
+                        normalizeInputSchema(tool.getJSONObject("inputSchema"))));
+            }
+        }
+        return tools;
+    }
+
+    public String callTool(McpRuntimeTool tool, JSONObject arguments) throws IOException {
+        if (tool == null) {
+            return buildToolErrorContent("MCP_TOOL_NOT_FOUND", "MCP tool metadata is missing.");
+        }
+        JSONObject requestBody = new JSONObject()
+                .fluentPut("mcp_server_id", StringUtils.defaultString(tool.serverId()))
+                .fluentPut("mcp_server_url", StringUtils.defaultString(tool.serverUrl()))
+                .fluentPut("tool_name", tool.toolName())
+                .fluentPut("tool_args", arguments == null ? new JSONObject() : arguments);
+        JSONObject response = post(MCP_CALL_TOOL_PATH, requestBody);
+        if (response.getIntValue("code") != 0) {
+            return buildToolErrorContent(
+                    "MCP_TOOL_CALL_FAILED",
+                    StringUtils.defaultIfBlank(response.getString("message"), "MCP tool call failed."));
+        }
+
+        JSONObject data = response.getJSONObject("data");
+        if (data == null) {
+            return response.toJSONString();
+        }
+        String content = stringifyMcpContent(data.getJSONArray("content"));
+        if (data.getBooleanValue("isError")) {
+            return buildToolErrorContent("MCP_TOOL_ERROR", StringUtils.defaultIfBlank(content, "MCP tool returned an error."));
+        }
+        return StringUtils.defaultIfBlank(content, data.toJSONString());
+    }
+
+    private JSONObject post(String path, JSONObject requestBody) throws IOException {
+        Request request = new Request.Builder()
+                .url(resolveGatewayUrl(path))
+                .post(RequestBody.create(requestBody.toJSONString(), JSON_MEDIA_TYPE))
+                .addHeader("Content-Type", "application/json")
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("MCP gateway request failed: " + response.message());
+            }
+            ResponseBody body = response.body();
+            if (body == null) {
+                throw new IOException("MCP gateway response body is empty");
+            }
+            return JSON.parseObject(body.string());
+        }
+    }
+
+    private String resolveGatewayUrl(String path) {
+        String baseUrl = StringUtils.defaultIfBlank(apiUrl.getToolUrl(), "http://127.0.0.1:18888");
+        return StringUtils.stripEnd(baseUrl, "/") + path;
+    }
+
+    private List<String> normalizeUrls(List<String> urls) {
+        if (urls == null || urls.isEmpty()) {
+            return List.of();
+        }
+        return urls.stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+
+    private JSONObject normalizeInputSchema(JSONObject inputSchema) {
+        if (inputSchema == null || inputSchema.isEmpty()) {
+            return new JSONObject()
+                    .fluentPut("type", "object")
+                    .fluentPut("properties", new JSONObject())
+                    .fluentPut("required", new JSONArray());
+        }
+        JSONObject normalized = JSON.parseObject(inputSchema.toJSONString());
+        if (StringUtils.isBlank(normalized.getString("type"))) {
+            normalized.put("type", "object");
+        }
+        if (normalized.get("properties") == null) {
+            normalized.put("properties", new JSONObject());
+        }
+        if (normalized.get("required") == null) {
+            normalized.put("required", new JSONArray());
+        }
+        return normalized;
+    }
+
+    private String buildFunctionName(String serverId, String serverUrl, String toolName, Set<String> usedFunctionNames) {
+        String hash = shortHash(serverId + "|" + serverUrl + "|" + toolName);
+        String safeToolName = sanitizeFunctionNamePart(toolName);
+        int maxToolNameLength = Math.max(1, MAX_FUNCTION_NAME_LENGTH - "mcp_".length() - hash.length() - 1);
+        if (safeToolName.length() > maxToolNameLength) {
+            safeToolName = safeToolName.substring(0, maxToolNameLength);
+        }
+        String base = "mcp_" + hash + "_" + safeToolName;
+        String candidate = base;
+        int suffix = 2;
+        while (usedFunctionNames.contains(candidate)) {
+            String suffixText = "_" + suffix++;
+            int maxBaseLength = MAX_FUNCTION_NAME_LENGTH - suffixText.length();
+            candidate = base.length() > maxBaseLength ? base.substring(0, maxBaseLength) + suffixText : base + suffixText;
+        }
+        usedFunctionNames.add(candidate);
+        return candidate;
+    }
+
+    private String sanitizeFunctionNamePart(String value) {
+        String sanitized = StringUtils.defaultString(value)
+                .replaceAll("[^A-Za-z0-9_-]", "_")
+                .replaceAll("_+", "_");
+        sanitized = StringUtils.strip(sanitized, "_-");
+        return StringUtils.defaultIfBlank(sanitized, "tool");
+    }
+
+    private String shortHash(String value) {
+        CRC32 crc32 = new CRC32();
+        crc32.update(StringUtils.defaultString(value).getBytes(StandardCharsets.UTF_8));
+        return Long.toHexString(crc32.getValue());
+    }
+
+    private String stringifyMcpContent(JSONArray content) {
+        if (content == null || content.isEmpty()) {
+            return "";
+        }
+        List<String> parts = new ArrayList<>();
+        for (int i = 0; i < content.size(); i++) {
+            JSONObject item = content.getJSONObject(i);
+            if (item == null) {
+                continue;
+            }
+            if ("text".equals(item.getString("type"))) {
+                parts.add(StringUtils.defaultString(item.getString("text")));
+            } else {
+                parts.add(item.toJSONString());
+            }
+        }
+        return String.join("\n", parts);
+    }
+
+    private String buildToolErrorContent(String code, String message) {
+        return new JSONObject()
+                .fluentPut("error", code)
+                .fluentPut("message", message)
+                .toJSONString();
+    }
+
+    public record McpRuntimeTool(String functionName, String serverId, String serverUrl, String toolName,
+            String description, JSONObject inputSchema) {
+
+        JSONObject toJson() {
+            return new JSONObject()
+                    .fluentPut("functionName", functionName)
+                    .fluentPut("serverId", serverId)
+                    .fluentPut("serverUrl", serverUrl)
+                    .fluentPut("toolName", toolName)
+                    .fluentPut("description", description)
+                    .fluentPut("inputSchema", inputSchema);
+        }
+
+        static McpRuntimeTool fromJson(JSONObject jsonObject) {
+            if (jsonObject == null) {
+                return null;
+            }
+            return new McpRuntimeTool(
+                    jsonObject.getString("functionName"),
+                    jsonObject.getString("serverId"),
+                    jsonObject.getString("serverUrl"),
+                    jsonObject.getString("toolName"),
+                    jsonObject.getString("description"),
+                    jsonObject.getJSONObject("inputSchema"));
+        }
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/PromptChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/PromptChatService.java
@@ -19,9 +19,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -37,6 +39,7 @@ public class PromptChatService {
     private static final String OPENAI_SEARCH_TOOL_NAME = "web_search";
     private static final String LEGACY_OPENAI_SEARCH_TOOL_NAME = "ifly_search";
     private static final String CURRENT_TIME_TOOL_NAME = CurrentTimeTool.TOOL_NAME;
+    private static final String MANAGED_MCP_TOOLS_FIELD = "managedMcpTools";
     private static final int MAX_OPENAI_TOOL_ROUNDS = 15;
     private static final int MAX_OPENAI_TOOL_CALLS = 15;
     private static final String WEB_SEARCH_DECISION_INSTRUCTION = """
@@ -55,6 +58,11 @@ public class PromptChatService {
             Use web_search for questions that require current or recently changed external information, including latest news, prices, policies, schedules, releases, rankings, or status.
             For static knowledge that does not need tools, answer directly without using a tool.
             """;
+    private static final String MCP_TOOL_DECISION_INSTRUCTION = """
+            You have access to configured MCP tools from external servers. Decide whether to call them.
+            Use an MCP tool when its name, description, and parameters match the user's request.
+            For requests that do not need these external tools, answer directly without using them.
+            """;
     private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
 
     private final OkHttpClient httpClient;
@@ -67,6 +75,9 @@ public class PromptChatService {
 
     @Autowired
     private ManagedWebSearchService managedWebSearchService;
+
+    @Autowired
+    private McpRuntimeToolService mcpRuntimeToolService;
 
     /**
      * Function to handle chat stream requests
@@ -104,6 +115,7 @@ public class PromptChatService {
     private void performChatRequest(JSONObject request, SseEmitter emitter, String streamId, ChatReqRecords chatReqRecords, boolean edit, boolean isDebug) throws IOException {
         String provider = normalizeProvider(request.getString("provider"));
         ensureManagedToolsForOpenAiCompatibleProvider(provider, request);
+        ensureMcpToolsForOpenAiCompatibleProvider(provider, request);
         boolean shouldHandleOpenAiFunctionTools = shouldHandleOpenAiFunctionToolCall(provider, request);
         JSONObject fallbackRequest = null;
         if (shouldHandleOpenAiFunctionTools) {
@@ -261,7 +273,7 @@ public class PromptChatService {
         if (PROVIDER_GOOGLE.equals(provider) || PROVIDER_ANTHROPIC.equals(provider)) {
             return false;
         }
-        return hasOpenAiManagedTool(request.getJSONArray("tools"));
+        return hasOpenAiManagedTool(request.getJSONArray("tools")) || hasMcpRuntimeTool(request);
     }
 
     private boolean hasOpenAiManagedTool(JSONArray tools) {
@@ -306,6 +318,11 @@ public class PromptChatService {
         return false;
     }
 
+    private boolean hasMcpRuntimeTool(JSONObject request) {
+        JSONArray mcpTools = request == null ? null : request.getJSONArray(MANAGED_MCP_TOOLS_FIELD);
+        return mcpTools != null && !mcpTools.isEmpty();
+    }
+
     private void ensureManagedToolsForOpenAiCompatibleProvider(String provider, JSONObject request) {
         if (!request.getBooleanValue("managedWebSearch")
                 || PROVIDER_GOOGLE.equals(provider)
@@ -326,6 +343,49 @@ public class PromptChatService {
         if (StringUtils.isBlank(request.getString("tool_choice"))
                 && StringUtils.isBlank(request.getString("toolChoice"))) {
             request.put("tool_choice", "auto");
+        }
+    }
+
+    private void ensureMcpToolsForOpenAiCompatibleProvider(String provider, JSONObject request) throws IOException {
+        if (PROVIDER_GOOGLE.equals(provider) || PROVIDER_ANTHROPIC.equals(provider)) {
+            return;
+        }
+        List<String> mcpServerUrls = parseMcpServerUrls(request.get("mcpServerUrls"));
+        if (mcpServerUrls.isEmpty()) {
+            return;
+        }
+        if (mcpRuntimeToolService == null) {
+            throw new IOException("MCP runtime tool service is unavailable");
+        }
+        List<McpRuntimeToolService.McpRuntimeTool> mcpTools = mcpRuntimeToolService.listTools(mcpServerUrls);
+        if (mcpTools.isEmpty()) {
+            log.warn("No MCP tools available from configured server URLs: {}", mcpServerUrls);
+            return;
+        }
+        JSONArray tools = request.getJSONArray("tools");
+        if (tools == null) {
+            tools = new JSONArray();
+            request.put("tools", tools);
+        }
+        JSONArray registry = new JSONArray();
+        for (McpRuntimeToolService.McpRuntimeTool mcpTool : mcpTools) {
+            if (mcpTool == null || StringUtils.isBlank(mcpTool.functionName())) {
+                continue;
+            }
+            tools.add(new JSONObject()
+                    .fluentPut("type", "function")
+                    .fluentPut("function", new JSONObject()
+                            .fluentPut("name", mcpTool.functionName())
+                            .fluentPut("description", mcpTool.description())
+                            .fluentPut("parameters", mcpTool.inputSchema())));
+            registry.add(mcpTool.toJson());
+        }
+        if (!registry.isEmpty()) {
+            request.put(MANAGED_MCP_TOOLS_FIELD, registry);
+            if (StringUtils.isBlank(request.getString("tool_choice"))
+                    && StringUtils.isBlank(request.getString("toolChoice"))) {
+                request.put("tool_choice", "auto");
+            }
         }
     }
 
@@ -415,12 +475,16 @@ public class PromptChatService {
         JSONArray tools = request.getJSONArray("tools");
         boolean hasSearchTool = hasOpenAiSearchTool(tools);
         boolean hasCurrentTimeTool = hasOpenAiCurrentTimeTool(tools);
+        boolean hasMcpTool = hasMcpRuntimeTool(request);
         if (hasSearchTool && hasCurrentTimeTool) {
             applyDecisionInstruction(request, OPENAI_TOOL_DECISION_INSTRUCTION, "current_time and web_search tools");
         } else if (hasCurrentTimeTool) {
             applyDecisionInstruction(request, CURRENT_TIME_DECISION_INSTRUCTION, "current_time tool");
         } else if (hasSearchTool) {
             applyDecisionInstruction(request, WEB_SEARCH_DECISION_INSTRUCTION, "web_search tool");
+        }
+        if (hasMcpTool) {
+            applyDecisionInstruction(request, MCP_TOOL_DECISION_INSTRUCTION, "configured MCP tools");
         }
     }
 
@@ -509,7 +573,8 @@ public class PromptChatService {
                     chatReqRecords,
                     seenToolCalls,
                     MAX_OPENAI_TOOL_CALLS - executedToolCalls,
-                    resolveAllowedManagedToolNames(loopRequest.getJSONArray("tools")));
+                    resolveAllowedManagedToolNames(loopRequest),
+                    resolveMcpRuntimeTools(loopRequest));
             appendTraceEntries(managedSearchTrace, batchResult.traceEntries());
             appendToolMessages(loopRequest, extractAssistantMessage(planningResponse), toolCalls, batchResult.outputs());
             executedToolCalls += batchResult.executedToolCalls();
@@ -759,10 +824,13 @@ public class PromptChatService {
         request.remove("tools");
         request.remove("toolChoice");
         request.remove("tool_choice");
+        request.remove("mcpServerUrls");
+        request.remove(MANAGED_MCP_TOOLS_FIELD);
     }
 
     private ManagedToolBatchResult executeManagedTools(JSONArray toolCalls, JSONObject request, ChatReqRecords chatReqRecords,
-            Set<String> seenToolCalls, int remainingToolCallBudget, Set<String> allowedToolNames) {
+            Set<String> seenToolCalls, int remainingToolCallBudget, Set<String> allowedToolNames,
+            Map<String, McpRuntimeToolService.McpRuntimeTool> mcpRuntimeTools) {
         List<ManagedToolOutput> outputs = new ArrayList<>();
         JSONArray traceEntries = new JSONArray();
         boolean limitExceeded = false;
@@ -784,7 +852,8 @@ public class PromptChatService {
                 continue;
             }
 
-            if (!isManagedToolName(toolName)) {
+            McpRuntimeToolService.McpRuntimeTool mcpRuntimeTool = mcpRuntimeTools.get(toolName);
+            if (!isManagedToolName(toolName) && mcpRuntimeTool == null) {
                 outputs.add(new ManagedToolOutput(toolCallId, buildToolErrorContent("UNSUPPORTED_TOOL", "Unsupported tool: " + toolName)));
                 continue;
             }
@@ -813,14 +882,17 @@ public class PromptChatService {
                 outputs.add(output);
             } else if (isCurrentTimeToolName(toolName)) {
                 outputs.add(new ManagedToolOutput(toolCallId, CurrentTimeTool.execute(arguments.getString("timezone"))));
+            } else if (mcpRuntimeTool != null) {
+                outputs.add(executeMcpTool(toolCallId, mcpRuntimeTool, arguments, traceEntries));
             }
         }
 
         return new ManagedToolBatchResult(outputs, traceEntries, executedToolCalls, limitExceeded, duplicateDetected);
     }
 
-    private Set<String> resolveAllowedManagedToolNames(JSONArray tools) {
+    private Set<String> resolveAllowedManagedToolNames(JSONObject request) {
         Set<String> allowedToolNames = new HashSet<>();
+        JSONArray tools = request.getJSONArray("tools");
         if (tools == null || tools.isEmpty()) {
             return allowedToolNames;
         }
@@ -835,7 +907,23 @@ public class PromptChatService {
                 allowedToolNames.add(name);
             }
         }
+        allowedToolNames.addAll(resolveMcpRuntimeTools(request).keySet());
         return allowedToolNames;
+    }
+
+    private Map<String, McpRuntimeToolService.McpRuntimeTool> resolveMcpRuntimeTools(JSONObject request) {
+        Map<String, McpRuntimeToolService.McpRuntimeTool> runtimeTools = new LinkedHashMap<>();
+        JSONArray registry = request == null ? null : request.getJSONArray(MANAGED_MCP_TOOLS_FIELD);
+        if (registry == null || registry.isEmpty()) {
+            return runtimeTools;
+        }
+        for (int i = 0; i < registry.size(); i++) {
+            McpRuntimeToolService.McpRuntimeTool tool = McpRuntimeToolService.McpRuntimeTool.fromJson(registry.getJSONObject(i));
+            if (tool != null && StringUtils.isNotBlank(tool.functionName())) {
+                runtimeTools.put(tool.functionName(), tool);
+            }
+        }
+        return runtimeTools;
     }
 
     private ManagedToolOutput executeSearchTool(String toolCallId, JSONObject arguments, JSONObject request,
@@ -853,6 +941,32 @@ public class PromptChatService {
         return new ManagedToolOutput(toolCallId, augmentation.summary());
     }
 
+    private ManagedToolOutput executeMcpTool(String toolCallId, McpRuntimeToolService.McpRuntimeTool tool,
+            JSONObject arguments, JSONArray traceEntries) {
+        try {
+            String result = mcpRuntimeToolService.callTool(tool, arguments);
+            appendMcpTraceEntry(traceEntries, tool, arguments, result);
+            return new ManagedToolOutput(toolCallId, result);
+        } catch (Exception e) {
+            log.warn("MCP tool call failed, tool: {}, error: {}", tool.toolName(), e.getMessage());
+            return new ManagedToolOutput(toolCallId, buildToolErrorContent("MCP_TOOL_CALL_FAILED", e.getMessage()));
+        }
+    }
+
+    private void appendMcpTraceEntry(JSONArray traceEntries, McpRuntimeToolService.McpRuntimeTool tool,
+            JSONObject arguments, String result) {
+        if (traceEntries == null || tool == null) {
+            return;
+        }
+        traceEntries.add(new JSONObject()
+                .fluentPut("type", "mcp")
+                .fluentPut("deskToolName", "MCP: " + tool.toolName())
+                .fluentPut("toolName", tool.toolName())
+                .fluentPut("serverUrl", tool.serverUrl())
+                .fluentPut("arguments", arguments)
+                .fluentPut("content", StringUtils.abbreviate(StringUtils.defaultString(result), 2000)));
+    }
+
     private JSONObject parseToolArguments(String arguments) {
         if (StringUtils.isBlank(arguments)) {
             return new JSONObject();
@@ -864,6 +978,35 @@ public class PromptChatService {
             log.warn("Failed to parse tool arguments: {}", arguments, e);
             return new JSONObject();
         }
+    }
+
+    private List<String> parseMcpServerUrls(Object value) {
+        if (value == null) {
+            return List.of();
+        }
+        JSONArray parsedUrls = null;
+        if (value instanceof JSONArray urls) {
+            parsedUrls = urls;
+        } else if (value instanceof List<?> urls) {
+            parsedUrls = new JSONArray(urls);
+        } else if (value instanceof String text && StringUtils.isNotBlank(text)) {
+            try {
+                parsedUrls = JSON.parseArray(text);
+            } catch (Exception e) {
+                log.warn("Failed to parse mcpServerUrls: {}", text, e);
+            }
+        }
+        if (parsedUrls == null || parsedUrls.isEmpty()) {
+            return List.of();
+        }
+        List<String> urls = new ArrayList<>();
+        for (int i = 0; i < parsedUrls.size(); i++) {
+            String url = parsedUrls.getString(i);
+            if (StringUtils.isNotBlank(url) && !urls.contains(url.trim())) {
+                urls.add(url.trim());
+            }
+        }
+        return urls;
     }
 
     private String buildToolErrorContent(String code, String message) {
@@ -1201,6 +1344,8 @@ public class PromptChatService {
                     "managedWebSearch",
                     "managedSearchQuery",
                     "managedSearchTrace",
+                    "mcpServerUrls",
+                    MANAGED_MCP_TOOLS_FIELD,
                     "anthropicBeta")) {
                 return;
             }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
@@ -148,7 +148,8 @@ public class BotChatServiceImpl implements BotChatService {
                             messages,
                             toolPlan,
                             chatBotReqDto.getAsk(),
-                            chatBotReqDto.getUid());
+                            chatBotReqDto.getUid(),
+                            botConfig.mcpServerUrls);
                     promptChatService.chatStream(jsonObject, sseEmitter, sseId, chatReqRecords, false, false);
                 }
             }
@@ -196,7 +197,8 @@ public class BotChatServiceImpl implements BotChatService {
                         messages,
                         toolPlan,
                         chatBotReqDto.getAsk(),
-                        chatBotReqDto.getUid());
+                        chatBotReqDto.getUid(),
+                        botConfig.mcpServerUrls);
                 promptChatService.chatStream(jsonObject, sseEmitter, sseId, chatReqRecords, false, false);
             }
         } catch (Exception e) {
@@ -247,7 +249,8 @@ public class BotChatServiceImpl implements BotChatService {
                         messageList,
                         toolPlan,
                         request.getText(),
-                        request.getUid());
+                        request.getUid(),
+                        request.getMcpServerUrls());
                 promptChatService.chatStream(jsonObject, sseEmitter, sseId, null, false, true);
             }
         } catch (Exception e) {
@@ -413,7 +416,8 @@ public class BotChatServiceImpl implements BotChatService {
                     chatBotMarket.getOpenedTool(),
                     chatBotMarket.getVersion(),
                     chatBotMarket.getModelId(),
-                    chatBotMarket.getSupportDocument() == 1);
+                    chatBotMarket.getSupportDocument() == 1,
+                    resolveBaseMcpServerUrls(botId));
         } else {
             ChatBotBase chatBotBase = chatBotDataService.findById(botId)
                     .orElseThrow(() -> new BusinessException(ResponseEnum.BOT_NOT_EXISTS));
@@ -424,8 +428,17 @@ public class BotChatServiceImpl implements BotChatService {
                     chatBotBase.getOpenedTool(),
                     chatBotBase.getVersion(),
                     chatBotBase.getModelId(),
-                    chatBotBase.getSupportDocument() == 1);
+                    chatBotBase.getSupportDocument() == 1,
+                    chatBotBase.getMcpServerUrls());
         }
+    }
+
+    private String resolveBaseMcpServerUrls(Integer botId) {
+        if (botId == null) {
+            return null;
+        }
+        var botBase = chatBotDataService.findById(botId);
+        return botBase == null ? null : botBase.map(ChatBotBase::getMcpServerUrls).orElse(null);
     }
 
     /**
@@ -744,7 +757,8 @@ public class BotChatServiceImpl implements BotChatService {
             List<SparkChatRequest.MessageDto> messages,
             ProviderToolOrchestrator.ToolExecutionPlan toolPlan,
             String managedSearchQuery,
-            String userId) {
+            String userId,
+            String mcpServerUrls) {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("url", llmInfoVo.getUrl());
         jsonObject.put("apiKey", llmInfoVo.getApiKey());
@@ -752,6 +766,9 @@ public class BotChatServiceImpl implements BotChatService {
         jsonObject.put("provider", ProviderToolOrchestrator.normalizeProvider(llmInfoVo.getProvider()));
         jsonObject.put("userId", userId);
         jsonObject.put("managedSearchQuery", managedSearchQuery);
+        if (StringUtils.isNotBlank(mcpServerUrls)) {
+            jsonObject.put("mcpServerUrls", mcpServerUrls);
+        }
         jsonObject.put("messages", messages);
         // Convert Object to JSONArray type
         Object configObj = llmInfoVo.getConfig();
@@ -790,7 +807,7 @@ public class BotChatServiceImpl implements BotChatService {
     }
 
     private record BotConfiguration(String prompt, boolean supportContext, String model, String openedTool,
-            Integer version, Long modelId, boolean supportDocument) {}
+            Integer version, Long modelId, boolean supportDocument, String mcpServerUrls) {}
 
     private record TokenStatistics(int systemTokens, int currentUserTokens, int reservedTokens, int availableTokens) {}
 

--- a/console/backend/hub/src/main/resources/db/migration/V1.37__add_bot_mcp_server_urls.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.37__add_bot_mcp_server_urls.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `chat_bot_base`
+    ADD COLUMN `mcp_server_urls` text DEFAULT NULL COMMENT 'Custom MCP server URL list' AFTER `opened_tool`;

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/McpRuntimeToolServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/McpRuntimeToolServiceTest.java
@@ -1,0 +1,155 @@
+package com.iflytek.astron.console.hub.service;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class McpRuntimeToolServiceTest {
+
+    @Mock
+    private OkHttpClient httpClient;
+
+    @Mock
+    private ApiUrl apiUrl;
+
+    @Mock
+    private Call call;
+
+    @Mock
+    private Response response;
+
+    private McpRuntimeToolService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new McpRuntimeToolService(httpClient, apiUrl);
+        when(apiUrl.getToolUrl()).thenReturn("http://core-link:18888");
+    }
+
+    @Test
+    void testListTools_MapsGatewayResponseToRuntimeTools() throws Exception {
+        String serverUrl = "https://mcp.example.com/sse";
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "code": 0,
+                  "message": "success",
+                  "sid": "sid",
+                  "data": {
+                    "servers": [
+                      {
+                        "server_id": "",
+                        "server_url": "https://mcp.example.com/sse",
+                        "server_status": 0,
+                        "server_message": "success",
+                        "tools": [
+                          {
+                            "name": "get_weather",
+                            "description": "Get weather.",
+                            "inputSchema": {
+                              "type": "object",
+                              "properties": {
+                                "city": {"type": "string"}
+                              },
+                              "required": ["city"]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        List<McpRuntimeToolService.McpRuntimeTool> tools = service.listTools(List.of(serverUrl));
+
+        assertEquals(1, tools.size());
+        McpRuntimeToolService.McpRuntimeTool tool = tools.getFirst();
+        assertEquals(serverUrl, tool.serverUrl());
+        assertEquals("get_weather", tool.toolName());
+        assertTrue(tool.functionName().startsWith("mcp_"));
+        assertTrue(tool.functionName().contains("get_weather"));
+        assertEquals("Get weather.", tool.description());
+        assertEquals("object", tool.inputSchema().getString("type"));
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient).newCall(requestCaptor.capture());
+        Request request = requestCaptor.getValue();
+        assertEquals("http://core-link:18888/api/v1/mcp/tool_list", request.url().toString());
+        JSONObject body = parseRequestBody(request);
+        assertEquals(serverUrl, body.getJSONArray("mcp_server_urls").getString(0));
+    }
+
+    @Test
+    void testCallTool_ReturnsTextContentFromGatewayResponse() throws Exception {
+        McpRuntimeToolService.McpRuntimeTool tool = new McpRuntimeToolService.McpRuntimeTool(
+                "mcp_weather_get_weather",
+                "",
+                "https://mcp.example.com/sse",
+                "get_weather",
+                "Get weather.",
+                JSON.parseObject("{\"type\":\"object\",\"properties\":{}}"));
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "code": 0,
+                  "message": "success",
+                  "sid": "sid",
+                  "data": {
+                    "isError": false,
+                    "content": [
+                      {"type": "text", "text": "北京今天晴。"}
+                    ]
+                  }
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        String result = service.callTool(tool, JSON.parseObject("{\"city\":\"北京\"}"));
+
+        assertEquals("北京今天晴。", result);
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient).newCall(requestCaptor.capture());
+        Request request = requestCaptor.getValue();
+        assertEquals("http://core-link:18888/api/v1/mcp/call_tool", request.url().toString());
+        JSONObject body = parseRequestBody(request);
+        assertEquals("https://mcp.example.com/sse", body.getString("mcp_server_url"));
+        assertEquals("get_weather", body.getString("tool_name"));
+        assertEquals("北京", body.getJSONObject("tool_args").getString("city"));
+    }
+
+    private JSONObject parseRequestBody(Request request) throws IOException {
+        assertNotNull(request.body());
+        Buffer sink = new Buffer();
+        request.body().writeTo(sink);
+        return JSON.parseObject(sink.readUtf8());
+    }
+}

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,6 +40,9 @@ class PromptChatServiceTest {
 
     @Mock
     private ManagedWebSearchService managedWebSearchService;
+
+    @Mock
+    private McpRuntimeToolService mcpRuntimeToolService;
 
     @Mock
     private SseEmitter emitter;
@@ -64,6 +68,7 @@ class PromptChatServiceTest {
         ReflectionTestUtils.setField(promptChatService, "chatDataService", chatDataService);
         ReflectionTestUtils.setField(promptChatService, "chatRecordModelService", chatRecordModelService);
         ReflectionTestUtils.setField(promptChatService, "managedWebSearchService", managedWebSearchService);
+        ReflectionTestUtils.setField(promptChatService, "mcpRuntimeToolService", mcpRuntimeToolService);
 
         streamId = "test-stream-id";
         request = new JSONObject();
@@ -894,6 +899,84 @@ class PromptChatServiceTest {
         verify(httpClient, times(4)).newCall(any(Request.class));
         verify(finalStreamCall).enqueue(any(Callback.class));
         verify(managedWebSearchService).search("2026年6月9日 今日热点新闻", "debug-user");
+    }
+
+    @Test
+    void testChatStream_OpenAiMcpToolCall_ExecutesConfiguredServerTool() throws Exception {
+        String mcpServerUrl = "https://mcp.example.com/sse";
+        request.put("provider", "openai");
+        request.put("model", "deepseek-chat");
+        request.put("userId", "debug-user");
+        request.put("mcpServerUrls", "[\"" + mcpServerUrl + "\"]");
+        request.put("messages", JSON.parseArray("""
+                [
+                  {"role":"system","content":"You are helpful."},
+                  {"role":"user","content":"查一下北京天气"}
+                ]
+                """));
+        JSONObject inputSchema = JSON.parseObject("""
+                {
+                  "type": "object",
+                  "properties": {
+                    "city": {"type": "string", "description": "城市名称"}
+                  },
+                  "required": ["city"]
+                }
+                """);
+        McpRuntimeToolService.McpRuntimeTool weatherTool = new McpRuntimeToolService.McpRuntimeTool(
+                "mcp_weather_get_weather",
+                "",
+                mcpServerUrl,
+                "get_weather",
+                "Get weather for a city.",
+                inputSchema);
+        when(mcpRuntimeToolService.listTools(List.of(mcpServerUrl))).thenReturn(List.of(weatherTool));
+        when(mcpRuntimeToolService.callTool(eq(weatherTool), argThat(args -> "北京".equals(args.getString("city")))))
+                .thenReturn("北京今天晴。");
+
+        Call planningCall = mock(Call.class);
+        Call finalPlanningCall = mock(Call.class);
+        Call finalStreamCall = mock(Call.class);
+        Response planningResponse = mock(Response.class);
+        Response finalPlanningResponse = mock(Response.class);
+        when(httpClient.newCall(any(Request.class))).thenReturn(planningCall, finalPlanningCall, finalStreamCall);
+        when(planningCall.execute()).thenReturn(planningResponse);
+        when(finalPlanningCall.execute()).thenReturn(finalPlanningResponse);
+        when(planningResponse.isSuccessful()).thenReturn(true);
+        when(finalPlanningResponse.isSuccessful()).thenReturn(true);
+        when(planningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-mcp","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_weather","type":"function","function":{"name":"mcp_weather_get_weather","arguments":"{\\"city\\":\\"北京\\"}"}}]}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        when(finalPlanningResponse.body()).thenReturn(ResponseBody.create(
+                """
+                {"id":"plan-final","choices":[{"message":{"role":"assistant","content":"北京今天晴。"}}]}
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+        doNothing().when(finalStreamCall).enqueue(any(Callback.class));
+
+        promptChatService.chatStream(request, emitter, streamId, null, false, true);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient, times(3)).newCall(requestCaptor.capture());
+        JSONObject planningBody = parseRequestBody(requestCaptor.getAllValues().get(0));
+        JSONObject secondRoundBody = parseRequestBody(requestCaptor.getAllValues().get(1));
+        JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(2));
+        JSONArray tools = planningBody.getJSONArray("tools");
+        assertNotNull(tools);
+        assertTrue(tools.toJSONString().contains("mcp_weather_get_weather"));
+        assertFalse(planningBody.containsKey("mcpServerUrls"));
+        assertFalse(planningBody.containsKey("managedMcpTools"));
+        JSONObject toolMessage = secondRoundBody.getJSONArray("messages").getJSONObject(3);
+        assertEquals("tool", toolMessage.getString("role"));
+        assertEquals("call_weather", toolMessage.getString("tool_call_id"));
+        assertTrue(toolMessage.getString("content").contains("北京今天晴"));
+        assertFalse(finalBody.containsKey("mcpServerUrls"));
+        assertFalse(finalBody.containsKey("managedMcpTools"));
+        verify(mcpRuntimeToolService).listTools(List.of(mcpServerUrl));
+        verify(mcpRuntimeToolService).callTool(eq(weatherTool), any(JSONObject.class));
+        verify(managedWebSearchService, never()).search(anyString(), anyString());
     }
 
     @Test

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
@@ -507,6 +507,83 @@ class BotChatServiceImplUnitTest {
     }
 
     @Test
+    void testDebugChatMessageBot_WithModelIdPassesMcpServerUrlsToPromptRequest() {
+        DebugChatBotReqDto request = new DebugChatBotReqDto();
+        request.setText("test message");
+        request.setPrompt("test prompt");
+        request.setMessages(Arrays.asList("message1", "message2"));
+        request.setUid("test-uid");
+        request.setOpenedTool("");
+        request.setModel("test-model");
+        request.setModelId(1L);
+        request.setMcpServerUrls("[\"https://mcp.example.com/sse\"]");
+        request.setPersonalityConfig(null);
+
+        SseEmitter sseEmitter = new SseEmitter();
+        String sseId = "test-sse-id";
+
+        LLMInfoVo llmInfoVo = createLLMInfoVo();
+        llmInfoVo.setLlmId(100L);
+        llmInfoVo.setServiceId("test-service-id");
+        when(personalityConfigService.getChatPrompt(isNull(), eq("test prompt"))).thenReturn("test prompt");
+        when(modelService.getDetail(anyInt(), anyLong(), any())).thenReturn(new ApiResult<>(0, "success", llmInfoVo, 1L));
+        when(modelService.checkModelBase(anyLong(), anyString(), anyString(), anyString(), any())).thenReturn(true);
+        doNothing().when(promptChatService).chatStream(any(JSONObject.class), any(SseEmitter.class), anyString(), any(), anyBoolean(), anyBoolean());
+
+        try (var mockedSpaceInfoUtil = mockStatic(com.iflytek.astron.console.commons.util.space.SpaceInfoUtil.class)) {
+            mockedSpaceInfoUtil.when(com.iflytek.astron.console.commons.util.space.SpaceInfoUtil::getSpaceId).thenReturn(1L);
+
+            botChatService.debugChatMessageBot(request, sseEmitter, sseId);
+
+            verify(promptChatService).chatStream(
+                    argThat(json -> "[\"https://mcp.example.com/sse\"]".equals(json.getString("mcpServerUrls"))),
+                    eq(sseEmitter),
+                    eq(sseId),
+                    isNull(),
+                    eq(false),
+                    eq(true));
+        }
+    }
+
+    @Test
+    void testChatMessageBot_BaseBotPassesSavedMcpServerUrlsToPromptRequest() {
+        ChatBotReqDto chatBotReqDto = createChatBotReqDto();
+        SseEmitter sseEmitter = new SseEmitter();
+        String sseId = "test-sse-id";
+
+        ChatBotBase chatBotBase = createChatBotBase();
+        chatBotBase.setModelId(1L);
+        chatBotBase.setModel("test-model");
+        chatBotBase.setOpenedTool("");
+        chatBotBase.setMcpServerUrls("[\"https://mcp.example.com/sse\"]");
+
+        ChatReqRecords createdRecord = createChatReqRecords();
+        List<SparkChatRequest.MessageDto> historyMessages = new ArrayList<>();
+        SparkChatRequest.MessageDto currentAskMessage = new SparkChatRequest.MessageDto();
+        currentAskMessage.setRole("user");
+        currentAskMessage.setContent("test question");
+        historyMessages.add(currentAskMessage);
+        LLMInfoVo llmInfoVo = createLLMInfoVo();
+
+        when(chatBotDataService.findMarketBotByBotId(anyInt())).thenReturn(null);
+        when(chatBotDataService.findById(anyInt())).thenReturn(Optional.of(chatBotBase));
+        when(chatDataService.createRequest(any())).thenReturn(createdRecord);
+        when(chatHistoryService.getSystemBotHistory(anyString(), anyLong(), anyBoolean())).thenReturn(historyMessages);
+        when(modelService.getDetail(anyInt(), anyLong(), any())).thenReturn(new ApiResult<>(0, "success", llmInfoVo, 1L));
+        doNothing().when(promptChatService).chatStream(any(JSONObject.class), any(SseEmitter.class), anyString(), any(), anyBoolean(), anyBoolean());
+
+        botChatService.chatMessageBot(chatBotReqDto, sseEmitter, sseId, null, null);
+
+        verify(promptChatService).chatStream(
+                argThat(json -> "[\"https://mcp.example.com/sse\"]".equals(json.getString("mcpServerUrls"))),
+                eq(sseEmitter),
+                eq(sseId),
+                any(),
+                eq(false),
+                eq(false));
+    }
+
+    @Test
     void testDebugChatMessageBot_WithGoogleModelId_PropagatesProvider() {
         DebugChatBotReqDto request = new DebugChatBotReqDto();
         request.setText("test message");

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -2198,6 +2198,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
 
         boolean fixedAppEnv = CommonConst.FIXED_APPID_ENV.contains(env);
         Workflow workflow = getOne(Wrappers.lambdaQuery(Workflow.class).eq(Workflow::getFlowId, flowId));
+        List<String> configuredMcpServerUrls = resolveBotMcpServerUrls(saveDto, workflow);
         try {
             if (workflow == null) {
                 appId = commonConfig.getAppId();
@@ -2226,7 +2227,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
                 configs = Arrays.asList(configInfo.getValue().split(","));
             }
             // check and fix node
-            checkAndFixNode(nodes, fixedAppEnv, configs, appId, apiKey, apiSecret);
+            checkAndFixNode(nodes, fixedAppEnv, configs, appId, apiKey, apiSecret, configuredMcpServerUrls);
             injectScriptSandboxIntoCodeNodes(nodes, flowId);
 
             // Update core system flow
@@ -2246,7 +2247,8 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         return protocol;
     }
 
-    private void checkAndFixNode(List<BizWorkflowNode> nodes, boolean fixedAppEnv, List<String> configs, String appId, String apiKey, String apiSecret) {
+    private void checkAndFixNode(List<BizWorkflowNode> nodes, boolean fixedAppEnv, List<String> configs, String appId,
+            String apiKey, String apiSecret, List<String> configuredMcpServerUrls) {
         for (BizWorkflowNode node : nodes) {
             boolean notFlowNode = !node.getId().startsWith(WorkflowConst.NodeType.FLOW);
             BizNodeData bizNodeData = node.getData();
@@ -2275,7 +2277,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
                     }
                 }
                 // Agent node changes
-                checkAndEditData(bizNodeData, prefix);
+                checkAndEditData(bizNodeData, prefix, configuredMcpServerUrls);
                 // Knowledge base node new parameter passing logic
                 fixOnRepoNode(type, bizNodeData, prefix);
                 // Handle retry strategy information
@@ -2352,8 +2354,12 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void checkAndEditData(BizNodeData bizNodeData, String prefix) {
+        checkAndEditData(bizNodeData, prefix, List.of());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkAndEditData(BizNodeData bizNodeData, String prefix, List<String> configuredMcpServerUrls) {
         if (!isAgentNode(bizNodeData, prefix)) {
             return;
         }
@@ -2371,6 +2377,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
 
         // (2.1) MCP: copy mcpServerIds to mcpServerUrls
         copyMcpServerIdsToUrls(plugin);
+        mergeConfiguredMcpServerUrls(plugin, configuredMcpServerUrls);
 
         // (2.2) Skills: inject stable metadata and on-demand download urls
         enrichSkills(plugin);
@@ -2448,6 +2455,49 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         }
     }
 
+    private List<String> resolveBotMcpServerUrls(WorkflowReq saveDto, Workflow workflow) {
+        Integer botId = resolveWorkflowBotId(saveDto, workflow);
+        if (botId == null || chatBotBaseMapper == null) {
+            return List.of();
+        }
+        ChatBotBase botBase = chatBotBaseMapper.selectById(botId);
+        return botBase == null ? List.of() : parseMcpServerUrls(botBase.getMcpServerUrls());
+    }
+
+    private Integer resolveWorkflowBotId(WorkflowReq saveDto, Workflow workflow) {
+        JSONObject ext = saveDto == null ? null : saveDto.getExt();
+        Integer botId = ext == null ? null : ext.getInteger("botId");
+        if (botId != null) {
+            return botId;
+        }
+        String workflowExt = workflow == null ? null : workflow.getExt();
+        if (StringUtils.isBlank(workflowExt)) {
+            return null;
+        }
+        try {
+            return JSON.parseObject(workflowExt).getInteger("botId");
+        } catch (Exception e) {
+            log.warn("Failed to parse workflow ext while resolving MCP config, ext={}", workflowExt, e);
+            return null;
+        }
+    }
+
+    private void mergeConfiguredMcpServerUrls(JSONObject plugin, List<String> configuredMcpServerUrls) {
+        if (plugin == null || configuredMcpServerUrls == null || configuredMcpServerUrls.isEmpty()) {
+            return;
+        }
+        JSONArray mcpServerUrls = plugin.getJSONArray("mcpServerUrls");
+        if (mcpServerUrls == null) {
+            mcpServerUrls = new JSONArray();
+            plugin.put("mcpServerUrls", mcpServerUrls);
+        }
+        for (String serverUrl : configuredMcpServerUrls) {
+            if (StringUtils.isNotBlank(serverUrl) && !mcpServerUrls.contains(serverUrl)) {
+                mcpServerUrls.add(serverUrl);
+            }
+        }
+    }
+
     /** Check whether it is an AGENT node and has valid metadata */
     private boolean isAgentNode(BizNodeData bizNodeData, String prefix) {
         if (bizNodeData == null || bizNodeData.getNodeMeta() == null) {
@@ -2483,6 +2533,29 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             if (StringUtils.isNotBlank(server)) {
                 mcpServerUrls.add(server);
             }
+        }
+    }
+
+    private List<String> parseMcpServerUrls(String mcpServerUrls) {
+        if (StringUtils.isBlank(mcpServerUrls)) {
+            return List.of();
+        }
+        try {
+            JSONArray urls = JSON.parseArray(mcpServerUrls);
+            if (urls == null || urls.isEmpty()) {
+                return List.of();
+            }
+            List<String> result = new ArrayList<>();
+            for (int i = 0; i < urls.size(); i++) {
+                String url = urls.getString(i);
+                if (StringUtils.isNotBlank(url) && !result.contains(url.trim())) {
+                    result.add(url.trim());
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            log.warn("Failed to parse bot MCP server urls: {}", mcpServerUrls, e);
+            return List.of();
         }
     }
 
@@ -4156,7 +4229,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         if (bizWorkflowData == null || CollectionUtils.isEmpty(bizWorkflowData.getNodes())) {
             return false;
         }
-        if (!containsSkillConfiguration(bizWorkflowData)) {
+        if (!containsRuntimePluginConfiguration(bizWorkflowData) && !hasConfiguredBotMcpServerUrls(workflow)) {
             return false;
         }
 
@@ -4164,7 +4237,11 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         return true;
     }
 
-    private boolean containsSkillConfiguration(BizWorkflowData bizWorkflowData) {
+    private boolean hasConfiguredBotMcpServerUrls(Workflow workflow) {
+        return !resolveBotMcpServerUrls(null, workflow).isEmpty();
+    }
+
+    private boolean containsRuntimePluginConfiguration(BizWorkflowData bizWorkflowData) {
         if (bizWorkflowData == null || CollectionUtils.isEmpty(bizWorkflowData.getNodes())) {
             return false;
         }
@@ -4180,6 +4257,10 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             JSONObject plugin = nodeParam == null ? null : nodeParam.getJSONObject("plugin");
             JSONArray skills = plugin == null ? null : plugin.getJSONArray("skills");
             if (skills != null && !skills.isEmpty()) {
+                return true;
+            }
+            JSONArray mcpServerUrls = plugin == null ? null : plugin.getJSONArray("mcpServerUrls");
+            if (mcpServerUrls != null && !mcpServerUrls.isEmpty()) {
                 return true;
             }
         }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceMcpRuntimeConfigTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceMcpRuntimeConfigTest.java
@@ -1,0 +1,92 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.entity.bot.ChatBotBase;
+import com.iflytek.astron.console.commons.entity.workflow.Workflow;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
+import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowData;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowNode;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizNodeData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowServiceMcpRuntimeConfigTest {
+
+    @Mock
+    private ChatBotBaseMapper chatBotBaseMapper;
+
+    private WorkflowService workflowService;
+
+    @BeforeEach
+    void setUp() {
+        workflowService = new WorkflowService();
+        ReflectionTestUtils.setField(workflowService, "chatBotBaseMapper", chatBotBaseMapper);
+    }
+
+    @Test
+    void resolveBotMcpServerUrlsReadsBotConfigFromWorkflowExt() {
+        Workflow workflow = new Workflow();
+        workflow.setExt("{\"botId\":123}");
+        ChatBotBase botBase = new ChatBotBase();
+        botBase.setMcpServerUrls("[\"https://mcp.example.com/sse\"]");
+        when(chatBotBaseMapper.selectById(123)).thenReturn(botBase);
+
+        List<String> urls = ReflectionTestUtils.invokeMethod(
+                workflowService,
+                "resolveBotMcpServerUrls",
+                null,
+                workflow);
+
+        assertThat(urls).containsExactly("https://mcp.example.com/sse");
+    }
+
+    @Test
+    void checkAndEditDataMergesConfiguredMcpUrlsIntoAgentPlugin() {
+        BizNodeData data = new BizNodeData();
+        data.setNodeMeta(new JSONObject());
+        JSONObject plugin = new JSONObject()
+                .fluentPut("mcpServerUrls", new JSONArray(List.of("https://existing.example.com/sse")));
+        data.setNodeParam(new JSONObject().fluentPut("plugin", plugin));
+
+        ReflectionTestUtils.invokeMethod(
+                workflowService,
+                "checkAndEditData",
+                data,
+                WorkflowConst.NodeType.AGENT,
+                List.of("https://existing.example.com/sse", "https://mcp.example.com/sse"));
+
+        assertThat(plugin.getJSONArray("mcpServerUrls"))
+                .containsExactly("https://existing.example.com/sse", "https://mcp.example.com/sse");
+    }
+
+    @Test
+    void containsRuntimePluginConfigurationReturnsTrueForMcpUrls() {
+        BizNodeData data = new BizNodeData();
+        data.setNodeParam(new JSONObject().fluentPut("plugin", new JSONObject()
+                .fluentPut("mcpServerUrls", new JSONArray(List.of("https://mcp.example.com/sse")))));
+        BizWorkflowNode node = new BizWorkflowNode();
+        node.setId(WorkflowConst.NodeType.AGENT + "::agent-1");
+        node.setData(data);
+        BizWorkflowData workflowData = new BizWorkflowData();
+        workflowData.setNodes(List.of(node));
+
+        Boolean result = ReflectionTestUtils.invokeMethod(
+                workflowService,
+                "containsRuntimePluginConfiguration",
+                workflowData);
+
+        assertThat(result).isTrue();
+    }
+}

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.module.scss
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.module.scss
@@ -99,6 +99,53 @@
     }
   }
 }
+
+.mcpAddButton {
+  color: #6356ea;
+  padding-right: 0;
+
+  &:hover {
+    color: #4f46d8;
+  }
+}
+
+.mcpServerList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 20px 4px;
+}
+
+.mcpServerRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 40px;
+  gap: 8px;
+  align-items: start;
+
+  :global {
+    .ant-input {
+      height: 40px;
+      border-radius: 8px;
+    }
+
+    .ant-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 8px;
+      color: #5f6f86;
+    }
+  }
+}
+
+.mcpErrorText {
+  grid-column: 1 / -1;
+  margin-top: -4px;
+  font-size: 12px;
+  line-height: 18px;
+  color: #f53f3f;
+}
+
 .datasetModalWrap {
   :global {
     .ant-modal-content {

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -22,7 +22,13 @@ import { useLocaleStore } from '@/store/spark-store/locale-store';
 import SpeakerModal, { MyVCNItem, VcnItem } from '@/components/speaker-modal';
 import UploadBackgroundModal from '@/components/upload-background';
 import Personality from './personality-component';
-import { RightOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import {
+  DeleteOutlined,
+  LinkOutlined,
+  PlusOutlined,
+  RightOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons';
 
 import settingFile from '@/assets/imgs/sparkImg/icon_bot_setting_file.png';
 import settingKaichangbai from '@/assets/imgs/sparkImg/icon_bot_setting_kaichangbai.png';
@@ -41,11 +47,12 @@ import { useTranslation } from 'react-i18next';
 import styles from './CapabilityDevelopment.module.scss';
 import cls from 'classnames';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
+import { isValidMcpServerUrl } from '../mcp-url-config';
 
 const { TextArea } = Input;
 
 interface CapabilityDevelopmentProps {
-  viewMode?: 'full' | 'personalization' | 'knowledge';
+  viewMode?: 'full' | 'personalization' | 'knowledge' | 'capability';
   botCreateActiveV: any;
   setBotCreateActiveV: (v: any) => void;
   baseinfo: any;
@@ -63,6 +70,8 @@ interface CapabilityDevelopmentProps {
   setSupportContextFlag: (v: boolean) => void;
   tools: any[];
   setTools: (v: any[]) => void;
+  mcpServerUrls: string[];
+  setMcpServerUrls: (v: string[]) => void;
   files: any[];
   tree: any[];
   setTree: (v: any[]) => void;
@@ -97,6 +106,8 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
     setSupportContextFlag,
     tools,
     setTools,
+    mcpServerUrls,
+    setMcpServerUrls,
     files,
     tree,
     setTree,
@@ -324,11 +335,35 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
   }, [dataSource]);
 
   const showCapabilitySection = viewMode === 'full';
-  const showKnowledgeSection = viewMode === 'full' || viewMode === 'knowledge';
+  const showKnowledgeSection =
+    viewMode === 'full' ||
+    viewMode === 'knowledge' ||
+    viewMode === 'capability';
+  const showMcpSection = viewMode === 'full' || viewMode === 'capability';
   const showPersonalizationSection =
     viewMode === 'full' || viewMode === 'personalization';
   const showSupportContextSwitch = viewMode === 'full';
   const isScopedMode = viewMode !== 'full';
+
+  const displayedMcpServerUrls =
+    mcpServerUrls.length > 0 ? mcpServerUrls : [''];
+
+  const updateMcpServerUrl = (index: number, value: string) => {
+    const nextUrls = [...displayedMcpServerUrls];
+    nextUrls[index] = value;
+    setMcpServerUrls(nextUrls);
+  };
+
+  const addMcpServerUrl = () => {
+    setMcpServerUrls([...displayedMcpServerUrls, '']);
+  };
+
+  const removeMcpServerUrl = (index: number) => {
+    const nextUrls = displayedMcpServerUrls.filter((_, itemIndex) => {
+      return itemIndex !== index;
+    });
+    setMcpServerUrls(nextUrls.length > 0 ? nextUrls : []);
+  };
 
   return (
     <div
@@ -770,6 +805,60 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
               ))}
             </div>
           )}
+        </div>
+      )}
+      {showMcpSection && (
+        <div className={showKnowledgeSection ? 'mt-[52px]' : ''}>
+          <div className="w-full font-medium text-second">
+            <div
+              className="flex items-center"
+              style={{ marginBottom: '20px', justifyContent: 'space-between' }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <LinkOutlined
+                  style={{ fontSize: 22, color: '#6356EA', marginRight: 8 }}
+                />
+                <span className="text-[#6356EA] font-medium">MCP</span>
+              </div>
+              <Button
+                type="link"
+                icon={<PlusOutlined />}
+                className={styles.mcpAddButton}
+                onClick={addMcpServerUrl}
+              >
+                添加 MCP Server URL
+              </Button>
+            </div>
+            <div className={styles.mcpServerList}>
+              {displayedMcpServerUrls.map((url, index) => {
+                const invalidUrl = !isValidMcpServerUrl(url);
+
+                return (
+                  <div className={styles.mcpServerRow} key={index}>
+                    <Input
+                      value={url}
+                      status={invalidUrl ? 'error' : undefined}
+                      placeholder="https://example.com/mcp"
+                      onChange={event =>
+                        updateMcpServerUrl(index, event.target.value)
+                      }
+                    />
+                    <Tooltip title="删除">
+                      <Button
+                        icon={<DeleteOutlined />}
+                        onClick={() => removeMcpServerUrl(index)}
+                      />
+                    </Tooltip>
+                    {invalidUrl && (
+                      <div className={styles.mcpErrorText}>
+                        请输入 http 或 https 开头的 MCP Server URL
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
       )}
       {showPersonalizationSection && (

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -78,6 +78,10 @@ import {
   Knowledge,
 } from './types';
 import { getEffectiveToolConfig, serializeOpenedTool } from './tool-config';
+import {
+  hasInvalidMcpServerUrls,
+  normalizeMcpServerUrls,
+} from './mcp-url-config';
 import { VcnItem } from '@/components/speaker-modal';
 import { getVcnList } from '@/services/chat';
 import type { MessageListType } from '@/types/chat';
@@ -245,6 +249,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     text_to_image: false,
     codeinterpreter: false,
   });
+  const [mcpServerUrls, setMcpServerUrls] = useState<string[]>([]);
   const effectiveToolConfig = useMemo(
     () => getEffectiveToolConfig(choosedAlltool, isNewWorkbench),
     [choosedAlltool, isNewWorkbench]
@@ -529,6 +534,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
       isSentence: 0,
       openedTool: effectiveOpenedTool,
+      mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
       prologue: prologue,
       ...getModelConfig(model),
       prompt: prompt,
@@ -559,6 +565,14 @@ const BaseConfig: React.FC<ChatProps> = ({
     return true;
   };
 
+  const validateMcpServerUrls = (): boolean => {
+    if (hasInvalidMcpServerUrls(mcpServerUrls)) {
+      message.warning('请先修正 MCP Server URL');
+      return false;
+    }
+    return true;
+  };
+
   const savebot = (e: any) => {
     if (!coverUrl) {
       return message.warning(t('configBase.defaultAvatar'));
@@ -570,6 +584,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     ) {
       return message.warning(t('configBase.requiredInfoNotFilled'));
     }
+    if (!validateMcpServerUrls()) return;
 
     const isRag = selectSource[0]?.tag === 'SparkDesk-RAG';
     const useFormValues = !(
@@ -599,6 +614,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     if (!baseinfo?.botName || !baseinfo?.botType || !baseinfo?.botDesc) {
       return message.warning(t('configBase.requiredInfoNotFilled'));
     }
+    if (!validateMcpServerUrls()) return;
     closeModal();
     setPublishModalShow(true);
     const botId = searchParams.get('botId');
@@ -797,6 +813,10 @@ const BaseConfig: React.FC<ChatProps> = ({
           } else {
             obj.codeinterpreter = false;
           }
+          const currentConfigData = save == 'true' ? configPageData : res;
+          setMcpServerUrls(
+            normalizeMcpServerUrls(currentConfigData?.mcpServerUrls)
+          );
           setSupportContextFlag(
             save == 'true'
               ? configPageData?.supportContext == 1
@@ -836,7 +856,7 @@ const BaseConfig: React.FC<ChatProps> = ({
           });
 
           // 处理模型回显逻辑
-          const currentModelData = save == 'true' ? configPageData : res;
+          const currentModelData = currentConfigData;
           const modelId = currentModelData?.modelId;
           const modelDomain = currentModelData?.model;
 
@@ -924,7 +944,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     if (sentence) {
       setSentence(1);
     }
-  }, [searchParams, configPageData?.openedTool]);
+  }, [searchParams, configPageData?.openedTool, configPageData?.mcpServerUrls]);
 
   useEffect(() => {
     setInputExampleTip('');
@@ -986,6 +1006,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     feedback,
     repoConfig,
     tools,
+    mcpServerUrls,
     flows,
   ]);
 
@@ -1019,6 +1040,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         name: item.name,
         description: item.description,
       })),
+      mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
       flows,
     };
     setConfig(params);
@@ -1378,6 +1400,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     sentence,
     choosedAlltool,
     effectiveOpenedTool,
+    mcpServerUrls,
   ]);
 
   /** 提示词对比 */
@@ -1453,6 +1476,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       message.warning(t('configBase.requiredInfoNotFilled'));
       return;
     }
+    if (!validateMcpServerUrls()) return;
     if (!validatePersonality()) return;
 
     const isRag = selectSource[0]?.tag === 'SparkDesk-RAG';
@@ -1568,6 +1592,7 @@ const BaseConfig: React.FC<ChatProps> = ({
               message.warning(t('configBase.createAgentBeforePublish'));
               return;
             }
+            if (!validateMcpServerUrls()) return;
             setOpenWxmol(true);
           }}
         >
@@ -1626,6 +1651,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 promptText={promptNow}
                 supportContext={supportContextFlag ? 1 : 0}
                 choosedAlltool={effectiveToolConfig}
+                mcpServerUrls={mcpServerUrls}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1685,6 +1711,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 promptText={promptNow}
                 supportContext={supportContextFlag ? 1 : 0}
                 choosedAlltool={effectiveToolConfig}
+                mcpServerUrls={mcpServerUrls}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1717,6 +1744,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         promptText={promptNow}
         supportContext={supportContextFlag ? 1 : 0}
         choosedAlltool={effectiveToolConfig}
+        mcpServerUrls={mcpServerUrls}
         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
         personalityConfig={
           personalityData.enablePersonality
@@ -1778,7 +1806,7 @@ const BaseConfig: React.FC<ChatProps> = ({
   );
 
   const renderCapabilityDevelopment = (
-    viewMode: 'full' | 'personalization' | 'knowledge' = 'full'
+    viewMode: 'full' | 'personalization' | 'knowledge' | 'capability' = 'full'
   ) => (
     <CapabilityDevelopment
       viewMode={viewMode}
@@ -1802,6 +1830,8 @@ const BaseConfig: React.FC<ChatProps> = ({
       setTree={setTree}
       tools={tools}
       setTools={setTools}
+      mcpServerUrls={mcpServerUrls}
+      setMcpServerUrls={setMcpServerUrls}
       conversation={conversation}
       setConversation={setConversation}
       multiModelDebugging={multiModelDebugging}
@@ -1915,7 +1945,7 @@ const BaseConfig: React.FC<ChatProps> = ({
 
   const renderCapabilityWorkspace = () => (
     <div className={styles.workbenchCapabilityShell}>
-      {renderCapabilityDevelopment('knowledge')}
+      {renderCapabilityDevelopment('capability')}
     </div>
   );
 
@@ -2185,6 +2215,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     message.warning(t('configBase.requiredInfoNotFilled'));
                     return;
                   }
+                  if (!validateMcpServerUrls()) return;
 
                   if (selectSource[0]?.tag == 'SparkDesk-RAG') {
                     const datasetList: string[] = [];
@@ -2219,6 +2250,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                       isSentence: 0,
                       openedTool: effectiveOpenedTool,
+                      mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2267,6 +2299,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                       isSentence: 0,
                       openedTool: effectiveOpenedTool,
+                      mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2313,6 +2346,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                   message.warning(t('configBase.requiredInfoNotFilled'));
                   return;
                 }
+                if (!validateMcpServerUrls()) return;
                 if (selectSource[0]?.tag == 'SparkDesk-RAG') {
                   const datasetList: string[] = [];
                   (selectSource || []).forEach((item: any) => {
@@ -2345,6 +2379,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                     isSentence: sentence,
                     openedTool: effectiveOpenedTool,
+                    mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2392,6 +2427,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     vcnCn: botCreateActiveV?.cn || vcnList[0]?.voiceType,
                     isSentence: sentence,
                     openedTool: effectiveOpenedTool,
+                    mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2456,6 +2492,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     message.warning(t('configBase.createAgentBeforePublish'));
                     return;
                   }
+                  if (!validateMcpServerUrls()) return;
                   setOpenWxmol(true);
                   return;
                 }}
@@ -2710,6 +2747,8 @@ const BaseConfig: React.FC<ChatProps> = ({
                           setTree={setTree}
                           tools={tools}
                           setTools={setTools}
+                          mcpServerUrls={mcpServerUrls}
+                          setMcpServerUrls={setMcpServerUrls}
                           conversation={conversation}
                           setConversation={setConversation}
                           multiModelDebugging={multiModelDebugging}
@@ -2838,6 +2877,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       promptText={promptNow}
                       supportContext={supportContextFlag ? 1 : 0}
                       choosedAlltool={effectiveToolConfig}
+                      mcpServerUrls={mcpServerUrls}
                       findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                       personalityConfig={
                         personalityData.enablePersonality
@@ -2881,6 +2921,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                           promptText={promptNow}
                           supportContext={supportContextFlag ? 1 : 0}
                           choosedAlltool={effectiveToolConfig}
+                          mcpServerUrls={mcpServerUrls}
                           findModelOptionByUniqueKey={
                             findModelOptionByUniqueKey
                           }
@@ -2954,6 +2995,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                         promptText={promptNow}
                         supportContext={supportContextFlag ? 1 : 0}
                         choosedAlltool={effectiveToolConfig}
+                        mcpServerUrls={mcpServerUrls}
                         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                         personalityConfig={
                           personalityData.enablePersonality

--- a/console/frontend/src/components/config-page-component/config-base/mcp-url-config.ts
+++ b/console/frontend/src/components/config-page-component/config-base/mcp-url-config.ts
@@ -1,0 +1,67 @@
+export const isValidMcpServerUrl = (url: string): boolean => {
+  const value = url.trim();
+  if (!value) {
+    return true;
+  }
+
+  try {
+    const parsedUrl = new URL(value);
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const normalizeMcpServerUrls = (urls?: unknown): string[] => {
+  if (!urls) {
+    return [];
+  }
+
+  let source = urls;
+  if (typeof urls === 'string') {
+    try {
+      source = JSON.parse(urls);
+    } catch {
+      source = urls.split(',');
+    }
+  }
+
+  if (!Array.isArray(source)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      source
+        .map(item => (typeof item === 'string' ? item.trim() : ''))
+        .filter(url => Boolean(url) && isValidMcpServerUrl(url))
+    )
+  );
+};
+
+export const hasInvalidMcpServerUrls = (urls?: unknown): boolean => {
+  if (!urls) {
+    return false;
+  }
+
+  let source = urls;
+  if (typeof urls === 'string') {
+    try {
+      source = JSON.parse(urls);
+    } catch {
+      source = urls.split(',');
+    }
+  }
+
+  if (!Array.isArray(source)) {
+    return false;
+  }
+
+  return source.some(item => {
+    if (typeof item !== 'string') {
+      return false;
+    }
+    const value = item.trim();
+    return Boolean(value) && !isValidMcpServerUrl(value);
+  });
+};

--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -15,6 +15,10 @@ import { fetchEventSource } from '@microsoft/fetch-event-source';
 import eventBus from '@/utils/event-bus';
 import { baseURL } from '@/utils/http';
 import { ModelListData } from '@/services/spark-common';
+import {
+  hasInvalidMcpServerUrls,
+  normalizeMcpServerUrls,
+} from '@/components/config-page-component/config-base/mcp-url-config';
 
 // PromptTry组件暴露的方法接口
 export interface PromptTryRef {
@@ -60,6 +64,7 @@ const PromptTry = forwardRef<
     choosedAlltool?: {
       [key: string]: boolean;
     };
+    mcpServerUrls?: string[];
     findModelOptionByUniqueKey: (
       uniqueKey: string
     ) => ModelListData | undefined;
@@ -81,6 +86,7 @@ const PromptTry = forwardRef<
       model,
       supportContext,
       choosedAlltool,
+      mcpServerUrls,
       initialMessages,
       onMessagesChange,
       showHeaderAndRecommend = true,
@@ -179,6 +185,10 @@ const PromptTry = forwardRef<
 
     // 获取答案
     const getAnswer = (question: string) => {
+      if (hasInvalidMcpServerUrls(mcpServerUrls)) {
+        message.warning('请先修正 MCP Server URL');
+        return;
+      }
       const esURL = `${baseURL}/chat-message/bot-debug`;
       const form = new FormData();
       const useModel = findModelOptionByUniqueKey(model || '');
@@ -211,6 +221,10 @@ const PromptTry = forwardRef<
             .filter((key: string) => choosedAlltool[key])
             .join(',')
         );
+      }
+      const normalizedMcpServerUrls = normalizeMcpServerUrls(mcpServerUrls);
+      if (normalizedMcpServerUrls.length > 0) {
+        form.append('mcpServerUrls', JSON.stringify(normalizedMcpServerUrls));
       }
 
       // 添加人设配置信息


### PR DESCRIPTION
## Summary
- Persist custom MCP server URLs on bot configuration and debug requests.
- Load configured MCP tools through the core-link MCP gateway and expose them as OpenAI-compatible function tools.
- Pass saved MCP URLs into chat requests and workflow runtime agent plugin config so published agents can call configured MCP tools.

## Tests
- `mvn -pl commons,toolkit,hub -am "-Dtest=WorkflowServiceMcpRuntimeConfigTest,PromptChatServiceTest,McpRuntimeToolServiceTest,BotChatServiceImplUnitTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `git diff --check`