### PR TITLE
fix(ci): address remaining remote test failures

### DIFF
--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceMcpRuntimeConfigTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceMcpRuntimeConfigTest.java
@@ -9,6 +9,7 @@ import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
 import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowData;
 import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowNode;
 import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizNodeData;
+import com.iflytek.astron.console.toolkit.service.skill.SkillEnrichmentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,12 +28,16 @@ class WorkflowServiceMcpRuntimeConfigTest {
     @Mock
     private ChatBotBaseMapper chatBotBaseMapper;
 
+    @Mock
+    private SkillEnrichmentService skillEnrichmentService;
+
     private WorkflowService workflowService;
 
     @BeforeEach
     void setUp() {
         workflowService = new WorkflowService();
         ReflectionTestUtils.setField(workflowService, "chatBotBaseMapper", chatBotBaseMapper);
+        ReflectionTestUtils.setField(workflowService, "skillEnrichmentService", skillEnrichmentService);
     }
 
     @Test

--- a/core/agent/tests/test_base_builder.py
+++ b/core/agent/tests/test_base_builder.py
@@ -136,9 +136,12 @@ class TestBaseApiBuilder:
             ],
         )
 
-        assert len(plugins) == 1
-        assert plugins[0].typ == "skill"
-        assert plugins[0].name == "read_skill_skill-1"
+        assert len(plugins) == 2
+        assert [plugin.typ for plugin in plugins] == ["skill", "skill"]
+        assert [plugin.name for plugin in plugins] == [
+            "read_skill_skill-1",
+            "run_skill_skill-1",
+        ]
 
     @pytest.mark.asyncio
     async def test_build_plugins_filters_empty_mcp_urls(

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -98,11 +98,12 @@ class RagflowRAGStrategy(RAGStrategy):
     async def _resolve_dataset_id(
         self,
         dataset_id_input: Optional[str],
+        group: Optional[str] = None,
     ) -> Optional[str]:
         """Return requested dataset id or the default dataset id."""
         if dataset_id_input:
             return dataset_id_input
-        default_name = RagflowUtils.get_default_dataset_name()
+        default_name = group or RagflowUtils.get_default_dataset_name()
         return await RagflowUtils.ensure_dataset(default_name)
 
     def _build_retrieval_payload(
@@ -339,7 +340,9 @@ class RagflowRAGStrategy(RAGStrategy):
 
         try:
             # Step 1: Resolve dataset
-            dataset_id = await self._resolve_dataset_id(kwargs.get(_DATASET_ID_KWARG))
+            dataset_id = await self._resolve_dataset_id(
+                kwargs.get(_DATASET_ID_KWARG), kwargs.get("group")
+            )
             if not dataset_id:
                 raise CustomException(
                     CodeEnum.RAGFLOW_RAGError,


### PR DESCRIPTION
## Summary
- Inject SkillEnrichmentService in WorkflowService MCP runtime config unit test
- Update agent skill plugin builder test for read/run skill tools
- Preserve caller-provided Ragflow split group when resolving datasets

## Validation
- Code review subagent: no Critical/Important/Minor findings
- Remote CI server is currently not accepting SSH banner after an environment smoke build; will pull and rerun remote validation once SSH recovers