### PR TITLE
feat: add basic A2A workflow adapter

### DIFF
--- a/core/workflow/api/v1/chat/__init__.py
+++ b/core/workflow/api/v1/chat/__init__.py
@@ -5,11 +5,15 @@ This module provides chat-related API endpoints including debug chat,
 node debugging, and open API chat completions.
 """
 
+from workflow.api.v1.chat.a2a import discovery_router as a2a_discovery_router
+from workflow.api.v1.chat.a2a import router as a2a_router
 from workflow.api.v1.chat.debug import router as sse_debug_chat_router
 from workflow.api.v1.chat.node_debug import router as node_debug_router
 from workflow.api.v1.chat.open import router as sse_openapi_router
 
 __all__ = [
+    "a2a_discovery_router",
+    "a2a_router",
     "node_debug_router",
     "sse_debug_chat_router",
     "sse_openapi_router",

--- a/core/workflow/api/v1/chat/a2a.py
+++ b/core/workflow/api/v1/chat/a2a.py
@@ -1,0 +1,95 @@
+"""
+Minimal Agent2Agent endpoints for published workflows.
+
+The adapter exposes public discovery metadata and reuses the authenticated
+workflow chat endpoint for synchronous text messages.
+"""
+
+import os
+from typing import Annotated, Union
+
+from fastapi import APIRouter, Header, HTTPException
+from starlette.responses import JSONResponse, StreamingResponse
+
+from workflow.api.v1.chat.open import chat_open
+from workflow.domain.entities.a2a import (
+    A2AAgentCard,
+    A2ACapability,
+    A2ASendMessageRequest,
+)
+from workflow.domain.entities.chat import ChatVo
+
+discovery_router = APIRouter(tags=["A2A"])
+router = APIRouter(prefix="/a2a", tags=["A2A"])
+
+
+def build_agent_card() -> A2AAgentCard:
+    """Build public A2A discovery metadata for Astron Agent workflows."""
+    base_url = os.getenv("A2A_PUBLIC_BASE_URL", "").rstrip("/")
+    return A2AAgentCard(
+        name=os.getenv("A2A_AGENT_NAME", "Astron Agent"),
+        description=(
+            "Astron Agent workflow runtime with A2A discovery and text message "
+            "forwarding to published workflows."
+        ),
+        version=os.getenv("A2A_AGENT_VERSION", "0.1.0"),
+        url=f"{base_url}/workflow/v1/a2a/message:send" if base_url else "",
+        capabilities=[
+            A2ACapability(
+                name="text-message",
+                description="Send a text message to a published workflow.",
+            )
+        ],
+    )
+
+
+@discovery_router.get("/.well-known/agent-card.json", response_model=A2AAgentCard)
+async def root_agent_card() -> A2AAgentCard:
+    """
+    Return public A2A discovery metadata at the root well-known path.
+    """
+    return build_agent_card()
+
+
+@router.get("/agent-card.json", response_model=A2AAgentCard)
+async def versioned_agent_card() -> A2AAgentCard:
+    """
+    Return public A2A discovery metadata for Astron Agent workflows.
+    """
+    return build_agent_card()
+
+
+@router.get("/.well-known/agent-card.json", response_model=A2AAgentCard)
+async def versioned_well_known_agent_card() -> A2AAgentCard:
+    """
+    Return public A2A discovery metadata under the workflow API prefix.
+    """
+    return build_agent_card()
+
+
+@router.post("/message:send", response_model=None)
+async def send_message(
+    x_consumer_username: Annotated[str, Header()],
+    request: A2ASendMessageRequest,
+) -> Union[StreamingResponse, JSONResponse]:
+    """
+    Map an A2A text message to the existing workflow chat completion API.
+    """
+    message_text = request.text().strip()
+    if not message_text:
+        raise HTTPException(status_code=400, detail="Message content cannot be empty")
+
+    parameters = dict(request.parameters)
+    parameters["input"] = message_text
+
+    chat_vo = ChatVo(
+        flow_id=request.flow_id,
+        uid=request.uid,
+        stream=request.stream,
+        ext=request.ext,
+        parameters=parameters,
+        chat_id=request.chat_id or request.message.message_id or "",
+        history=[],
+        version=request.version,
+    )
+    return await chat_open(x_consumer_username=x_consumer_username, chat_vo=chat_vo)

--- a/core/workflow/api/v1/router.py
+++ b/core/workflow/api/v1/router.py
@@ -8,6 +8,8 @@ for different API endpoints including chat, flow management, and debugging.
 from fastapi import APIRouter
 
 from workflow.api.v1.chat import (
+    a2a_discovery_router,
+    a2a_router,
     node_debug_router,
     sse_debug_chat_router,
     sse_openapi_router,
@@ -22,8 +24,13 @@ workflow_router.include_router(layout_router)
 workflow_router.include_router(auth_router)
 workflow_router.include_router(node_debug_router)
 workflow_router.include_router(file_router)
+workflow_router.include_router(a2a_router)
 workflow_router.include_router(sse_debug_chat_router)
 workflow_router.include_router(sse_openapi_router)
+
+
+root_a2a_router = APIRouter()
+root_a2a_router.include_router(a2a_discovery_router)
 
 
 # Legacy interface compatibility router

--- a/core/workflow/domain/entities/a2a.py
+++ b/core/workflow/domain/entities/a2a.py
@@ -1,0 +1,67 @@
+"""
+Minimal Agent2Agent protocol entities.
+
+These models cover the public agent card and the synchronous text message
+adapter used by the workflow service.
+"""
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class A2ACapability(BaseModel):
+    """Describes an A2A capability exposed by this service."""
+
+    name: str
+    description: str
+
+
+class A2AAgentCard(BaseModel):
+    """Public A2A discovery metadata."""
+
+    name: str
+    description: str
+    version: str
+    url: str
+    protocol_version: str = Field("0.3.0", alias="protocolVersion")
+    capabilities: List[A2ACapability]
+    default_input_modes: List[str] = Field(
+        default_factory=lambda: ["text/plain"], alias="defaultInputModes"
+    )
+    default_output_modes: List[str] = Field(
+        default_factory=lambda: ["text/plain", "text/event-stream"],
+        alias="defaultOutputModes",
+    )
+
+
+class A2ATextPart(BaseModel):
+    """A text part in an A2A message."""
+
+    kind: str = "text"
+    text: str
+
+
+class A2AMessage(BaseModel):
+    """Subset of the A2A message shape needed for text chat."""
+
+    role: str = "user"
+    parts: List[A2ATextPart]
+    message_id: str = Field("", alias="messageId")
+
+
+class A2ASendMessageRequest(BaseModel):
+    """Synchronous A2A message request mapped to workflow chat."""
+
+    message: A2AMessage
+    flow_id: str = Field(..., alias="flowId")
+    uid: str = ""
+    chat_id: str = Field("", alias="chatId")
+    stream: bool = True
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    ext: Dict[str, Any] = Field(default_factory=dict)
+    version: str = ""
+
+    def text(self) -> str:
+        """Return the concatenated text payload from all text parts."""
+        return "\n".join(part.text for part in self.message.parts if part.text)

--- a/core/workflow/extensions/fastapi/base.py
+++ b/core/workflow/extensions/fastapi/base.py
@@ -11,6 +11,7 @@ AUTH_OPEN_API_PATHS = [
     "/v1/auth",
     "/workflow/v1/publish",
     "/workflow/v1/auth",
+    "/workflow/v1/a2a/message:send",
 ]
 
 """

