### PR TITLE
feat: standalone agent Skill capability (read_skill / run_skill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# CLAUDE.md
 
 ## Project Overview
 

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
@@ -108,6 +108,9 @@ public class BotCreateForm {
     @Schema(description = "Custom MCP server URL list")
     private List<String> mcpServerUrls;
 
+    @Schema(description = "Selected skills imported from resource management")
+    private List<BotSkill> skills;
+
     @Schema(description = "Background image color scheme: 0 Light, 1 Dark")
     private Integer backgroundColor;
 
@@ -161,5 +164,13 @@ public class BotCreateForm {
     public static class PromptStruct {
         private String promptKey;
         private String promptValue;
+    }
+
+    @Data
+    public static class BotSkill {
+        @Schema(description = "Skill id (SkillImportDto.id)")
+        private Long skillId;
+        private String name;
+        private String description;
     }
 }

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotDetail.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotDetail.java
@@ -36,6 +36,7 @@ public class BotDetail {
     private Integer version;
     private String openedTool;
     private String mcpServerUrls;
+    private String skills;
     private Integer hotNum;
     private String marketBotId;
     private Integer supportSystem;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotInfoDto.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotInfoDto.java
@@ -111,6 +111,8 @@ public class BotInfoDto {
 
     private String mcpServerUrls;
 
+    private String skills;
+
     private String vcnCn;
 
     private String vcnEn;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/DebugChatBotReqDto.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/DebugChatBotReqDto.java
@@ -47,6 +47,11 @@ public class DebugChatBotReqDto {
     private String mcpServerUrls;
 
     /**
+     * Selected skills JSON list
+     */
+    private String skills;
+
+    /**
      * Model name
      */
     private String model;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/bot/ChatBotBase.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/bot/ChatBotBase.java
@@ -121,6 +121,9 @@ public class ChatBotBase {
     @Schema(description = "Custom MCP server URL list")
     private String mcpServerUrls;
 
+    @Schema(description = "Selected skills JSON list")
+    private String skills;
+
     @Schema(description = "Hidden on certain clients")
     private String clientHide;
 

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -392,6 +392,7 @@ public class BotServiceImpl implements BotService {
         botBase.setIsSentence(bot.getIsSentence());
         botBase.setOpenedTool(bot.getOpenedTool());
         botBase.setMcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()));
+        botBase.setSkills(serializeSkills(bot.getSkills()));
         botBase.setClientType(bot.getClientType());
         botBase.setBotNameEn(bot.getBotNameEn());
         botBase.setBotDescEn(bot.getBotDescEn());
@@ -431,6 +432,16 @@ public class BotServiceImpl implements BotService {
                 .distinct()
                 .collect(Collectors.toList());
         return JSON.toJSONString(normalizedUrls);
+    }
+
+    private String serializeSkills(List<BotCreateForm.BotSkill> skills) {
+        if (skills == null) {
+            return null;
+        }
+        List<BotCreateForm.BotSkill> valid = skills.stream()
+                .filter(skill -> skill != null && skill.getSkillId() != null)
+                .collect(Collectors.toList());
+        return JSON.toJSONString(valid);
     }
 
     private boolean isValidMcpServerUrl(String mcpServerUrl) {
@@ -551,6 +562,7 @@ public class BotServiceImpl implements BotService {
                 .isSentence(bot.getIsSentence())
                 .openedTool(bot.getOpenedTool())
                 .mcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()))
+                .skills(serializeSkills(bot.getSkills()))
                 .clientType(bot.getClientType())
                 .botNameEn(bot.getBotNameEn())
                 .botDescEn(bot.getBotDescEn())

--- a/console/backend/commons/src/main/resources/mapper/ChatBotBaseMapper.xml
+++ b/console/backend/commons/src/main/resources/mapper/ChatBotBaseMapper.xml
@@ -28,6 +28,7 @@
         a.version,
         a.opened_tool AS openedTool,
         a.mcp_server_urls AS mcpServerUrls,
+        a.skills AS skills,
         a.client_hide as clientHide,
         b.hot_num as hotNum,
         b.id as marketBotId,

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
@@ -397,6 +397,7 @@ public class ChatMessageController {
         debugChatReqDto.setUid(uid);
         debugChatReqDto.setOpenedTool(debugRequest.getOpenedTool());
         debugChatReqDto.setMcpServerUrls(debugRequest.getMcpServerUrls());
+        debugChatReqDto.setSkills(debugRequest.getSkills());
         debugChatReqDto.setModel(debugRequest.getModel());
         debugChatReqDto.setModelId(debugRequest.getModelId());
         debugChatReqDto.setMaasDatasetList(maasDatasetList);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/chat/BotDebugRequest.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/chat/BotDebugRequest.java
@@ -52,6 +52,11 @@ public class BotDebugRequest {
     private String mcpServerUrls;
 
     /**
+     * Selected skills JSON list
+     */
+    private String skills;
+
+    /**
      * Model name
      */
     private String model = "spark";

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
@@ -1,6 +1,9 @@
 package com.iflytek.astron.console.hub.service.chat.impl;
 
 import cn.hutool.core.collection.CollectionUtil;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.dto.bot.ChatBotReqDto;
@@ -39,6 +42,7 @@ import com.iflytek.astron.console.toolkit.entity.biz.modelconfig.ModelDto;
 import com.iflytek.astron.console.toolkit.entity.vo.CategoryTreeVO;
 import com.iflytek.astron.console.toolkit.entity.vo.LLMInfoVo;
 import com.iflytek.astron.console.toolkit.service.model.ModelService;
+import com.iflytek.astron.console.toolkit.service.skill.SkillEnrichmentService;
 import com.iflytek.astron.console.toolkit.service.workflow.WorkflowService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -68,6 +72,9 @@ public class BotChatServiceImpl implements BotChatService {
 
     @Autowired
     private SpringAiAgentChatService springAiAgentChatService;
+
+    @Autowired
+    private SkillEnrichmentService skillEnrichmentService;
 
     @Autowired
     private ChatHistoryService chatHistoryService;
@@ -135,6 +142,7 @@ public class BotChatServiceImpl implements BotChatService {
                         .messages(messages)
                         .openedTool(botConfig.openedTool)
                         .mcpServerUrls(botConfig.mcpServerUrls)
+                        .skills(enrichBotSkills(botConfig.skills()))
                         .userId(chatBotReqDto.getUid())
                         .chatId(chatBotReqDto.getChatId())
                         .chatReqRecords(chatReqRecords)
@@ -180,6 +188,7 @@ public class BotChatServiceImpl implements BotChatService {
                     .messages(messages)
                     .openedTool(botConfig.openedTool)
                     .mcpServerUrls(botConfig.mcpServerUrls)
+                    .skills(enrichBotSkills(botConfig.skills()))
                     .userId(chatBotReqDto.getUid())
                     .chatId(chatBotReqDto.getChatId())
                     .chatReqRecords(chatReqRecords)
@@ -223,6 +232,7 @@ public class BotChatServiceImpl implements BotChatService {
                     .messages(messageList)
                     .openedTool(request.getOpenedTool())
                     .mcpServerUrls(request.getMcpServerUrls())
+                    .skills(enrichBotSkills(request.getSkills()))
                     .userId(request.getUid())
                     .chatId(null)
                     .chatReqRecords(null)
@@ -394,7 +404,8 @@ public class BotChatServiceImpl implements BotChatService {
                     chatBotMarket.getVersion(),
                     chatBotMarket.getModelId(),
                     chatBotMarket.getSupportDocument() == 1,
-                    resolveBaseMcpServerUrls(botId));
+                    resolveBaseMcpServerUrls(botId),
+                    resolveBaseSkills(botId));
         } else {
             ChatBotBase chatBotBase = chatBotDataService.findById(botId)
                     .orElseThrow(() -> new BusinessException(ResponseEnum.BOT_NOT_EXISTS));
@@ -406,7 +417,8 @@ public class BotChatServiceImpl implements BotChatService {
                     chatBotBase.getVersion(),
                     chatBotBase.getModelId(),
                     chatBotBase.getSupportDocument() == 1,
-                    chatBotBase.getMcpServerUrls());
+                    chatBotBase.getMcpServerUrls(),
+                    chatBotBase.getSkills());
         }
     }
 
@@ -416,6 +428,36 @@ public class BotChatServiceImpl implements BotChatService {
         }
         var botBase = chatBotDataService.findById(botId);
         return botBase == null ? null : botBase.map(ChatBotBase::getMcpServerUrls).orElse(null);
+    }
+
+    private String resolveBaseSkills(Integer botId) {
+        if (botId == null) {
+            return null;
+        }
+        return chatBotDataService.findById(botId).map(ChatBotBase::getSkills).orElse(null);
+    }
+
+    /** Parse the saved skills JSON and enrich each entry with downloadUrl/resources/sandbox. */
+    private List<JSONObject> enrichBotSkills(String skillsJson) {
+        if (StringUtils.isBlank(skillsJson)) {
+            return List.of();
+        }
+        JSONArray array;
+        try {
+            array = JSON.parseArray(skillsJson);
+        } catch (Exception e) {
+            log.warn("Invalid skills json on bot: {}", skillsJson);
+            return List.of();
+        }
+        skillEnrichmentService.enrichSkillEntries(array);
+        List<JSONObject> result = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            JSONObject skill = array.getJSONObject(i);
+            if (skill != null && StringUtils.isNotBlank(skill.getString("downloadUrl"))) {
+                result.add(skill);
+            }
+        }
+        return result;
     }
 
     /**
@@ -703,7 +745,7 @@ public class BotChatServiceImpl implements BotChatService {
     }
 
     private record BotConfiguration(String prompt, boolean supportContext, String model, String openedTool,
-            Integer version, Long modelId, boolean supportDocument, String mcpServerUrls) {}
+            Integer version, Long modelId, boolean supportDocument, String mcpServerUrls, String skills) {}
 
     private record TokenStatistics(int systemTokens, int currentUserTokens, int reservedTokens, int availableTokens) {}
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentChatTask.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentChatTask.java
@@ -1,5 +1,6 @@
 package com.iflytek.astron.console.hub.service.chat.springai;
 
+import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.commons.dto.llm.SparkChatRequest;
 import com.iflytek.astron.console.commons.entity.chat.ChatReqRecords;
 import com.iflytek.astron.console.toolkit.entity.vo.LLMInfoVo;
@@ -24,6 +25,13 @@ public class AgentChatTask {
     private List<SparkChatRequest.MessageDto> messages;
     private String openedTool;
     private String mcpServerUrls;
+
+    /**
+     * Enriched skills (skillId/name/description/downloadUrl/resources/sandbox), resolved on the request
+     * thread before streaming begins.
+     */
+    private List<JSONObject> skills;
+
     private String userId;
     private Long chatId;
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.hub.service.chat.springai;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.hub.service.ManagedWebSearchService;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -25,16 +26,19 @@ public class AgentToolCallbackResolver {
 
     private final ManagedWebSearchService managedWebSearchService;
     private final McpToolCallbackFactory mcpToolCallbackFactory;
+    private final SkillToolCallbackFactory skillToolCallbackFactory;
 
     /**
      * @param openedTool retained for future per-tool gating; built-in tools are always included.
+     * @param skills enriched skill entries; each yields read_skill_/run_skill_ tool callbacks.
      */
-    public List<ToolCallback> resolve(String openedTool, String mcpServerUrls, ChatToolContext context)
-            throws IOException {
+    public List<ToolCallback> resolve(String openedTool, String mcpServerUrls, List<JSONObject> skills,
+            ChatToolContext context) throws IOException {
         List<ToolCallback> callbacks = new ArrayList<>();
         callbacks.add(new WebSearchToolCallback(managedWebSearchService, context));
         callbacks.add(new CurrentTimeToolCallback());
         callbacks.addAll(mcpToolCallbackFactory.build(parseMcpUrls(mcpServerUrls), context));
+        callbacks.addAll(skillToolCallbackFactory.build(skills));
         return callbacks;
     }
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/ReadSkillToolCallback.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/ReadSkillToolCallback.java
@@ -1,0 +1,128 @@
+package com.iflytek.astron.console.hub.service.chat.springai;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+/**
+ * Spring AI tool: read a skill's SKILL.md (called with empty parameters) or a specific referenced
+ * resource (called with a relative {@code path}). Mirrors the Python read_skill runtime: pure HTTP
+ * download of the presigned URLs resolved by skill enrichment.
+ */
+@Slf4j
+public class ReadSkillToolCallback implements ToolCallback {
+
+    private static final String INPUT_SCHEMA = """
+            {"type":"object","properties":{"path":{"type":"string",\
+            "description":"Optional relative resource path under the skill folder, e.g. references/beijing.md. \
+            Leave empty to read SKILL.md and list available resources."}},"required":[]}""";
+
+    private final String skillId;
+    private final String name;
+    private final String description;
+    private final String downloadUrl;
+    private final JSONArray resources;
+    private final SkillRuntimeToolService runtime;
+
+    public ReadSkillToolCallback(JSONObject skill, SkillRuntimeToolService runtime) {
+        this.skillId = skill.getString("skillId");
+        this.name = StringUtils.defaultString(skill.getString("name"));
+        this.description = StringUtils.defaultString(skill.getString("description"));
+        this.downloadUrl = StringUtils.defaultString(skill.getString("downloadUrl"));
+        this.resources = skill.getJSONArray("resources") == null ? new JSONArray() : skill.getJSONArray("resources");
+        this.runtime = runtime;
+    }
+
+    @Override
+    public ToolDefinition getToolDefinition() {
+        return ToolDefinition.builder()
+                .name("read_skill_" + skillId)
+                .description("Read SKILL.md and referenced files for skill '" + name
+                        + "'. First call with empty parameters to read SKILL.md and get the resource manifest. "
+                        + "If SKILL.md references a relative path like references/beijing.md, call again with that path.")
+                .inputSchema(INPUT_SCHEMA)
+                .build();
+    }
+
+    @Override
+    public String call(String toolInput) {
+        String requestedPath = parsePath(toolInput);
+        log.info("read_skill invoked, skillId={}, path={}", skillId, requestedPath);
+        JSONObject result = new JSONObject();
+        result.put("skill_id", skillId);
+        result.put("name", name);
+        result.put("description", description);
+        try {
+            if (StringUtils.isNotBlank(requestedPath)) {
+                JSONObject resource = findResource(requestedPath);
+                if (resource == null) {
+                    result.put("path", requestedPath);
+                    result.put("error", "resource_not_found");
+                    result.put("available_resources", manifest());
+                    return result.toJSONString();
+                }
+                result.put("path", normalizePath(resource.getString("path")));
+                result.put("content", runtime.downloadText(resource.getString("downloadUrl")));
+                return result.toJSONString();
+            }
+            result.put("content", runtime.downloadText(downloadUrl));
+            result.put("resources", manifest());
+            return result.toJSONString();
+        } catch (Exception e) {
+            log.warn("read_skill failed, skillId={}, error={}", skillId, e.getMessage());
+            result.put("error", "read_failed");
+            result.put("message", e.getMessage());
+            return result.toJSONString();
+        }
+    }
+
+    private String parsePath(String toolInput) {
+        if (StringUtils.isBlank(toolInput)) {
+            return "";
+        }
+        try {
+            JSONObject args = JSON.parseObject(toolInput);
+            return args == null ? "" : normalizePath(args.getString("path"));
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private JSONObject findResource(String path) {
+        for (int i = 0; i < resources.size(); i++) {
+            JSONObject r = resources.getJSONObject(i);
+            if (r != null && path.equals(normalizePath(r.getString("path")))) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    private JSONArray manifest() {
+        JSONArray out = new JSONArray();
+        for (int i = 0; i < resources.size(); i++) {
+            JSONObject r = resources.getJSONObject(i);
+            if (r == null) {
+                continue;
+            }
+            out.add(new JSONObject()
+                    .fluentPut("path", r.getString("path"))
+                    .fluentPut("name", r.getString("name"))
+                    .fluentPut("file_ext", r.getString("fileExt"))
+                    .fluentPut("file_size", r.get("fileSize")));
+        }
+        return out;
+    }
+
+    private String normalizePath(String value) {
+        String p = StringUtils.defaultString(value).trim().replace("\\", "/");
+        while (p.startsWith("./")) {
+            p = p.substring(2);
+        }
+        return StringUtils.stripStart(p, "/");
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/RunSkillToolCallback.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/RunSkillToolCallback.java
@@ -1,0 +1,78 @@
+package com.iflytek.astron.console.hub.service.chat.springai;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+/**
+ * Spring AI tool: execute a command from the skill package in the configured E2B sandbox. Delegates
+ * the actual sandbox execution to core/agent's sandbox-exec endpoint (E2B has no Java SDK). When no
+ * sandbox is configured the endpoint returns a fixed unsupported-environment message.
+ */
+@Slf4j
+public class RunSkillToolCallback implements ToolCallback {
+
+    private static final String INPUT_SCHEMA = """
+            {"type":"object","properties":{"command":{"type":"string",\
+            "description":"Command to execute from the Skill workspace root, e.g. python -m scripts.clean_csv. \
+            Choose this from SKILL.md instructions."},"stdin":{"description":"Optional JSON-serializable stdin."}},\
+            "required":["command"]}""";
+
+    private final String skillId;
+    private final String name;
+    private final JSONObject skill;
+    private final SkillRuntimeToolService runtime;
+
+    public RunSkillToolCallback(JSONObject skill, SkillRuntimeToolService runtime) {
+        this.skill = skill;
+        this.skillId = skill.getString("skillId");
+        this.name = StringUtils.defaultString(skill.getString("name"));
+        this.runtime = runtime;
+    }
+
+    @Override
+    public ToolDefinition getToolDefinition() {
+        return ToolDefinition.builder()
+                .name("run_skill_" + skillId)
+                .description("Execute a command from skill '" + name + "' in the configured script sandbox. "
+                        + "Read SKILL.md first and follow its instructions. If no sandbox is configured, "
+                        + "this returns a fixed unsupported-environment message.")
+                .inputSchema(INPUT_SCHEMA)
+                .build();
+    }
+
+    @Override
+    public String call(String toolInput) {
+        JSONObject args;
+        try {
+            args = StringUtils.isBlank(toolInput) ? new JSONObject() : JSON.parseObject(toolInput);
+        } catch (Exception e) {
+            args = new JSONObject();
+        }
+        String command = args == null ? null : args.getString("command");
+        if (StringUtils.isBlank(command)) {
+            return new JSONObject().fluentPut("skill_id", skillId)
+                    .fluentPut("error", "command_required")
+                    .toJSONString();
+        }
+        JSONObject body = new JSONObject();
+        body.put("skill_id", skillId);
+        body.put("command", command);
+        body.put("stdin", args.get("stdin"));
+        body.put("resources", skill.getJSONArray("resources"));
+        body.put("sandbox", skill.getJSONObject("sandbox") == null ? new JSONObject() : skill.getJSONObject("sandbox"));
+        log.info("run_skill invoked, skillId={}, command={}", skillId, command);
+        try {
+            return runtime.executeSandbox(body);
+        } catch (Exception e) {
+            log.warn("run_skill failed, skillId={}, error={}", skillId, e.getMessage());
+            return new JSONObject().fluentPut("skill_id", skillId)
+                    .fluentPut("error", "run_failed")
+                    .fluentPut("message", e.getMessage())
+                    .toJSONString();
+        }
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillRuntimeToolService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillRuntimeToolService.java
@@ -1,11 +1,16 @@
 package com.iflytek.astron.console.hub.service.chat.springai;
 
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -20,7 +25,34 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class SkillRuntimeToolService {
 
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+
     private final OkHttpClient httpClient;
+    private final ApiUrl apiUrl;
+
+    /**
+     * POST a single skill command to core/agent's sandbox-exec endpoint; returns the raw JSON string.
+     */
+    public String executeSandbox(JSONObject body) throws IOException {
+        String base = StringUtils.defaultIfBlank(apiUrl.getAgentUrl(), "http://127.0.0.1:8700");
+        String url = StringUtils.stripEnd(base, "/") + "/agent/v1/skill/sandbox-exec";
+        Request request = new Request.Builder()
+                .url(url)
+                .post(RequestBody.create(body.toJSONString(), JSON_MEDIA_TYPE))
+                .addHeader("Content-Type", "application/json")
+                .build();
+        OkHttpClient client = httpClient.newBuilder()
+                .callTimeout(Duration.ofSeconds(120))
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            ResponseBody respBody = response.body();
+            String text = respBody == null ? "" : respBody.string();
+            if (!response.isSuccessful()) {
+                throw new IOException("sandbox-exec failed: HTTP " + response.code() + " " + text);
+            }
+            return text;
+        }
+    }
 
     /** Download a text resource (SKILL.md or a referenced file) from a presigned URL. */
     public String downloadText(String url) throws IOException {

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillRuntimeToolService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillRuntimeToolService.java
@@ -1,0 +1,42 @@
+package com.iflytek.astron.console.hub.service.chat.springai;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/**
+ * HTTP helpers backing the standalone-agent skill tools: downloading SKILL.md / resources for
+ * {@code read_skill} (and, in a later phase, calling the sandbox endpoint for {@code run_skill}).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SkillRuntimeToolService {
+
+    private final OkHttpClient httpClient;
+
+    /** Download a text resource (SKILL.md or a referenced file) from a presigned URL. */
+    public String downloadText(String url) throws IOException {
+        Request request = new Request.Builder().url(url).get().build();
+        OkHttpClient client = httpClient.newBuilder()
+                .callTimeout(Duration.ofSeconds(30))
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("Skill resource download failed: HTTP " + response.code());
+            }
+            ResponseBody body = response.body();
+            if (body == null) {
+                throw new IOException("Skill resource download returned empty body");
+            }
+            return body.string();
+        }
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillToolCallbackFactory.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillToolCallbackFactory.java
@@ -1,0 +1,40 @@
+package com.iflytek.astron.console.hub.service.chat.springai;
+
+import com.alibaba.fastjson2.JSONObject;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds {@code read_skill_*} (and, in a later phase, {@code run_skill_*}) Spring AI tool callbacks
+ * from enriched skill entries. Entries missing skillId/name/downloadUrl are skipped (mirroring the
+ * Python SkillPluginFactory's required-field check).
+ */
+@Service
+@RequiredArgsConstructor
+public class SkillToolCallbackFactory {
+
+    private final SkillRuntimeToolService skillRuntimeToolService;
+
+    public List<ToolCallback> build(List<JSONObject> skills) {
+        List<ToolCallback> callbacks = new ArrayList<>();
+        if (skills == null) {
+            return callbacks;
+        }
+        for (JSONObject skill : skills) {
+            if (skill == null
+                    || StringUtils.isBlank(skill.getString("skillId"))
+                    || StringUtils.isBlank(skill.getString("name"))
+                    || StringUtils.isBlank(skill.getString("downloadUrl"))) {
+                continue;
+            }
+            callbacks.add(new ReadSkillToolCallback(skill, skillRuntimeToolService));
+            // run_skill_* added in Phase 3
+        }
+        return callbacks;
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillToolCallbackFactory.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillToolCallbackFactory.java
@@ -33,7 +33,7 @@ public class SkillToolCallbackFactory {
                 continue;
             }
             callbacks.add(new ReadSkillToolCallback(skill, skillRuntimeToolService));
-            // run_skill_* added in Phase 3
+            callbacks.add(new RunSkillToolCallback(skill, skillRuntimeToolService));
         }
         return callbacks;
     }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillToolCallbackFactory.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillToolCallbackFactory.java
@@ -7,7 +7,9 @@ import org.springframework.ai.tool.ToolCallback;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Builds {@code read_skill_*} (and, in a later phase, {@code run_skill_*}) Spring AI tool callbacks
@@ -25,11 +27,16 @@ public class SkillToolCallbackFactory {
         if (skills == null) {
             return callbacks;
         }
+        Set<String> seenSkillIds = new HashSet<>();
         for (JSONObject skill : skills) {
             if (skill == null
                     || StringUtils.isBlank(skill.getString("skillId"))
                     || StringUtils.isBlank(skill.getString("name"))
                     || StringUtils.isBlank(skill.getString("downloadUrl"))) {
+                continue;
+            }
+            // Skip duplicate skillIds so we never register two tools with the same name.
+            if (!seenSkillIds.add(skill.getString("skillId"))) {
                 continue;
             }
             callbacks.add(new ReadSkillToolCallback(skill, skillRuntimeToolService));

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
@@ -54,7 +54,8 @@ public class SpringAiAgentChatService {
                     ? chatModelFactory.forCustomModel(task.getLlmInfoVo())
                     : chatModelFactory.forSparkModel(task.getSparkModelName());
 
-            List<ToolCallback> tools = toolCallbackResolver.resolve(task.getOpenedTool(), task.getMcpServerUrls(), context);
+            List<ToolCallback> tools = toolCallbackResolver.resolve(task.getOpenedTool(), task.getMcpServerUrls(),
+                    task.getSkills(), context);
             log.info("Agent chat start, streamId={}, modelId={}, spark={}, toolCount={}, openedTool={}, mcpServerUrls={}",
                     streamId, agentModel.modelId(), task.getLlmInfoVo() == null, tools.size(), task.getOpenedTool(),
                     task.getMcpServerUrls());

--- a/console/backend/hub/src/main/resources/db/migration/V1.38__add_bot_skills.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.38__add_bot_skills.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `chat_bot_base`
+    ADD COLUMN `skills` text DEFAULT NULL COMMENT 'Selected skills JSON list' AFTER `mcp_server_urls`;

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
@@ -16,14 +16,16 @@ import static org.mockito.Mockito.when;
 class AgentToolCallbackResolverTest {
 
     private AgentToolCallbackResolver newResolver(McpRuntimeToolService mcp) {
-        return new AgentToolCallbackResolver(mock(ManagedWebSearchService.class), new McpToolCallbackFactory(mcp));
+        return new AgentToolCallbackResolver(mock(ManagedWebSearchService.class), new McpToolCallbackFactory(mcp),
+                new SkillToolCallbackFactory(mock(SkillRuntimeToolService.class)));
     }
 
     @Test
     void webSearchAndCurrentTimeFromOpenedTool() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
-        List<ToolCallback> tools = newResolver(mcp).resolve("web_search,current_time", null, new ChatToolContext("u"));
+        List<ToolCallback> tools =
+                newResolver(mcp).resolve("web_search,current_time", null, null, new ChatToolContext("u"));
         List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
         assertTrue(names.contains("web_search"));
         assertTrue(names.contains("current_time"));
@@ -33,7 +35,7 @@ class AgentToolCallbackResolverTest {
     void builtinToolsAlwaysPresentEvenWhenOpenedToolBlank() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
-        List<ToolCallback> tools = newResolver(mcp).resolve("", null, new ChatToolContext("u"));
+        List<ToolCallback> tools = newResolver(mcp).resolve("", null, null, new ChatToolContext("u"));
         List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
         assertTrue(names.contains("web_search"));
         assertTrue(names.contains("current_time"));
@@ -43,7 +45,7 @@ class AgentToolCallbackResolverTest {
     void mcpUrlsParsedFromJsonArrayString() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(List.of("http://a", "http://b"))).thenReturn(List.of());
-        newResolver(mcp).resolve(null, "[\"http://a\",\"http://b\"]", new ChatToolContext("u"));
+        newResolver(mcp).resolve(null, "[\"http://a\",\"http://b\"]", null, new ChatToolContext("u"));
         verify(mcp).listTools(List.of("http://a", "http://b"));
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/config/properties/ApiUrl.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/config/properties/ApiUrl.java
@@ -18,6 +18,7 @@ public class ApiUrl {
     String knowledgeUrl;
     String streamChatUrl;
     String toolUrl;
+    String agentUrl;
     String toolRpaUrl;
     String appUrl;
     String apiKey;

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/skill/SkillEnrichmentService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/skill/SkillEnrichmentService.java
@@ -1,0 +1,91 @@
+package com.iflytek.astron.console.toolkit.service.skill;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.iflytek.astron.console.toolkit.entity.dto.skill.SkillImportDto;
+import com.iflytek.astron.console.toolkit.entity.dto.skill.SkillSandboxConfigDto;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+/**
+ * Shared skill enrichment: augments skill entries (each carrying a skillId) in place with
+ * name/description/downloadUrl/resources and, when the sandbox is enabled, sandbox config. Used by
+ * both the workflow agent node and the standalone agent runtime.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SkillEnrichmentService {
+
+    private final SkillFileService skillFileService;
+    private final SkillSandboxConfigService skillSandboxConfigService;
+
+    public void enrichSkillEntries(JSONArray skillArray) {
+        if (skillArray == null || skillArray.isEmpty()) {
+            return;
+        }
+        List<Long> skillIds = new ArrayList<>();
+        for (int i = 0; i < skillArray.size(); i++) {
+            Object obj = skillArray.get(i);
+            if (!(obj instanceof Map skillObj)) {
+                continue;
+            }
+            Object skillIdObj = skillObj.get("skillId");
+            if (skillIdObj == null) {
+                skillIdObj = skillObj.get("id");
+            }
+            if (skillIdObj == null) {
+                continue;
+            }
+            try {
+                skillIds.add(Long.parseLong(String.valueOf(skillIdObj)));
+            } catch (NumberFormatException ex) {
+                log.warn("Ignore invalid skill id: {}", skillIdObj);
+            }
+        }
+        if (skillIds.isEmpty()) {
+            return;
+        }
+        Map<Long, SkillImportDto> importMap = skillFileService.getSkillImportsByIds(skillIds)
+                .stream()
+                .collect(Collectors.toMap(SkillImportDto::getId, item -> item, (a, b) -> a));
+        SkillSandboxConfigDto sandboxConfig = skillSandboxConfigService.toRuntimeDto();
+        for (int i = 0; i < skillArray.size(); i++) {
+            Object obj = skillArray.get(i);
+            if (!(obj instanceof Map skillObj)) {
+                continue;
+            }
+            Object skillIdObj = skillObj.get("skillId");
+            if (skillIdObj == null) {
+                skillIdObj = skillObj.get("id");
+            }
+            if (skillIdObj == null) {
+                continue;
+            }
+            try {
+                Long skillId = Long.parseLong(String.valueOf(skillIdObj));
+                SkillImportDto importDto = importMap.get(skillId);
+                if (importDto == null) {
+                    continue;
+                }
+                skillObj.put("skillId", String.valueOf(importDto.getId()));
+                skillObj.put("name", StringUtils.defaultString(importDto.getName()));
+                skillObj.put("description", StringUtils.defaultString(importDto.getDescription()));
+                skillObj.put("downloadUrl", StringUtils.defaultString(importDto.getDownloadUrl()));
+                skillObj.put("resources", importDto.getResources());
+                if (Boolean.TRUE.equals(sandboxConfig.getEnabled())
+                        && StringUtils.isNotBlank(sandboxConfig.getApiKey())) {
+                    skillObj.put("sandbox", JSON.parseObject(JSON.toJSONString(sandboxConfig)));
+                }
+            } catch (NumberFormatException ex) {
+                log.warn("Ignore invalid skill id while enriching: {}", skillIdObj);
+            }
+        }
+    }
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -70,7 +70,6 @@ import com.iflytek.astron.console.toolkit.entity.table.relation.FlowRepoRel;
 import com.iflytek.astron.console.toolkit.entity.table.relation.FlowToolRel;
 import com.iflytek.astron.console.toolkit.entity.table.repo.FileInfoV2;
 import com.iflytek.astron.console.toolkit.entity.table.repo.Repo;
-import com.iflytek.astron.console.toolkit.entity.dto.skill.SkillImportDto;
 import com.iflytek.astron.console.toolkit.entity.dto.skill.SkillSandboxConfigDto;
 import com.iflytek.astron.console.toolkit.entity.table.tool.*;
 import com.iflytek.astron.console.toolkit.entity.table.workflow.*;
@@ -96,7 +95,7 @@ import com.iflytek.astron.console.toolkit.service.extra.AppService;
 import com.iflytek.astron.console.toolkit.service.extra.CoreSystemService;
 import com.iflytek.astron.console.toolkit.service.extra.OpenPlatformService;
 import com.iflytek.astron.console.toolkit.service.model.ModelService;
-import com.iflytek.astron.console.toolkit.service.skill.SkillFileService;
+import com.iflytek.astron.console.toolkit.service.skill.SkillEnrichmentService;
 import com.iflytek.astron.console.toolkit.service.skill.SkillSandboxConfigService;
 import com.iflytek.astron.console.toolkit.sse.WorkflowSseEventSourceListener;
 import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
@@ -271,7 +270,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
     @Autowired
     private DbTableMapper dbTableMapper;
     @Autowired
-    private SkillFileService skillFileService;
+    private SkillEnrichmentService skillEnrichmentService;
     @Autowired
     private SkillSandboxConfigService skillSandboxConfigService;
     @Autowired
@@ -2392,67 +2391,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
 
     @SuppressWarnings("rawtypes")
     private void enrichSkills(JSONObject plugin) {
-        JSONArray skillArray = plugin.getJSONArray("skills");
-        if (skillArray == null || skillArray.isEmpty()) {
-            return;
-        }
-        List<Long> skillIds = new ArrayList<>();
-        for (int i = 0; i < skillArray.size(); i++) {
-            Object obj = skillArray.get(i);
-            if (!(obj instanceof Map skillObj)) {
-                continue;
-            }
-            Object skillIdObj = skillObj.get("skillId");
-            if (skillIdObj == null) {
-                skillIdObj = skillObj.get("id");
-            }
-            if (skillIdObj == null) {
-                continue;
-            }
-            try {
-                skillIds.add(Long.parseLong(String.valueOf(skillIdObj)));
-            } catch (NumberFormatException ex) {
-                log.warn("Ignore invalid skill id: {}", skillIdObj);
-            }
-        }
-        if (skillIds.isEmpty()) {
-            return;
-        }
-        Map<Long, SkillImportDto> importMap = skillFileService.getSkillImportsByIds(skillIds)
-                .stream()
-                .collect(Collectors.toMap(SkillImportDto::getId, item -> item, (a, b) -> a));
-        SkillSandboxConfigDto sandboxConfig = skillSandboxConfigService.toRuntimeDto();
-        for (int i = 0; i < skillArray.size(); i++) {
-            Object obj = skillArray.get(i);
-            if (!(obj instanceof Map skillObj)) {
-                continue;
-            }
-            Object skillIdObj = skillObj.get("skillId");
-            if (skillIdObj == null) {
-                skillIdObj = skillObj.get("id");
-            }
-            if (skillIdObj == null) {
-                continue;
-            }
-            try {
-                Long skillId = Long.parseLong(String.valueOf(skillIdObj));
-                SkillImportDto importDto = importMap.get(skillId);
-                if (importDto == null) {
-                    continue;
-                }
-                skillObj.put("skillId", String.valueOf(importDto.getId()));
-                skillObj.put("name", StringUtils.defaultString(importDto.getName()));
-                skillObj.put("description", StringUtils.defaultString(importDto.getDescription()));
-                skillObj.put("downloadUrl", StringUtils.defaultString(importDto.getDownloadUrl()));
-                skillObj.put("resources", importDto.getResources());
-                if (Boolean.TRUE.equals(sandboxConfig.getEnabled())
-                        && StringUtils.isNotBlank(sandboxConfig.getApiKey())) {
-                    skillObj.put("sandbox", JSON.parseObject(JSON.toJSONString(sandboxConfig)));
-                }
-            } catch (NumberFormatException ex) {
-                log.warn("Ignore invalid skill id while enriching: {}", skillIdObj);
-            }
-        }
+        skillEnrichmentService.enrichSkillEntries(plugin.getJSONArray("skills"));
     }
 
     private List<String> resolveBotMcpServerUrls(WorkflowReq saveDto, Workflow workflow) {

--- a/console/backend/toolkit/src/main/resources/application-toolkit.yml
+++ b/console/backend/toolkit/src/main/resources/application-toolkit.yml
@@ -23,6 +23,7 @@ api:
     tenantKey: ${TENANT_KEY:tenantKey}
     tenantSecret: ${TENANT_SECRET:tenantSecret}
     toolUrl: ${TOOL_URL:http://127.0.0.1:18888}
+    agentUrl: ${AGENT_URL:http://127.0.0.1:8700}
     toolRpaUrl: ${TOOL_RPA_URL:http://127.0.0.1:17198}
     workflow: ${WORKFLOW_URL:http://127.0.0.1:7880}
     sparkDB: ${SPARK_DB_URL:http://127.0.0.1:7990}

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.module.scss
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.module.scss
@@ -369,6 +369,88 @@
   color: #f53f3f;
 }
 
+.skillIcon {
+  background: #eef2ff;
+  color: #6356ea;
+}
+
+.skillList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.skillRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 40px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid #e5e6eb;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.skillRowMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.skillRowName {
+  font-size: 13px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.skillRowDesc {
+  font-size: 12px;
+  color: #8a8f99;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skillModalList {
+  max-height: 420px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skillModalRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid #e5e6eb;
+  border-radius: 8px;
+}
+
+.skillModalMeta {
+  min-width: 0;
+}
+
+.skillModalName {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1d2129;
+}
+
+.skillModalDesc {
+  font-size: 12px;
+  color: #8a8f99;
+}
+
+.skillModalEmpty {
+  text-align: center;
+  color: #8a8f99;
+  padding: 24px 0;
+}
+
 @media (max-width: 768px) {
   .capabilityBlock {
     padding: 18px;

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -51,6 +51,8 @@ import styles from './CapabilityDevelopment.module.scss';
 import cls from 'classnames';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { isValidMcpServerUrl } from '../mcp-url-config';
+import SkillSelectModal from './SkillSelectModal';
+import type { AgentSkill } from '@/types/skill';
 
 const { TextArea } = Input;
 
@@ -75,6 +77,8 @@ interface CapabilityDevelopmentProps {
   setTools: (v: any[]) => void;
   mcpServerUrls: string[];
   setMcpServerUrls: (v: string[]) => void;
+  skills: AgentSkill[];
+  setSkills: (v: AgentSkill[]) => void;
   files: any[];
   tree: any[];
   setTree: (v: any[]) => void;
@@ -111,6 +115,8 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
     setTools,
     mcpServerUrls,
     setMcpServerUrls,
+    skills,
+    setSkills,
     files,
     tree,
     setTree,
@@ -370,6 +376,11 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
       return itemIndex !== index;
     });
     setMcpServerUrls(nextUrls.length > 0 ? nextUrls : []);
+  };
+
+  const [skillModalOpen, setSkillModalOpen] = useState(false);
+  const removeSkill = (skillId: number) => {
+    setSkills(skills.filter(skill => skill.skillId !== skillId));
   };
 
   return (
@@ -856,6 +867,90 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
               ))}
             </div>
           )}
+        </div>
+      )}
+      {showMcpSection && (
+        <div
+          className={cls(
+            styles.capabilitySection,
+            showKnowledgeSection && styles.capabilitySectionCompact
+          )}
+        >
+          <div className={styles.capabilityBlock}>
+            <div className={styles.capabilityBlockHeader}>
+              <div className={styles.capabilityTitleGroup}>
+                <span className={cls(styles.capabilityIcon, styles.skillIcon)}>
+                  <ApiOutlined />
+                </span>
+                <div>
+                  <div className={styles.capabilityTitleRow}>
+                    <span className={styles.capabilityTitle}>Skill</span>
+                    <span
+                      className={cls(
+                        styles.capabilityStatus,
+                        skills.length > 0
+                          ? styles.statusReady
+                          : styles.statusMuted
+                      )}
+                    >
+                      {skills.length > 0
+                        ? `已添加 ${skills.length} 个`
+                        : '未添加'}
+                    </span>
+                  </div>
+                  <div className={styles.capabilityDescription}>
+                    添加资源管理中的 Skill，模型可读取 SKILL.md 并按说明执行。
+                  </div>
+                </div>
+              </div>
+              <Button
+                icon={<PlusOutlined />}
+                className={styles.capabilityActionButton}
+                onClick={() => setSkillModalOpen(true)}
+              >
+                {skills.length > 0 ? '管理 Skill' : '添加 Skill'}
+              </Button>
+            </div>
+
+            {skills.length > 0 ? (
+              <div className={styles.skillList}>
+                {skills.map(skill => (
+                  <div className={styles.skillRow} key={skill.skillId}>
+                    <div className={styles.skillRowMeta}>
+                      <span className={styles.skillRowName}>{skill.name}</span>
+                      <span className={styles.skillRowDesc}>
+                        {skill.description || '暂无描述'}
+                      </span>
+                    </div>
+                    <Tooltip title="删除">
+                      <Button
+                        className={styles.mcpDeleteButton}
+                        icon={<DeleteOutlined />}
+                        onClick={() => removeSkill(skill.skillId)}
+                      />
+                    </Tooltip>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <button
+                type="button"
+                className={styles.capabilityEmptyState}
+                onClick={() => setSkillModalOpen(true)}
+              >
+                <span className={styles.capabilityEmptyTitle}>暂无 Skill</span>
+                <span className={styles.capabilityEmptyDescription}>
+                  点击添加 Skill，或前往资源管理创建 Skill。
+                </span>
+              </button>
+            )}
+          </div>
+          <SkillSelectModal
+            open={skillModalOpen}
+            selected={skills}
+            onClose={() => setSkillModalOpen(false)}
+            onChange={setSkills}
+          />
         </div>
       )}
       {showMcpSection && (

--- a/console/frontend/src/components/config-page-component/config-base/components/SkillSelectModal.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/SkillSelectModal.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Input, Button, Spin, message } from 'antd';
+import { listImportableSkills } from '@/services/skill';
+import type { SkillImportItem, AgentSkill } from '@/types/skill';
+import styles from './CapabilityDevelopment.module.scss';
+
+const MAX_SKILLS = 30;
+
+interface SkillSelectModalProps {
+  open: boolean;
+  selected: AgentSkill[];
+  onClose: () => void;
+  onChange: (next: AgentSkill[]) => void;
+}
+
+const SkillSelectModal: React.FC<SkillSelectModalProps> = ({
+  open,
+  selected,
+  onClose,
+  onChange,
+}) => {
+  const [keyword, setKeyword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<SkillImportItem[]>([]);
+
+  const selectedIds = useMemo(
+    () => new Set(selected.map(s => s.skillId)),
+    [selected]
+  );
+
+  const fetchList = (kw?: string): void => {
+    setLoading(true);
+    listImportableSkills(kw)
+      .then(res => setData(res || []))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    if (open) {
+      setKeyword('');
+      fetchList();
+    }
+  }, [open]);
+
+  const toggle = (item: SkillImportItem): void => {
+    if (selectedIds.has(item.id)) {
+      onChange(selected.filter(s => s.skillId !== item.id));
+      return;
+    }
+    if (selected.length >= MAX_SKILLS) {
+      message.warning(`最多添加 ${MAX_SKILLS} 个 Skill`);
+      return;
+    }
+    onChange([
+      ...selected,
+      {
+        skillId: item.id,
+        name: item.name,
+        description: item.description || '',
+      },
+    ]);
+  };
+
+  return (
+    <Modal
+      open={open}
+      centered
+      footer={null}
+      closable
+      onCancel={onClose}
+      title={`选择 Skill（已选 ${selected.length}/${MAX_SKILLS}）`}
+    >
+      <Input.Search
+        allowClear
+        placeholder="搜索 Skill"
+        value={keyword}
+        onChange={e => setKeyword(e.target.value)}
+        onSearch={v => fetchList(v)}
+        style={{ marginBottom: 12 }}
+      />
+      <Spin spinning={loading}>
+        <div className={styles.skillModalList}>
+          {data.map(item => {
+            const checked = selectedIds.has(item.id);
+            return (
+              <div className={styles.skillModalRow} key={item.id}>
+                <div className={styles.skillModalMeta}>
+                  <div className={styles.skillModalName}>{item.name}</div>
+                  <div className={styles.skillModalDesc}>
+                    {item.description || '暂无描述'}
+                  </div>
+                </div>
+                <Button
+                  type={checked ? 'default' : 'primary'}
+                  onClick={() => toggle(item)}
+                >
+                  {checked ? '移除' : '添加'}
+                </Button>
+              </div>
+            );
+          })}
+          {!loading && data.length === 0 && (
+            <div className={styles.skillModalEmpty}>未找到可引入的 Skill</div>
+          )}
+        </div>
+      </Spin>
+    </Modal>
+  );
+};
+
+export default SkillSelectModal;

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -1657,6 +1657,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 supportContext={supportContextFlag ? 1 : 0}
                 choosedAlltool={effectiveToolConfig}
                 mcpServerUrls={mcpServerUrls}
+                skills={skills}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1717,6 +1718,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 supportContext={supportContextFlag ? 1 : 0}
                 choosedAlltool={effectiveToolConfig}
                 mcpServerUrls={mcpServerUrls}
+                skills={skills}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1750,6 +1752,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         supportContext={supportContextFlag ? 1 : 0}
         choosedAlltool={effectiveToolConfig}
         mcpServerUrls={mcpServerUrls}
+        skills={skills}
         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
         personalityConfig={
           personalityData.enablePersonality
@@ -2891,6 +2894,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       supportContext={supportContextFlag ? 1 : 0}
                       choosedAlltool={effectiveToolConfig}
                       mcpServerUrls={mcpServerUrls}
+                      skills={skills}
                       findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                       personalityConfig={
                         personalityData.enablePersonality
@@ -2935,6 +2939,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                           supportContext={supportContextFlag ? 1 : 0}
                           choosedAlltool={effectiveToolConfig}
                           mcpServerUrls={mcpServerUrls}
+                          skills={skills}
                           findModelOptionByUniqueKey={
                             findModelOptionByUniqueKey
                           }
@@ -3009,6 +3014,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                         supportContext={supportContextFlag ? 1 : 0}
                         choosedAlltool={effectiveToolConfig}
                         mcpServerUrls={mcpServerUrls}
+                        skills={skills}
                         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                         personalityConfig={
                           personalityData.enablePersonality

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -81,7 +81,9 @@ import { getEffectiveToolConfig, serializeOpenedTool } from './tool-config';
 import {
   hasInvalidMcpServerUrls,
   normalizeMcpServerUrls,
+  normalizeSkills,
 } from './mcp-url-config';
+import type { AgentSkill } from '@/types/skill';
 import { VcnItem } from '@/components/speaker-modal';
 import { getVcnList } from '@/services/chat';
 import type { MessageListType } from '@/types/chat';
@@ -250,6 +252,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     codeinterpreter: false,
   });
   const [mcpServerUrls, setMcpServerUrls] = useState<string[]>([]);
+  const [skills, setSkills] = useState<AgentSkill[]>([]);
   const effectiveToolConfig = useMemo(
     () => getEffectiveToolConfig(choosedAlltool, isNewWorkbench),
     [choosedAlltool, isNewWorkbench]
@@ -535,6 +538,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       isSentence: 0,
       openedTool: effectiveOpenedTool,
       mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
+      skills: normalizeSkills(skills),
       prologue: prologue,
       ...getModelConfig(model),
       prompt: prompt,
@@ -817,6 +821,7 @@ const BaseConfig: React.FC<ChatProps> = ({
           setMcpServerUrls(
             normalizeMcpServerUrls(currentConfigData?.mcpServerUrls)
           );
+          setSkills(normalizeSkills(currentConfigData?.skills));
           setSupportContextFlag(
             save == 'true'
               ? configPageData?.supportContext == 1
@@ -1832,6 +1837,8 @@ const BaseConfig: React.FC<ChatProps> = ({
       setTools={setTools}
       mcpServerUrls={mcpServerUrls}
       setMcpServerUrls={setMcpServerUrls}
+      skills={skills}
+      setSkills={setSkills}
       conversation={conversation}
       setConversation={setConversation}
       multiModelDebugging={multiModelDebugging}
@@ -2251,6 +2258,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       isSentence: 0,
                       openedTool: effectiveOpenedTool,
                       mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
+                      skills: normalizeSkills(skills),
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2300,6 +2308,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       isSentence: 0,
                       openedTool: effectiveOpenedTool,
                       mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
+                      skills: normalizeSkills(skills),
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2380,6 +2389,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     isSentence: sentence,
                     openedTool: effectiveOpenedTool,
                     mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
+                    skills: normalizeSkills(skills),
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2428,6 +2438,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     isSentence: sentence,
                     openedTool: effectiveOpenedTool,
                     mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
+                    skills: normalizeSkills(skills),
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2749,6 +2760,8 @@ const BaseConfig: React.FC<ChatProps> = ({
                           setTools={setTools}
                           mcpServerUrls={mcpServerUrls}
                           setMcpServerUrls={setMcpServerUrls}
+                          skills={skills}
+                          setSkills={setSkills}
                           conversation={conversation}
                           setConversation={setConversation}
                           multiModelDebugging={multiModelDebugging}

--- a/console/frontend/src/components/config-page-component/config-base/mcp-url-config.ts
+++ b/console/frontend/src/components/config-page-component/config-base/mcp-url-config.ts
@@ -1,3 +1,5 @@
+import type { AgentSkill } from '@/types/skill';
+
 export const isValidMcpServerUrl = (url: string): boolean => {
   const value = url.trim();
   if (!value) {
@@ -37,6 +39,37 @@ export const normalizeMcpServerUrls = (urls?: unknown): string[] => {
         .filter(url => Boolean(url) && isValidMcpServerUrl(url))
     )
   );
+};
+
+export const normalizeSkills = (skills?: unknown): AgentSkill[] => {
+  let source = skills;
+  if (typeof skills === 'string') {
+    try {
+      source = JSON.parse(skills);
+    } catch {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(source)) {
+    return [];
+  }
+
+  const seen = new Set<number>();
+  const result: AgentSkill[] = [];
+  for (const item of source) {
+    const skillId = Number(item?.skillId ?? item?.id);
+    if (!skillId || seen.has(skillId)) {
+      continue;
+    }
+    seen.add(skillId);
+    result.push({
+      skillId,
+      name: String(item?.name ?? ''),
+      description: String(item?.description ?? ''),
+    });
+  }
+  return result.slice(0, 30);
 };
 
 export const hasInvalidMcpServerUrls = (urls?: unknown): boolean => {

--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -19,6 +19,7 @@ import {
   hasInvalidMcpServerUrls,
   normalizeMcpServerUrls,
 } from '@/components/config-page-component/config-base/mcp-url-config';
+import type { AgentSkill } from '@/types/skill';
 
 // PromptTry组件暴露的方法接口
 export interface PromptTryRef {
@@ -65,6 +66,7 @@ const PromptTry = forwardRef<
       [key: string]: boolean;
     };
     mcpServerUrls?: string[];
+    skills?: AgentSkill[];
     findModelOptionByUniqueKey: (
       uniqueKey: string
     ) => ModelListData | undefined;
@@ -87,6 +89,7 @@ const PromptTry = forwardRef<
       supportContext,
       choosedAlltool,
       mcpServerUrls,
+      skills,
       initialMessages,
       onMessagesChange,
       showHeaderAndRecommend = true,
@@ -225,6 +228,9 @@ const PromptTry = forwardRef<
       const normalizedMcpServerUrls = normalizeMcpServerUrls(mcpServerUrls);
       if (normalizedMcpServerUrls.length > 0) {
         form.append('mcpServerUrls', JSON.stringify(normalizedMcpServerUrls));
+      }
+      if (skills && skills.length > 0) {
+        form.append('skills', JSON.stringify(skills));
       }
 
       // 添加人设配置信息

--- a/console/frontend/src/types/skill.ts
+++ b/console/frontend/src/types/skill.ts
@@ -45,6 +45,13 @@ export interface SkillImportItem {
   updateTime?: string;
 }
 
+/** A skill reference saved on an agent (resolved/enriched on the backend at runtime). */
+export interface AgentSkill {
+  skillId: number;
+  name: string;
+  description: string;
+}
+
 export interface CreateSkillFolderParams {
   parentId?: number;
   name: string;

--- a/core/agent/api/router.py
+++ b/core/agent/api/router.py
@@ -6,9 +6,11 @@ It sets up the common prefix '/agent/v1' for all agent API endpoints.
 
 from fastapi import APIRouter
 
+from agent.api.v1.skill_sandbox_api import skill_sandbox_router
 from agent.api.v1.workflow_agent import workflow_agent_router
 
 router_v1 = APIRouter(
     prefix="/agent/v1",
 )
 router_v1.include_router(workflow_agent_router)
+router_v1.include_router(skill_sandbox_router)

--- a/core/agent/api/v1/skill_sandbox_api.py
+++ b/core/agent/api/v1/skill_sandbox_api.py
@@ -1,0 +1,93 @@
+"""HTTP endpoint that runs a single skill command in the E2B sandbox.
+
+Reuses the audited ``E2BSandboxProvider`` so the Java standalone-agent runtime
+(which has no E2B SDK) can execute ``run_skill`` via one internal HTTP call.
+v1 returns only exit_code/stdout/stderr; artifact collection/upload is skipped.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from agent.service.plugin.skill import SkillResource
+from agent.service.plugin.skill_sandbox import (
+    SCRIPT_SANDBOX_UNCONFIGURED_MESSAGE,
+    E2BSandboxProvider,
+    SandboxExecutionRequest,
+    SkillSandboxConfig,
+)
+
+skill_sandbox_router = APIRouter()
+
+
+class SandboxExecBody(BaseModel):
+    skill_id: str
+    command: str
+    stdin: Any = None
+    resources: list[dict[str, Any]] = Field(default_factory=list)
+    sandbox: dict[str, Any] = Field(default_factory=dict)
+
+
+class SandboxExecResponse(BaseModel):
+    configured: bool
+    exit_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    message: str = ""
+
+
+def _build_config(raw: dict[str, Any]) -> SkillSandboxConfig:
+    return SkillSandboxConfig(
+        provider=str(raw.get("provider") or "e2b").strip().lower(),
+        enabled=bool(raw.get("enabled")),
+        api_key=str(raw.get("api_key") or raw.get("apiKey") or ""),
+        timeout_seconds=int(
+            raw.get("timeout_seconds") or raw.get("timeoutSeconds") or 60
+        ),
+        allow_internet_access=bool(
+            raw.get("allow_internet_access") or raw.get("allowInternetAccess")
+        ),
+    )
+
+
+@skill_sandbox_router.post(  # type: ignore[misc]
+    "/skill/sandbox-exec",
+    description="Execute a single skill command in the E2B sandbox (no artifact handling).",
+    response_model=SandboxExecResponse,
+)
+async def sandbox_exec(body: SandboxExecBody) -> SandboxExecResponse:
+    config = _build_config(body.sandbox)
+    configured = config.enabled and config.provider == "e2b" and bool(config.api_key)
+    if not configured:
+        return SandboxExecResponse(
+            configured=False, message=SCRIPT_SANDBOX_UNCONFIGURED_MESSAGE
+        )
+    if not body.command.strip():
+        return SandboxExecResponse(
+            configured=True, exit_code=1, stderr="command_required"
+        )
+
+    resources = [
+        SkillResource(
+            path=str(r.get("path") or ""),
+            name=str(r.get("name") or ""),
+            download_url=str(r.get("download_url") or r.get("downloadUrl") or ""),
+            file_ext=str(r.get("file_ext") or r.get("fileExt") or ""),
+            file_size=int(r.get("file_size") or r.get("fileSize") or 0),
+        )
+        for r in body.resources
+    ]
+    request = SandboxExecutionRequest(
+        skill_id=body.skill_id,
+        command=body.command,
+        stdin=body.stdin,
+        resources=resources,
+    )
+    result = await E2BSandboxProvider(config).execute(request)
+    return SandboxExecResponse(
+        configured=True,
+        exit_code=int(result.get("exit_code") or 0),
+        stdout=str(result.get("stdout") or ""),
+        stderr=str(result.get("stderr") or ""),
+    )

--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -227,6 +227,7 @@ ADMIN_UID=9999
 APP_URL=http://core-tenant:${CORE_TENANT_PORT:-5052}/v2/app
 KNOWLEDGE_URL=http://core-knowledge:${CORE_KNOWLEDGE_PORT:-20010}/knowledge
 TOOL_URL=http://core-link:18888
+AGENT_URL=http://core-agent:${CORE_AGENT_PORT:-17870}
 TOOL_RPA_URL=http://core-rpa:17198
 WORKFLOW_URL=http://core-workflow:${CORE_WORKFLOW_PORT:-7880}
 SPARK_DB_URL=http://core-database:${CORE_DATABASE_PORT:-7990}

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -591,6 +591,7 @@ services:
       APP_URL: "${APP_URL:-}"
       KNOWLEDGE_URL: "${KNOWLEDGE_URL:-}"
       TOOL_URL: "${TOOL_URL:-}"
+      AGENT_URL: "${AGENT_URL:-http://core-agent:${CORE_AGENT_PORT}}"
       TOOL_RPA_URL: "${TOOL_RPA_URL:-}"
       WORKFLOW_URL: "${WORKFLOW_URL:-}"
       SPARK_DB_URL: "${SPARK_DB_URL:-}"


### PR DESCRIPTION
## What

Adds a **Skill capability to the standalone Agent** (the Java Spring AI chat runtime), in three phases:

1. **Persistence + capability-page UI** — a Skill block on the agent capability page (between Knowledge Base and MCP Server) that reuses the importable-skill list (`GET /skill-file/importable`) with search / multi-select / remove and a 30-item cap. Selected skills are stored as a JSON column `chat_bot_base.skills` (`[{skillId,name,description}]`, Flyway `V1.38`) and rehydrated on edit.
2. **read_skill runtime** — shared `SkillEnrichmentService` (extracted from `WorkflowService`, which now delegates) resolves downloadUrl/resources/sandbox by skillId; `ReadSkillToolCallback` (pure-Java HTTP download of SKILL.md + referenced resources) is registered per skill, and the enriched skills flow through all standalone chat branches (formal / re-answer / debug).
3. **run_skill runtime** — `RunSkillToolCallback` executes a skill command in the E2B sandbox via a new internal `core/agent` endpoint `POST /agent/v1/skill/sandbox-exec` (reuses the audited `E2BSandboxProvider`; E2B has no Java SDK). `api.url.agentUrl` (env `AGENT_URL`) wires console-hub → core-agent. v1 does not collect/upload sandbox artifacts.

## Notes

- Targets `main` (the runtime refactor from #1418 is already here); cherry-picked cleanly onto `main` with zero conflicts.
- The standalone bot has no `plugin` JSON, so skills live on `chat_bot_base.skills` rather than `plugin.skills`.
- `run_skill` only executes when an E2B sandbox is configured in resource management; otherwise it returns the standard "unconfigured" message. `AGENT_URL` defaults to `http://core-agent:${CORE_AGENT_PORT}` in docker.

## Verification

- `mvn -DskipTests package -pl hub -am` → BUILD SUCCESS (test compilation included).
- Frontend `type-check` clean for the touched files.
- Passed an internal code review (no Critical issues; skillId dedup hardening applied).
