### PR TITLE
fix: spark tool-call filtering + chat loading-spinner edge cases

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/BlankToolCallFilteringToolCallingManager.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/BlankToolCallFilteringToolCallingManager.java
@@ -1,0 +1,77 @@
+package com.iflytek.astron.console.hub.service.chat.springai;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wraps a {@link ToolCallingManager} to drop tool calls whose function name is blank before they
+ * are executed. Some OpenAI-compatible providers (e.g. iFlytek Spark) stream a spurious empty-name
+ * tool_call; without this, Spring AI's resolver throws "toolName cannot be null or empty" and
+ * aborts the whole turn. Standard providers (e.g. deepseek) are unaffected since they never emit
+ * blank names.
+ */
+@Slf4j
+public class BlankToolCallFilteringToolCallingManager implements ToolCallingManager {
+
+    private final ToolCallingManager delegate;
+
+    public BlankToolCallFilteringToolCallingManager(ToolCallingManager delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<ToolDefinition> resolveToolDefinitions(ToolCallingChatOptions chatOptions) {
+        return delegate.resolveToolDefinitions(chatOptions);
+    }
+
+    @Override
+    public ToolExecutionResult executeToolCalls(Prompt prompt, ChatResponse chatResponse) {
+        return delegate.executeToolCalls(prompt, stripBlankToolCalls(chatResponse));
+    }
+
+    private ChatResponse stripBlankToolCalls(ChatResponse chatResponse) {
+        if (chatResponse == null) {
+            return null;
+        }
+        boolean changed = false;
+        List<Generation> generations = new ArrayList<>();
+        for (Generation generation : chatResponse.getResults()) {
+            AssistantMessage message = generation.getOutput();
+            if (message != null && message.hasToolCalls()) {
+                List<ToolCall> valid = new ArrayList<>();
+                for (ToolCall call : message.getToolCalls()) {
+                    if (StringUtils.isNotBlank(call.name())) {
+                        valid.add(call);
+                    } else {
+                        log.warn("Dropping tool call with blank name (provider sent a malformed tool_call)");
+                    }
+                }
+                if (valid.size() != message.getToolCalls().size()) {
+                    changed = true;
+                    AssistantMessage filtered = AssistantMessage.builder()
+                            .content(message.getText())
+                            .properties(message.getMetadata())
+                            .toolCalls(valid)
+                            .media(message.getMedia())
+                            .build();
+                    generations.add(new Generation(filtered, generation.getMetadata()));
+                    continue;
+                }
+            }
+            generations.add(generation);
+        }
+        return changed ? new ChatResponse(generations, chatResponse.getMetadata()) : chatResponse;
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/ChatModelFactory.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/ChatModelFactory.java
@@ -5,6 +5,7 @@ import com.iflytek.astron.console.toolkit.entity.vo.LLMInfoVo;
 import com.iflytek.astron.console.toolkit.service.platform.PlatformAccountService;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
@@ -62,7 +63,11 @@ public class ChatModelFactory {
                 .apiKey(apiKey)
                 .build();
         OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
-        return OpenAiChatModel.builder().openAiApi(api).defaultOptions(options).build();
+        return OpenAiChatModel.builder()
+                .openAiApi(api)
+                .defaultOptions(options)
+                .toolCallingManager(new BlankToolCallFilteringToolCallingManager(ToolCallingManager.builder().build()))
+                .build();
     }
 
     static String sparkModelToOpenAiModelId(String sparkModelName) {

--- a/console/frontend/src/pages/chat-page/components/message-list.tsx
+++ b/console/frontend/src/pages/chat-page/components/message-list.tsx
@@ -204,10 +204,12 @@ const MessageList = (props: {
     item: MessageListType,
     messageIndex: number
   ): ReactElement => {
-    const showLoading = !item.sid && (isLoading || !!answerPercent);
+    const isLastMessage = messageIndex === messageList.length - 1; //是否是最后一条消息
+    // Only the current (last) answer bubble may show the loading spinner; otherwise a previous
+    // unfinished/errored bubble (no sid) would also spin when a new question starts streaming.
+    const showLoading = isLastMessage && !item.sid && (isLoading || !!answerPercent);
     const workflowContent = item?.workflowEventData?.content;
     const messageContent = workflowContent ? workflowContent : item.message;
-    const isLastMessage = messageIndex === messageList.length - 1; //是否是最后一条消息
     return (
       <div
         className="mt-[14px] w-[inherit] max-w-full"

--- a/console/frontend/src/pages/chat-page/index.tsx
+++ b/console/frontend/src/pages/chat-page/index.tsx
@@ -232,6 +232,9 @@ const ChatPage = (): ReactElement => {
 
   //stop answer
   const stopAnswer = () => {
+    // Clear the streaming/loading state immediately so the spinner stops even if the SSE `end`
+    // event never arrives after stopping (the connection may close before it is delivered).
+    useChatStore.getState().finishStreamingMessage();
     postStopChat(streamId).catch(err => {
       console.error(err);
     });


### PR DESCRIPTION
## Summary

Three fixes for Spark tool-calls and chat loading-spinner edge cases.

### 1. Spark tool-call filtering
Spark's OpenAI-compatible endpoint streams a spurious empty-name `tool_call`, which made Spring AI's resolver throw `toolName cannot be null or empty` and abort the turn. A `BlankToolCallFilteringToolCallingManager` wrapper now drops blank-name tool calls before execution, so Spark tool calls work (deepseek is unaffected).

### 2. Loading spinner on previous bubble
The spinner appeared on a prior answer bubble when a new question started, because `showLoading` was keyed only on the global `isLoading` flag plus a missing sid. It is now gated on `isLastMessage`.

### 3. Spinner not clearing after stop
`stopAnswer` only called the backend stop API and never cleared the streaming state, so the spinner lingered after the user stopped generation. It now calls `finishStreamingMessage()` to clear the spinner immediately.

## Changed files
- `console/backend/.../service/chat/springai/BlankToolCallFilteringToolCallingManager.java` (new)
- `console/backend/.../service/chat/springai/ChatModelFactory.java`
- `console/frontend/src/pages/chat-page/components/message-list.tsx`
- `console/frontend/src/pages/chat-page/index.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
