### PR TITLE
fix: correct standalone agent runtime (streaming, tools, default models)

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/bot/BotCreateController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/bot/BotCreateController.java
@@ -11,7 +11,6 @@ import com.iflytek.astron.console.commons.dto.bot.BotModelDto;
 import com.iflytek.astron.console.commons.entity.bot.BotTemplate;
 import com.iflytek.astron.console.commons.entity.bot.BotTypeList;
 import com.iflytek.astron.console.hub.enums.ConfigTypeEnum;
-import com.iflytek.astron.console.commons.enums.bot.DefaultBotModelEnum;
 import com.iflytek.astron.console.commons.mapper.bot.BotTemplateMapper;
 import com.iflytek.astron.console.commons.response.ApiResult;
 import com.iflytek.astron.console.commons.service.bot.BotDatasetService;
@@ -275,22 +274,8 @@ public class BotCreateController {
     public ApiResult<List<BotModelDto>> botModel(HttpServletRequest request) {
         List<BotModelDto> allModels = new ArrayList<>();
 
-        // 1. Add default models: Spark 4.0 and x1
-        BotModelDto x1Model = new BotModelDto();
-        x1Model.setModelDomain(DefaultBotModelEnum.X1.getDomain());
-        x1Model.setModelName(DefaultBotModelEnum.X1.getName());
-        x1Model.setModelIcon(DefaultBotModelEnum.X1.getIcon());
-        x1Model.setIsCustom(false);
-        allModels.add(x1Model);
-
-        BotModelDto sparkModel = new BotModelDto();
-        sparkModel.setModelDomain(DefaultBotModelEnum.SPARK_4_0.getDomain());
-        sparkModel.setModelName(DefaultBotModelEnum.SPARK_4_0.getName());
-        sparkModel.setModelIcon(DefaultBotModelEnum.SPARK_4_0.getIcon());
-        sparkModel.setIsCustom(false);
-        allModels.add(sparkModel);
-
-        // 2. Get custom models
+        // Custom models only. The built-in default Spark models (x1 / spark) were removed because
+        // they are not provisioned through model management and cannot be invoked at runtime.
         JSONObject result = JSONObject.from(llmService.getLlmAuthList(request, null, "workflow", "spark-llm"));
 
         try {

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/CurrentTimeToolCallback.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/CurrentTimeToolCallback.java
@@ -38,6 +38,7 @@ public class CurrentTimeToolCallback implements ToolCallback {
                 log.warn("Failed to parse current_time tool input as JSON: {}", toolInput);
             }
         }
+        log.info("current_time tool invoked, timezone={}", timezone);
         return CurrentTimeTool.execute(timezone);
     }
 }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/McpToolCallbackFactory.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/McpToolCallbackFactory.java
