### PR TITLE
test: reset shared BizConfig state between toolkit tests

### DIFF
--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -2403,6 +2403,14 @@ class KnowledgeServiceTest {
     @DisplayName("datasetId routing tests")
     class DatasetIdRoutingTests {
 
+        @BeforeEach
+        void resetBizConfig() {
+            // These tests assert the legacy fallback routing where only CBG-RAG is
+            // CBG-compatible, so pin the static BizConfig to null instead of relying
+            // on test execution order.
+            new ProjectContent().setBizConfig(null);
+        }
+
         @Test
         @DisplayName("resolveRagflowDatasetIdOrNull returns null for non-Ragflow-RAG sources")
         void resolveRagflowDatasetIdOrNull_NonRagflowRAG_returnsNull() {

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/RepoServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/RepoServiceTest.java
@@ -220,12 +220,13 @@ class RepoServiceTest {
     }
 
     /**
-     * Clean up after each test method. Clears the RequestContextHolder to avoid side effects between
-     * tests.
+     * Clean up after each test method. Clears the RequestContextHolder and the static BizConfig on
+     * ProjectContent to avoid side effects between tests.
      */
     @AfterEach
     void tearDown() {
         RequestContextHolder.resetRequestAttributes();
+        new ProjectContent().setBizConfig(null);
     }
 
     /**


### PR DESCRIPTION
﻿## 背景
CI 的 "🧪 Test console-backend" 间歇性失败（如 #1402 的两次运行），根因是测试顺序依赖的静态状态污染：`RepoServiceTest.setUp()` 给静态字段 `ProjectContent.bizConfig` 赋值（`cbgRagCompatibleSources` 含 `Ragflow-RAG`）且从不清理。当 surefire 先跑 `RepoServiceTest` 时，`KnowledgeServiceTest$DatasetIdRoutingTests` 中 3 个依赖 `bizConfig == null` fallback 的删除用例必挂：`isCbgRagCompatible("Ragflow-RAG")` 变 `true` → `deleteKnowledgeDoc` 的 `needDelete=false` → `deleteDocOrChunk` 未被调用 → Mockito "Wanted but not invoked"。

## 本次变更
- `RepoServiceTest.tearDown()` 重置 `ProjectContent.bizConfig` 为 `null`（污染源头清理）
- `KnowledgeServiceTest$DatasetIdRoutingTests` 增加 `@BeforeEach` 显式将 `bizConfig` 置 `null`，并注释说明这些用例断言 legacy fallback 路由
- 均沿用同文件既有清理模式；已核查全部 `setBizConfig` 调用点，其余均已有 try/finally 或 `@AfterEach` 清理

## 说明（需 feature 作者确认的产品层面疑点，本 PR 未改产品代码）
- 生产配置 `application-toolkit.yml` 将 `Ragflow-RAG` 列入 `cbg-rag-compatible-sources`，因此生产中 `deleteKnowledgeDoc` 对无 `chunkIds` 的 `Ragflow-RAG` 文档会跳过外部删除，6a9fe482 中文档级删除的 `datasetId` 转发断言在生产配置下不会触发，`datasetId` 转发实际仅在 chunk 级删除路径生效
- `deleteKnowledgeDoc` 中 `needDelete` 在循环外声明、跨文档粘连，一个 CBG 兼容文档会使同批次后续文档全部跳过外部删除，疑似 bug

## 验证
- 本机无 Java/Maven 运行时，未跑本地单测；改动为纯测试代码，验证依赖 CI 的 "🧪 Test console-backend"