--- a/core/workflow/main.py
+++ b/core/workflow/main.py
@@ -17,7 +17,12 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from loguru import logger
 from starlette.middleware.cors import CORSMiddleware
-from workflow.api.v1.router import old_auth_router, sparkflow_router, workflow_router
+from workflow.api.v1.router import (
+    old_auth_router,
+    root_a2a_router,
+    sparkflow_router,
+    workflow_router,
+)
 from workflow.cache.event_registry import EventRegistry
 from workflow.extensions.fastapi.handler.validation import validation_exception_handler
 from workflow.extensions.fastapi.lifespan.database_migration import (
@@ -105,6 +110,7 @@ def create_app() -> FastAPI:
 
     # Include API routers for different endpoints
     app.include_router(create_health_router("core-workflow", service_manager))
+    app.include_router(root_a2a_router)
     app.include_router(sparkflow_router)
     app.include_router(workflow_router)
     app.include_router(old_auth_router)


### PR DESCRIPTION
## Summary
- add minimal Agent2Agent (A2A) discovery metadata for Astron Agent workflows
- expose a root `/.well-known/agent-card.json` and versioned `/workflow/v1/a2a/agent-card.json` agent card
- add an authenticated `/workflow/v1/a2a/message:send` text-message adapter that maps A2A requests onto the existing workflow chat completion path

Closes #709

## Validation
- `python -m compileall core\workflow\main.py core\workflow\api\v1\router.py core\workflow\api\v1\chat\__init__.py core\workflow\api\v1\chat\a2a.py core\workflow\domain\entities\a2a.py core\workflow\extensions\fastapi\base.py`
- `git diff --check`

Note: full pytest execution was not available in the local environment because `pytest` and runtime dependencies such as `pydantic` are not installed in the system Python.