### PR TITLE
fix(agent-skills): update AgentToolCallbackResolverTest for new resol…

### DIFF
--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
@@ -16,14 +16,16 @@ import static org.mockito.Mockito.when;
 class AgentToolCallbackResolverTest {
 
     private AgentToolCallbackResolver newResolver(McpRuntimeToolService mcp) {
-        return new AgentToolCallbackResolver(mock(ManagedWebSearchService.class), new McpToolCallbackFactory(mcp));
+        return new AgentToolCallbackResolver(mock(ManagedWebSearchService.class), new McpToolCallbackFactory(mcp),
+                new SkillToolCallbackFactory(mock(SkillRuntimeToolService.class)));
     }
 
     @Test
     void webSearchAndCurrentTimeFromOpenedTool() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
-        List<ToolCallback> tools = newResolver(mcp).resolve("web_search,current_time", null, new ChatToolContext("u"));
+        List<ToolCallback> tools =
+                newResolver(mcp).resolve("web_search,current_time", null, null, new ChatToolContext("u"));
         List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
         assertTrue(names.contains("web_search"));
         assertTrue(names.contains("current_time"));
@@ -33,7 +35,7 @@ class AgentToolCallbackResolverTest {
     void builtinToolsAlwaysPresentEvenWhenOpenedToolBlank() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
-        List<ToolCallback> tools = newResolver(mcp).resolve("", null, new ChatToolContext("u"));
+        List<ToolCallback> tools = newResolver(mcp).resolve("", null, null, new ChatToolContext("u"));
         List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
         assertTrue(names.contains("web_search"));
         assertTrue(names.contains("current_time"));
@@ -43,7 +45,7 @@ class AgentToolCallbackResolverTest {
     void mcpUrlsParsedFromJsonArrayString() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(List.of("http://a", "http://b"))).thenReturn(List.of());
-        newResolver(mcp).resolve(null, "[\"http://a\",\"http://b\"]", new ChatToolContext("u"));
+        newResolver(mcp).resolve(null, "[\"http://a\",\"http://b\"]", null, new ChatToolContext("u"));
         verify(mcp).listTools(List.of("http://a", "http://b"));
     }
 }


### PR DESCRIPTION
…ve API

The skills work added a SkillToolCallbackFactory constructor arg and a skills param to AgentToolCallbackResolver.resolve(); the existing test still used the old 2-arg constructor / 3-arg resolve, which broke `mvn package` test compilation and the hub Docker image build.

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
<!-- Closes #123 or Fixes #456 -->

## Changes
<!-- Key changes made in this PR -->
-

## Testing
<!-- How these changes were tested -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