@@ -54,6 +54,7 @@ public class McpToolCallbackFactory {
 
         @Override
         public String call(String toolInput) {
+            log.info("mcp tool invoked, tool={}", tool.toolName());
             JSONObject args;
             try {
                 args = StringUtils.isBlank(toolInput) ? new JSONObject() : JSON.parseObject(toolInput);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
@@ -16,32 +16,28 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Runs a standalone-agent chat turn on Spring AI: builds a per-request model + tool callbacks,
- * drives the streaming tool-call loop manually (for trace fidelity), bridges chunks to the legacy
- * SSE contract, and persists chat records.
+ * Runs a standalone-agent chat turn on Spring AI. Tools (web_search / current_time / MCP) are
+ * registered as {@link ToolCallback}s and executed internally by the framework (Spring AI's default
+ * internal tool execution); each streamed chunk is forwarded to the legacy SSE contract and chat
+ * records are persisted.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SpringAiAgentChatService {
-
-    private static final int MAX_TOOL_ROUNDS = 15;
 
     private final ChatModelFactory chatModelFactory;
     private final AgentToolCallbackResolver toolCallbackResolver;
@@ -57,40 +53,32 @@ public class SpringAiAgentChatService {
                     : chatModelFactory.forSparkModel(task.getSparkModelName());
 
             List<ToolCallback> tools = toolCallbackResolver.resolve(task.getOpenedTool(), task.getMcpServerUrls(), context);
+            log.info("Agent chat start, streamId={}, modelId={}, spark={}, toolCount={}, openedTool={}, mcpServerUrls={}",
+                    streamId, agentModel.modelId(), task.getLlmInfoVo() == null, tools.size(), task.getOpenedTool(),
+                    task.getMcpServerUrls());
+
+            // internalToolExecutionEnabled defaults to true: Spring AI executes tool calls internally
+            // and streams the final answer. We only forward each chunk to the SSE bridge.
             OpenAiChatOptions options = OpenAiChatOptions.builder()
                     .model(agentModel.modelId())
                     .toolCallbacks(tools)
-                    .internalToolExecutionEnabled(false)
                     .build();
-
             Prompt prompt = new Prompt(toMessages(task.getMessages()), options);
-            ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
 
-            for (int round = 0; round < MAX_TOOL_ROUNDS; round++) {
-                if (SseEmitterUtil.isStreamStopped(streamId)) {
-                    log.info("Stream stopped by user, breaking tool loop, streamId: {}", streamId);
-                    break;
-                }
-                AtomicReference<ChatResponse> aggregatedRef = new AtomicReference<>();
-                new MessageAggregator()
-                        .aggregate(agentModel.chatModel()
-                                .stream(prompt)
-                                .takeWhile(resp -> !SseEmitterUtil.isStreamStopped(streamId))
-                                .doOnNext(resp -> emitChunk(resp, bridge)), aggregatedRef::set)
-                        .blockLast();
+            agentModel.chatModel()
+                    .stream(prompt)
+                    .takeWhile(resp -> !SseEmitterUtil.isStreamStopped(streamId))
+                    .doOnNext(resp -> emitChunk(resp, bridge))
+                    .blockLast();
 
-                ChatResponse aggregated = aggregatedRef.get();
-                if (aggregated == null || SseEmitterUtil.isStreamStopped(streamId) || !aggregated.hasToolCalls()) {
-                    break;
-                }
-                ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, aggregated);
-                bridge.emitToolTrace(context.drainTrace());
-                prompt = new Prompt(result.conversationHistory(), options);
-            }
-
+            bridge.emitToolTrace(context.drainTrace());
             persist(task, bridge);
             Long requestId = task.getChatReqRecords() == null ? null : task.getChatReqRecords().getId();
             bridge.complete(task.getChatId(), requestId);
+        } catch (WebClientResponseException e) {
+            log.error("Spring AI agent chat failed (HTTP {}), streamId: {}, responseBody: {}", e.getStatusCode(),
+                    streamId, e.getResponseBodyAsString(), e);
+            SseEmitterUtil.completeWithError(emitter, "Failed to process chat request: " + e.getMessage());
         } catch (Exception e) {
             log.error("Spring AI agent chat failed, streamId: {}", streamId, e);
             SseEmitterUtil.completeWithError(emitter, "Failed to process chat request: " + e.getMessage());

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/WebSearchToolCallback.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/WebSearchToolCallback.java
@@ -56,6 +56,7 @@ public class WebSearchToolCallback implements ToolCallback {
         if (StringUtils.isBlank(query)) {
             return "No query provided.";
         }
+        log.info("web_search tool invoked, userId={}, query={}", context.getUserId(), query);
 
         SearchAugmentation result = managedWebSearchService.search(query, context.getUserId());
         if (result.failed()) {


### PR DESCRIPTION
Fixes for the standalone agent runtime found via production logs.

## Changes

1. **Tool calling and streaming were broken** — the runtime disabled Spring AI's internal tool execution (`internalToolExecutionEnabled=false`) and hand-rolled a `MessageAggregator`/`ToolCallingManager` loop. Switched to the framework default (`internalToolExecutionEnabled=true`) with a plain `chatModel.stream()` pipeline. This fixes tool calling (`web_search`/`current_time`/MCP) and streaming for all providers.

2. **Removed the two built-in default Spark models** (domains `x1`/`spark`) from `/bot-model`, since their model ids are invalid for the open endpoint (returned 400). Users now pick models configured via model management.

3. **Diagnosability** — added tool-invocation logging and capture of WebClient 4xx response bodies.
