### PR TITLE
style: polish capability settings UI

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.module.scss
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.module.scss
@@ -1,6 +1,179 @@
+.capabilitySection {
+  width: 100%;
+}
+
+.capabilitySectionOffset {
+  margin-top: 24px;
+}
+
+.capabilitySectionCompact {
+  margin-top: 16px;
+}
+
+.capabilityBlock {
+  width: 100%;
+  padding: 22px 24px;
+  border: 1px solid #dbe6ff;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.capabilityBlockHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.capabilityTitleGroup {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.capabilityCollapseIcon {
+  width: 16px;
+  height: 16px;
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.capabilityIcon {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  font-size: 20px;
+
+  img {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.knowledgeIcon {
+  color: #0f9f36;
+  background: #ecfdf3;
+}
+
+.mcpIcon {
+  color: #4f46e5;
+  background: #eef2ff;
+}
+
+.capabilityTitleRow {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.capabilityTitle {
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+  color: #0f172a;
+}
+
+.capabilityDescription {
+  margin-top: 4px;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  color: #64748b;
+}
+
+.capabilityStatus {
+  display: inline-flex;
+  height: 24px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.statusReady {
+  color: #067647;
+  background: #ecfdf3;
+}
+
+.statusMuted {
+  color: #64748b;
+  background: #f1f5f9;
+}
+
+.capabilityActionButton {
+  height: 34px;
+  flex: 0 0 auto;
+  border-color: #bfdbfe;
+  border-radius: 8px;
+  color: #2563eb;
+  font-weight: 500;
+  box-shadow: none;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    border-color: #93c5fd !important;
+    background: #eff6ff !important;
+    color: #1d4ed8 !important;
+  }
+}
+
+.capabilityEmptyState {
+  display: flex;
+  width: 100%;
+  min-height: 76px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 16px 18px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: #93c5fd;
+    background: #eff6ff;
+    outline: none;
+  }
+}
+
+.capabilityEmptyTitle {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  color: #334155;
+}
+
+.capabilityEmptyDescription {
+  margin-top: 4px;
+  font-size: 13px;
+  line-height: 20px;
+  color: #64748b;
+}
+
 .selectDataset {
-  margin-bottom: 22px;
-  width: 75%;
+  width: 100%;
+  margin-bottom: 0;
+
   .selectDatasetBtn {
     height: 39px;
     padding: 10px 41px;
@@ -25,15 +198,15 @@
   }
 
   .selectDatasetBox {
-    padding: 11.5px 15px;
-    background-color: #ffffff;
+    padding: 14px 16px;
+    background-color: #f8fafc;
     opacity: 0.95;
-    border: 1px solid #d2dbe7;
-    border-radius: 6px;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
 
     .selectDatasetBoxBtn {
       font-size: 12px;
-      color: #43436b;
+      color: #2563eb;
       cursor: pointer;
       display: flex;
       align-items: center;
@@ -51,12 +224,12 @@
       justify-content: space-between;
 
       .dataset {
-        width: 45%;
+        width: calc(50% - 6px);
         margin-bottom: 10px;
         padding: 10px 12px;
-        border: 0.8px solid #eceef4;
-        border-radius: 6px;
-        background: #f8f8fa;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        background: #ffffff;
 
         .datasetNameBox {
           display: flex;
@@ -100,28 +273,33 @@
   }
 }
 
-.mcpAddButton {
-  color: #6356ea;
-  padding-right: 0;
-
-  &:hover {
-    color: #4f46d8;
-  }
-}
-
 .mcpServerList {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 0 20px 4px;
+  gap: 10px;
+  padding: 0;
 }
 
 .mcpServerRow {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 40px;
-  gap: 8px;
+  grid-template-columns: 88px minmax(0, 1fr) 40px;
+  gap: 10px;
   align-items: start;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: #bfdbfe;
+    background: #ffffff;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  }
 
   :global {
     .ant-input {
@@ -138,12 +316,93 @@
   }
 }
 
+.mcpServerMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 2px;
+}
+
+.mcpServerName {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+  color: #334155;
+}
+
+.mcpServerState {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+  color: #64748b;
+}
+
+.mcpServerStateReady {
+  color: #067647;
+}
+
+.mcpServerStateError {
+  color: #dc2626;
+}
+
+.mcpInputWrap {
+  min-width: 0;
+}
+
+.mcpDeleteButton {
+  background: #ffffff;
+
+  &:hover {
+    border-color: #fecaca !important;
+    color: #dc2626 !important;
+  }
+}
+
 .mcpErrorText {
-  grid-column: 1 / -1;
-  margin-top: -4px;
+  grid-column: 2 / -1;
+  margin-top: -2px;
   font-size: 12px;
   line-height: 18px;
   color: #f53f3f;
+}
+
+@media (max-width: 768px) {
+  .capabilityBlock {
+    padding: 18px;
+  }
+
+  .capabilityBlockHeader {
+    flex-direction: column;
+  }
+
+  .capabilityActionButton {
+    width: 100%;
+  }
+
+  .mcpServerRow {
+    grid-template-columns: minmax(0, 1fr) 40px;
+  }
+
+  .mcpServerMeta {
+    grid-column: 1 / -1;
+  }
+
+  .mcpErrorText {
+    grid-column: 1 / -1;
+  }
+
+  .selectDataset {
+    .selectDatasetBox {
+      .datasetList {
+        .dataset {
+          width: 100%;
+        }
+      }
+    }
+  }
 }
 
 .datasetModalWrap {

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -23,6 +23,9 @@ import SpeakerModal, { MyVCNItem, VcnItem } from '@/components/speaker-modal';
 import UploadBackgroundModal from '@/components/upload-background';
 import Personality from './personality-component';
 import {
+  ApiOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
   DeleteOutlined,
   LinkOutlined,
   PlusOutlined,
@@ -347,6 +350,10 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
 
   const displayedMcpServerUrls =
     mcpServerUrls.length > 0 ? mcpServerUrls : [''];
+  const selectedKnowledgeCount = selectSource?.length || 0;
+  const configuredMcpServerCount = mcpServerUrls.filter(url =>
+    isValidMcpServerUrl(url.trim())
+  ).length;
 
   const updateMcpServerUrl = (index: number, value: string) => {
     const nextUrls = [...displayedMcpServerUrls];
@@ -490,39 +497,67 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
         </>
       )}
       {showKnowledgeSection && (
-        <div className={showCapabilitySection ? 'mt-[52px]' : ''}>
-          <div className="w-full font-medium text-second">
-            <div
-              className="flex items-center"
-              style={{ marginBottom: '20px', justifyContent: 'space-between' }}
-            >
-              {multiModelDebugging && (
-                <img
-                  src={growOrShrinkConfig?.knowledges ? arrowDown : arrowUp}
-                  className="w-[16px] h-[16px] mr-2 cursor-pointer"
-                  alt=""
-                  onClick={() =>
-                    setGrowOrShrinkConfig({
-                      ...growOrShrinkConfig,
-                      knowledges: !growOrShrinkConfig.knowledges,
-                    })
-                  }
-                />
-              )}
-              <div style={{ display: 'flex' }}>
-                <img src={settingFile} className="w-6 h-6" alt="" />
-                <span className="text-[#13A10E] font-medium ml-2">
-                  {t('configBase.CapabilityDevelopment.knowledgeBase')}
+        <div
+          className={cls(
+            styles.capabilitySection,
+            showCapabilitySection && styles.capabilitySectionOffset
+          )}
+        >
+          <div className={styles.capabilityBlock}>
+            <div className={styles.capabilityBlockHeader}>
+              <div className={styles.capabilityTitleGroup}>
+                {multiModelDebugging && (
+                  <img
+                    src={growOrShrinkConfig?.knowledges ? arrowDown : arrowUp}
+                    className={styles.capabilityCollapseIcon}
+                    alt=""
+                    onClick={() =>
+                      setGrowOrShrinkConfig({
+                        ...growOrShrinkConfig,
+                        knowledges: !growOrShrinkConfig.knowledges,
+                      })
+                    }
+                  />
+                )}
+                <span
+                  className={cls(styles.capabilityIcon, styles.knowledgeIcon)}
+                >
+                  <img src={settingFile} alt="" />
                 </span>
+                <div>
+                  <div className={styles.capabilityTitleRow}>
+                    <span className={styles.capabilityTitle}>
+                      {t('configBase.CapabilityDevelopment.knowledgeBase')}
+                    </span>
+                    <span
+                      className={cls(
+                        styles.capabilityStatus,
+                        selectedKnowledgeCount > 0
+                          ? styles.statusReady
+                          : styles.statusMuted
+                      )}
+                    >
+                      {selectedKnowledgeCount > 0
+                        ? `已关联 ${selectedKnowledgeCount} 个`
+                        : '未关联'}
+                    </span>
+                  </div>
+                  <div className={styles.capabilityDescription}>
+                    关联知识库后，智能体会在调试会话中按需检索私有知识。
+                  </div>
+                </div>
               </div>
-              <div
+              <Button
+                icon={<PlusOutlined />}
+                className={styles.capabilityActionButton}
                 onClick={() => {
                   setVisible(true);
                 }}
-                style={{ color: '#6356EA', cursor: 'pointer' }}
               >
-                + {t('configBase.CapabilityDevelopment.addKnowledgeBase')}
-              </div>
+                {selectedKnowledgeCount > 0
+                  ? '管理知识库'
+                  : t('configBase.CapabilityDevelopment.addKnowledgeBase')}
+              </Button>
             </div>
             <Modal
               wrapClassName={styles.datasetModalWrap}
@@ -779,6 +814,22 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
                 </div>
               </div>
             )}
+            {selectedKnowledgeCount === 0 && (
+              <button
+                type="button"
+                className={styles.capabilityEmptyState}
+                onClick={() => {
+                  setVisible(true);
+                }}
+              >
+                <span className={styles.capabilityEmptyTitle}>
+                  暂无关联知识库
+                </span>
+                <span className={styles.capabilityEmptyDescription}>
+                  点击添加知识库，为智能体补充可检索的业务资料。
+                </span>
+              </button>
+            )}
           </div>
           {growOrShrinkConfig.knowledges && files.length > 0 && (
             <div className="mt-1.5 w-full overflow-auto max-h-[300px]">
@@ -808,22 +859,42 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
         </div>
       )}
       {showMcpSection && (
-        <div className={showKnowledgeSection ? 'mt-[52px]' : ''}>
-          <div className="w-full font-medium text-second">
-            <div
-              className="flex items-center"
-              style={{ marginBottom: '20px', justifyContent: 'space-between' }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center' }}>
-                <LinkOutlined
-                  style={{ fontSize: 22, color: '#6356EA', marginRight: 8 }}
-                />
-                <span className="text-[#6356EA] font-medium">MCP</span>
+        <div
+          className={cls(
+            styles.capabilitySection,
+            showKnowledgeSection && styles.capabilitySectionCompact
+          )}
+        >
+          <div className={styles.capabilityBlock}>
+            <div className={styles.capabilityBlockHeader}>
+              <div className={styles.capabilityTitleGroup}>
+                <span className={cls(styles.capabilityIcon, styles.mcpIcon)}>
+                  <ApiOutlined />
+                </span>
+                <div>
+                  <div className={styles.capabilityTitleRow}>
+                    <span className={styles.capabilityTitle}>MCP Server</span>
+                    <span
+                      className={cls(
+                        styles.capabilityStatus,
+                        configuredMcpServerCount > 0
+                          ? styles.statusReady
+                          : styles.statusMuted
+                      )}
+                    >
+                      {configuredMcpServerCount > 0
+                        ? `已配置 ${configuredMcpServerCount} 个`
+                        : '未配置'}
+                    </span>
+                  </div>
+                  <div className={styles.capabilityDescription}>
+                    接入外部 MCP 工具，模型会根据工具描述自主选择调用。
+                  </div>
+                </div>
               </div>
               <Button
-                type="link"
                 icon={<PlusOutlined />}
-                className={styles.mcpAddButton}
+                className={styles.capabilityActionButton}
                 onClick={addMcpServerUrl}
               >
                 添加 MCP Server URL
@@ -831,20 +902,53 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
             </div>
             <div className={styles.mcpServerList}>
               {displayedMcpServerUrls.map((url, index) => {
-                const invalidUrl = !isValidMcpServerUrl(url);
+                const trimmedUrl = url.trim();
+                const invalidUrl =
+                  trimmedUrl.length > 0 && !isValidMcpServerUrl(trimmedUrl);
+                const isConfigured = trimmedUrl.length > 0 && !invalidUrl;
 
                 return (
                   <div className={styles.mcpServerRow} key={index}>
-                    <Input
-                      value={url}
-                      status={invalidUrl ? 'error' : undefined}
-                      placeholder="https://example.com/mcp"
-                      onChange={event =>
-                        updateMcpServerUrl(index, event.target.value)
-                      }
-                    />
+                    <div className={styles.mcpServerMeta}>
+                      <span className={styles.mcpServerName}>
+                        Server {index + 1}
+                      </span>
+                      <span
+                        className={cls(
+                          styles.mcpServerState,
+                          isConfigured && styles.mcpServerStateReady,
+                          invalidUrl && styles.mcpServerStateError
+                        )}
+                      >
+                        {isConfigured ? (
+                          <CheckCircleOutlined />
+                        ) : invalidUrl ? (
+                          <CloseCircleOutlined />
+                        ) : (
+                          <LinkOutlined />
+                        )}
+                        {isConfigured
+                          ? '可用'
+                          : invalidUrl
+                            ? '格式错误'
+                            : '待填写'}
+                      </span>
+                    </div>
+                    <div className={styles.mcpInputWrap}>
+                      <Input
+                        aria-label={`MCP Server URL ${index + 1}`}
+                        value={url}
+                        status={invalidUrl ? 'error' : undefined}
+                        placeholder="https://example.com/mcp"
+                        onChange={event =>
+                          updateMcpServerUrl(index, event.target.value)
+                        }
+                      />
+                    </div>
                     <Tooltip title="删除">
                       <Button
+                        aria-label={`删除 MCP Server ${index + 1}`}
+                        className={styles.mcpDeleteButton}
                         icon={<DeleteOutlined />}
                         onClick={() => removeMcpServerUrl(index)}
                       />

--- a/console/frontend/src/components/config-page-component/config-base/index.module.scss
+++ b/console/frontend/src/components/config-page-component/config-base/index.module.scss
@@ -782,6 +782,12 @@
   min-height: max-content;
 }
 
+.workbenchCapabilityShell {
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
 .workbenchSectionTitle {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Refine the capability settings layout into clearer Knowledge Base and MCP Server sections.
- Add status indicators, compact empty states, and improved MCP URL row feedback.
- Remove the extra outer capability shell border to avoid a large empty container.

## Verification
- npm run build
- npx eslint "src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx" "src/components/config-page-component/config-base/index.tsx" (0 errors, existing warnings remain)
