### PR TITLE
fix: address gemini-code-assist review on PR #1418

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -437,7 +437,10 @@ public class BotServiceImpl implements BotService {
         try {
             URI uri = URI.create(mcpServerUrl);
             String scheme = uri.getScheme();
-            return StringUtils.isNotBlank(uri.getHost())
+            // Use getAuthority() not getHost(): URI.getHost() returns null for hostnames containing
+            // underscores (e.g. http://mcp_server:8080), common in internal Docker/K8s networks,
+            // which would otherwise silently drop valid MCP server URLs.
+            return StringUtils.isNotBlank(uri.getAuthority())
                     && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
         } catch (IllegalArgumentException e) {
             return false;

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/McpRuntimeToolService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/McpRuntimeToolService.java
@@ -136,7 +136,17 @@ public class McpRuntimeToolService {
             if (body == null) {
                 throw new IOException("MCP gateway response body is empty");
             }
-            return JSON.parseObject(body.string());
+            String bodyString = body.string();
+            JSONObject json;
+            try {
+                json = JSON.parseObject(bodyString);
+            } catch (RuntimeException e) {
+                throw new IOException("Failed to parse MCP gateway response as JSON: " + bodyString, e);
+            }
+            if (json == null) {
+                throw new IOException("MCP gateway returned empty or null JSON response: " + bodyString);
+            }
+            return json;
         }
     }
 
@@ -227,14 +237,15 @@ public class McpRuntimeToolService {
         }
         List<String> parts = new ArrayList<>();
         for (int i = 0; i < content.size(); i++) {
-            JSONObject item = content.getJSONObject(i);
-            if (item == null) {
-                continue;
-            }
-            if ("text".equals(item.getString("type"))) {
-                parts.add(StringUtils.defaultString(item.getString("text")));
-            } else {
-                parts.add(item.toJSONString());
+            Object element = content.get(i);
+            if (element instanceof JSONObject item) {
+                if ("text".equals(item.getString("type"))) {
+                    parts.add(StringUtils.defaultString(item.getString("text")));
+                } else {
+                    parts.add(item.toJSONString());
+                }
+            } else if (element != null) {
+                parts.add(element.toString());
             }
         }
         return String.join("\n", parts);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
@@ -84,7 +84,7 @@ public class SpringAiAgentChatService {
                                 }
                                 emitChunk(resp, bridge);
                             },
-                            error -> handleStreamError(error, emitter, streamId),
+                            error -> handleStreamError(error, emitter, streamId, task, bridge),
                             () -> {
                                 log.info("agent stream complete, streamId={}, totalChunks={}", streamId,
                                         chunkCount.get());
@@ -100,12 +100,19 @@ public class SpringAiAgentChatService {
         }
     }
 
-    private void handleStreamError(Throwable e, SseEmitter emitter, String streamId) {
+    private void handleStreamError(Throwable e, SseEmitter emitter, String streamId, AgentChatTask task,
+            AgentSseBridge bridge) {
         if (e instanceof WebClientResponseException w) {
             log.error("Spring AI agent chat failed (HTTP {}), streamId: {}, responseBody: {}", w.getStatusCode(),
                     streamId, w.getResponseBodyAsString(), e);
         } else {
             log.error("Spring AI agent chat failed, streamId: {}", streamId, e);
+        }
+        // Persist whatever was generated before the error so the partial reply is not lost.
+        try {
+            persist(task, bridge);
+        } catch (Exception persistError) {
+            log.error("Failed to persist partial response after stream error, streamId: {}", streamId, persistError);
         }
         SseEmitterUtil.completeWithError(emitter, "Failed to process chat request: " + e.getMessage());
     }


### PR DESCRIPTION
- BotServiceImpl: validate MCP server URLs with URI.getAuthority() instead of getHost(), so hostnames containing underscores (e.g. http://mcp_server:8080, common in internal Docker/K8s networks) are not silently dropped
- McpRuntimeToolService: wrap gateway JSON parsing with a null check, surfacing a clean IOException carrying the body when the gateway returns malformed/HTML responses; tolerate non-JSONObject elements in tool content arrays
- SpringAiAgentChatService: persist the partially generated reply on stream error so it is not lost when onComplete is skipped

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
