### PR TITLE
fix: preserve MCP runtime tool names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 ## Project Overview
 
@@ -139,3 +139,4 @@ These guidelines are working if there are fewer unnecessary changes in diffs, fe
 ## Key Workflow Expectations
 
 1. After the feature work and testing are completed, ask the user whether the local branch needs to be pushed. If the user requires a push, start a new subagent to execute the .claude\skills\astron-agent-pr-publish skill. After the push is completed, then ask the user whether the project needs to be redeployed. If the user confirms redeployment is needed, start a new subagent to execute the .claude\skills\astron-agent-server-deploy skill.
+2. After the project deployment is completed, ask the user whether acceptance testing needs to be performed. If the user requires it, execute the .claude\skills\astron-agent-e2e-acceptanceskill to run the acceptance testing.

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/McpRuntimeToolService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/McpRuntimeToolService.java
@@ -31,6 +31,8 @@ public class McpRuntimeToolService {
     private static final String MCP_TOOL_LIST_PATH = "/api/v1/mcp/tool_list";
     private static final String MCP_CALL_TOOL_PATH = "/api/v1/mcp/call_tool";
     private static final int MAX_FUNCTION_NAME_LENGTH = 64;
+    private static final String MCP_FUNCTION_PREFIX = "mcp_";
+    private static final Set<String> RESERVED_FUNCTION_NAMES = Set.of("web_search", "ifly_search", "current_time");
     private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
 
     private final OkHttpClient httpClient;
@@ -175,22 +177,34 @@ public class McpRuntimeToolService {
     }
 
     private String buildFunctionName(String serverId, String serverUrl, String toolName, Set<String> usedFunctionNames) {
-        String hash = shortHash(serverId + "|" + serverUrl + "|" + toolName);
         String safeToolName = sanitizeFunctionNamePart(toolName);
-        int maxToolNameLength = Math.max(1, MAX_FUNCTION_NAME_LENGTH - "mcp_".length() - hash.length() - 1);
+        if (canUseOriginalToolName(toolName, safeToolName, usedFunctionNames)) {
+            usedFunctionNames.add(safeToolName);
+            return safeToolName;
+        }
+
+        String hash = shortHash(serverId + "|" + serverUrl + "|" + toolName);
+        int maxToolNameLength = Math.max(1, MAX_FUNCTION_NAME_LENGTH - MCP_FUNCTION_PREFIX.length() - hash.length() - 1);
         if (safeToolName.length() > maxToolNameLength) {
             safeToolName = safeToolName.substring(0, maxToolNameLength);
         }
-        String base = "mcp_" + hash + "_" + safeToolName;
+        String base = MCP_FUNCTION_PREFIX + hash + "_" + safeToolName;
         String candidate = base;
         int suffix = 2;
-        while (usedFunctionNames.contains(candidate)) {
+        while (usedFunctionNames.contains(candidate) || RESERVED_FUNCTION_NAMES.contains(candidate)) {
             String suffixText = "_" + suffix++;
             int maxBaseLength = MAX_FUNCTION_NAME_LENGTH - suffixText.length();
             candidate = base.length() > maxBaseLength ? base.substring(0, maxBaseLength) + suffixText : base + suffixText;
         }
         usedFunctionNames.add(candidate);
         return candidate;
+    }
+
+    private boolean canUseOriginalToolName(String toolName, String safeToolName, Set<String> usedFunctionNames) {
+        return StringUtils.equals(toolName, safeToolName)
+                && safeToolName.length() <= MAX_FUNCTION_NAME_LENGTH
+                && !RESERVED_FUNCTION_NAMES.contains(safeToolName)
+                && !usedFunctionNames.contains(safeToolName);
     }
 
     private String sanitizeFunctionNamePart(String value) {

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/McpRuntimeToolServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/McpRuntimeToolServiceTest.java
@@ -92,8 +92,7 @@ class McpRuntimeToolServiceTest {
         McpRuntimeToolService.McpRuntimeTool tool = tools.getFirst();
         assertEquals(serverUrl, tool.serverUrl());
         assertEquals("get_weather", tool.toolName());
-        assertTrue(tool.functionName().startsWith("mcp_"));
-        assertTrue(tool.functionName().contains("get_weather"));
+        assertEquals("get_weather", tool.functionName());
         assertEquals("Get weather.", tool.description());
         assertEquals("object", tool.inputSchema().getString("type"));
 
@@ -144,6 +143,45 @@ class McpRuntimeToolServiceTest {
         assertEquals("https://mcp.example.com/sse", body.getString("mcp_server_url"));
         assertEquals("get_weather", body.getString("tool_name"));
         assertEquals("北京", body.getJSONObject("tool_args").getString("city"));
+    }
+
+    @Test
+    void testListTools_ReservedFunctionNameUsesPrefixedFallback() throws Exception {
+        String serverUrl = "https://mcp.example.com/sse";
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(ResponseBody.create(
+                """
+                {
+                  "code": 0,
+                  "message": "success",
+                  "data": {
+                    "servers": [
+                      {
+                        "server_id": "",
+                        "server_url": "https://mcp.example.com/sse",
+                        "server_status": 0,
+                        "tools": [
+                          {
+                            "name": "web_search",
+                            "description": "Search through a remote MCP server.",
+                            "inputSchema": {"type": "object", "properties": {}}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """,
+                MediaType.get("application/json; charset=utf-8")));
+
+        List<McpRuntimeToolService.McpRuntimeTool> tools = service.listTools(List.of(serverUrl));
+
+        assertEquals(1, tools.size());
+        assertEquals("web_search", tools.getFirst().toolName());
+        assertTrue(tools.getFirst().functionName().startsWith("mcp_"));
+        assertTrue(tools.getFirst().functionName().contains("web_search"));
     }
 
     private JSONObject parseRequestBody(Request request) throws IOException {

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/PromptChatServiceTest.java
@@ -924,10 +924,10 @@ class PromptChatServiceTest {
                 }
                 """);
         McpRuntimeToolService.McpRuntimeTool weatherTool = new McpRuntimeToolService.McpRuntimeTool(
-                "mcp_weather_get_weather",
+                "maps_weather",
                 "",
                 mcpServerUrl,
-                "get_weather",
+                "maps_weather",
                 "Get weather for a city.",
                 inputSchema);
         when(mcpRuntimeToolService.listTools(List.of(mcpServerUrl))).thenReturn(List.of(weatherTool));
@@ -946,7 +946,7 @@ class PromptChatServiceTest {
         when(finalPlanningResponse.isSuccessful()).thenReturn(true);
         when(planningResponse.body()).thenReturn(ResponseBody.create(
                 """
-                {"id":"plan-mcp","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_weather","type":"function","function":{"name":"mcp_weather_get_weather","arguments":"{\\"city\\":\\"北京\\"}"}}]}}]}
+                {"id":"plan-mcp","choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_weather","type":"function","function":{"name":"maps_weather","arguments":"{\\"city\\":\\"北京\\"}"}}]}}]}
                 """,
                 MediaType.get("application/json; charset=utf-8")));
         when(finalPlanningResponse.body()).thenReturn(ResponseBody.create(
@@ -965,7 +965,7 @@ class PromptChatServiceTest {
         JSONObject finalBody = parseRequestBody(requestCaptor.getAllValues().get(2));
         JSONArray tools = planningBody.getJSONArray("tools");
         assertNotNull(tools);
-        assertTrue(tools.toJSONString().contains("mcp_weather_get_weather"));
+        assertTrue(tools.toJSONString().contains("maps_weather"));
         assertFalse(planningBody.containsKey("mcpServerUrls"));
         assertFalse(planningBody.containsKey("managedMcpTools"));
         JSONObject toolMessage = secondRoundBody.getJSONArray("messages").getJSONObject(3);


### PR DESCRIPTION
## Summary
- Preserve valid MCP tool names when injecting runtime tools into OpenAI-compatible function tools
- Keep prefixed fallback only for reserved, duplicated, invalid, or overlong tool names
- Include CLAUDE.md workflow note updates

## Tests
- mvn -pl commons,toolkit,hub -am "-Dtest=McpRuntimeToolServiceTest,PromptChatServiceTest" "-Dsurefire.failIfNoSpecifiedTests=false" test