### PR TITLE
fix(console): pass orderFlag in plugin select modal to fix list-tool-square 500

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/components/PluginSelectModal.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/components/PluginSelectModal.tsx
@@ -30,7 +30,9 @@ const PluginSelectModal: React.FC<PluginSelectModalProps> = ({
 
   const fetchList = (kw?: string): void => {
     setLoading(true);
-    listToolSquare({ content: kw, page: 1, pageSize: 200 })
+    // orderFlag is required: the backend sorts by it and NPEs on a null value (-> HTTP 500).
+    // Omitting tagFlag keeps MCP tools out of the result (they have their own capability block).
+    listToolSquare({ content: kw, page: 1, pageSize: 200, orderFlag: 0 })
       .then(res => {
         // Only regular Link/HTTP plugins are addable here; MCP tools have their own block.
         const list = (res?.pageData || []).filter(


### PR DESCRIPTION
## What
能力页「添加插件」弹窗调用 `/tool/list-tool-square` 时补传 `orderFlag: 0`。

## Why
此前前端漏传 `orderFlag`，后端 `sortAndPaginate` 对 null 的 orderFlag 拆箱抛 NPE，接口返回 500，导致插件列表为空。

## Change
- `console/frontend/src/components/config-page-component/config-base/components/PluginSelectModal.tsx`：`listToolSquare` 调用补 `orderFlag: 0`。