### PR TITLE
fix: standalone agent runtime — always expose built-in tools and restore async streaming

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
@@ -10,49 +10,32 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
- * Resolves the set of Spring AI tool callbacks for a bot from its {@code openedTool} CSV and MCP
- * server URLs. Replaces the tool-selection role of the removed ProviderToolOrchestrator. All
- * providers use the managed web_search tool (decision C); no provider-native search.
+ * Resolves the Spring AI tool callbacks for a standalone agent. {@code web_search} and
+ * {@code current_time} are built-in tools that are ALWAYS available (matching the legacy default
+ * behavior where OpenAI-compatible providers always exposed them, regardless of the bot's
+ * {@code openedTool}); MCP tools are added from the bot's configured MCP server URLs. All providers
+ * use the managed web_search tool (decision C).
  */
 @Service
 @RequiredArgsConstructor
 public class AgentToolCallbackResolver {
 
-    private static final String TOOL_WEB_SEARCH = "web_search";
-    private static final String TOOL_IFLY_SEARCH_LEGACY = "ifly_search";
-    private static final String TOOL_CURRENT_TIME = "current_time";
-
     private final ManagedWebSearchService managedWebSearchService;
     private final McpToolCallbackFactory mcpToolCallbackFactory;
 
+    /**
+     * @param openedTool retained for future per-tool gating; built-in tools are always included.
+     */
     public List<ToolCallback> resolve(String openedTool, String mcpServerUrls, ChatToolContext context)
             throws IOException {
-        Set<String> enabled = parseEnabledTools(openedTool);
         List<ToolCallback> callbacks = new ArrayList<>();
-        if (enabled.contains(TOOL_WEB_SEARCH) || enabled.contains(TOOL_IFLY_SEARCH_LEGACY)) {
-            callbacks.add(new WebSearchToolCallback(managedWebSearchService, context));
-        }
-        if (enabled.contains(TOOL_CURRENT_TIME)) {
-            callbacks.add(new CurrentTimeToolCallback());
-        }
+        callbacks.add(new WebSearchToolCallback(managedWebSearchService, context));
+        callbacks.add(new CurrentTimeToolCallback());
         callbacks.addAll(mcpToolCallbackFactory.build(parseMcpUrls(mcpServerUrls), context));
         return callbacks;
-    }
-
-    private Set<String> parseEnabledTools(String openedTool) {
-        if (StringUtils.isBlank(openedTool)) {
-            return Set.of();
-        }
-        return Arrays.stream(openedTool.split(","))
-                .map(String::trim)
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private List<String> parseMcpUrls(String mcpServerUrls) {

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Runs a standalone-agent chat turn on Spring AI. Tools (web_search / current_time / MCP) are
@@ -65,11 +66,22 @@ public class SpringAiAgentChatService {
                     .build();
             Prompt prompt = new Prompt(toMessages(task.getMessages()), options);
 
+            AtomicInteger chunkCount = new AtomicInteger();
             agentModel.chatModel()
                     .stream(prompt)
                     .takeWhile(resp -> !SseEmitterUtil.isStreamStopped(streamId))
-                    .doOnNext(resp -> emitChunk(resp, bridge))
+                    .doOnNext(resp -> {
+                        int n = chunkCount.incrementAndGet();
+                        if (n <= 5) {
+                            Generation g = resp.getResult();
+                            String t = g != null && g.getOutput() != null ? g.getOutput().getText() : null;
+                            log.info("agent stream chunk #{}, streamId={}, textLen={}", n, streamId,
+                                    t == null ? -1 : t.length());
+                        }
+                        emitChunk(resp, bridge);
+                    })
                     .blockLast();
+            log.info("agent stream complete, streamId={}, totalChunks={}", streamId, chunkCount.get());
 
             bridge.emitToolTrace(context.drainTrace());
             persist(task, bridge);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
@@ -32,8 +32,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Runs a standalone-agent chat turn on Spring AI. Tools (web_search / current_time / MCP) are
  * registered as {@link ToolCallback}s and executed internally by the framework (Spring AI's default
- * internal tool execution); each streamed chunk is forwarded to the legacy SSE contract and chat
- * records are persisted.
+ * internal tool execution). The model is streamed asynchronously: the reactive pipeline is
+ * subscribed (NOT blocked) so the controller can return the {@link SseEmitter} immediately and
+ * chunks are forwarded incrementally; chat records are persisted on completion.
  */
 @Slf4j
 @Service
@@ -47,8 +48,8 @@ public class SpringAiAgentChatService {
 
     public void chat(AgentChatTask task, SseEmitter emitter, String streamId) {
         AgentSseBridge bridge = new AgentSseBridge(emitter, streamId);
+        ChatToolContext context = new ChatToolContext(task.getUserId());
         try {
-            ChatToolContext context = new ChatToolContext(task.getUserId());
             AgentModel agentModel = task.getLlmInfoVo() != null
                     ? chatModelFactory.forCustomModel(task.getLlmInfoVo())
                     : chatModelFactory.forSparkModel(task.getSparkModelName());
@@ -58,43 +59,55 @@ public class SpringAiAgentChatService {
                     streamId, agentModel.modelId(), task.getLlmInfoVo() == null, tools.size(), task.getOpenedTool(),
                     task.getMcpServerUrls());
 
-            // internalToolExecutionEnabled defaults to true: Spring AI executes tool calls internally
-            // and streams the final answer. We only forward each chunk to the SSE bridge.
             OpenAiChatOptions options = OpenAiChatOptions.builder()
                     .model(agentModel.modelId())
                     .toolCallbacks(tools)
                     .build();
             Prompt prompt = new Prompt(toMessages(task.getMessages()), options);
 
+            // Subscribe asynchronously: do NOT block the request thread. The controller returns the
+            // SseEmitter right after this call, so Spring MVC starts the streaming response and the
+            // chunks below are flushed incrementally. Blocking (blockLast) buffers every SSE event
+            // until the controller returns, which breaks streaming.
             AtomicInteger chunkCount = new AtomicInteger();
             agentModel.chatModel()
                     .stream(prompt)
                     .takeWhile(resp -> !SseEmitterUtil.isStreamStopped(streamId))
-                    .doOnNext(resp -> {
-                        int n = chunkCount.incrementAndGet();
-                        if (n <= 5) {
-                            Generation g = resp.getResult();
-                            String t = g != null && g.getOutput() != null ? g.getOutput().getText() : null;
-                            log.info("agent stream chunk #{}, streamId={}, textLen={}", n, streamId,
-                                    t == null ? -1 : t.length());
-                        }
-                        emitChunk(resp, bridge);
-                    })
-                    .blockLast();
-            log.info("agent stream complete, streamId={}, totalChunks={}", streamId, chunkCount.get());
-
-            bridge.emitToolTrace(context.drainTrace());
-            persist(task, bridge);
-            Long requestId = task.getChatReqRecords() == null ? null : task.getChatReqRecords().getId();
-            bridge.complete(task.getChatId(), requestId);
-        } catch (WebClientResponseException e) {
-            log.error("Spring AI agent chat failed (HTTP {}), streamId: {}, responseBody: {}", e.getStatusCode(),
-                    streamId, e.getResponseBodyAsString(), e);
-            SseEmitterUtil.completeWithError(emitter, "Failed to process chat request: " + e.getMessage());
+                    .subscribe(
+                            resp -> {
+                                int n = chunkCount.incrementAndGet();
+                                if (n <= 5) {
+                                    Generation g = resp.getResult();
+                                    String t = g != null && g.getOutput() != null ? g.getOutput().getText() : null;
+                                    log.info("agent stream chunk #{}, streamId={}, textLen={}", n, streamId,
+                                            t == null ? -1 : t.length());
+                                }
+                                emitChunk(resp, bridge);
+                            },
+                            error -> handleStreamError(error, emitter, streamId),
+                            () -> {
+                                log.info("agent stream complete, streamId={}, totalChunks={}", streamId,
+                                        chunkCount.get());
+                                bridge.emitToolTrace(context.drainTrace());
+                                persist(task, bridge);
+                                Long requestId =
+                                        task.getChatReqRecords() == null ? null : task.getChatReqRecords().getId();
+                                bridge.complete(task.getChatId(), requestId);
+                            });
         } catch (Exception e) {
-            log.error("Spring AI agent chat failed, streamId: {}", streamId, e);
+            log.error("Spring AI agent chat setup failed, streamId: {}", streamId, e);
             SseEmitterUtil.completeWithError(emitter, "Failed to process chat request: " + e.getMessage());
         }
+    }
+
+    private void handleStreamError(Throwable e, SseEmitter emitter, String streamId) {
+        if (e instanceof WebClientResponseException w) {
+            log.error("Spring AI agent chat failed (HTTP {}), streamId: {}, responseBody: {}", w.getStatusCode(),
+                    streamId, w.getResponseBodyAsString(), e);
+        } else {
+            log.error("Spring AI agent chat failed, streamId: {}", streamId, e);
+        }
+        SseEmitterUtil.completeWithError(emitter, "Failed to process chat request: " + e.getMessage());
     }
 
     private void emitChunk(ChatResponse response, AgentSseBridge bridge) {

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
@@ -30,11 +30,13 @@ class AgentToolCallbackResolverTest {
     }
 
     @Test
-    void blankOpenedToolYieldsNoBuiltinTools() throws Exception {
+    void builtinToolsAlwaysPresentEvenWhenOpenedToolBlank() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
         List<ToolCallback> tools = newResolver(mcp).resolve("", null, new ChatToolContext("u"));
-        assertTrue(tools.isEmpty());
+        List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
+        assertTrue(names.contains("web_search"));
+        assertTrue(names.contains("current_time"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two follow-up fixes for the standalone agent runtime.

### 1. Always expose built-in `web_search` / `current_time` tools (`fac2306d`)
Production logs showed `toolCount=0` with an empty `openedTool`: the resolver only attached the built-in `web_search` / `current_time` tools when `openedTool` listed them, but the legacy behavior exposed these built-in tools **unconditionally** for OpenAI-compatible models. They are now always attached, which fixes tool calling for all models. Also adds per-chunk stream logging (`textLen` + count) to help pinpoint streaming behavior.

### 2. Stream replies asynchronously (`364808bc`)
The runtime blocked the request thread with `blockLast()`, so every `SseEmitter.send()` happened before the controller returned the emitter to Spring MVC — the events were buffered and flushed all at once (no streaming). The reply is now streamed by subscribing to the reactive stream instead of blocking, so the controller returns the emitter immediately and chunks flush incrementally (restoring token streaming, matching the legacy async OkHttp callback behavior).

## Commits
- `fac2306d` fix: always expose built-in web_search/current_time tools; add stream diagnostics
- `364808bc` fix: stream standalone agent replies asynchronously (restore token streaming)
