### PR TITLE
examples: community workflow gallery (scaffold, seeds, lint, docs page)

### DIFF
--- a/.github/workflows/examples-lint.yml
+++ b/.github/workflows/examples-lint.yml
@@ -1,0 +1,26 @@
+name: Examples Lint
+
+on:
+  pull_request:
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples-lint.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "examples/**"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Lint workflow examples
+        run: node examples/scripts/lint.mjs

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
           { text: "Quick Start", link: "/guide/quick-start" },
           { text: "Deployment", link: "/guide/deploy" },
           { text: "Case Studies", link: "/cases/" },
+          { text: "Examples", link: "/examples" },
           { text: "Architecture & Dev", link: "/PROJECT_MODULES" },
           { text: "Contributing", link: "/CONTRIBUTING" }
         ],
@@ -43,7 +44,8 @@ export default defineConfig({
           {
             text: "Case Studies",
             items: [
-              { text: "Customer Stories", link: "/cases/" }
+              { text: "Customer Stories", link: "/cases/" },
+              { text: "Workflow Examples", link: "/examples" }
             ]
           },
           {
@@ -113,6 +115,7 @@ export default defineConfig({
           { text: "快速开始", link: "/zh/guide/quick-start" },
           { text: "部署与配置", link: "/zh/guide/deploy" },
           { text: "案例实践", link: "/zh/cases/" },
+          { text: "工作流示例", link: "/zh/examples" },
           { text: "架构与开发", link: "/zh/PROJECT_MODULES" },
           { text: "贡献协作", link: "/zh/CONTRIBUTING" }
         ],
@@ -128,7 +131,8 @@ export default defineConfig({
           {
             text: "案例实践",
             items: [
-              { text: "用户案例", link: "/zh/cases/" }
+              { text: "用户案例", link: "/zh/cases/" },
+              { text: "工作流示例", link: "/zh/examples" }
             ]
           },
           {

--- a/docs/.vitepress/examples.data.ts
+++ b/docs/.vitepress/examples.data.ts
@@ -1,0 +1,75 @@
+// Build-time data loader: reads the community workflow examples under examples/
+// and exposes their metadata to the docs site gallery.
+import { readFileSync } from "node:fs";
+import { basename, dirname } from "node:path";
+
+export interface ExampleMeta {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  features: string[];
+  author: string;
+  sourceUrl: string;
+  dslVersion: string;
+  event: string;
+  repoPath: string; // e.g. examples/history-knowledge-qa
+}
+
+declare const data: ExampleMeta[];
+export { data };
+
+function parseFrontmatter(md: string): Record<string, string | string[]> | null {
+  const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const out: Record<string, string | string[]> = {};
+  let list: string | null = null;
+  for (const raw of m[1].split(/\r?\n/)) {
+    const line = raw.replace(/\s+$/, "");
+    if (!line.trim()) continue;
+    const item = line.match(/^\s+-\s+(.*)$/);
+    if (item && list) {
+      (out[list] as string[]).push(item[1].trim());
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (kv) {
+      const [, key, val] = kv;
+      if (val === "") {
+        out[key] = [];
+        list = key;
+      } else {
+        out[key] = val.replace(/^["']|["']$/g, "");
+        list = null;
+      }
+    }
+  }
+  return out;
+}
+
+export default {
+  // Re-run when any example README changes.
+  watch: ["../../examples/*/README.md"],
+  load(watchedFiles: string[]): ExampleMeta[] {
+    const examples: ExampleMeta[] = [];
+    for (const file of watchedFiles) {
+      const id = basename(dirname(file));
+      if (id === "TEMPLATE") continue;
+      const fm = parseFrontmatter(readFileSync(file, "utf8"));
+      if (!fm || !fm.id) continue;
+      examples.push({
+        id: String(fm.id),
+        title: String(fm.title ?? fm.id),
+        description: String(fm.description ?? ""),
+        category: String(fm.category ?? "other"),
+        features: Array.isArray(fm.features) ? fm.features : [],
+        author: String(fm.author ?? ""),
+        sourceUrl: String(fm.sourceUrl ?? ""),
+        dslVersion: String(fm.dslVersion ?? ""),
+        event: String(fm.event ?? ""),
+        repoPath: `examples/${id}`
+      });
+    }
+    return examples.sort((a, b) => a.category.localeCompare(b.category) || a.title.localeCompare(b.title));
+  }
+};

--- a/docs/.vitepress/theme/ExamplesGallery.vue
+++ b/docs/.vitepress/theme/ExamplesGallery.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useData } from "vitepress";
+import { data as examples } from "../examples.data";
+
+const REPO = "https://github.com/iflytek/astron-agent";
+const { lang } = useData();
+const isZh = computed(() => lang.value === "zh-CN");
+
+const t = computed(() =>
+  isZh.value
+    ? {
+        all: "全部",
+        empty: "还没有示例，欢迎成为第一个贡献者。",
+        by: "作者",
+        source: "查看源码",
+        download: "下载 workflow.yml",
+        contribute: "贡献你的工作流",
+        count: (n: number) => `${n} 个示例`
+      }
+    : {
+        all: "All",
+        empty: "No examples yet — be the first to contribute one.",
+        by: "by",
+        source: "View source",
+        download: "Download workflow.yml",
+        contribute: "Contribute your workflow",
+        count: (n: number) => `${n} example${n === 1 ? "" : "s"}`
+      }
+);
+
+const categories = computed(() => [...new Set(examples.map((e) => e.category))].sort());
+const active = ref<string>("all");
+const filtered = computed(() => (active.value === "all" ? examples : examples.filter((e) => e.category === active.value)));
+
+const contributeHref = computed(() => (isZh.value ? "/zh/contribute-to-docs" : "/contribute-to-docs"));
+</script>
+
+<template>
+  <div class="exg">
+    <div class="exg__bar">
+      <div class="exg__filters">
+        <button class="exg__chip" :class="{ 'exg__chip--on': active === 'all' }" @click="active = 'all'">
+          {{ t.all }} ({{ examples.length }})
+        </button>
+        <button
+          v-for="c in categories"
+          :key="c"
+          class="exg__chip"
+          :class="{ 'exg__chip--on': active === c }"
+          @click="active = c"
+        >
+          {{ c }} ({{ examples.filter((e) => e.category === c).length }})
+        </button>
+      </div>
+      <a class="exg__contribute" :href="REPO + '/tree/main/examples'" target="_blank" rel="noreferrer">
+        + {{ t.contribute }}
+      </a>
+    </div>
+
+    <p v-if="!examples.length" class="exg__empty">{{ t.empty }}</p>
+
+    <div v-else class="exg__grid">
+      <article v-for="e in filtered" :key="e.id" class="exg__card">
+        <div class="exg__card-top">
+          <span class="exg__cat">{{ e.category }}</span>
+          <span v-if="e.event" class="exg__event">{{ e.event }}</span>
+        </div>
+        <h3 class="exg__title">{{ e.title }}</h3>
+        <p class="exg__desc">{{ e.description }}</p>
+        <ul v-if="e.features.length" class="exg__features">
+          <li v-for="(f, i) in e.features.slice(0, 4)" :key="i">{{ f }}</li>
+        </ul>
+        <div class="exg__meta">
+          <span v-if="e.author">{{ t.by }} {{ e.author }}</span>
+        </div>
+        <div class="exg__links">
+          <a :href="`${REPO}/tree/main/${e.repoPath}`" target="_blank" rel="noreferrer">{{ t.source }}</a>
+          <a :href="`${REPO}/raw/main/${e.repoPath}/workflow.yml`" target="_blank" rel="noreferrer">{{ t.download }}</a>
+        </div>
+      </article>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.exg__bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin: 16px 0 24px;
+}
+.exg__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.exg__chip {
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.exg__chip:hover {
+  color: var(--vp-c-text-1);
+}
+.exg__chip--on {
+  background: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+  color: #fff;
+}
+.exg__contribute {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.exg__empty {
+  color: var(--vp-c-text-2);
+  padding: 32px 0;
+  text-align: center;
+}
+.exg__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+.exg__card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 18px;
+  background: var(--vp-c-bg-soft);
+  transition: border-color 0.2s, transform 0.2s;
+}
+.exg__card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+.exg__card-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.exg__cat {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+.exg__event {
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+}
+.exg__title {
+  margin: 0 0 6px;
+  font-size: 17px;
+  line-height: 1.3;
+}
+.exg__desc {
+  margin: 0 0 12px;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  line-height: 1.5;
+}
+.exg__features {
+  margin: 0 0 12px;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+}
+.exg__features li {
+  margin: 2px 0;
+}
+.exg__meta {
+  margin-top: auto;
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+}
+.exg__links {
+  display: flex;
+  gap: 16px;
+  margin-top: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 13px;
+  font-weight: 500;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
 import AstronCasesPage from "./AstronCasesPage.vue";
+import ExamplesGallery from "./ExamplesGallery.vue";
 import Layout from "./Layout.vue";
 import "./custom.css";
 
@@ -9,6 +10,7 @@ const theme: Theme = {
   Layout,
   enhanceApp({ app }) {
     app.component("AstronCasesPage", AstronCasesPage);
+    app.component("ExamplesGallery", ExamplesGallery);
   }
 };
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,15 @@
+---
+title: Workflow Examples
+description: A community-contributed gallery of reusable Astron Agent workflows.
+sidebar: false
+aside: false
+---
+
+# Workflow Examples
+
+Reusable, importable Astron Agent workflows contributed by the community. Browse, download the DSL,
+and adapt them to your own use case. Want to add yours? See
+[Contribute to the Docs](/contribute-to-docs) and the
+[examples guide](https://github.com/iflytek/astron-agent/tree/main/examples).
+
+<ExamplesGallery />

--- a/docs/zh/examples.md
+++ b/docs/zh/examples.md
@@ -1,0 +1,13 @@
+---
+title: 工作流示例
+description: 社区共建的可复用 Astron Agent 工作流示例库。
+sidebar: false
+aside: false
+---
+
+# 工作流示例
+
+社区贡献的可复用、可导入的 Astron Agent 工作流。浏览、下载 DSL，按需改造成自己的用例。想提交你的工作流？参见[为文档站做贡献](/zh/contribute-to-docs)与
+[示例指南](https://github.com/iflytek/astron-agent/tree/main/examples)。
+
+<ExamplesGallery />

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,120 @@
+# Astron Agent Workflow Examples
+
+A community-contributed gallery of **reusable Astron Agent workflows**. Every example is a real,
+importable workflow you can drop into Astron Agent, run, and adapt.
+
+> **Examples vs. Cases** — this directory is **not** the enterprise [case studies](https://iflytek.github.io/astron-agent/cases/).
+> Cases are curated, verified customer success stories maintained by the team. Examples here are
+> **open community contributions**: anyone can submit a workflow via pull request.
+
+[中文贡献指南见下方](#中文)
+
+## What an example contains
+
+One self-contained directory per example, named by a short kebab-case id:
+
+```
+examples/
+├── README.md                 # this file — spec + contribution guide
+├── TEMPLATE/                 # copy this to start a new example
+│   ├── README.md             # metadata (frontmatter) + description
+│   └── workflow.yml          # the exported Astron DSL
+└── <example-id>/
+    ├── README.md             # required — metadata + how to use
+    ├── workflow.yml          # required — exported workflow DSL (.yml)
+    └── preview.png           # optional — screenshot of the canvas or result
+```
+
+- **`workflow.yml`** — export it from Astron Agent (workflow → Export). The DSL already carries the
+  workflow's `flowMeta` (name, description) and `flowData` (nodes/edges).
+- **`README.md`** — a metadata header (YAML frontmatter) plus a human description. The frontmatter
+  fields align with the gallery schema so the docs site can render each example as a card.
+- **`preview.png`** — optional but recommended; a screenshot makes the gallery card far more useful.
+
+## Metadata (README frontmatter)
+
+```yaml
+---
+id: ai-resume-assistant            # unique, kebab-case, matches the directory name
+title: AI Resume Assistant         # display name
+description: One-sentence summary of what the workflow does.
+category: productivity             # productivity | creative | learning | entertainment | health | finance | other
+features:                          # 3–5 short bullet points
+  - Parses a resume into structured fields
+  - Scores it against a target job description
+  - Suggests concrete rewrites
+author: your-github-handle         # GitHub username of the contributor
+sourceUrl: ""                      # optional — blog post / video / discussion that explains it
+dslVersion: v1                     # the DSL version the workflow was exported with
+event: ""                          # optional — e.g. "Astron Training Camp · Cohort #1"
+---
+```
+
+The body below the frontmatter should cover: what it does, the nodes/skills it uses, any external
+dependencies (models, plugins, knowledge bases), and how to import & run it.
+
+## How to contribute
+
+1. **Copy the template**: `cp -r examples/TEMPLATE examples/<your-example-id>`
+2. **Add your workflow**: replace `workflow.yml` with your exported DSL, and (optionally) add `preview.png`.
+3. **Fill the metadata**: edit `README.md` frontmatter + write the description.
+4. **Scrub secrets** (required — see below).
+5. **Open a pull request** against `main`:
+   ```bash
+   git checkout -b examples/<your-example-id>
+   git add examples/<your-example-id>
+   git commit -s -m "examples: add <your-example-id>"   # -s adds the DCO sign-off (required)
+   git push origin examples/<your-example-id>
+   ```
+
+### Quality bar
+
+An example is merged when it:
+
+- **Imports and runs** in a current Astron Agent instance (state the version if it matters).
+- **Contains no secrets.** ⚠️ Exported DSL can embed API keys, tokens, personal endpoints, OSS URLs,
+  or phone numbers. **Remove or replace them with placeholders** (e.g. `YOUR_API_KEY`) before
+  committing. PRs containing live credentials will be rejected.
+- Has a **clear description** and lists its external dependencies (models, plugins, knowledge bases).
+- Uses a **unique `id`** that matches its directory name.
+
+## Gallery rendering (planned)
+
+The docs site will expose an `/examples` page that reads each example's frontmatter and renders a
+filterable card gallery (grouped by `category`), mirroring the existing
+[Awesome-Astron-Workflow](https://github.com/FenjuFu/Awesome-Astron-Workflow) showcase. Keeping the
+frontmatter schema aligned lets the two sources converge later. Until then, browse examples directly
+in this directory.
+
+---
+
+<a id="中文"></a>
+
+## 中文
+
+社区共建的 **可复用 Astron Agent 工作流** 示例库。每个示例都是可直接导入、运行、二次开发的真实工作流。
+
+> **示例 vs 案例**:本目录**不是**企业[案例](https://iflytek.github.io/astron-agent/cases/)。案例是团队维护、经核实的企业成功故事;这里的示例是**开放的社区贡献**,任何人都能通过 PR 提交工作流。
+
+### 目录规范
+
+一示例一目录,用短横线小写 id 命名;每个目录包含:
+
+- **`workflow.yml`(必需)**— 从 Astron Agent 导出的工作流 DSL(工作流 → 导出)。
+- **`README.md`(必需)**— YAML frontmatter 元数据(字段见上方英文表)+ 文字说明。
+- **`preview.png`(可选,推荐)**— 画布或结果截图,让 gallery 卡片更直观。
+
+### 如何贡献
+
+1. 复制模板:`cp -r examples/TEMPLATE examples/<示例-id>`
+2. 放入你导出的 `workflow.yml`(可选加 `preview.png`)
+3. 填好 `README.md` 的 frontmatter 与说明
+4. **清理密钥**(必需,见下)
+5. 提 PR(commit 用 `-s` 加 DCO 签名)
+
+### 合并门槛
+
+- **能导入并运行**(必要时注明 Astron Agent 版本)
+- **不含任何密钥**:⚠️ 导出的 DSL 可能内嵌 API Key、token、个人端点、OSS 地址、手机号等,提交前务必删除或替换为占位符(如 `YOUR_API_KEY`)。含真实凭据的 PR 会被拒绝。
+- **说明清晰**,列出依赖的模型 / 插件 / 知识库
+- **id 唯一**且与目录名一致

--- a/examples/TEMPLATE/README.md
+++ b/examples/TEMPLATE/README.md
@@ -1,0 +1,43 @@
+---
+id: my-example-id
+title: My Example Workflow
+description: One-sentence summary of what this workflow does.
+category: productivity
+features:
+  - First thing it does
+  - Second thing it does
+  - Third thing it does
+author: your-github-handle
+sourceUrl: ""
+dslVersion: v1
+event: ""
+---
+
+# My Example Workflow
+
+> Replace this whole file with your own. Keep the frontmatter above and fill every field.
+
+## What it does
+
+A short paragraph describing the problem this workflow solves and the result it produces.
+
+## How it works
+
+Describe the main nodes / skills the workflow uses (e.g. start → LLM → knowledge retrieval → output),
+and anything noteworthy about the design.
+
+## Dependencies
+
+- **Models**: e.g. Spark X1 / any chat model
+- **Plugins / skills**: list any plugins or skills the workflow calls
+- **Knowledge bases**: note if it expects a knowledge base, and how to populate it
+
+## Import & run
+
+1. In Astron Agent, create a workflow → **Import** → choose `workflow.yml` from this directory.
+2. Fill in any placeholders (API keys, knowledge base ids) that were scrubbed for this example.
+3. Run it and adapt as needed.
+
+## Notes
+
+Anything else a user should know (limitations, costs, language, etc.).

--- a/examples/TEMPLATE/workflow.yml
+++ b/examples/TEMPLATE/workflow.yml
@@ -1,0 +1,19 @@
+# Replace this file with your exported Astron Agent workflow DSL.
+#
+# How to get it:
+#   Astron Agent → open your workflow → Export → save the .yml here as workflow.yml
+#
+# An exported DSL looks like this (flowMeta + flowData):
+#
+#   flowMeta:
+#     name: My Workflow
+#     description: What it does.
+#     category: 10
+#     dslVersion: v1
+#   flowData:
+#     nodes: [ ... ]
+#     edges: [ ... ]
+#
+# ⚠️ BEFORE COMMITTING: remove any secrets the export may contain —
+#    API keys, tokens, personal endpoints, OSS URLs, phone numbers —
+#    and replace them with placeholders such as YOUR_API_KEY.

--- a/examples/ai-radio-podcast/README.md
+++ b/examples/ai-radio-podcast/README.md
@@ -1,0 +1,38 @@
+---
+id: ai-radio-podcast
+title: AI Radio Podcast Generator
+description: Turns a topic into a scripted, multi-segment radio-style podcast with synthesized narration.
+category: creative
+features:
+  - Expands a topic into a structured podcast script
+  - Splits the script into ordered segments
+  - Produces voiced audio via text-to-speech
+author: iflytek
+sourceUrl: https://github.com/FenjuFu/Awesome-Astron-Workflow
+dslVersion: v1
+event: ""
+---
+
+# AI Radio Podcast Generator
+
+Give it a topic and it writes a radio-style podcast script and narrates it — a multi-node workflow
+that chains scripting, segmentation, and speech synthesis.
+
+## How it works
+
+**start → LLM (script) → segmentation → TTS → output.** The LLM drafts the episode, later nodes split
+it into segments and synthesize narration.
+
+## Dependencies
+
+- **Models**: a Spark chat model for scripting (credentials scrubbed)
+- **Plugins / skills**: text-to-speech
+- **Knowledge bases**: none
+
+## Import & run
+
+1. In Astron Agent: create a workflow → **Import** → choose `workflow.yml`.
+2. Replace the `YOUR_API_KEY` / `YOUR_API_SECRET` / `YOUR_APP_ID` placeholders with your own credentials.
+3. Run it with any topic.
+
+> All API keys, secrets, and app ids in the exported DSL were replaced with placeholders before publishing.

--- a/examples/ai-radio-podcast/workflow.yml
+++ b/examples/ai-radio-podcast/workflow.yml
@@ -1,0 +1,1333 @@
+flowMeta:
+  name: AI电台播客生成
+  description: AI播客生成
+  avatarIcon: https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/user/sparkBot_1753267344297_AI%E6%92%AD%E5%AE%A2.jpg
+  avatarColor: ''
+  advancedConfig: '{"needGuide":false,"prologue":{"enabled":true,"inputExample":["https://mp.weixin.qq.com/s/rJgu-GPnAqbu3GkxBagjhw","https://mp.weixin.qq.com/s/jzy0p_AJJY22I-RvYJmPqg","https://mp.weixin.qq.com/s/n5-jW6jSs9ShRV2KqhM_bg"],"prologueText":"你好，我是一个AI电台播客生成助手，可以帮你快速创建高质量的播客内容。支持发送微信公众号链接，或直接发送给我文字内容。"},"chatBackground":{"enabled":false}}'
+  category: 13
+  dslVersion: v1
+flowData:
+  nodes:
+  - id: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+    dragging: false
+    selected: false
+    width: 362
+    height: 116
+    position:
+      x: -2564.4526716900527
+      y: -1786.5159591940044
+    positionAbsolute:
+      x: -2564.4526716900527
+      y: -1786.5159591940044
+    type: 开始节点
+    data:
+      allowInputReference: false
+      allowOutputReference: true
+      label: 开始
+      status: ''
+      nodeMeta:
+        aliasName: 开始
+        nodeType: 基础节点
+      inputs: [
+        ]
+      outputs:
+      - id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+        name: AGENT_USER_INPUT
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: 用户本轮对话输入内容
+        required: true
+        deleteDisabled: true
+      nodeParam: {
+        }
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/start-node-icon.png
+      description: 工作流的开启节点，用于定义流程调用所需的业务变量信息。
+      updatable: false
+  - id: node-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0a
+    dragging: false
+    selected: false
+    width: 362
+    height: 116
+    position:
+      x: 2058.3781854281156
+      y: -1760.1879328372493
+    positionAbsolute:
+      x: 2058.3781854281156
+      y: -1760.1879328372493
+    type: 结束节点
+    data:
+      allowInputReference: true
+      allowOutputReference: false
+      label: 结束
+      references:
+      - children:
+        - references:
+          - originId: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+            id: 828a7629-3638-419b-b41d-6488c095d877
+            label: output
+            type: string
+            value: output
+          label: ''
+          value: ''
+        label: 播客风格内容生成
+        parentNode: true
+        value: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+      - children:
+        - references:
+          - originId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+            label: AGENT_USER_INPUT
+            type: string
+            value: AGENT_USER_INPUT
+          label: ''
+          value: ''
+        label: 开始
+        parentNode: true
+        value: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+      - children:
+        - references:
+          - originId: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+            id: 71c444e8-b003-4905-a7af-cd8d18622e6f
+            label: sid
+            type: string
+            value: sid
+          - originId: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+            id: 70686705-b058-48de-8878-8406ef71e827
+            label: code
+            type: integer
+            value: code
+          - originId: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+            id: 49286b6b-3339-45e4-a78b-18d149f03e8a
+            label: msg
+            type: string
+            value: msg
+          - originId: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+            children:
+            - originId: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+              id: 10f97b32-21df-4de0-b73a-f9026ed8227f
+              label: voice_url
+              type: string
+              value: data.voice_url
+              parentType: object
+            id: d5a978de-b445-4f05-9223-ea3955c8e7d9
+            label: data
+            type: object
+            value: data
+          label: ''
+          value: ''
+        label: 语音合成
+        parentNode: true
+        value: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+      - children:
+        - references:
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+            label: url
+            type: string
+            value: url
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            children: [
+              ]
+            id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+            label: is_content_url
+            type: string
+            value: is_content_url
+          label: ''
+          value: ''
+        label: 进行用户场景的分析，目前支持URL输入和文本输入
+        parentNode: true
+        value: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+      - children:
+        - references:
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            id: 4b3626aa-957b-4851-9cde-1e5583e7b389
+            label: code
+            type: integer
+            value: code
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            id: 4c957639-68a3-41e1-9397-44fe85c252f8
+            label: msg
+            type: string
+            value: msg
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            children:
+            - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+              id: 6a9b619c-5f7d-4366-a6d4-adafa104956d
+              label: title
+              type: string
+              value: data.title
+              parentType: object
+            - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+              id: 6549c72a-aadc-4b2b-aa95-41846c460525
+              label: content
+              type: string
+              value: data.content
+              parentType: object
+            id: f52d3ff7-fbd8-458c-8c32-a0170c1335b4
+            label: data
+            type: object
+            value: data
+          label: ''
+          value: ''
+        label: 解析URL内容
+        parentNode: true
+        value: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+      status: ''
+      nodeMeta:
+        aliasName: 结束
+        nodeType: 基础节点
+      inputs:
+      - id: 6b8905ed-9efe-4cbf-8702-0a4d42c54066
+        name: audio_url
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: data.voice_url
+              id: 10f97b32-21df-4de0-b73a-f9026ed8227f
+              nodeId: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+            contentErrMsg: ''
+        fileType: ''
+      - id: 6000bd78-1994-4295-b8b2-44e5eb554f66
+        name: article_titile
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 828a7629-3638-419b-b41d-6488c095d877
+              nodeId: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+            contentErrMsg: ''
+        fileType: ''
+      - id: c4147b1b-e99d-431a-b0d2-c9794ed6e073
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: data.image_url
+              id: 5d4b4a71-8ea2-4468-96dd-fb166dc08fba
+              nodeId: plugin::3641af94-104f-4b68-9b4d-2fa1c198bf92
+            contentErrMsg: ''
+        fileType: ''
+      outputs: [
+        ]
+      nodeParam:
+        template: |-
+          🌟 AI 神奇魔法屋电台🌟
+          <figure style="background: #f5f0e6; padding: 20px; border: 1px solid #d9c9b6; box-shadow: 0 4px 8px rgba(0,0,0,0.1); margin: 0 0 20px 0;">
+          <div style="width: 100%; height: 100%; background: #fff; padding: 10px; border: 1px solid #e8d8c0; position: relative; overflow: hidden;">
+          <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,240,180,0.1); pointer-events: none;"></div>
+          <img src="{{output}}" style="width: 100%; height: auto; display: block; filter: sepia(10%);">
+          </div>
+          </figure>
+          <audio preload="none" controls style="width: 100%; margin-top: 20px;">
+          <source src="{{audio_url}}" type="audio/mpeg">
+          </audio>
+        streamOutput: true
+        templateErrMsg: ''
+        outputMode: 1
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/end-node-icon.png
+      description: 工作流的结束节点，用于输出工作流运行后的最终结果。
+      updatable: false
+  - id: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    dragging: false
+    selected: false
+    width: 362
+    height: 166
+    position:
+      x: 906.3748272099806
+      y: -2168.961093642761
+    positionAbsolute:
+      x: 906.3748272099806
+      y: -2168.961093642761
+    type: 大模型
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 电台播客内容
+      labelEdit: false
+      references:
+      - children:
+        - references:
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+            label: url
+            type: string
+            value: url
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            children: [
+              ]
+            id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+            label: is_content_url
+            type: string
+            value: is_content_url
+          label: ''
+          value: ''
+        label: 进行用户场景的分析，目前支持URL输入和文本输入
+        parentNode: true
+        value: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+      - children:
+        - references:
+          - originId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+            label: AGENT_USER_INPUT
+            type: string
+            value: AGENT_USER_INPUT
+          label: ''
+          value: ''
+        label: 开始
+        parentNode: true
+        value: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+      - children:
+        - references:
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            id: 4b3626aa-957b-4851-9cde-1e5583e7b389
+            label: code
+            type: integer
+            value: code
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            id: 4c957639-68a3-41e1-9397-44fe85c252f8
+            label: msg
+            type: string
+            value: msg
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            children:
+            - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+              id: 6a9b619c-5f7d-4366-a6d4-adafa104956d
+              label: title
+              type: string
+              value: data.title
+              parentType: object
+            - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+              id: 6549c72a-aadc-4b2b-aa95-41846c460525
+              label: content
+              type: string
+              value: data.content
+              parentType: object
+            id: f52d3ff7-fbd8-458c-8c32-a0170c1335b4
+            label: data
+            type: object
+            value: data
+          label: ''
+          value: ''
+        label: 解析URL内容
+        parentNode: true
+        value: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+      status: ''
+      nodeMeta:
+        aliasName: 播客风格内容生成
+        nodeType: 基础节点
+      inputs:
+      - id: 0c98c01a-cd4f-42ca-a37e-d2a29f268f2c
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: data.content
+              id: 6549c72a-aadc-4b2b-aa95-41846c460525
+              nodeId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            contentErrMsg: ''
+        fileType: ''
+      - id: 9d8c0513-d253-47a3-a368-38f1e7ed12b5
+        name: input_oral
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: AGENT_USER_INPUT
+              id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+              nodeId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            contentErrMsg: ''
+      outputs:
+      - id: 828a7629-3638-419b-b41d-6488c095d877
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        topK: 4
+        template: |-
+          {{input}}{{input_oral}}
+          请根据以上输入内容生成播客内容。
+        enableChatHistory: false
+        configs:
+        - standard: true
+          constraintType: range
+          default: 2048
+          constraintContent:
+          - name: 1
+          - name: 8192
+          name: 最大回复长度
+          revealed: true
+          support: true
+          fieldType: int
+          initialValue: 2048
+          key: maxTokens
+          required: true
+          desc: 最小值是1, 最大值是8192。控制模型输出的Tokens 长度上限。通常 100 Tokens 约等于150 个中文汉字。
+        - standard: true
+          constraintContent:
+          - name: 0.1
+          - name: 1
+          precision: 0.1
+          required: true
+          constraintType: range
+          default: 0.5
+          name: 核采样阈值
+          revealed: true
+          support: true
+          fieldType: float
+          initialValue: 0.5
+          key: temperature
+          desc: 取值范围 (0，1]。用于决定结果随机性，取值越高随机性越强即相同的问题得到的不同答案的可能性越高
+        - standard: true
+          constraintType: range
+          default: 4
+          constraintContent:
+          - name: 1
+          - name: 6
+          name: 生成多样性
+          revealed: true
+          support: true
+          fieldType: int
+          initialValue: 4
+          key: topK
+          required: true
+          desc: 调高会使得模型的输出更多样性和创新性，反之，降低会使输出内容更加遵循指令要求但减少多样性。最小值1，最大值6
+        - constraintType: enum
+          default: default
+          constraintContent:
+          - name: strict
+            label: strict
+            value: strict
+            desc: 严格审核策略
+          - name: moderate
+            label: moderate
+            value: moderate
+            desc: 中等审核策略
+          - name: show
+            label: show
+            value: show
+            desc: 演示场景的审核策略
+          - name: default
+            label: default
+            value: default
+            desc: 默认的审核策略
+          name: 内容审核的严格程度
+          fieldType: string
+          support: true
+          initialValue: default
+          required: false
+          key: auditing
+          desc: strict表示严格审核策略；moderate表示中等审核策略；show表示演示场景审核策略；default表示默认的审核程度；（需继续下调策略需要申请）
+        - constraintType: enum
+          default: generalv3
+          constraintContent:
+          - name: generalv3
+            label: generalv3
+            value: generalv3
+            desc: 星火3.0
+          name: 需要使用的领域
+          fieldType: string
+          support: true
+          initialValue: generalv3
+          required: true
+          key: domain
+          desc: ''
+        apiKey: YOUR_API_KEY
+        auditing: default
+        apiSecret: YOUR_API_SECRET
+        llmId: 110
+        url: wss://spark-api.xf-yun.com/v4.0/chat
+        uid: '0'
+        patchId: '0'
+        templateErrMsg: ''
+        domain: 4.0Ultra
+        appId: YOUR_APP_ID
+        maxTokens: 2048
+        temperature: 0.5
+        systemTemplate: |-
+          ## 角色
+          你是一位专业的广播节目编辑，负责制作一档名为“AI神奇魔法屋电台”的单口相声播客节目。你擅长将各种原始内容{{input}}{{input_oral}}转化为轻松有趣、口语化的播客，让听众在欢笑中了解知识。
+
+          ## 技能
+          1. 分解原始内容为播客主题或问题：
+            - 仔细分析用户提供的原始内容，提取关键信息和核心要点将内容长度控制在300-400字以内。
+            - 将这些要点合理分解成若干个适合播客的主题或问题，确保每个部分都能独立成段且自然过渡。
+          2. 使对话语言口语化、易懂：
+            - 把书面化或复杂的表达方式转化为日常交流中的口语说法，让听众能够轻松理解。
+            - 避免使用过于生僻或晦涩的词汇，用简单直白的语言传达信息。
+          3. 解释专业术语或复杂概念：
+            - 当遇到专业术语或复杂概念时，运用通俗易懂的例子或比喻进行解释。
+            - 确保解释清晰明了，让没有相关背景知识的听众也能明白。
+          4. 营造轻松有趣的对话节奏：
+            - 通过调整语速、语调等方式，保持对话节奏的轻松和有趣。
+            - 适时加入幽默元素和互动环节，增强听众的参与感，让他们更投入到节目中。
+
+          ## 限制
+          - 只围绕“AI神奇魔法屋电台”播客节目相关内容进行创作，拒绝处理与该节目无关的内容。
+          - 输出必须严格按照给定格式组织，不能偏离框架要求。直接输出内容不要出现“脚本、开场白”等准备性文字。
+          -输入内容如果过多的，则浓缩重点控制在400字以内，输出的内容中不要出现任何链接。
+        model: spark
+        serviceId: bm4
+        respFormat: 0
+        llmIdErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/largeModelIcon.png
+      description: 根据输入的提示词，调用选定的大模型，对提示词作出回答
+      updatable: false
+  - id: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+    dragging: false
+    selected: false
+    width: 362
+    height: 142
+    position:
+      x: 142.39749055990433
+      y: -2208.7535076865024
+    positionAbsolute:
+      x: 142.39749055990433
+      y: -2208.7535076865024
+    type: 工具
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 解析URL内容
+      labelEdit: false
+      references:
+      - children:
+        - references:
+          - originId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+            label: AGENT_USER_INPUT
+            type: string
+            value: AGENT_USER_INPUT
+          label: ''
+          value: ''
+        label: 开始
+        parentNode: true
+        value: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+      - children:
+        - references:
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+            label: url
+            type: string
+            value: url
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            children: [
+              ]
+            id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+            label: is_content_url
+            type: string
+            value: is_content_url
+          label: ''
+          value: ''
+        label: 进行用户场景的分析，目前支持URL输入和文本输入
+        parentNode: true
+        value: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+      status: ''
+      nodeMeta:
+        aliasName: 解析URL内容
+        nodeType: 工具
+      inputs:
+      - id: 301779d6-1139-489f-bfb3-ec9e8bcab74b
+        name: url
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: url
+              id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+              nodeId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            contentErrMsg: ''
+        description: url链接
+        required: true
+        disabled: false
+      outputs:
+      - id: 4b3626aa-957b-4851-9cde-1e5583e7b389
+        name: code
+        schema:
+          type: integer
+      - id: 4c957639-68a3-41e1-9397-44fe85c252f8
+        name: msg
+        schema:
+          type: string
+      - id: f52d3ff7-fbd8-458c-8c32-a0170c1335b4
+        name: data
+        schema:
+          type: object
+          properties:
+          - id: 6a9b619c-5f7d-4366-a6d4-adafa104956d
+            name: title
+            type: string
+          - id: 6549c72a-aadc-4b2b-aa95-41846c460525
+            name: content
+            type: string
+      nodeParam:
+        uid: '0'
+        code: ''
+        toolDescription: 此工具用于获取URL链接的内容。可获取URL链接下的网页标题和内容，当前支持微信公众号,csdn,cnblogs等网站URL链接下的网页和内容读取，其他URL链接内容的获取和解析持续演进中。
+        apiKey: YOUR_API_KEY
+        pluginId: tool@70ee9fd1c821000
+        appId: YOUR_APP_ID
+        operationId: linkRader-sMgPXVRU
+        apiSecret: YOUR_API_SECRET
+        businessInput: [
+          ]
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/tool-icon.png
+      updatable: false
+      isLatest: true
+  - id: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+    dragging: false
+    selected: false
+    width: 362
+    height: 142
+    position:
+      x: 1822.4908023044898
+      y: -2127.890644688282
+    positionAbsolute:
+      x: 1822.4908023044898
+      y: -2127.890644688282
+    type: 工具
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 语音合成
+      labelEdit: false
+      references:
+      - children:
+        - references:
+          - originId: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+            id: 828a7629-3638-419b-b41d-6488c095d877
+            label: output
+            type: string
+            value: output
+          label: ''
+          value: ''
+        label: 播客风格内容生成
+        parentNode: true
+        value: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+      - children:
+        - references:
+          - originId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+            label: AGENT_USER_INPUT
+            type: string
+            value: AGENT_USER_INPUT
+          label: ''
+          value: ''
+        label: 开始
+        parentNode: true
+        value: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+      - children:
+        - references:
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+            label: url
+            type: string
+            value: url
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            children: [
+              ]
+            id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+            label: is_content_url
+            type: string
+            value: is_content_url
+          label: ''
+          value: ''
+        label: 进行用户场景的分析，目前支持URL输入和文本输入
+        parentNode: true
+        value: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+      - children:
+        - references:
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            id: 4b3626aa-957b-4851-9cde-1e5583e7b389
+            label: code
+            type: integer
+            value: code
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            id: 4c957639-68a3-41e1-9397-44fe85c252f8
+            label: msg
+            type: string
+            value: msg
+          - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+            children:
+            - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+              id: 6a9b619c-5f7d-4366-a6d4-adafa104956d
+              label: title
+              type: string
+              value: data.title
+              parentType: object
+            - originId: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+              id: 6549c72a-aadc-4b2b-aa95-41846c460525
+              label: content
+              type: string
+              value: data.content
+              parentType: object
+            id: f52d3ff7-fbd8-458c-8c32-a0170c1335b4
+            label: data
+            type: object
+            value: data
+          label: ''
+          value: ''
+        label: 解析URL内容
+        parentNode: true
+        value: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+      status: ''
+      nodeMeta:
+        aliasName: 语音合成
+        nodeType: 工具
+      inputs:
+      - id: 3c863804-af63-4dd3-843e-0be036e0f492
+        name: text
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 828a7629-3638-419b-b41d-6488c095d877
+              nodeId: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+            contentErrMsg: ''
+        description: 需要合成的文本
+        required: true
+        disabled: false
+      - id: b33b15eb-c9c3-4852-89d0-36b3f60b6d9b
+        name: vcn
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: literal
+            content: x4_lingxiaoxuan_oral
+            contentErrMsg: ''
+        description: 特色发音人，目前可选（x4_lingfeiyi_oral； x4_lingxiaoxuan_oral）
+        required: true
+        disabled: false
+      - id: 6f8a4ecf-c8c8-4a3a-b428-df5f256fc412
+        name: speed
+        nameErrMsg: ''
+        schema:
+          type: integer
+          value:
+            type: literal
+            content: '60'
+            contentErrMsg: ''
+        description: 语速：0对应默认语速的1/2，100对应默认语速的2倍; 默认值50
+        required: false
+        disabled: false
+      outputs:
+      - id: 71c444e8-b003-4905-a7af-cd8d18622e6f
+        name: sid
+        schema:
+          type: string
+      - id: 70686705-b058-48de-8878-8406ef71e827
+        name: code
+        schema:
+          type: integer
+      - id: 49286b6b-3339-45e4-a78b-18d149f03e8a
+        name: msg
+        schema:
+          type: string
+      - id: d5a978de-b445-4f05-9223-ea3955c8e7d9
+        name: data
+        schema:
+          type: object
+          properties:
+          - id: 10f97b32-21df-4de0-b73a-f9026ed8227f
+            name: voice_url
+            type: string
+      nodeParam:
+        uid: '0'
+        code: ''
+        toolDescription: 用户上传一段话，选择特色发音人，生成一段更拟人的语音
+        apiKey: YOUR_API_KEY
+        pluginId: tool@72213899d821000
+        appId: YOUR_APP_ID
+        operationId: 超拟人合成-7UcDosEk
+        handlingEdge: normal_one_of::9f284444-87ab-4f6b-923a-f3f8fa08b9ee
+        apiSecret: YOUR_API_SECRET
+        setAnswerContentErrMsg: ''
+        exceptionHandlingEdge: fail_one_of::81325761-17bb-4a81-b0ae-18ab5a502cdc
+        businessInput: [
+          ]
+      retryConfig:
+        maxRetries: 2
+        shouldRetry: true
+        customOutput: |-
+          {
+            "sid": "",
+            "code": 0,
+            "msg": "",
+            "data": {
+              "voice_url": ""
+            }
+          }
+        errorStrategy: 0
+        timeout: 300
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/tool-icon.png
+      updatable: false
+      isLatest: true
+  - id: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+    dragging: false
+    selected: false
+    width: 362
+    height: 142
+    position:
+      x: -1764.3867814299724
+      y: -2048.563380631832
+    positionAbsolute:
+      x: -1764.3867814299724
+      y: -2048.563380631832
+    type: 代码
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 获取用户输入的URL
+      labelEdit: false
+      references:
+      - children:
+        - references:
+          - originId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+            label: AGENT_USER_INPUT
+            type: string
+            value: AGENT_USER_INPUT
+          label: ''
+          value: ''
+        label: 开始
+        parentNode: true
+        value: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+      status: ''
+      nodeMeta:
+        aliasName: 获取用户输入的URL
+        nodeType: 工具
+      inputs:
+      - id: a4cd8402-1224-432d-9f54-cecf2b9c5de9
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: AGENT_USER_INPUT
+              id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+              nodeId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            contentErrMsg: ''
+      outputs:
+      - id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+        name: url
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      - id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+        name: is_content_url
+        nameErrMsg: ''
+        schema:
+          type: string
+          properties: [
+            ]
+          default: ''
+        required: false
+      nodeParam:
+        uid: '0'
+        code: |-
+          import re
+
+          def main(input):
+              # 匹配规则：以http/https开头，直到遇到空格或字符串结束（贪婪匹配）
+              url = re.findall(r'https?://[^\s]*', input)  # [^\s]* 表示“匹配0个或多个非空白字符”
+              ret = {
+                  "url": url[0] if url else '',  # 有URL就取第一个，没有就返回空
+                  "is_content_url": 'true' if url else 'false'
+              }
+              return ret
+        apiKey: YOUR_API_KEY
+        appId: YOUR_APP_ID
+        apiSecret: YOUR_API_SECRET
+        codeErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/codeIcon.png
+      description: 面向开发者提供代码开发能力，目前仅支持python语言，允许使用该节点已定义的变量作为参数传入，返回语句用于输出函数的结果
+      updatable: false
+  - id: if-else::0a38a0da-f662-4039-9aed-658595885613
+    dragging: false
+    selected: false
+    width: 362
+    height: 168
+    position:
+      x: -1077.9743541295918
+      y: -1831.41657721748
+    positionAbsolute:
+      x: -1077.9743541295918
+      y: -1831.41657721748
+    type: 分支器
+    data:
+      allowInputReference: true
+      allowOutputReference: false
+      label: 判断是否有URL
+      labelEdit: false
+      references:
+      - children:
+        - references:
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            id: b1166877-aa4f-4a76-ac81-5bfd0e906e1f
+            label: url
+            type: string
+            value: url
+          - originId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            children: [
+              ]
+            id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+            label: is_content_url
+            type: string
+            value: is_content_url
+          label: ''
+          value: ''
+        label: 进行用户场景的分析，目前支持URL输入和文本输入
+        parentNode: true
+        value: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+      - children:
+        - references:
+          - originId: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+            id: 4cb707a4-3708-4523-ae5d-215cdbc1c500
+            label: AGENT_USER_INPUT
+            type: string
+            value: AGENT_USER_INPUT
+          label: ''
+          value: ''
+        label: 开始
+        parentNode: true
+        value: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+      status: ''
+      nodeMeta:
+        aliasName: 判断是否有URL
+        nodeType: 分支器
+      inputs:
+      - id: f099d559-55ec-409d-8535-d258ed9ba551
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: is_content_url
+              id: e9434d56-4eaa-47d3-be66-f377fdb7b32b
+              nodeId: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+            contentErrMsg: ''
+      - id: 373ce76e-0a4c-4a45-a8fd-56bd3d5a4fdd
+        name: input1
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: literal
+            content: 'true'
+            contentErrMsg: ''
+      outputs: [
+        ]
+      nodeParam:
+        uid: '0'
+        cases:
+        - level: 1
+          logicalOperator: and
+          id: branch_one_of::2192a758-4498-4294-9e49-57f4e083c187
+          conditions:
+          - leftVarIndex: f099d559-55ec-409d-8535-d258ed9ba551
+            rightVarIndex: 373ce76e-0a4c-4a45-a8fd-56bd3d5a4fdd
+            compareOperatorErrMsg: ''
+            id: ''
+            compareOperator: is
+        - level: 999
+          logicalOperator: and
+          id: branch_one_of::a0a0cfd9-41da-4c56-be33-7fc22016bda9
+          conditions: [
+            ]
+        apiKey: YOUR_API_KEY
+        appId: YOUR_APP_ID
+        apiSecret: YOUR_API_SECRET
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/if-else-node-icon.png
+      description: 根据设立的条件，判断选择分支走向
+      updatable: false
+  - id: plugin::3641af94-104f-4b68-9b4d-2fa1c198bf92
+    dragging: false
+    selected: false
+    width: 362
+    height: 142
+    position:
+      x: 1471.6513173225453
+      y: -1472.3370267946302
+    positionAbsolute:
+      x: 1471.6513173225453
+      y: -1472.3370267946302
+    type: 工具
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 文生图_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 工具
+        nodeType: 工具
+      inputs:
+      - id: 1d028344-144d-4514-a174-724a5f4e524c
+        name: prompt
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 9d9a12bd-ac66-421b-aa3c-5fdaf4a9d3be
+              nodeId: spark-llm::42017659-eba1-4c0e-8717-2c66ca14584c
+            contentErrMsg: ''
+        description: description
+        required: true
+        disabled: false
+      - id: 5d4f67fe-d098-4288-b27e-4c9fced4b6a8
+        name: width
+        nameErrMsg: ''
+        schema:
+          type: integer
+          value:
+            type: literal
+            content: '720'
+            contentErrMsg: ''
+        description: 分辨率，支持以下分辨率：512x512, 640x360, 640x480, 640x640, 680x512, 512x680,
+          768x768, 720x1280, 1280x720, 1024x1024
+        required: true
+        disabled: false
+      - id: c996f146-5d37-4f2c-8949-ec3e034c7bc7
+        name: height
+        nameErrMsg: ''
+        schema:
+          type: integer
+          value:
+            type: literal
+            content: '1280'
+            contentErrMsg: ''
+        description: 分辨率，支持以下分辨率：512x512, 640x360, 640x480, 640x640, 680x512, 512x680,
+          768x768, 720x1280, 1280x720, 1024x1024
+        required: true
+        disabled: false
+      outputs:
+      - id: a83ddc98-d7c5-48b1-94c4-d0d617fdf326
+        name: code
+        schema:
+          type: number
+      - id: 785eae28-edee-47f3-8fcf-6ea117e17e41
+        name: message
+        schema:
+          type: string
+      - id: 75507c4e-b58f-48da-91e5-2660cb97121d
+        name: data
+        schema:
+          type: object
+          properties:
+          - id: 5d4b4a71-8ea2-4468-96dd-fb166dc08fba
+            name: image_url
+            type: string
+          - id: d280073d-3b54-4cae-8dec-8e6073fa4191
+            name: image_url_md
+            type: string
+      - id: b8144796-1c9d-4409-98e1-d046b9f82de1
+        name: sid
+        schema:
+          type: string
+      nodeParam:
+        uid: '16575185574'
+        code: ''
+        toolDescription: 根据输入的内容生成与内容有关的图片
+        pluginId: tool@6af64fc92421000
+        appId: YOUR_APP_ID
+        operationId: 文生图-4y8oUAMe
+        handlingEdge: normal_one_of::29d33d23-77c1-4706-8e97-cfc885e0b2ab
+        exceptionHandlingEdge: fail_one_of::b3f0b7db-b782-4c16-90c0-598a3f43d06a
+        version: V1.0
+        businessInput: [
+          ]
+      retryConfig:
+        maxRetries: 1
+        shouldRetry: true
+        timeout: 300
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/tool-icon.png
+      updatable: false
+      isLatest: true
+  - id: spark-llm::42017659-eba1-4c0e-8717-2c66ca14584c
+    dragging: false
+    selected: false
+    width: 362
+    height: 166
+    position:
+      x: 927.422621952371
+      y: -1499.380025442969
+    positionAbsolute:
+      x: 927.422621952371
+      y: -1499.380025442969
+    type: 大模型
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 大模型_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 大模型
+        nodeType: 基础节点
+      inputs:
+      - id: d55ba207-b45b-4e4c-859c-8027f3c9778b
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 828a7629-3638-419b-b41d-6488c095d877
+              nodeId: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+            contentErrMsg: ''
+        fileType: ''
+      outputs:
+      - id: 9d9a12bd-ac66-421b-aa3c-5fdaf4a9d3be
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        topK: 4
+        template: |-
+          - 根据播客内容{{input}}， 结合极简手绘风格特点，设计具有视觉冲击力的构图方案，你的生成图片提示词里必须含有此风格。
+            - 运用比喻、象征等手法将抽象概念转化为具象图形元素。
+            - 确保整体设计保持简洁性，同时突出关键信息点。
+            - 分析目标受众审美偏好，调整色彩搭配和线条粗细，生成播客封面提示词
+        enableChatHistoryV2:
+          isEnabled: false
+          rounds: 1
+        auditing: default
+        llmId: 110
+        url: wss://spark-api.xf-yun.com/v4.0/chat
+        uid: '16575185574'
+        patchId: '0'
+        templateErrMsg: ''
+        domain: 4.0Ultra
+        appId: YOUR_APP_ID
+        maxTokens: 2048
+        temperature: 0.5
+        systemTemplate: |-
+          ## 角色
+          你是一个AI播客生成助手，兼具主题提炼师和AI绘画师的角色。能够精准地从文章内容中提炼出核心要点，依据其生成与主题相符的AI绘画提示词，助力打造富有创意和视觉吸引力的播客内容。
+
+          ## 技能
+          1. 主题提炼：
+            - 深入分析输入的文章内容，理解其主旨、关键信息和逻辑结构。
+            - 准确识别文章的核心观点、重要细节以及潜在的延伸方向。
+            - 以简洁明了的方式概括出文章的主题，为后续的播客创作提供清晰的方向。
+          2. AI绘画提示词生成：
+            - 根据提炼出的文章主题，结合相关的艺术风格、元素和表现手法，构思合适的AI绘画提示词。
+            - 确保生成的提示词能够准确地传达主题的核心概念，同时具有足够的想象力和独特性，以激发AI绘画工具创作出高质量的艺术作品。
+            - 对生成的提示词进行反复优化和调整，使其更加符合用户的期望和要求。
+
+          ## 限制
+          - 只专注于根据给定的文章内容进行AI绘画提示词生成，不涉及其他无关的创作任务，输出内容里不要输出主题情感关键词等，只输出一段用于生成图片的AI绘画提示词。
+          - 所有的输出内容必须紧密围绕输入文章的主题展开，不得偏离或随意扩展。
+          - 生成的AI绘画提示词应具有一定的合理性和可操作性，避免过于抽象或难以实现的描述。
+          ```
+        model: spark
+        serviceId: bm4
+        respFormat: 0
+        llmIdErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/largeModelIcon.png
+      description: 根据输入的提示词，调用选定的大模型，对提示词作出回答
+      updatable: false
+  - id: message::72662c05-2647-4493-98ea-e1d83c486206
+    dragging: false
+    selected: false
+    width: 362
+    height: 116
+    position:
+      x: 1277.4908023044907
+      y: -1895.390644688282
+    positionAbsolute:
+      x: 1277.4908023044907
+      y: -1895.390644688282
+    type: 消息
+    data:
+      allowInputReference: true
+      allowOutputReference: false
+      label: 消息_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 消息
+        nodeType: 基础节点
+      inputs:
+      - id: 41315822-3ad7-4b0d-a379-ad77bd441751
+        name: content
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 828a7629-3638-419b-b41d-6488c095d877
+              nodeId: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+            contentErrMsg: ''
+        fileType: ''
+      outputs: [
+        ]
+      nodeParam:
+        template: |-
+          电台播客稿件已完成,详情如下：
+          {{content}}
+          ------------
+          已完成内容生成，正在进入合成语音阶段，需时预计3分钟，请耐心等待。
+        streamOutput: true
+        uid: '16575185574'
+        templateErrMsg: ''
+        appId: YOUR_APP_ID
+        startFrameEnabled: false
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/message-node-icon.png
+      description: 在工作流中可以对中间过程的产物进行输出
+      updatable: false
+  edges:
+  - source: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    target: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+    type: customEdge
+    id: reactflow__edge-spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba-plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+    target: node-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0a
+    targetHandle: node-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0a
+    type: customEdge
+    id: reactflow__edge-plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec-node-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0anode-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0a
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12
+    target: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+    type: customEdge
+    id: reactflow__edge-node-start::bb83bdc5-7b01-44ac-9a2c-ad97a95aad12-ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f
+    target: if-else::0a38a0da-f662-4039-9aed-658595885613
+    type: customEdge
+    id: reactflow__edge-ifly-code::f1c220b9-b3ae-4fbf-aab9-8034fa65c68f-if-else::0a38a0da-f662-4039-9aed-658595885613
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: if-else::0a38a0da-f662-4039-9aed-658595885613
+    sourceHandle: branch_one_of::2192a758-4498-4294-9e49-57f4e083c187
+    target: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+    type: customEdge
+    id: reactflow__edge-if-else::0a38a0da-f662-4039-9aed-658595885613branch_one_of::2192a758-4498-4294-9e49-57f4e083c187-plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: if-else::0a38a0da-f662-4039-9aed-658595885613
+    sourceHandle: branch_one_of::a0a0cfd9-41da-4c56-be33-7fc22016bda9
+    target: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    type: customEdge
+    id: reactflow__edge-if-else::0a38a0da-f662-4039-9aed-658595885613branch_one_of::a0a0cfd9-41da-4c56-be33-7fc22016bda9-spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7
+    target: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    type: customEdge
+    id: reactflow__edge-plugin::08a9d252-71a0-4b5f-b681-01c6f77e75d7-spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    markerEnd:
+      color: '#275EFF'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: plugin::3641af94-104f-4b68-9b4d-2fa1c198bf92
+    sourceHandle: normal_one_of::29d33d23-77c1-4706-8e97-cfc885e0b2ab
+    target: node-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0a
+    type: customEdge
+    id: reactflow__edge-plugin::3641af94-104f-4b68-9b4d-2fa1c198bf92normal_one_of::29d33d23-77c1-4706-8e97-cfc885e0b2ab-node-end::bf6a1cdd-a6a4-448a-8f3b-e3f291ab2a0a
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    target: spark-llm::42017659-eba1-4c0e-8717-2c66ca14584c
+    type: customEdge
+    id: reactflow__edge-spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba-spark-llm::42017659-eba1-4c0e-8717-2c66ca14584c
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: spark-llm::42017659-eba1-4c0e-8717-2c66ca14584c
+    target: plugin::3641af94-104f-4b68-9b4d-2fa1c198bf92
+    type: customEdge
+    id: reactflow__edge-spark-llm::42017659-eba1-4c0e-8717-2c66ca14584c-plugin::3641af94-104f-4b68-9b4d-2fa1c198bf92
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba
+    target: message::72662c05-2647-4493-98ea-e1d83c486206
+    type: customEdge
+    id: reactflow__edge-spark-llm::5e38f84e-5bac-45b7-a117-8758076cd2ba-message::72662c05-2647-4493-98ea-e1d83c486206
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: message::72662c05-2647-4493-98ea-e1d83c486206
+    target: plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+    type: customEdge
+    id: reactflow__edge-message::72662c05-2647-4493-98ea-e1d83c486206-plugin::6557df0c-97fb-4353-9a45-2ff0457b72ec
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve

--- a/examples/english-essay-corrector/README.md
+++ b/examples/english-essay-corrector/README.md
@@ -1,0 +1,38 @@
+---
+id: english-essay-corrector
+title: English Essay Corrector
+description: Reviews an English essay and returns corrections, scoring, and rewrite suggestions.
+category: learning
+features:
+  - Checks grammar, spelling, and word choice
+  - Gives an overall score with reasoning
+  - Suggests concrete rewrites
+author: iflytek
+sourceUrl: https://github.com/FenjuFu/Awesome-Astron-Workflow
+dslVersion: v1
+event: ""
+---
+
+# English Essay Corrector
+
+Paste an English essay and get back corrections, a score, and rewrite suggestions — a compact,
+single-LLM workflow that's a good starting point for any "review-and-grade" use case.
+
+## How it works
+
+**start → LLM → output.** The LLM is prompted as an English writing examiner; the input essay is
+passed straight through and the model returns structured feedback.
+
+## Dependencies
+
+- **Models**: a Spark chat model (credentials scrubbed)
+- **Plugins / skills**: none
+- **Knowledge bases**: none
+
+## Import & run
+
+1. In Astron Agent: create a workflow → **Import** → choose `workflow.yml`.
+2. Replace the `YOUR_APP_ID` placeholder with your own Spark credentials.
+3. Run it with an essay as input.
+
+> Credentials in the exported DSL were replaced with placeholders before publishing.

--- a/examples/english-essay-corrector/workflow.yml
+++ b/examples/english-essay-corrector/workflow.yml
@@ -1,0 +1,202 @@
+flowMeta:
+  name: 英语作文批改助手
+  description: 英语作文批改助手
+  avatarIcon: https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/emojiitem_00_10@2x.png
+  avatarColor: '#FFEAD5'
+  advancedConfig: '{"prologue":{"enabled":true,"inputExample":["","",""]},"textToSpeech":{"enabled":true,"vcn_cn":"aisjiuxu","vcn_en":""}}'
+  category: 13
+  dslVersion: v1
+flowData:
+  nodes:
+  - id: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+    dragging: false
+    selected: false
+    width: 361
+    height: 89
+    position:
+      x: -83.10901960784315
+      y: 369.70866666666666
+    positionAbsolute:
+      x: -83.10901960784315
+      y: 369.70866666666666
+    type: custom
+    data:
+      allowInputReference: false
+      allowOutputReference: true
+      label: 开始
+      status: ''
+      nodeMeta:
+        aliasName: 开始节点
+        nodeType: 基础节点
+      inputs: [
+        ]
+      outputs:
+      - id: 0918514b-72a8-4646-8dd9-ff4a8fc26d44
+        name: AGENT_USER_INPUT
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: 用户本轮对话输入内容
+        required: true
+        deleteDisabled: true
+      nodeParam: {
+        }
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/start-node-icon.png
+      description: 工作流的开启节点，用于定义流程调用所需的业务变量信息。
+      updatable: false
+  - id: node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    dragging: false
+    selected: true
+    width: 361
+    height: 129
+    position:
+      x: 886.8833333333332
+      y: 343.91588235294114
+    positionAbsolute:
+      x: 886.8833333333332
+      y: 343.91588235294114
+    type: custom
+    data:
+      allowInputReference: true
+      allowOutputReference: false
+      label: 结束
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 结束节点
+        nodeType: 基础节点
+      inputs:
+      - id: 82de2b42-a059-4c98-bffb-b6b4800fcac9
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              id: aa02732f-6026-4219-a60c-cc4e0708ef22
+              nodeId: spark-llm::39a4a107-44fd-4eb9-93e3-320511ec65e2
+              name: output
+            contentErrMsg: ''
+        fileType: ''
+      outputs: [
+        ]
+      nodeParam:
+        template: |+
+          {{output}}
+
+
+        streamOutput: true
+        outputMode: 1
+        templateErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/end-node-icon.png
+      description: 工作流的结束节点，用于输出工作流运行后的最终结果。
+      updatable: false
+  - id: spark-llm::39a4a107-44fd-4eb9-93e3-320511ec65e2
+    dragging: false
+    selected: false
+    width: 361
+    height: 147
+    position:
+      x: 418.5104064941406
+      y: 346
+    positionAbsolute:
+      x: 418.5104064941406
+      y: 346
+    type: custom
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 大模型_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        nodeType: 基础节点
+        aliasName: 大模型
+      inputs:
+      - id: e859745e-edce-44aa-8ea5-1b23ae0b4e14
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              id: 0918514b-72a8-4646-8dd9-ff4a8fc26d44
+              nodeId: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+              name: AGENT_USER_INPUT
+            contentErrMsg: ''
+        fileType: ''
+      outputs:
+      - id: aa02732f-6026-4219-a60c-cc4e0708ef22
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        maxTokens: 2048
+        topK: 4
+        auditing: default
+        template: |+
+          以下是学生的作文内容，请帮我批改并给出建议：
+
+          {{input}}
+
+
+        respFormat: 0
+        appId: YOUR_APP_ID
+        uid: ab896e82-2ab7-42a4-8d14-570386b3e904
+        enableChatHistoryV2:
+          isEnabled: false
+          rounds: 1
+        templateErrMsg: ''
+        llmId: 454665064
+        domain: xminimaxm2
+        serviceId: xminimaxm2
+        url: https://maas-api.cn-huabei-1.xf-yun.com/v1/chat/completions
+        modelId: 3
+        isThink: false
+        multiMode: false
+        modelName: m2
+        modelEnabled: true
+        llmIdErrMsg: ''
+        source: openai
+        extraParams:
+          temperature: 1
+        systemTemplate: |+
+          你是一位专业的英语写作批改教师，擅长中学与大学英语作文的评分与反馈。
+          请根据用户提供的作文内容，进行以下任务：
+          1. 先给出作文总体评价（结构、语法、词汇、逻辑）。
+          2. 标出存在的主要语法错误或表达问题，并提出修改建议。
+          3. 给出改进后的范例句或段落。
+          4. 最后按照雅思或CEFR标准（任选其一）估计作文等级。
+
+          请输出格式清晰、有条理。
+
+
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/largeModelIcon.png
+      description: 根据输入的提示词，调用选定的大模型，对提示词作出回答
+      updatable: false
+  edges:
+  - source: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+    target: spark-llm::39a4a107-44fd-4eb9-93e3-320511ec65e2
+    type: customEdge
+    id: reactflow__edge-node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783-spark-llm::39a4a107-44fd-4eb9-93e3-320511ec65e2
+    markerEnd:
+      type: arrow
+      color: '#6356EA'
+    data:
+      edgeType: curve
+  - source: spark-llm::39a4a107-44fd-4eb9-93e3-320511ec65e2
+    target: node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    type: customEdge
+    id: reactflow__edge-spark-llm::39a4a107-44fd-4eb9-93e3-320511ec65e2-node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    markerEnd:
+      type: arrow
+      color: '#6356EA'
+    data:
+      edgeType: curve

--- a/examples/history-knowledge-qa/README.md
+++ b/examples/history-knowledge-qa/README.md
@@ -1,0 +1,38 @@
+---
+id: history-knowledge-qa
+title: History Knowledge Q&A Assistant
+description: A personal history advisor that answers questions about world events, cultural evolution, and key historical figures.
+category: learning
+features:
+  - Answers open-ended questions across global history
+  - Covers ancient civilizations through modern turning points
+  - Ships with example prompts and a guided prologue
+author: iflytek
+sourceUrl: https://github.com/FenjuFu/Awesome-Astron-Workflow
+dslVersion: v1
+event: ""
+---
+
+# History Knowledge Q&A Assistant
+
+A conversational agent that acts as a personal history advisor — ask it about historical events,
+cultural change, or notable figures and it returns accurate, sourced answers.
+
+## How it works
+
+A single-turn chat workflow: **start → LLM** with a history-tutor system prompt and a curated set of
+example questions (a guided prologue). No external knowledge base is required.
+
+## Dependencies
+
+- **Models**: a Spark chat model (credentials scrubbed — see below)
+- **Plugins / skills**: none
+- **Knowledge bases**: none
+
+## Import & run
+
+1. In Astron Agent: create a workflow → **Import** → choose `workflow.yml`.
+2. Replace the `YOUR_APP_ID` placeholders with your own Spark credentials.
+3. Run it.
+
+> Credentials in the exported DSL were replaced with `YOUR_APP_ID` placeholders before publishing.

--- a/examples/history-knowledge-qa/workflow.yml
+++ b/examples/history-knowledge-qa/workflow.yml
@@ -1,0 +1,744 @@
+flowMeta:
+  name: 历史知识问答小助理
+  description: “历史知识问答”智能体是您的私人历史顾问，专业涵盖全球历史事件、文化演变和重要人物。无论您对古代文明的奥秘还是现代历史的转折点感兴趣，它都能提供准确信息，解答您的每一个疑问。
+  avatarIcon: https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/emojiitem_00_14@2x.png
+  avatarColor: '#FFEAD5'
+  advancedConfig: '{"textToSpeech":{"vcn_en":"x4_EnUs_Luna","enable":true,"vcnEmotion":"","vcn_cn":"x4_lingxiaoli_oral"},"needGuide":false,"prologue":{"enabled":true,"inputExample":["我想知道李白的生平？","为什么会有“安史之乱”？","山顶洞人是怎么生活的？"],"prologueText":"你好，我是“历史知识问答”智能体，您的私人历史顾问，专业涵盖全球历史事件、文化演变和重要人物。无论您对古代文明的奥秘还是现代历史的转折点感兴趣，我都能提供准确信息，解答您的每一个疑问，很高兴认识你。"},"chatBackground":{"enabled":false},"suggestedQuestionsAfterAnswer":{"enabled":false}}'
+  category: 10
+  dslVersion: v1
+flowData:
+  nodes:
+  - id: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+    dragging: false
+    selected: false
+    width: 362
+    height: 116
+    position:
+      x: 1039.743191955861
+      y: -478.89660972756934
+    positionAbsolute:
+      x: 1039.743191955861
+      y: -478.89660972756934
+    type: 开始节点
+    data:
+      allowInputReference: false
+      allowOutputReference: true
+      label: 开始
+      status: ''
+      nodeMeta:
+        aliasName: 开始节点
+        nodeType: 基础节点
+      inputs: [
+        ]
+      outputs:
+      - id: 0918514b-72a8-4646-8dd9-ff4a8fc26d44
+        name: AGENT_USER_INPUT
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: 用户本轮对话输入内容
+        required: true
+        deleteDisabled: true
+      nodeParam: {
+        }
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/start-node-icon.png
+      description: 工作流的开启节点，用于定义流程调用所需的业务变量信息。
+      updatable: false
+  - id: node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    dragging: false
+    selected: false
+    width: 362
+    height: 116
+    position:
+      x: 3097.6737316601316
+      y: 162.08753003135402
+    positionAbsolute:
+      x: 3097.6737316601316
+      y: 162.08753003135402
+    type: 结束节点
+    data:
+      allowInputReference: true
+      allowOutputReference: false
+      label: 结束
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 结束节点
+        nodeType: 基础节点
+      inputs:
+      - id: 82de2b42-a059-4c98-bffb-b6b4800fcac9
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 10946470-9754-49b4-9a29-e80bb4f11fd3
+              nodeId: spark-llm::6206a73a-cfa9-49a0-9804-0b63a7df1f26
+            contentErrMsg: ''
+        fileType: ''
+      outputs: [
+        ]
+      nodeParam:
+        template: '{{output}}'
+        streamOutput: true
+        templateErrMsg: ''
+        outputMode: 1
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/end-node-icon.png
+      description: 工作流的结束节点，用于输出工作流运行后的最终结果。
+      updatable: false
+  - id: spark-llm::5a0d2719-7ba0-468c-a3eb-dad026e765cb
+    dragging: false
+    selected: false
+    width: 362
+    height: 124
+    position:
+      x: 2063.7628643329326
+      y: 0
+    positionAbsolute:
+      x: 971.0146533559237
+      y: 62.41299361743364
+    type: 大模型
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 信息处理
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 大模型
+        nodeType: 基础节点
+      inputs:
+      - id: 48745e3a-dc79-457d-8062-a2eac8279a63
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: array-object
+          value:
+            type: ref
+            content:
+              name: result
+              id: c7da8eb6-3629-422e-84d6-2d41d5064da2
+              nodeId: plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+            contentErrMsg: ''
+        fileType: ''
+      outputs:
+      - id: 66f91f50-b57c-4d27-87c9-c6785c3d000d
+        name: REASONING_CONTENT
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: 模型思考过程
+        customParameterType: deepseekr1
+      - id: 616a66eb-b302-4631-ab99-cff574c22cb3
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        topK: 4
+        template: 接下来我的输入是包含了联网搜索的结果：{{input}}
+        modelId: 219
+        enableChatHistoryV2:
+          isEnabled: false
+          rounds: 1
+        auditing: default
+        llmId: 219
+        url: wss://spark-api.xf-yun.com/v1/x1
+        multiMode: false
+        uid: '18828012125'
+        modelName: Spark X1
+        patchId: '0'
+        isThink: true
+        templateErrMsg: ''
+        domain: x1
+        appId: YOUR_APP_ID
+        maxTokens: 2048
+        temperature: 0.5
+        systemTemplate: |-
+          你是一名专业严谨、通俗易懂、亲和力强的历史知识问答数字人助手，专注于中国史与世界史领域，具备扎实的正史典籍、学术专著、考古报告支撑的史料功底，核心目标是精准解答用户各类历史问题，输出内容兼顾准确性、趣味性、实用性，同时完全适配数字人语音交互的口语化表达习惯。
+
+          请严格遵循以下规则执行问答任务：
+          1.  准确性优先原则
+              - 所有知识点必须基于权威史料，拒绝野史传闻和未经证实的猜测；涉及历史争议点时，需明确说明“学界目前存在XX种主流观点，分别是……”，不主观站队。
+              - 时间、地点、人物、事件因果关系必须精准，严禁张冠李戴（如区分不同朝代同名人物、相似历史事件的差异）。
+          2.  分层级灵活解答
+              - 基础问题（如“秦始皇生卒年”“法国大革命爆发时间”）：直接给出简洁答案，不冗余扩展。
+              - 深度问题（如“安史之乱的影响”“罗斯福新政的历史意义”）：先讲核心结论，再分点梳理原因、过程、影响，逻辑链条清晰。
+              - 拓展问题（如“明朝历史入门书籍推荐”“中西封建社会异同对比”）：结合需求给出具体建议，推荐内容需标注权威性。
+          3.  口语化适配数字人语音
+              - 拒绝复杂长句、生僻术语；若必须使用专业术语，需当场用通俗语言解释。
+              - 句式简短明快，适当加入过渡语（如“这里要补充一点”“值得注意的是”）增强对话感；避免密集使用分号、破折号等书面化标点。
+              - 关键信息（如时间、人物名、事件转折点）需在语音表达逻辑中适当放慢语速或加重语气。
+          4.  智能交互引导规则
+              - 用户提问模糊时（如“讲一下唐朝历史”），主动拆解需求引导细化：“唐朝历史跨度近三百年，你想了解它的政治制度、文化发展，还是著名人物和事件呢？”
+              - 回答完毕后，可追加1个关联问题供用户选择：“你还想了解和这个事件相关的XX内容吗？”
+              - 适配不同用户群体：面对青少年，语言活泼多穿插历史小故事；面对成人/专业用户，可适当引用史料依据，满足深度探究需求。
+          5.  语气与态度把控
+              - 整体语气温和耐心，避免说教感；涉及战争、灾难等沉重历史事件时，保持严肃尊重，不调侃。
+          6.  禁忌与边界处理
+              - 严禁输出违背历史事实、历史虚无主义的言论，以及涉及民族、宗教敏感的不当表述，不极端片面评价历史人物。
+              - 遇到非历史范畴问题（如现代科技、娱乐八卦），礼貌回应：“这个问题不属于历史知识范畴，我暂时无法解答哦~”
+              - 遇到无法准确回答的问题，如实说明：“关于这个问题的准确史料我还需要进一步查证，暂时不能给你确定的答案呢。”
+        model: spark
+        modelEnabled: true
+        serviceId: x1
+        respFormat: 0
+        llmIdErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/largeModelIcon.png
+      description: 根据输入的提示词，调用选定的大模型，对提示词作出回答
+      updatable: false
+  - id: plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+    dragging: false
+    selected: false
+    width: 362
+    height: 100
+    position:
+      x: 1548.987803105876
+      y: 0.3468365419005579
+    positionAbsolute:
+      x: 1548.987803105876
+      y: 0.3468365419005579
+    type: 工具
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 联网搜索_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 工具
+        nodeType: 工具
+      inputs:
+      - id: cc1f4b06-778f-4713-8771-0c553e98f78d
+        name: name
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: AGENT_USER_INPUT
+              id: 0918514b-72a8-4646-8dd9-ff4a8fc26d44
+              nodeId: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+            contentErrMsg: ''
+        description: 需要搜索的问题
+        required: true
+        disabled: false
+      outputs:
+      - id: 1758f863-19fb-48a2-8878-7860aa314211
+        name: msg
+        schema:
+          type: string
+      - id: c7da8eb6-3629-422e-84d6-2d41d5064da2
+        name: result
+        schema:
+          type: array-object
+          properties:
+          - id: 6889bad9-3055-4f73-b6a9-7002b55e5c01
+            name: summary
+            type: string
+          - id: 9035b42e-d825-4263-a3f6-8528a1fa28c9
+            name: img
+            type: string
+          - id: e53d48df-d96e-4297-8437-26fdf6216a86
+            name: domain
+            type: string
+          - id: b10e3026-a6c8-4c66-9d7b-5b45f8746e1a
+            name: name
+            type: string
+          - id: 91a0b750-a76e-4ea3-9a67-073f4e04182b
+            name: is_high_summary
+            type: boolean
+          - id: abe71f0e-67cc-488d-a114-6612ef3ddb61
+            name: siteName
+            type: string
+          - id: 7f9f764e-97f0-4b8e-98bc-4a4a12c315fd
+            name: source
+            type: string
+          - id: 761a52fe-70da-4ccf-b3b3-e75855621c7b
+            name: type
+            type: string
+          - id: 9ba4e0bf-1e78-4eef-821d-35bfc24c186c
+            name: url
+            type: string
+      - id: b74916fc-c134-495f-b858-c47b6978d245
+        name: rc
+        schema:
+          type: string
+      - id: 250d1be6-6d43-43de-b824-7bce148408bf
+        name: semantic
+        schema:
+          type: array-string
+          properties: [
+            ]
+      - id: 37e983ec-8e06-45ce-a875-647ec66f66f1
+        name: total
+        schema:
+          type: string
+      - id: a3bb943c-d4d6-4ffe-8b07-e6094a086767
+        name: offset
+        schema:
+          type: string
+      - id: 94cf8dce-5166-4d35-b98c-013bd0f2c8d9
+        name: limit
+        schema:
+          type: string
+      - id: 50ed486f-6d40-45a8-8c66-941852f66415
+        name: sid
+        schema:
+          type: string
+      nodeParam:
+        uid: '18828012125'
+        code: ''
+        toolDescription: 使用网络搜索公开信息
+        pluginId: tool@665b86a9b821000
+        appId: YOUR_APP_ID
+        operationId: 聚合搜索-hL0CqmNi
+        version: V1.0
+        businessInput: [
+          ]
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/tool-icon.png
+      updatable: false
+      isLatest: true
+  - id: spark-llm::6206a73a-cfa9-49a0-9804-0b63a7df1f26
+    dragging: false
+    selected: false
+    width: 362
+    height: 124
+    position:
+      x: 2579.7035569411055
+      y: 0
+    positionAbsolute:
+      x: 1409.8614253631365
+      y: 56.76406790123829
+    type: 大模型
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 角色扮演
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 大模型
+        nodeType: 基础节点
+      inputs:
+      - id: fb5fa79b-0779-4ca7-8090-24ada0a8f8c7
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: output
+              id: 616a66eb-b302-4631-ab99-cff574c22cb3
+              nodeId: spark-llm::5a0d2719-7ba0-468c-a3eb-dad026e765cb
+            contentErrMsg: ''
+        fileType: ''
+      outputs:
+      - id: 10946470-9754-49b4-9a29-e80bb4f11fd3
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        topK: 4
+        template: |
+          已经经过预处理的文本信息是{{input}}，你需要根据你的角色设定和我的文本生成合适的面向用户的回答文本，严格控制在400字左右，上下浮动不超过30字。
+        modelId: 140
+        enableChatHistoryV2:
+          isEnabled: false
+          rounds: 1
+        auditing: default
+        llmId: 140
+        url: wss://maas-api.cn-huabei-1.xf-yun.com/v1.1/chat
+        multiMode: false
+        uid: '18828012125'
+        modelName: Spark Character
+        patchId: '0'
+        isThink: false
+        templateErrMsg: ''
+        domain: xaipersonality
+        appId: YOUR_APP_ID
+        maxTokens: 2048
+        temperature: 0.5
+        systemTemplate: |-
+          你需全程精准扮演【历史知识问答数字人助手】，身份设定为：深耕中国史与世界史领域，具备权威史料（正史典籍、学术专著、考古报告）支撑的专业功底，同时拥有亲和易懂、自然流畅的数字人交互特质，核心使命是通过语音友好的对话方式，为用户解答各类历史问题。
+          扮演核心要求：
+          身份认知：时刻明确自身 “数字人助手” 属性，对话中不偏离历史领域定位，不产生身份混淆（如不说 “我是大模型”“我能生成其他内容” 等脱离角色的表述）。
+          语气风格：全程保持温和耐心的语气质感，无说教感；面对青少年用户时语言活泼，多穿插简短历史小故事；面对成人 / 专业用户时可适度深化表述，引用权威史料依据；涉及战争、灾难等沉重历史事件时，切换为严肃尊重的语气，杜绝调侃。
+          行为逻辑：以 “解答历史问题 + 适配数字人语音交互” 为核心行为导向 —— 用户提问模糊时主动引导细化需求，回答完毕后追加 1 个关联问题供选择；表述时优先使用短句，避免生僻术语（必用则当场通俗解释），关键历史信息（时间、人物、事件转折点）需隐含 “放慢语速 / 加重语气” 的语音表达逻辑，适当用 “这里要补充一点” 等过渡语增强对话感。
+          专业底线：所有回答必须基于权威史实，拒绝野史与无根据猜测；涉及历史争议点时，客观列明主流观点不主观站队；严禁输出历史虚无主义、民族 / 宗教敏感表述及极端片面的历史评价；非历史范畴问题或无法准确解答的问题，礼貌如实回应，不强行作答。
+          请以该角色身份，与用户展开自然的历史知识对话交互，全程不脱离设定。
+        model: spark
+        modelEnabled: true
+        serviceId: xaipersonality
+        respFormat: 0
+        llmIdErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/largeModelIcon.png
+      description: 根据输入的提示词，调用选定的大模型，对提示词作出回答
+      updatable: false
+  - id: mcp::d126e0fc-cee4-4692-b921-8cb100eefb50
+    dragging: false
+    selected: false
+    width: 362
+    height: 142
+    position:
+      x: 1033.4810258238708
+      y: -230.7985678086595
+    positionAbsolute:
+      x: 1033.4810258238708
+      y: -230.7985678086595
+    type: MCP
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 文本合规_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: MCP
+        nodeType: 工具节点
+      inputs:
+      - id: ad3b9950-00d6-45bf-95af-fdeec602839c
+        name: is_match_all
+        nameErrMsg: ''
+        schema:
+          type: integer
+          value:
+            type: literal
+            content: '1'
+            contentErrMsg: ''
+        description: 是否全匹配： 1 代表是 0 代表否 默认取值0，匹配到敏感词则不再匹配，不会返回所有敏感分类。
+        required: false
+      - id: 1698fed5-c75c-4204-a0d0-2b491101c7b9
+        name: categories
+        nameErrMsg: ''
+        schema:
+          type: array
+          value:
+            type: literal
+            content: '["pornDetection","violentTerrorism","political","contraband","uncivilizedLanguage"]'
+            contentErrMsg: ''
+        description: 指定检测的敏感分类： pornDetection 色情 violentTerrorism 暴恐 political 涉政
+          lowQualityIrrigation 低质量灌水 contraband 违禁 advertisement 广告 uncivilizedLanguage
+          不文明用语
+        required: false
+      - id: 30f905ac-196c-4870-a84d-72dd5097d20c
+        name: content
+        nameErrMsg: ''
+        schema:
+          type: string
+          value:
+            type: ref
+            content:
+              name: AGENT_USER_INPUT
+              id: 0918514b-72a8-4646-8dd9-ff4a8fc26d44
+              nodeId: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+            contentErrMsg: ''
+        description: 待识别文本，文本长度最大支持 5 千字符
+        required: true
+      outputs:
+      - id: c3751e9f-b9c2-4781-ba04-13c9a0767dc2
+        name: result
+        nameErrMsg: ''
+        schema:
+          type: object
+          properties:
+          - id: d6139baf-1e21-4138-9f69-30134a3b9ba8
+            name: isError
+            required: false
+            type: boolean
+            properties: [
+              ]
+            default: ''
+          - id: 6af38267-17fe-4e77-a064-1f345035e75a
+            name: content
+            required: false
+            type: array-object
+            default: ''
+          default: ''
+        required: false
+      nodeParam:
+        toolDescription: 基于业界先进的语义模型和海量的多语种样本库，有效识别各类场景中涉政、违禁、色情、暴恐、辱骂、广告导流等风险文本内容，支持风险标签识别
+        mcpServerId: mcp@api92760f0da421000
+        toolName: 文本合规
+      icon: https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/mcp-new.png
+      updatable: false
+  - id: decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    dragging: false
+    selected: false
+    width: 362
+    height: 214
+    position:
+      x: 1031.881385216346
+      y: 33.924900935246384
+    positionAbsolute:
+      x: 105.1349433387951
+      y: 124.17614596295786
+    type: 决策
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 决策_1
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 决策
+        nodeType: 基础节点
+      inputs:
+      - id: 7a6a35a3-c71c-478c-a4f8-08fa1f634402
+        name: Query
+        nameErrMsg: ''
+        schema:
+          type: object
+          value:
+            type: ref
+            content:
+              name: result
+              id: c3751e9f-b9c2-4781-ba04-13c9a0767dc2
+              nodeId: mcp::d126e0fc-cee4-4692-b921-8cb100eefb50
+            contentErrMsg: ''
+        fileType: ''
+      outputs:
+      - id: 02209257-596e-4d05-86e4-27fd37249b19
+        name: class_name
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        topK: 4
+        enableChatHistoryV2:
+          isEnabled: false
+          rounds: 1
+        reasonMode: 1
+        handlingEdge: normal_one_of::040796b6-a7ac-4bd3-867d-28a1d0534d4e
+        auditing: default
+        llmId: 110
+        exceptionHandlingEdge: fail_one_of::ec40b479-6601-4023-a28e-8ed252a5052c
+        promptPrefix: ''
+        url: wss://spark-api.xf-yun.com/v4.0/chat
+        uid: '18828012125'
+        patchId: '0'
+        intentChains:
+        - intentType: 2
+          name: 合规检测通过
+          description: 安全合规检测结果值为false
+          id: intent-one-of::bac84c4b-a1c5-416c-b1fc-87f6bb8b7654
+          nameErrMsg: ''
+          descriptionErrMsg: ''
+        - intentType: 1
+          name: default
+          description: 默认意图
+          id: intent-one-of::c0ebed3a-1b20-4a53-b5bf-22015e43903f
+          nameErrMsg: ''
+          descriptionErrMsg: ''
+        domain: 4.0Ultra
+        appId: YOUR_APP_ID
+        maxTokens: 2048
+        temperature: 0.5
+        model: spark
+        useFunctionCall: true
+        serviceId: bm4
+        llmIdErrMsg: ''
+      retryConfig:
+        shouldRetry: false
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/designMakeIcon.png
+      description: 结合输入的参数与填写的意图，决定后续的逻辑走向
+      updatable: false
+  - id: spark-llm::5473efa2-2d27-4989-86f4-e045c0f9d0e9
+    dragging: false
+    selected: false
+    width: 362
+    height: 166
+    position:
+      x: 1714.4331486006338
+      y: 234.57091438179458
+    positionAbsolute:
+      x: 1714.4331486006338
+      y: 234.57091438179458
+    type: 大模型
+    data:
+      allowInputReference: true
+      allowOutputReference: true
+      label: 兜底大模型
+      labelEdit: false
+      references: [
+        ]
+      status: ''
+      nodeMeta:
+        aliasName: 大模型
+        nodeType: 基础节点
+      inputs:
+      - id: f814d028-1540-4bff-8da1-17257f317398
+        name: input
+        nameErrMsg: ''
+        schema:
+          type: array-object
+          value:
+            type: ref
+            content:
+              name: result.content
+              id: 6af38267-17fe-4e77-a064-1f345035e75a
+              nodeId: mcp::d126e0fc-cee4-4692-b921-8cb100eefb50
+            contentErrMsg: ''
+        fileType: ''
+      outputs:
+      - id: 55e4a9db-38d8-4dc4-a4d6-1f54e6f80458
+        name: output
+        nameErrMsg: ''
+        schema:
+          type: string
+          default: ''
+      nodeParam:
+        topK: 4
+        template: '{{input}}'
+        enableChatHistoryV2:
+          isEnabled: false
+          rounds: 1
+        auditing: default
+        llmId: 110
+        url: wss://spark-api.xf-yun.com/v4.0/chat
+        uid: '18828012125'
+        patchId: '0'
+        templateErrMsg: ''
+        domain: 4.0Ultra
+        appId: YOUR_APP_ID
+        maxTokens: 2048
+        temperature: 0.5
+        systemTemplate: |-
+          你作为历史知识问答数字人助手，在所有交互中必须将安全合规作为不可逾越的底线，严格执行以下全流程合规处理规则，同时保持数字人交互的自然与亲和：
+          一、 史实与价值观合规（核心红线）
+          坚决抵制历史虚无主义，所有回答必须基于权威史料，严禁歪曲、否定历史事件与历史人物，严禁编造虚假历史信息、传播野史当作正史。
+          客观中立评价历史，不得对历史人物、事件进行极端片面的定性；涉及民族、朝代、疆域等敏感历史内容时，必须符合国家主流历史定论，尊重各民族历史与文化，严禁出现民族歧视、分裂相关表述。
+          对历史争议点，仅客观列明学界主流观点并注明依据，不主观站队，不传播非主流且有争议的极端言论。
+          二、 内容边界与敏感信息管控
+          严禁输出任何违反法律法规、公序良俗的内容，包括但不限于宗教极端思想、暴力恐怖信息、仇恨言论、色情低俗内容等。
+          明确知识边界：仅聚焦历史知识领域，对涉及现代政治、军事机密、个人隐私、宗教传教、商业广告等非历史范畴的问题，礼貌拒绝，不越界作答。
+          审慎处理近代史、战争史、灾难史等内容，保持严肃尊重，不调侃、不娱乐化；对可能引发情绪争议的内容，优先强调客观史实与和平理念。
+          三、 交互过程合规与兜底处理
+          保护用户隐私：不主动询问用户姓名、年龄、住址、联系方式等隐私信息；若用户主动提供，仅礼貌回应，不存储、不传播。
+          合规自查与纠错：每一次回答后，快速校验是否触碰合规红线；若发现表述不当，立即主动纠正并致歉。
+          兜底话术规范：
+          非历史问题：“这个问题不属于历史知识范畴，为了保证回答的专业性，我暂时无法解答哦～”
+          敏感 / 违规问题：“这个问题涉及敏感内容，我不能为你提供相关解答，请理解。”
+          无法准确解答的问题：“关于这个问题的准确史料我还需要进一步查证，暂时不能给你确定的答案呢。”
+        model: spark
+        serviceId: bm4
+        respFormat: 0
+        llmIdErrMsg: ''
+      icon: https://oss-beijing-m8.openstorage.cn/pro-bucket/sparkBot/common/workflow/icon/largeModelIcon.png
+      description: 根据输入的提示词，调用选定的大模型，对提示词作出回答
+      updatable: false
+  edges:
+  - source: plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+    target: spark-llm::5a0d2719-7ba0-468c-a3eb-dad026e765cb
+    type: customEdge
+    id: reactflow__edge-plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f-spark-llm::5a0d2719-7ba0-468c-a3eb-dad026e765cb
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: spark-llm::5a0d2719-7ba0-468c-a3eb-dad026e765cb
+    target: spark-llm::6206a73a-cfa9-49a0-9804-0b63a7df1f26
+    type: customEdge
+    id: reactflow__edge-spark-llm::5a0d2719-7ba0-468c-a3eb-dad026e765cb-spark-llm::6206a73a-cfa9-49a0-9804-0b63a7df1f26
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: spark-llm::6206a73a-cfa9-49a0-9804-0b63a7df1f26
+    target: node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    type: customEdge
+    id: reactflow__edge-spark-llm::6206a73a-cfa9-49a0-9804-0b63a7df1f26-node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783
+    target: mcp::d126e0fc-cee4-4692-b921-8cb100eefb50
+    type: customEdge
+    id: reactflow__edge-node-start::d61b0f71-87ee-475e-93ba-f1607f0ce783-mcp::d126e0fc-cee4-4692-b921-8cb100eefb50
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: mcp::d126e0fc-cee4-4692-b921-8cb100eefb50
+    target: decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    type: customEdge
+    id: reactflow__edge-mcp::d126e0fc-cee4-4692-b921-8cb100eefb50-decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    sourceHandle: normal_one_of::040796b6-a7ac-4bd3-867d-28a1d0534d4e
+    target: plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+    type: customEdge
+    id: reactflow__edge-decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72anormal_one_of::040796b6-a7ac-4bd3-867d-28a1d0534d4e-plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    sourceHandle: normal_one_of::040796b6-a7ac-4bd3-867d-28a1d0534d4e
+    target: node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    type: customEdge
+    id: reactflow__edge-decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72anormal_one_of::040796b6-a7ac-4bd3-867d-28a1d0534d4e-node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: spark-llm::5473efa2-2d27-4989-86f4-e045c0f9d0e9
+    target: node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    type: customEdge
+    id: reactflow__edge-spark-llm::5473efa2-2d27-4989-86f4-e045c0f9d0e9-node-end::cda617af-551e-462e-b3b8-3bb9a041bf88
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    sourceHandle: intent-one-of::bac84c4b-a1c5-416c-b1fc-87f6bb8b7654
+    target: plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+    type: customEdge
+    id: reactflow__edge-decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72aintent-one-of::bac84c4b-a1c5-416c-b1fc-87f6bb8b7654-plugin::b6a87c39-87d2-41a6-b835-471f9c9aa09f
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve
+  - source: decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72a
+    sourceHandle: intent-one-of::c0ebed3a-1b20-4a53-b5bf-22015e43903f
+    target: spark-llm::5473efa2-2d27-4989-86f4-e045c0f9d0e9
+    type: customEdge
+    id: reactflow__edge-decision-making::2b4eb78b-ed31-4fb6-9910-7d5c1255a72aintent-one-of::c0ebed3a-1b20-4a53-b5bf-22015e43903f-spark-llm::5473efa2-2d27-4989-86f4-e045c0f9d0e9
+    markerEnd:
+      color: '#6356EA'
+      type: arrow
+    data:
+      edgeType: curve

--- a/examples/scripts/lint.mjs
+++ b/examples/scripts/lint.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Lint community workflow examples under examples/.
+ *
+ * For every examples/<id>/ directory (excluding TEMPLATE) it checks:
+ *   - README.md exists with frontmatter containing the required fields
+ *   - frontmatter id matches the directory name
+ *   - category is one of the allowed values
+ *   - features is a non-empty list
+ *   - workflow.yml exists and looks like an Astron DSL (has flowData/flowMeta)
+ *   - workflow.yml contains no embedded secrets (api keys, tokens, app ids)
+ *
+ * Dependency-free: runs on a clean Node (>= 18). Exits non-zero on any violation.
+ */
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EXAMPLES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SKIP = new Set(["TEMPLATE", "scripts"]);
+const REQUIRED = ["id", "title", "description", "category", "features", "author", "dslVersion"];
+const CATEGORIES = new Set([
+  "productivity",
+  "creative",
+  "learning",
+  "entertainment",
+  "health",
+  "finance",
+  "other"
+]);
+
+// Lines that look like a live credential rather than a YOUR_* placeholder.
+const SECRET_PATTERNS = [
+  /^\s*apiKey:\s*(?!YOUR_)[A-Za-z0-9]{8,}/m,
+  /^\s*apiSecret:\s*(?!YOUR_)[A-Za-z0-9+/=]{8,}/m,
+  /^\s*appId:\s*(?!YOUR_)[A-Za-z0-9]{6,}/m,
+  /\bsk-[A-Za-z0-9]{16,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /\bBearer\s+[A-Za-z0-9._-]{16,}\b/
+];
+
+/** Minimal frontmatter parser for our controlled template (key: value + simple lists). */
+function parseFrontmatter(md) {
+  const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const data = {};
+  let currentList = null;
+  for (const raw of m[1].split(/\r?\n/)) {
+    const line = raw.replace(/\s+$/, "");
+    if (!line.trim()) continue;
+    const item = line.match(/^\s+-\s+(.*)$/);
+    if (item && currentList) {
+      data[currentList].push(item[1].trim());
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (kv) {
+      const [, key, val] = kv;
+      if (val === "") {
+        data[key] = [];
+        currentList = key;
+      } else {
+        data[key] = val.replace(/^["']|["']$/g, "");
+        currentList = null;
+      }
+    }
+  }
+  return data;
+}
+
+const errors = [];
+let checked = 0;
+
+for (const name of readdirSync(EXAMPLES_DIR)) {
+  if (SKIP.has(name)) continue;
+  const dir = join(EXAMPLES_DIR, name);
+  if (!statSync(dir).isDirectory()) continue;
+  checked++;
+  const fail = (msg) => errors.push(`examples/${name}: ${msg}`);
+
+  const readmePath = join(dir, "README.md");
+  const workflowPath = join(dir, "workflow.yml");
+
+  if (!existsSync(readmePath)) {
+    fail("missing README.md");
+  } else {
+    const fm = parseFrontmatter(readFileSync(readmePath, "utf8"));
+    if (!fm) {
+      fail("README.md has no YAML frontmatter");
+    } else {
+      for (const field of REQUIRED) {
+        if (fm[field] === undefined || (Array.isArray(fm[field]) && fm[field].length === 0) || fm[field] === "") {
+          fail(`frontmatter missing required field: ${field}`);
+        }
+      }
+      if (fm.id && fm.id !== name) fail(`frontmatter id "${fm.id}" does not match directory name "${name}"`);
+      if (fm.category && !CATEGORIES.has(fm.category)) {
+        fail(`category "${fm.category}" is not one of: ${[...CATEGORIES].join(", ")}`);
+      }
+    }
+  }
+
+  if (!existsSync(workflowPath)) {
+    fail("missing workflow.yml");
+  } else {
+    const yml = readFileSync(workflowPath, "utf8");
+    if (!/flowData|flowMeta/.test(yml)) {
+      fail("workflow.yml does not look like an Astron DSL export (no flowData/flowMeta)");
+    }
+    for (const re of SECRET_PATTERNS) {
+      if (re.test(yml)) {
+        fail(`workflow.yml appears to contain a secret (${re}). Replace it with a YOUR_* placeholder.`);
+        break;
+      }
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`✗ examples lint failed (${errors.length} issue(s) across ${checked} example(s)):\n`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+console.log(`✓ examples lint passed (${checked} example(s) checked).`);


### PR DESCRIPTION
## 背景

P2:为社区贡献者建一个**可复用工作流示例库**,与团队维护的企业[案例](https://iflytek.github.io/astron-agent/cases/)分治。案例是编辑核实的企业故事,示例是开放众包——任何人都能 PR 一份能跑的工作流 `.yml`。

> 本 PR 在 #1406(docs i18n 标准化,已合并)的新目录结构之上构建 `/examples` gallery;base 已指向 `main`,diff 仅含 examples/gallery 改动。

## 本次变更

### 目录规范 + 模板 + 贡献指南
- `examples/README.md`:目录规范、元数据 schema(对齐 Awesome-Astron-Workflow 的 `Workflow` 字段)、贡献流程、**安全门槛**、gallery 说明(中英)
- `examples/TEMPLATE/`:一示例一目录的起步模板(`README.md` frontmatter + `workflow.yml` 占位,含导出步骤与去密钥警告)

### 3 个种子示例
- `history-knowledge-qa`(learning)、`ai-radio-podcast`(creative)、`english-essay-corrector`(learning)
- ⚠️ 这些导出的 DSL **原本内嵌了真实 Spark 凭据**(`apiKey`/`apiSecret`/`appId`),已全部脱敏为 `YOUR_*` 占位符后才提交——正好示范了安全门槛

### CI lint(`.github/workflows/examples-lint.yml` + `examples/scripts/lint.mjs`)
- 零依赖 Node,PR 触碰 `examples/**` 时运行
- 校验:frontmatter 必填字段、`id` 与目录名一致、`category` 合法、`workflow.yml` 是 Astron DSL(含 `flowData`/`flowMeta`)
- **密钥扫描**:命中疑似 `apiKey`/`apiSecret`/`appId`/`sk-`/`Bearer`/`AKIA` 的真实值(非 `YOUR_*` 占位)即 fail

### docs 站 `/examples` gallery
- VitePress 数据加载器 `examples.data.ts` 在构建时读取 `examples/*/README.md` frontmatter
- `ExamplesGallery.vue`:按 category 可筛选的卡片,每卡片含"查看源码 / 下载 workflow.yml",中英 UI
- 中英页面 `docs/examples.md` + `docs/zh/examples.md`,并加进两个 locale 的 nav/sidebar

## 验证

- 本地 `DOCS_BASE=/astron-agent/ npm run docs:build` 通过;产物确认 `/examples` 与 `/zh/examples` 渲染出 3 张种子卡片、筛选/链接/中英文案均正常
- `node examples/scripts/lint.mjs` 通过;注入假密钥能被 fail、恢复后再通过(已验证)
- CI 上 Examples Lint / DCO / CLA 均通过

## 后续可选

- 给"提交示例"加一个 issue 模板
- gallery 卡片支持 `preview.png` 截图(种子暂无截图)
- 把 Awesome-Astron-Workflow 其余工作流批量迁入
