### PR TITLE
feat(console): add plugin capability to standard agent ability page

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotCreateForm.java
@@ -111,6 +111,9 @@ public class BotCreateForm {
     @Schema(description = "Selected skills imported from resource management")
     private List<BotSkill> skills;
 
+    @Schema(description = "Selected plugin tools imported from the tool square")
+    private List<BotTool> tools;
+
     @Schema(description = "Background image color scheme: 0 Light, 1 Dark")
     private Integer backgroundColor;
 
@@ -172,5 +175,14 @@ public class BotCreateForm {
         private Long skillId;
         private String name;
         private String description;
+    }
+
+    @Data
+    public static class BotTool {
+        @Schema(description = "Tool id from the tool square, e.g. tool@xxx")
+        private String toolId;
+        private String name;
+        private String description;
+        private String icon;
     }
 }

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/DebugChatBotReqDto.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/DebugChatBotReqDto.java
@@ -52,6 +52,11 @@ public class DebugChatBotReqDto {
     private String skills;
 
     /**
+     * Selected plugin tools (tool square) JSON list
+     */
+    private String tools;
+
+    /**
      * Model name
      */
     private String model;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/bot/ChatBotBase.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/entity/bot/ChatBotBase.java
@@ -124,6 +124,9 @@ public class ChatBotBase {
     @Schema(description = "Selected skills JSON list")
     private String skills;
 
+    @Schema(description = "Selected plugin tools (tool square) JSON list")
+    private String tools;
+
     @Schema(description = "Hidden on certain clients")
     private String clientHide;
 

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -49,8 +49,10 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -393,6 +395,7 @@ public class BotServiceImpl implements BotService {
         botBase.setOpenedTool(bot.getOpenedTool());
         botBase.setMcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()));
         botBase.setSkills(serializeSkills(bot.getSkills()));
+        botBase.setTools(serializeTools(bot.getTools()));
         botBase.setClientType(bot.getClientType());
         botBase.setBotNameEn(bot.getBotNameEn());
         botBase.setBotDescEn(bot.getBotDescEn());
@@ -441,6 +444,24 @@ public class BotServiceImpl implements BotService {
         List<BotCreateForm.BotSkill> valid = skills.stream()
                 .filter(skill -> skill != null && skill.getSkillId() != null)
                 .collect(Collectors.toList());
+        return JSON.toJSONString(valid);
+    }
+
+    private String serializeTools(List<BotCreateForm.BotTool> tools) {
+        if (tools == null) {
+            return null;
+        }
+        Set<String> seenToolIds = new LinkedHashSet<>();
+        List<BotCreateForm.BotTool> valid = new ArrayList<>();
+        for (BotCreateForm.BotTool tool : tools) {
+            if (tool == null || StringUtils.isBlank(tool.getToolId())) {
+                continue;
+            }
+            tool.setToolId(tool.getToolId().trim());
+            if (seenToolIds.add(tool.getToolId())) {
+                valid.add(tool);
+            }
+        }
         return JSON.toJSONString(valid);
     }
 
@@ -563,6 +584,7 @@ public class BotServiceImpl implements BotService {
                 .openedTool(bot.getOpenedTool())
                 .mcpServerUrls(serializeMcpServerUrls(bot.getMcpServerUrls()))
                 .skills(serializeSkills(bot.getSkills()))
+                .tools(serializeTools(bot.getTools()))
                 .clientType(bot.getClientType())
                 .botNameEn(bot.getBotNameEn())
                 .botDescEn(bot.getBotDescEn())

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/bot/BotCreateController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/bot/BotCreateController.java
@@ -24,6 +24,7 @@ import com.iflytek.astron.console.hub.service.bot.PersonalityConfigService;
 import com.iflytek.astron.console.hub.util.BotPermissionUtil;
 import com.iflytek.astron.console.toolkit.service.model.LLMService;
 import com.iflytek.astron.console.toolkit.service.repo.MassDatasetInfoService;
+import com.iflytek.astron.console.toolkit.service.tool.AgentToolRuntimeService;
 import com.iflytek.astron.console.toolkit.util.RedisUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -70,6 +71,19 @@ public class BotCreateController {
     @Autowired
     private PersonalityConfigService personalityConfigService;
 
+    @Autowired
+    private AgentToolRuntimeService agentToolRuntimeService;
+
+    private List<String> extractToolIds(BotCreateForm bot) {
+        if (bot.getTools() == null) {
+            return Collections.emptyList();
+        }
+        return bot.getTools().stream()
+                .filter(tool -> tool != null && tool.getToolId() != null && !tool.getToolId().trim().isEmpty())
+                .map(tool -> tool.getToolId().trim())
+                .toList();
+    }
+
     /**
      * Create workflow assistant
      *
@@ -89,6 +103,10 @@ public class BotCreateController {
         List<Long> datasetList = bot.getDatasetList();
         List<Long> maasDatasetList = bot.getMaasDatasetList();
         if (!botDatasetService.checkDatasetBelong(uid, spaceId, datasetList)) {
+            return ApiResult.error(ResponseEnum.BOT_BELONG_ERROR);
+        }
+        // Validate plugin-tool ownership: only public / own / same-space tools can be imported
+        if (!agentToolRuntimeService.checkToolsAccessible(uid, spaceId, extractToolIds(bot))) {
             return ApiResult.error(ResponseEnum.BOT_BELONG_ERROR);
         }
         if (Boolean.TRUE.equals(bot.getEnablePersonality()) && personalityConfigService.checkPersonalityConfig(bot.getPersonalityConfig())) {
@@ -240,6 +258,10 @@ public class BotCreateController {
         List<Long> datasetList = bot.getDatasetList();
         List<Long> maasDatasetList = bot.getMaasDatasetList();
         if (!botDatasetService.checkDatasetBelong(uid, spaceId, datasetList)) {
+            return ApiResult.error(ResponseEnum.BOT_BELONG_ERROR);
+        }
+        // Validate plugin-tool ownership: only public / own / same-space tools can be imported
+        if (!agentToolRuntimeService.checkToolsAccessible(uid, spaceId, extractToolIds(bot))) {
             return ApiResult.error(ResponseEnum.BOT_BELONG_ERROR);
         }
         boolean selfDocumentExist = (datasetList != null && !datasetList.isEmpty());

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
@@ -398,6 +398,7 @@ public class ChatMessageController {
         debugChatReqDto.setOpenedTool(debugRequest.getOpenedTool());
         debugChatReqDto.setMcpServerUrls(debugRequest.getMcpServerUrls());
         debugChatReqDto.setSkills(debugRequest.getSkills());
+        debugChatReqDto.setTools(debugRequest.getTools());
         debugChatReqDto.setModel(debugRequest.getModel());
         debugChatReqDto.setModelId(debugRequest.getModelId());
         debugChatReqDto.setMaasDatasetList(maasDatasetList);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/chat/BotDebugRequest.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/dto/chat/BotDebugRequest.java
@@ -57,6 +57,11 @@ public class BotDebugRequest {
     private String skills;
 
     /**
+     * Selected plugin tools (tool square) JSON list
+     */
+    private String tools;
+
+    /**
      * Model name
      */
     private String model = "spark";

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
@@ -143,6 +143,7 @@ public class BotChatServiceImpl implements BotChatService {
                         .openedTool(botConfig.openedTool)
                         .mcpServerUrls(botConfig.mcpServerUrls)
                         .skills(enrichBotSkills(botConfig.skills()))
+                        .tools(botConfig.tools())
                         .userId(chatBotReqDto.getUid())
                         .chatId(chatBotReqDto.getChatId())
                         .chatReqRecords(chatReqRecords)
@@ -189,6 +190,7 @@ public class BotChatServiceImpl implements BotChatService {
                     .openedTool(botConfig.openedTool)
                     .mcpServerUrls(botConfig.mcpServerUrls)
                     .skills(enrichBotSkills(botConfig.skills()))
+                    .tools(botConfig.tools())
                     .userId(chatBotReqDto.getUid())
                     .chatId(chatBotReqDto.getChatId())
                     .chatReqRecords(chatReqRecords)
@@ -233,6 +235,7 @@ public class BotChatServiceImpl implements BotChatService {
                     .openedTool(request.getOpenedTool())
                     .mcpServerUrls(request.getMcpServerUrls())
                     .skills(enrichBotSkills(request.getSkills()))
+                    .tools(request.getTools())
                     .userId(request.getUid())
                     .chatId(null)
                     .chatReqRecords(null)
@@ -405,7 +408,8 @@ public class BotChatServiceImpl implements BotChatService {
                     chatBotMarket.getModelId(),
                     chatBotMarket.getSupportDocument() == 1,
                     resolveBaseMcpServerUrls(botId),
-                    resolveBaseSkills(botId));
+                    resolveBaseSkills(botId),
+                    resolveBaseTools(botId));
         } else {
             ChatBotBase chatBotBase = chatBotDataService.findById(botId)
                     .orElseThrow(() -> new BusinessException(ResponseEnum.BOT_NOT_EXISTS));
@@ -418,7 +422,8 @@ public class BotChatServiceImpl implements BotChatService {
                     chatBotBase.getModelId(),
                     chatBotBase.getSupportDocument() == 1,
                     chatBotBase.getMcpServerUrls(),
-                    chatBotBase.getSkills());
+                    chatBotBase.getSkills(),
+                    chatBotBase.getTools());
         }
     }
 
@@ -435,6 +440,13 @@ public class BotChatServiceImpl implements BotChatService {
             return null;
         }
         return chatBotDataService.findById(botId).map(ChatBotBase::getSkills).orElse(null);
+    }
+
+    private String resolveBaseTools(Integer botId) {
+        if (botId == null) {
+            return null;
+        }
+        return chatBotDataService.findById(botId).map(ChatBotBase::getTools).orElse(null);
     }
 
     /** Parse the saved skills JSON and enrich each entry with downloadUrl/resources/sandbox. */
@@ -745,7 +757,8 @@ public class BotChatServiceImpl implements BotChatService {
     }
 
     private record BotConfiguration(String prompt, boolean supportContext, String model, String openedTool,
-            Integer version, Long modelId, boolean supportDocument, String mcpServerUrls, String skills) {}
+            Integer version, Long modelId, boolean supportDocument, String mcpServerUrls, String skills,
+            String tools) {}
 
     private record TokenStatistics(int systemTokens, int currentUserTokens, int reservedTokens, int availableTokens) {}
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentChatTask.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentChatTask.java
@@ -32,6 +32,9 @@ public class AgentChatTask {
      */
     private List<JSONObject> skills;
 
+    /** Saved tool-square plugins JSON ({@code [{"toolId":"tool@xxx",...}]}); resolved to Link tools. */
+    private String tools;
+
     private String userId;
     private Long chatId;
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
@@ -1,9 +1,11 @@
 package com.iflytek.astron.console.hub.service.chat.springai;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.hub.service.ManagedWebSearchService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ import java.util.List;
  * {@code openedTool}); MCP tools are added from the bot's configured MCP server URLs. All providers
  * use the managed web_search tool (decision C).
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AgentToolCallbackResolver {
@@ -27,19 +30,48 @@ public class AgentToolCallbackResolver {
     private final ManagedWebSearchService managedWebSearchService;
     private final McpToolCallbackFactory mcpToolCallbackFactory;
     private final SkillToolCallbackFactory skillToolCallbackFactory;
+    private final LinkToolCallbackFactory linkToolCallbackFactory;
 
     /**
      * @param openedTool retained for future per-tool gating; built-in tools are always included.
      * @param skills enriched skill entries; each yields read_skill_/run_skill_ tool callbacks.
+     * @param tools saved tool-square plugins JSON ({@code [{"toolId":"tool@xxx",...}]}); each yields a
+     *        Link tool callback executed through the core-link runtime.
      */
     public List<ToolCallback> resolve(String openedTool, String mcpServerUrls, List<JSONObject> skills,
-            ChatToolContext context) throws IOException {
+            String tools, ChatToolContext context) throws IOException {
         List<ToolCallback> callbacks = new ArrayList<>();
         callbacks.add(new WebSearchToolCallback(managedWebSearchService, context));
         callbacks.add(new CurrentTimeToolCallback());
         callbacks.addAll(mcpToolCallbackFactory.build(parseMcpUrls(mcpServerUrls), context));
         callbacks.addAll(skillToolCallbackFactory.build(skills));
+        callbacks.addAll(linkToolCallbackFactory.build(parseToolIds(tools), context));
         return callbacks;
+    }
+
+    /** Extract the {@code toolId} list from the saved plugin tools JSON; tolerant of malformed input. */
+    private List<String> parseToolIds(String tools) {
+        if (StringUtils.isBlank(tools)) {
+            return List.of();
+        }
+        List<String> toolIds = new ArrayList<>();
+        try {
+            JSONArray array = JSON.parseArray(tools.trim());
+            for (int i = 0; i < array.size(); i++) {
+                JSONObject item = array.getJSONObject(i);
+                if (item == null) {
+                    continue;
+                }
+                String toolId = item.getString("toolId");
+                if (StringUtils.isNotBlank(toolId)) {
+                    toolIds.add(toolId.trim());
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Invalid bot tools json, ignored: {}", tools);
+            return List.of();
+        }
+        return toolIds.stream().distinct().toList();
     }
 
     private List<String> parseMcpUrls(String mcpServerUrls) {

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/LinkToolCallbackFactory.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/LinkToolCallbackFactory.java
@@ -1,0 +1,81 @@
+package com.iflytek.astron.console.hub.service.chat.springai;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.entity.tool.AgentToolDefinition;
+import com.iflytek.astron.console.toolkit.service.tool.AgentToolRuntimeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds Spring AI tool callbacks from tool-square plugins (Link tools) the bot has imported. Each
+ * imported {@code tool@xxx} is resolved to a callable definition and executed through the core-link
+ * {@code http_run} runtime by {@link AgentToolRuntimeService} (the same production path used by the
+ * plugin "debug" feature and the workflow agent).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LinkToolCallbackFactory {
+
+    private final AgentToolRuntimeService agentToolRuntimeService;
+
+    public List<ToolCallback> build(List<String> toolIds, ChatToolContext context) {
+        List<ToolCallback> callbacks = new ArrayList<>();
+        for (AgentToolDefinition definition : agentToolRuntimeService.resolveTools(toolIds)) {
+            callbacks.add(new LinkToolCallback(definition, context));
+        }
+        return callbacks;
+    }
+
+    private class LinkToolCallback implements ToolCallback {
+
+        private final AgentToolDefinition definition;
+        private final ChatToolContext context;
+
+        LinkToolCallback(AgentToolDefinition definition, ChatToolContext context) {
+            this.definition = definition;
+            this.context = context;
+        }
+
+        @Override
+        public ToolDefinition getToolDefinition() {
+            return ToolDefinition.builder()
+                    .name(definition.getFunctionName())
+                    .description(StringUtils.defaultIfBlank(definition.getDescription(),
+                            "Call plugin " + definition.getFunctionName() + "."))
+                    .inputSchema(StringUtils.defaultIfBlank(definition.getInputSchema(),
+                            "{\"type\":\"object\",\"properties\":{}}"))
+                    .build();
+        }
+
+        @Override
+        public String call(String toolInput) {
+            log.info("link tool invoked, tool={}, toolId={}", definition.getFunctionName(), definition.getToolId());
+            JSONObject args;
+            try {
+                args = StringUtils.isBlank(toolInput) ? new JSONObject() : JSON.parseObject(toolInput);
+            } catch (Exception e) {
+                log.warn("Failed to parse link tool input as JSON, tool: {}, input: {}",
+                        definition.getFunctionName(), toolInput);
+                args = new JSONObject();
+            }
+            String content = agentToolRuntimeService.runTool(definition, args);
+            context.addTrace(new JSONObject()
+                    .fluentPut("type", "link")
+                    .fluentPut("deskToolName", "Plugin: " + definition.getFunctionName())
+                    .fluentPut("toolName", definition.getFunctionName())
+                    .fluentPut("toolId", definition.getToolId())
+                    .fluentPut("arguments", args)
+                    .fluentPut("content", StringUtils.abbreviate(content, 2000)));
+            return content;
+        }
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SpringAiAgentChatService.java
@@ -55,10 +55,10 @@ public class SpringAiAgentChatService {
                     : chatModelFactory.forSparkModel(task.getSparkModelName());
 
             List<ToolCallback> tools = toolCallbackResolver.resolve(task.getOpenedTool(), task.getMcpServerUrls(),
-                    task.getSkills(), context);
-            log.info("Agent chat start, streamId={}, modelId={}, spark={}, toolCount={}, openedTool={}, mcpServerUrls={}",
+                    task.getSkills(), task.getTools(), context);
+            log.info("Agent chat start, streamId={}, modelId={}, spark={}, toolCount={}, openedTool={}, mcpServerUrls={}, tools={}",
                     streamId, agentModel.modelId(), task.getLlmInfoVo() == null, tools.size(), task.getOpenedTool(),
-                    task.getMcpServerUrls());
+                    task.getMcpServerUrls(), task.getTools());
 
             OpenAiChatOptions options = OpenAiChatOptions.builder()
                     .model(agentModel.modelId())

--- a/console/backend/hub/src/main/resources/db/migration/V1.39__add_bot_tools.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.39__add_bot_tools.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `chat_bot_base`
+    ADD COLUMN `tools` text DEFAULT NULL COMMENT 'Selected plugin tools (tool square) JSON list' AFTER `skills`;

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
@@ -2,6 +2,8 @@ package com.iflytek.astron.console.hub.service.chat.springai;
 
 import com.iflytek.astron.console.hub.service.ManagedWebSearchService;
 import com.iflytek.astron.console.hub.service.McpRuntimeToolService;
+import com.iflytek.astron.console.toolkit.entity.tool.AgentToolDefinition;
+import com.iflytek.astron.console.toolkit.service.tool.AgentToolRuntimeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.ToolCallback;
 
@@ -16,8 +18,12 @@ import static org.mockito.Mockito.when;
 class AgentToolCallbackResolverTest {
 
     private AgentToolCallbackResolver newResolver(McpRuntimeToolService mcp) {
+        return newResolver(mcp, mock(AgentToolRuntimeService.class));
+    }
+
+    private AgentToolCallbackResolver newResolver(McpRuntimeToolService mcp, AgentToolRuntimeService link) {
         return new AgentToolCallbackResolver(mock(ManagedWebSearchService.class), new McpToolCallbackFactory(mcp),
-                new SkillToolCallbackFactory(mock(SkillRuntimeToolService.class)));
+                new SkillToolCallbackFactory(mock(SkillRuntimeToolService.class)), new LinkToolCallbackFactory(link));
     }
 
     @Test
@@ -25,7 +31,7 @@ class AgentToolCallbackResolverTest {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
         List<ToolCallback> tools =
-                newResolver(mcp).resolve("web_search,current_time", null, null, new ChatToolContext("u"));
+                newResolver(mcp).resolve("web_search,current_time", null, null, null, new ChatToolContext("u"));
         List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
         assertTrue(names.contains("web_search"));
         assertTrue(names.contains("current_time"));
@@ -35,7 +41,7 @@ class AgentToolCallbackResolverTest {
     void builtinToolsAlwaysPresentEvenWhenOpenedToolBlank() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(any())).thenReturn(List.of());
-        List<ToolCallback> tools = newResolver(mcp).resolve("", null, null, new ChatToolContext("u"));
+        List<ToolCallback> tools = newResolver(mcp).resolve("", null, null, null, new ChatToolContext("u"));
         List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
         assertTrue(names.contains("web_search"));
         assertTrue(names.contains("current_time"));
@@ -45,7 +51,26 @@ class AgentToolCallbackResolverTest {
     void mcpUrlsParsedFromJsonArrayString() throws Exception {
         McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
         when(mcp.listTools(List.of("http://a", "http://b"))).thenReturn(List.of());
-        newResolver(mcp).resolve(null, "[\"http://a\",\"http://b\"]", null, new ChatToolContext("u"));
+        newResolver(mcp).resolve(null, "[\"http://a\",\"http://b\"]", null, null, new ChatToolContext("u"));
         verify(mcp).listTools(List.of("http://a", "http://b"));
+    }
+
+    @Test
+    void pluginToolIdsParsedFromToolsJsonAndExposedAsCallbacks() throws Exception {
+        McpRuntimeToolService mcp = mock(McpRuntimeToolService.class);
+        when(mcp.listTools(any())).thenReturn(List.of());
+        AgentToolRuntimeService link = mock(AgentToolRuntimeService.class);
+        when(link.resolveTools(List.of("tool@a", "tool@b"))).thenReturn(List.of(
+                AgentToolDefinition.builder().toolId("tool@a").functionName("getWeather")
+                        .description("d").inputSchema("{\"type\":\"object\",\"properties\":{}}").build()));
+
+        String toolsJson = "[{\"toolId\":\"tool@a\",\"name\":\"A\"},{\"toolId\":\"tool@b\"},{\"toolId\":\"tool@a\"}]";
+        List<ToolCallback> tools =
+                newResolver(mcp, link).resolve(null, null, null, toolsJson, new ChatToolContext("u"));
+
+        // duplicate tool@a is de-duplicated before resolveTools is called
+        verify(link).resolveTools(List.of("tool@a", "tool@b"));
+        List<String> names = tools.stream().map(t -> t.getToolDefinition().name()).toList();
+        assertTrue(names.contains("getWeather"));
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/tool/AgentToolDefinition.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/tool/AgentToolDefinition.java
@@ -1,0 +1,44 @@
+package com.iflytek.astron.console.toolkit.entity.tool;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Resolved tool-square plugin ready to be exposed to a standalone agent as a single callable
+ * function. Built by {@code AgentToolRuntimeService} from a {@code ToolBox} record and consumed by
+ * the Spring AI tool-callback layer in the hub module.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentToolDefinition {
+
+    /** Tool-square tool id, e.g. {@code tool@xxx}. */
+    private String toolId;
+
+    /** OpenAPI operationId, sent to the link runtime as {@code parameter.operation_id}. */
+    private String operationId;
+
+    /** Tool version (e.g. {@code V1.0}); sent so core-link resolves the matching stored schema. */
+    private String version;
+
+    /** Tool owner uid, sent as {@code header.uid} (matching the tool-debug run path). */
+    private String uid;
+
+    /** Sanitized, unique, model-facing function name (matches {@code ^[A-Za-z0-9_-]{1,64}$}). */
+    private String functionName;
+
+    /** Human-readable description shown to the model. */
+    private String description;
+
+    /** JSON-schema string describing the model-visible parameters. */
+    private String inputSchema;
+
+    /** Original webSchema {@code toolRequestInput} items, retained for request assembly. */
+    private List<WebSchemaItem> inputs;
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/tool/Message.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/tool/Message.java
@@ -6,5 +6,6 @@ import lombok.Data;
 public class Message {
     String header;
     String query;
+    String path;
     String body;
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/tool/ToolParameter.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/tool/ToolParameter.java
@@ -9,4 +9,5 @@ public class ToolParameter {
     String toolId;
     @JSONField(name = "operation_id")
     String operationId;
+    String version;
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeService.java
@@ -1,0 +1,335 @@
+package com.iflytek.astron.console.toolkit.service.tool;
+
+import cn.hutool.core.codec.Base64;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
+import com.iflytek.astron.console.toolkit.entity.table.tool.ToolBox;
+import com.iflytek.astron.console.toolkit.entity.tool.AgentToolDefinition;
+import com.iflytek.astron.console.toolkit.entity.tool.Message;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolHeader;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolParameter;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolPayload;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolProtocolDto;
+import com.iflytek.astron.console.toolkit.entity.tool.WebSchema;
+import com.iflytek.astron.console.toolkit.entity.tool.WebSchemaItem;
+import com.iflytek.astron.console.toolkit.handler.ToolServiceCallHandler;
+import com.iflytek.astron.console.toolkit.mapper.tool.ToolBoxMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resolves tool-square plugins (Link tools, id {@code tool@xxx}) into agent-callable definitions and
+ * executes them through the core-link {@code http_run} endpoint. Mirrors the production tool-run path
+ * already used by the plugin "debug" feature ({@code ToolBoxService.debugTool}) and the workflow
+ * agent's Python {@code LinkPluginFactory}: model-visible parameters ({@code from == 0}) are exposed
+ * in the input schema, business-passthrough parameters ({@code from == 1}) are filled from their
+ * defaults, and the request is assembled as base64-encoded header/query/body segments.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AgentToolRuntimeService {
+
+    private static final String TYPE_OBJECT = "object";
+    private static final int FROM_BUSINESS = 1;
+    private static final Set<String> RESERVED_FUNCTION_NAMES = Set.of("web_search", "current_time");
+    private static final int MAX_FUNCTION_NAME_LENGTH = 64;
+
+    private final ToolBoxMapper toolBoxMapper;
+    private final CommonConfig commonConfig;
+    private final ToolServiceCallHandler toolServiceCallHandler;
+
+    /** Load the latest version of each tool id and build an agent-callable definition per tool. */
+    public List<AgentToolDefinition> resolveTools(List<String> toolIds) {
+        List<String> ids = normalize(toolIds);
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        List<ToolBox> toolBoxes = toolBoxMapper.getToolsLastVersion(ids);
+        if (toolBoxes == null || toolBoxes.isEmpty()) {
+            log.warn("No tool-square tools found for ids: {}", ids);
+            return List.of();
+        }
+        List<AgentToolDefinition> definitions = new ArrayList<>();
+        Set<String> usedNames = new LinkedHashSet<>();
+        for (ToolBox toolBox : toolBoxes) {
+            try {
+                AgentToolDefinition definition = buildDefinition(toolBox, usedNames);
+                if (definition != null) {
+                    definitions.add(definition);
+                }
+            } catch (Exception e) {
+                log.warn("Skip agent tool, toolId: {}, error: {}",
+                        toolBox == null ? null : toolBox.getToolId(), e.getMessage());
+            }
+        }
+        log.info("Resolved {} agent plugin tool(s) from {} requested id(s)", definitions.size(), ids.size());
+        return definitions;
+    }
+
+    /**
+     * Save-time guard: every requested tool must be importable by this user — public, owned by the
+     * user, or shared in the same space. Blocks crafted requests that reference another user's private
+     * {@code tool@xxx} (which would otherwise run under the owner's identity at chat time).
+     */
+    public boolean checkToolsAccessible(String uid, Long spaceId, List<String> toolIds) {
+        List<String> ids = normalize(toolIds);
+        if (ids.isEmpty()) {
+            return true;
+        }
+        List<ToolBox> toolBoxes = toolBoxMapper.getToolsLastVersion(ids);
+        Map<String, ToolBox> byToolId = new HashMap<>();
+        if (toolBoxes != null) {
+            for (ToolBox toolBox : toolBoxes) {
+                if (toolBox != null && StringUtils.isNotBlank(toolBox.getToolId())) {
+                    byToolId.put(toolBox.getToolId(), toolBox);
+                }
+            }
+        }
+        for (String id : ids) {
+            ToolBox toolBox = byToolId.get(id);
+            if (toolBox == null) {
+                log.warn("Reject bot tool, not found: {}", id);
+                return false;
+            }
+            boolean accessible = Boolean.TRUE.equals(toolBox.getIsPublic())
+                    || StringUtils.equals(uid, toolBox.getUserId())
+                    || (spaceId != null && spaceId.equals(toolBox.getSpaceId()));
+            if (!accessible) {
+                log.warn("Reject bot tool, not accessible by uid {}: {}", uid, id);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Execute the resolved tool with the model-provided arguments; returns a string for the model. */
+    public String runTool(AgentToolDefinition definition, JSONObject modelArgs) {
+        if (definition == null) {
+            return errorContent("TOOL_NOT_FOUND", "Tool metadata is missing.");
+        }
+        JSONObject args = modelArgs == null ? new JSONObject() : modelArgs;
+        JSONObject header = new JSONObject();
+        JSONObject query = new JSONObject();
+        JSONObject path = new JSONObject();
+        JSONObject body = new JSONObject();
+        for (WebSchemaItem item : safe(definition.getInputs())) {
+            if (item == null || StringUtils.isBlank(item.getName())) {
+                continue;
+            }
+            Object value = assembleValue(item, args);
+            String location = StringUtils.lowerCase(StringUtils.defaultString(item.getLocation()));
+            switch (location) {
+                case "header" -> header.put(item.getName(), value);
+                case "query" -> query.put(item.getName(), value);
+                case "path" -> path.put(item.getName(), value);
+                default -> body.put(item.getName(), value);
+            }
+        }
+
+        ToolProtocolDto request = buildRequest(definition, header, query, path, body);
+        ToolProtocolDto response;
+        try {
+            response = toolServiceCallHandler.toolRun(request);
+        } catch (Exception e) {
+            log.warn("Tool run failed, toolId: {}, error: {}", definition.getToolId(), e.getMessage());
+            return errorContent("TOOL_CALL_FAILED", "Tool call failed: " + e.getMessage());
+        }
+        return extractResult(response);
+    }
+
+    private ToolProtocolDto buildRequest(AgentToolDefinition definition, JSONObject header, JSONObject query,
+            JSONObject path, JSONObject body) {
+        ToolHeader toolHeader = new ToolHeader();
+        toolHeader.setUid(definition.getUid());
+        toolHeader.setAppId(commonConfig.getAppId());
+
+        ToolParameter parameter = new ToolParameter();
+        parameter.setToolId(definition.getToolId());
+        parameter.setOperationId(definition.getOperationId());
+        parameter.setVersion(definition.getVersion());
+
+        Message message = new Message();
+        if (!header.isEmpty()) {
+            message.setHeader(Base64.encode(header.toString()));
+        }
+        if (!query.isEmpty()) {
+            message.setQuery(Base64.encode(query.toString()));
+        }
+        if (!path.isEmpty()) {
+            message.setPath(Base64.encode(path.toString()));
+        }
+        if (!body.isEmpty()) {
+            message.setBody(Base64.encode(body.toString()));
+        }
+        ToolPayload payload = new ToolPayload();
+        payload.setMessage(message);
+
+        ToolProtocolDto request = new ToolProtocolDto();
+        request.setHeader(toolHeader);
+        request.setParameter(parameter);
+        request.setPayload(payload);
+        return request;
+    }
+
+    private String extractResult(ToolProtocolDto response) {
+        if (response == null || response.getHeader() == null) {
+            return errorContent("TOOL_EMPTY_RESPONSE", "Tool returned an empty response.");
+        }
+        Integer code = response.getHeader().getCode();
+        if (code != null && code != 0) {
+            return errorContent("TOOL_ERROR",
+                    StringUtils.defaultIfBlank(response.getHeader().getMessage(), "Tool returned an error."));
+        }
+        if (response.getPayload() == null || response.getPayload().getText() == null) {
+            return errorContent("TOOL_EMPTY_RESPONSE", "Tool returned no content.");
+        }
+        return StringUtils.defaultString(response.getPayload().getText().getText());
+    }
+
+    /** Build the request value for a single item, recursing into object children (flat arg lookup). */
+    private Object assembleValue(WebSchemaItem item, JSONObject args) {
+        if (TYPE_OBJECT.equalsIgnoreCase(StringUtils.defaultString(item.getType()))) {
+            JSONObject object = new JSONObject();
+            for (WebSchemaItem child : safe(item.getChildren())) {
+                if (child == null || StringUtils.isBlank(child.getName())) {
+                    continue;
+                }
+                object.put(child.getName(), assembleValue(child, args));
+            }
+            return object;
+        }
+        if (isBusiness(item)) {
+            return item.getDft();
+        }
+        return args.containsKey(item.getName()) ? args.get(item.getName()) : item.getDft();
+    }
+
+    private AgentToolDefinition buildDefinition(ToolBox toolBox, Set<String> usedNames) {
+        if (toolBox == null || StringUtils.isBlank(toolBox.getToolId())) {
+            return null;
+        }
+        List<WebSchemaItem> inputs = parseInputs(toolBox.getWebSchema());
+        String functionName = uniqueFunctionName(toolBox, usedNames);
+        String inputSchema = buildInputSchema(inputs);
+        return AgentToolDefinition.builder()
+                .toolId(toolBox.getToolId())
+                .operationId(toolBox.getOperationId())
+                .version(StringUtils.defaultIfBlank(toolBox.getVersion(), "V1.0"))
+                .uid(toolBox.getUserId())
+                .functionName(functionName)
+                .description(StringUtils.defaultIfBlank(toolBox.getDescription(),
+                        "Call tool " + StringUtils.defaultString(toolBox.getName())))
+                .inputSchema(inputSchema)
+                .inputs(inputs)
+                .build();
+    }
+
+    private List<WebSchemaItem> parseInputs(String webSchemaJson) {
+        if (StringUtils.isBlank(webSchemaJson)) {
+            return List.of();
+        }
+        WebSchema webSchema = JSON.parseObject(webSchemaJson, WebSchema.class);
+        if (webSchema == null || webSchema.getToolRequestInput() == null) {
+            return List.of();
+        }
+        return webSchema.getToolRequestInput();
+    }
+
+    /** Flatten model-visible leaf parameters into a single JSON schema, mirroring the Python factory. */
+    private String buildInputSchema(List<WebSchemaItem> inputs) {
+        JSONObject properties = new JSONObject();
+        JSONArray required = new JSONArray();
+        collectSchema(inputs, properties, required);
+        JSONObject schema = new JSONObject();
+        schema.put("type", "object");
+        schema.put("properties", properties);
+        schema.put("required", required);
+        return schema.toJSONString();
+    }
+
+    private void collectSchema(List<WebSchemaItem> items, JSONObject properties, JSONArray required) {
+        for (WebSchemaItem item : safe(items)) {
+            if (item == null || StringUtils.isBlank(item.getName())) {
+                continue;
+            }
+            if (TYPE_OBJECT.equalsIgnoreCase(StringUtils.defaultString(item.getType()))) {
+                collectSchema(item.getChildren(), properties, required);
+                continue;
+            }
+            if (isBusiness(item)) {
+                continue;
+            }
+            JSONObject property = new JSONObject();
+            property.put("type", StringUtils.defaultIfBlank(item.getType(), "string"));
+            if (StringUtils.isNotBlank(item.getDescription())) {
+                property.put("description", item.getDescription());
+            }
+            properties.put(item.getName(), property);
+            if (Boolean.TRUE.equals(item.getRequired()) && !required.contains(item.getName())) {
+                required.add(item.getName());
+            }
+        }
+    }
+
+    private boolean isBusiness(WebSchemaItem item) {
+        return item.getFrom() != null && item.getFrom() == FROM_BUSINESS;
+    }
+
+    private String uniqueFunctionName(ToolBox toolBox, Set<String> usedNames) {
+        String base = sanitize(StringUtils.defaultIfBlank(toolBox.getOperationId(), toolBox.getName()));
+        if (base.length() > MAX_FUNCTION_NAME_LENGTH) {
+            base = base.substring(0, MAX_FUNCTION_NAME_LENGTH);
+        }
+        String candidate = base;
+        int suffix = 2;
+        while (usedNames.contains(candidate) || RESERVED_FUNCTION_NAMES.contains(candidate)) {
+            String suffixText = "_" + suffix++;
+            int maxBaseLength = MAX_FUNCTION_NAME_LENGTH - suffixText.length();
+            candidate = (base.length() > maxBaseLength ? base.substring(0, maxBaseLength) : base) + suffixText;
+        }
+        usedNames.add(candidate);
+        return candidate;
+    }
+
+    private String sanitize(String value) {
+        String sanitized = StringUtils.defaultString(value)
+                .replaceAll("[^A-Za-z0-9_-]", "_")
+                .replaceAll("_+", "_");
+        sanitized = StringUtils.strip(sanitized, "_-");
+        return StringUtils.defaultIfBlank(sanitized, "tool");
+    }
+
+    private List<String> normalize(List<String> toolIds) {
+        if (toolIds == null || toolIds.isEmpty()) {
+            return List.of();
+        }
+        return toolIds.stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+
+    private <T> List<T> safe(List<T> list) {
+        return list == null ? List.of() : list;
+    }
+
+    private String errorContent(String code, String message) {
+        return new JSONObject()
+                .fluentPut("error", code)
+                .fluentPut("message", message)
+                .toJSONString();
+    }
+}

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeServiceTest.java
@@ -1,0 +1,170 @@
+package com.iflytek.astron.console.toolkit.service.tool;
+
+import cn.hutool.core.codec.Base64;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
+import com.iflytek.astron.console.toolkit.entity.table.tool.ToolBox;
+import com.iflytek.astron.console.toolkit.entity.tool.AgentToolDefinition;
+import com.iflytek.astron.console.toolkit.entity.tool.Text;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolHeader;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolPayload;
+import com.iflytek.astron.console.toolkit.entity.tool.ToolProtocolDto;
+import com.iflytek.astron.console.toolkit.handler.ToolServiceCallHandler;
+import com.iflytek.astron.console.toolkit.mapper.tool.ToolBoxMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AgentToolRuntimeServiceTest {
+
+    private static final String WEB_SCHEMA = "{\"toolRequestInput\":["
+            + "{\"name\":\"city\",\"type\":\"string\",\"description\":\"city name\",\"from\":0,"
+            + "\"required\":true,\"location\":\"query\"},"
+            + "{\"name\":\"id\",\"type\":\"string\",\"from\":0,\"location\":\"path\"},"
+            + "{\"name\":\"token\",\"type\":\"string\",\"from\":1,\"default\":\"secret\",\"location\":\"header\"},"
+            + "{\"name\":\"filter\",\"type\":\"object\",\"location\":\"body\",\"children\":["
+            + "{\"name\":\"keyword\",\"type\":\"string\",\"from\":0,\"location\":\"body\"}]}"
+            + "]}";
+
+    private ToolBox sampleToolBox() {
+        ToolBox toolBox = new ToolBox();
+        toolBox.setToolId("tool@abc");
+        toolBox.setName("Weather");
+        toolBox.setDescription("Query weather");
+        toolBox.setUserId("99");
+        toolBox.setOperationId("getWeather");
+        toolBox.setVersion("V2.0");
+        toolBox.setWebSchema(WEB_SCHEMA);
+        return toolBox;
+    }
+
+    private AgentToolRuntimeService newService(ToolBoxMapper mapper, ToolServiceCallHandler handler) {
+        CommonConfig commonConfig = new CommonConfig();
+        commonConfig.setAppId("app-123");
+        return new AgentToolRuntimeService(mapper, commonConfig, handler);
+    }
+
+    @Test
+    void resolveTools_exposesOnlyModelVisibleParams() {
+        ToolBoxMapper mapper = mock(ToolBoxMapper.class);
+        when(mapper.getToolsLastVersion(anyList())).thenReturn(List.of(sampleToolBox()));
+
+        List<AgentToolDefinition> defs =
+                newService(mapper, mock(ToolServiceCallHandler.class)).resolveTools(List.of("tool@abc"));
+
+        assertThat(defs).hasSize(1);
+        AgentToolDefinition def = defs.get(0);
+        assertThat(def.getFunctionName()).isEqualTo("getWeather");
+        assertThat(def.getToolId()).isEqualTo("tool@abc");
+
+        JSONObject schema = JSON.parseObject(def.getInputSchema());
+        JSONObject properties = schema.getJSONObject("properties");
+        // model-visible query/path params + nested model-visible body leaf are flattened in
+        assertThat(properties.keySet()).containsExactlyInAnyOrder("city", "id", "keyword");
+        // business-passthrough header param is hidden from the model
+        assertThat(properties.containsKey("token")).isFalse();
+        assertThat(schema.getJSONArray("required")).containsExactly("city");
+    }
+
+    @Test
+    void runTool_routesModelArgsAndBusinessDefaults() {
+        ToolBoxMapper mapper = mock(ToolBoxMapper.class);
+        when(mapper.getToolsLastVersion(anyList())).thenReturn(List.of(sampleToolBox()));
+        ToolServiceCallHandler handler = mock(ToolServiceCallHandler.class);
+
+        ArgumentCaptor<ToolProtocolDto> captor = ArgumentCaptor.forClass(ToolProtocolDto.class);
+        when(handler.toolRun(any())).thenReturn(successResponse("sunny"));
+
+        AgentToolRuntimeService service = newService(mapper, handler);
+        AgentToolDefinition def = service.resolveTools(List.of("tool@abc")).get(0);
+
+        JSONObject args = new JSONObject().fluentPut("city", "Beijing")
+                .fluentPut("keyword", "rain").fluentPut("id", "42");
+        String result = service.runTool(def, args);
+        assertThat(result).isEqualTo("sunny");
+
+        org.mockito.Mockito.verify(handler).toolRun(captor.capture());
+        ToolProtocolDto request = captor.getValue();
+        assertThat(request.getHeader().getAppId()).isEqualTo("app-123");
+        assertThat(request.getHeader().getUid()).isEqualTo("99");
+        assertThat(request.getParameter().getToolId()).isEqualTo("tool@abc");
+        assertThat(request.getParameter().getOperationId()).isEqualTo("getWeather");
+        // C1: the resolved latest version is forwarded so core-link picks the matching schema
+        assertThat(request.getParameter().getVersion()).isEqualTo("V2.0");
+
+        JSONObject query = decode(request.getPayload().getMessage().getQuery());
+        JSONObject header = decode(request.getPayload().getMessage().getHeader());
+        JSONObject body = decode(request.getPayload().getMessage().getBody());
+        JSONObject path = decode(request.getPayload().getMessage().getPath());
+        assertThat(query.getString("city")).isEqualTo("Beijing");
+        assertThat(header.getString("token")).isEqualTo("secret");
+        assertThat(body.getJSONObject("filter").getString("keyword")).isEqualTo("rain");
+        // I1: path-location params go to message.path, not query
+        assertThat(path.getString("id")).isEqualTo("42");
+        assertThat(query.containsKey("id")).isFalse();
+    }
+
+    @Test
+    void checkToolsAccessible_allowsPublicOwnAndSameSpace_rejectsOthers() {
+        ToolBoxMapper mapper = mock(ToolBoxMapper.class);
+        AgentToolRuntimeService service = newService(mapper, mock(ToolServiceCallHandler.class));
+
+        ToolBox pub = box("tool@pub", "1000", true, 7L);
+        ToolBox own = box("tool@own", "me", false, 7L);
+        ToolBox space = box("tool@space", "1000", false, 7L);
+        ToolBox foreign = box("tool@foreign", "1000", false, 99L);
+        when(mapper.getToolsLastVersion(anyList()))
+                .thenReturn(List.of(pub, own, space, foreign));
+
+        assertThat(service.checkToolsAccessible("me", 7L,
+                List.of("tool@pub", "tool@own", "tool@space"))).isTrue();
+        // a private tool owned by someone else in another space is rejected
+        assertThat(service.checkToolsAccessible("me", 7L, List.of("tool@foreign"))).isFalse();
+        // an unknown tool id is rejected
+        assertThat(service.checkToolsAccessible("me", 7L, List.of("tool@missing"))).isFalse();
+        // empty list is trivially accessible
+        assertThat(service.checkToolsAccessible("me", 7L, List.of())).isTrue();
+    }
+
+    private ToolBox box(String toolId, String userId, boolean isPublic, Long spaceId) {
+        ToolBox toolBox = new ToolBox();
+        toolBox.setToolId(toolId);
+        toolBox.setUserId(userId);
+        toolBox.setIsPublic(isPublic);
+        toolBox.setSpaceId(spaceId);
+        return toolBox;
+    }
+
+    @Test
+    void resolveTools_returnsEmptyWhenNoToolsFound() {
+        ToolBoxMapper mapper = mock(ToolBoxMapper.class);
+        when(mapper.getToolsLastVersion(anyList())).thenReturn(List.of());
+        assertThat(newService(mapper, mock(ToolServiceCallHandler.class)).resolveTools(List.of("tool@x")))
+                .isEmpty();
+    }
+
+    private JSONObject decode(String base64) {
+        return JSON.parseObject(Base64.decodeStr(base64));
+    }
+
+    private ToolProtocolDto successResponse(String text) {
+        ToolProtocolDto response = new ToolProtocolDto();
+        ToolHeader header = new ToolHeader();
+        header.setCode(0);
+        response.setHeader(header);
+        ToolPayload payload = new ToolPayload();
+        Text textObj = new Text();
+        textObj.setText(text);
+        payload.setText(textObj);
+        response.setPayload(payload);
+        return response;
+    }
+}

--- a/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/CapabilityDevelopment.tsx
@@ -52,6 +52,7 @@ import cls from 'classnames';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { isValidMcpServerUrl } from '../mcp-url-config';
 import SkillSelectModal from './SkillSelectModal';
+import PluginSelectModal from './PluginSelectModal';
 import type { AgentSkill } from '@/types/skill';
 
 const { TextArea } = Input;
@@ -382,6 +383,8 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
   const removeSkill = (skillId: number) => {
     setSkills(skills.filter(skill => skill.skillId !== skillId));
   };
+
+  const [pluginModalOpen, setPluginModalOpen] = useState(false);
 
   return (
     <div
@@ -1058,6 +1061,86 @@ const CapabilityDevelopment: React.FC<CapabilityDevelopmentProps> = props => {
               })}
             </div>
           </div>
+        </div>
+      )}
+      {showMcpSection && !showCapabilitySection && (
+        <div
+          className={cls(
+            styles.capabilitySection,
+            showKnowledgeSection && styles.capabilitySectionCompact
+          )}
+        >
+          <div className={styles.capabilityBlock}>
+            <div className={styles.capabilityBlockHeader}>
+              <div className={styles.capabilityTitleGroup}>
+                <span className={cls(styles.capabilityIcon, styles.mcpIcon)}>
+                  <ApiOutlined />
+                </span>
+                <div>
+                  <div className={styles.capabilityTitleRow}>
+                    <span className={styles.capabilityTitle}>插件</span>
+                    <span
+                      className={cls(
+                        styles.capabilityStatus,
+                        tools.length > 0 ? styles.statusReady : styles.statusMuted
+                      )}
+                    >
+                      {tools.length > 0 ? `已添加 ${tools.length} 个` : '未添加'}
+                    </span>
+                  </div>
+                  <div className={styles.capabilityDescription}>
+                    从插件广场引入插件，模型会根据插件描述自主选择调用。
+                  </div>
+                </div>
+              </div>
+              <Button
+                icon={<PlusOutlined />}
+                className={styles.capabilityActionButton}
+                onClick={() => setPluginModalOpen(true)}
+              >
+                {tools.length > 0 ? '管理插件' : '添加插件'}
+              </Button>
+            </div>
+
+            {tools.length > 0 ? (
+              <div className={styles.skillList}>
+                {tools.map((item: any) => (
+                  <div className={styles.skillRow} key={item.toolId}>
+                    <div className={styles.skillRowMeta}>
+                      <span className={styles.skillRowName}>{item.name}</span>
+                      <span className={styles.skillRowDesc}>
+                        {item.description || '暂无描述'}
+                      </span>
+                    </div>
+                    <Tooltip title="删除">
+                      <Button
+                        className={styles.mcpDeleteButton}
+                        icon={<DeleteOutlined />}
+                        onClick={() => deleteTool(item.toolId)}
+                      />
+                    </Tooltip>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <button
+                type="button"
+                className={styles.capabilityEmptyState}
+                onClick={() => setPluginModalOpen(true)}
+              >
+                <span className={styles.capabilityEmptyTitle}>暂无插件</span>
+                <span className={styles.capabilityEmptyDescription}>
+                  点击添加插件，从插件广场引入可调用的工具能力。
+                </span>
+              </button>
+            )}
+          </div>
+          <PluginSelectModal
+            open={pluginModalOpen}
+            selected={tools}
+            onClose={() => setPluginModalOpen(false)}
+            onChange={setTools}
+          />
         </div>
       )}
       {showPersonalizationSection && (

--- a/console/frontend/src/components/config-page-component/config-base/components/PluginSelectModal.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/PluginSelectModal.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Input, Button, Spin, message } from 'antd';
+import { listToolSquare } from '@/services/tool';
+import type { Tool, AgentTool } from '@/types/plugin-store';
+import styles from './CapabilityDevelopment.module.scss';
+
+const MAX_TOOLS = 30;
+
+interface PluginSelectModalProps {
+  open: boolean;
+  selected: AgentTool[];
+  onClose: () => void;
+  onChange: (next: AgentTool[]) => void;
+}
+
+const PluginSelectModal: React.FC<PluginSelectModalProps> = ({
+  open,
+  selected,
+  onClose,
+  onChange,
+}) => {
+  const [keyword, setKeyword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<Tool[]>([]);
+
+  const selectedIds = useMemo(
+    () => new Set(selected.map(t => t.toolId)),
+    [selected]
+  );
+
+  const fetchList = (kw?: string): void => {
+    setLoading(true);
+    listToolSquare({ content: kw, page: 1, pageSize: 200 })
+      .then(res => {
+        // Only regular Link/HTTP plugins are addable here; MCP tools have their own block.
+        const list = (res?.pageData || []).filter(
+          item => !item.isMcp && Boolean(item.toolId)
+        );
+        setData(list);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    if (open) {
+      setKeyword('');
+      fetchList();
+    }
+  }, [open]);
+
+  const toggle = (item: Tool): void => {
+    const toolId = item.toolId as string;
+    if (selectedIds.has(toolId)) {
+      onChange(selected.filter(t => t.toolId !== toolId));
+      return;
+    }
+    if (selected.length >= MAX_TOOLS) {
+      message.warning(`最多添加 ${MAX_TOOLS} 个插件`);
+      return;
+    }
+    onChange([
+      ...selected,
+      {
+        toolId,
+        name: item.name,
+        description: item.description || '',
+        icon: item.icon || item.avatar || undefined,
+      },
+    ]);
+  };
+
+  return (
+    <Modal
+      open={open}
+      centered
+      footer={null}
+      closable
+      onCancel={onClose}
+      title={`选择插件（已选 ${selected.length}/${MAX_TOOLS}）`}
+    >
+      <Input.Search
+        allowClear
+        placeholder="搜索插件"
+        value={keyword}
+        onChange={e => setKeyword(e.target.value)}
+        onSearch={v => fetchList(v)}
+        style={{ marginBottom: 12 }}
+      />
+      <Spin spinning={loading}>
+        <div className={styles.skillModalList}>
+          {data.map(item => {
+            const checked = selectedIds.has(item.toolId as string);
+            return (
+              <div className={styles.skillModalRow} key={item.toolId || item.id}>
+                <div className={styles.skillModalMeta}>
+                  <div className={styles.skillModalName}>{item.name}</div>
+                  <div className={styles.skillModalDesc}>
+                    {item.description || '暂无描述'}
+                  </div>
+                </div>
+                <Button
+                  type={checked ? 'default' : 'primary'}
+                  onClick={() => toggle(item)}
+                >
+                  {checked ? '移除' : '添加'}
+                </Button>
+              </div>
+            );
+          })}
+          {!loading && data.length === 0 && (
+            <div className={styles.skillModalEmpty}>未找到可引入的插件</div>
+          )}
+        </div>
+      </Spin>
+    </Modal>
+  );
+};
+
+export default PluginSelectModal;

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -82,6 +82,7 @@ import {
   hasInvalidMcpServerUrls,
   normalizeMcpServerUrls,
   normalizeSkills,
+  normalizeTools,
 } from './mcp-url-config';
 import type { AgentSkill } from '@/types/skill';
 import { VcnItem } from '@/components/speaker-modal';
@@ -539,6 +540,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       openedTool: effectiveOpenedTool,
       mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
       skills: normalizeSkills(skills),
+      tools: normalizeTools(tools),
       prologue: prologue,
       ...getModelConfig(model),
       prompt: prompt,
@@ -822,6 +824,7 @@ const BaseConfig: React.FC<ChatProps> = ({
             normalizeMcpServerUrls(currentConfigData?.mcpServerUrls)
           );
           setSkills(normalizeSkills(currentConfigData?.skills));
+          setTools(normalizeTools(currentConfigData?.tools));
           setSupportContextFlag(
             save == 'true'
               ? configPageData?.supportContext == 1
@@ -2262,6 +2265,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       openedTool: effectiveOpenedTool,
                       mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                       skills: normalizeSkills(skills),
+                      tools: normalizeTools(tools),
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2312,6 +2316,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       openedTool: effectiveOpenedTool,
                       mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                       skills: normalizeSkills(skills),
+                      tools: normalizeTools(tools),
                       prologue: prologue,
                       ...getModelConfig(model),
                       prompt: prompt,
@@ -2393,6 +2398,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     openedTool: effectiveOpenedTool,
                     mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                     skills: normalizeSkills(skills),
+                    tools: normalizeTools(tools),
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,
@@ -2442,6 +2448,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     openedTool: effectiveOpenedTool,
                     mcpServerUrls: normalizeMcpServerUrls(mcpServerUrls),
                     skills: normalizeSkills(skills),
+                    tools: normalizeTools(tools),
                     prologue: prologue,
                     ...getModelConfig(model),
                     prompt: prompt,

--- a/console/frontend/src/components/config-page-component/config-base/mcp-url-config.ts
+++ b/console/frontend/src/components/config-page-component/config-base/mcp-url-config.ts
@@ -1,4 +1,5 @@
 import type { AgentSkill } from '@/types/skill';
+import type { AgentTool } from '@/types/plugin-store';
 
 export const isValidMcpServerUrl = (url: string): boolean => {
   const value = url.trim();
@@ -70,6 +71,38 @@ export const normalizeSkills = (skills?: unknown): AgentSkill[] => {
     });
   }
   return result.slice(0, 30);
+};
+
+export const normalizeTools = (tools?: unknown): AgentTool[] => {
+  let source = tools;
+  if (typeof tools === 'string') {
+    try {
+      source = JSON.parse(tools);
+    } catch {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(source)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const result: AgentTool[] = [];
+  for (const item of source) {
+    const toolId = String(item?.toolId ?? '').trim();
+    if (!toolId || seen.has(toolId)) {
+      continue;
+    }
+    seen.add(toolId);
+    result.push({
+      toolId,
+      name: String(item?.name ?? ''),
+      description: String(item?.description ?? ''),
+      icon: item?.icon ? String(item.icon) : undefined,
+    });
+  }
+  return result;
 };
 
 export const hasInvalidMcpServerUrls = (urls?: unknown): boolean => {

--- a/console/frontend/src/types/plugin-store.ts
+++ b/console/frontend/src/types/plugin-store.ts
@@ -36,6 +36,13 @@ interface Tool {
   icon?: string;
   heatValue: number;
 }
+/** A tool-square plugin saved on an agent (resolved on the backend at runtime by toolId). */
+interface AgentTool {
+  toolId: string;
+  name: string;
+  description: string;
+  icon?: string;
+}
 //插件广场展示分类
 interface Classify {
   id: string;
@@ -291,6 +298,7 @@ export type {
   ListToolSquareParams,
   EnableToolFavoriteParams,
   Tool,
+  AgentTool,
   Classify,
   GetToolDetailParams,
   DebugToolParams,


### PR DESCRIPTION
## What

Add plugin capability to the standard Agent ability page.

- Frontend: a plugin selection modal lets users import Link plugins from the plugin store into the standard Agent ability page; the selected plugins are persisted with the bot configuration.
- Backend: bot tools wiring across commons/hub/toolkit, agent tool runtime resolution and Link tool callback factory, so imported plugins are invoked automatically during conversation.
- Persistence: migration `V1.39__add_bot_tools.sql` to store bot tools.

## Scope

- console/frontend: config-base plugin select modal, capability development, mcp-url-config, plugin-store types.
- console/backend: commons (bot DTO/entity/service), hub (controllers, chat services, spring-ai agent tool resolution/callback), toolkit (agent tool definition + runtime service).

## Tests

- Added `AgentToolRuntimeServiceTest` and updated `AgentToolCallbackResolverTest`.