### PR TITLE
fix: follow up code scanning hardening

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -486,14 +486,14 @@ public class UrlCheckTool {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
             }
             String asciiHost = IDN.toASCII(host);
-            String path = StringUtils.defaultIfBlank(uri.getRawPath(), "/");
+            String path = StringUtils.defaultIfBlank(uri.getPath(), "/");
             return new URI(
                     scheme,
                     null,
                     asciiHost,
                     uri.getPort(),
                     path,
-                    uri.getRawQuery(),
+                    uri.getQuery(),
                     null).toURL();
         } catch (URISyntaxException e) {
             throw new IOException("Illegal URL", e);

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
@@ -6,11 +6,14 @@ import com.iflytek.astron.console.toolkit.mapper.ConfigInfoMapper;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,6 +83,18 @@ class UrlCheckToolTest {
         UrlCheckTool tool = new UrlCheckTool(mapper);
 
         assertThrows(BusinessException.class, () -> tool.checkUrl("http://127.0.0.1/internal"));
+    }
+
+    @Test
+    void toSafeHttpUrlPreservesEncodedPathAndQuery() throws Exception {
+        ConfigInfoMapper mapper = mockConfigMapper("", "");
+        UrlCheckTool tool = new UrlCheckTool(mapper);
+        Method method = UrlCheckTool.class.getDeclaredMethod("toSafeHttpUrl", String.class);
+        method.setAccessible(true);
+
+        URL safeUrl = (URL) method.invoke(tool, "https://example.com/a%20b?q=a%20b");
+
+        assertEquals("https://example.com/a%20b?q=a%20b", safeUrl.toString());
     }
 
     private static ConfigInfoMapper mockConfigMapper(String ipBlackList, String segmentBlackList) {

--- a/core/memory/database/repository/middleware/adapters/mysql_adapter.py
+++ b/core/memory/database/repository/middleware/adapters/mysql_adapter.py
@@ -280,6 +280,6 @@ class MySQLAdapter(DatabaseAdapter):
         if not identifier:
             raise ValueError("MySQL identifier must not be empty")
         for char in identifier:
-            if not (char.isalnum() or char == "_"):
+            if not (char.isascii() and (char.isalnum() or char == "_")):
                 raise ValueError(f"Invalid MySQL identifier: {identifier}")
         return identifier

--- a/core/memory/database/tests/test_adapters.py
+++ b/core/memory/database/tests/test_adapters.py
@@ -321,6 +321,11 @@ class TestMySQLAdapter:
         with pytest.raises(ValueError):
             self.adapter.set_search_path_sql("my-schema")
 
+    def test_set_search_path_sql_rejects_non_ascii_identifier(self) -> None:
+        """set_search_path_sql rejects non-ASCII identifiers."""
+        with pytest.raises(ValueError):
+            self.adapter.set_search_path_sql("测试_schema")
+
     def test_alembic_version_table_schema(self) -> None:
         """Alembic version table schema is None for MySQL."""
         assert self.adapter.get_alembic_version_table_schema() is None


### PR DESCRIPTION
## 背景
跟进上一轮 code scanning 修复，补上两个后续收敛点：
- `toSafeHttpUrl` 在处理已编码 path/query 时存在双重编码风险
- MySQL 标识符校验使用 `isalnum()` 时会放行非 ASCII Unicode 字符

## 本次变更
- `UrlCheckTool.toSafeHttpUrl()` 改用 `getPath()` / `getQuery()`，避免 `%` 被再次编码为 `%25`
- `_validate_mysql_identifier()` 收紧为显式 ASCII 白名单校验
- 新增 URL 编码保真测试
- 新增非 ASCII MySQL 标识符拒绝测试

## 影响
- 不改变安全校验边界，但避免重定向探测打到错误路径
- 进一步减少 CodeQL 对自定义校验函数的误判空间

## 验证
- 已对修改文件执行静态诊断检查，无新增错误
- 当前执行环境未补跑 Java/Python 单测