### PR TITLE
fix(console): read back tools field in bot detail response

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotDetail.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotDetail.java
@@ -37,6 +37,7 @@ public class BotDetail {
     private String openedTool;
     private String mcpServerUrls;
     private String skills;
+    private String tools;
     private Integer hotNum;
     private String marketBotId;
     private Integer supportSystem;

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotInfoDto.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/dto/bot/BotInfoDto.java
@@ -113,6 +113,8 @@ public class BotInfoDto {
 
     private String skills;
 
+    private String tools;
+
     private String vcnCn;
 
     private String vcnEn;

--- a/console/backend/commons/src/main/resources/mapper/ChatBotBaseMapper.xml
+++ b/console/backend/commons/src/main/resources/mapper/ChatBotBaseMapper.xml
@@ -29,6 +29,7 @@
         a.opened_tool AS openedTool,
         a.mcp_server_urls AS mcpServerUrls,
         a.skills AS skills,
+        a.tools AS tools,
         a.client_hide as clientHide,
         b.hot_num as hotNum,
         b.id as marketBotId,

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeService.java
@@ -4,6 +4,7 @@ import cn.hutool.core.codec.Base64;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.BizConfig;
 import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
 import com.iflytek.astron.console.toolkit.entity.table.tool.ToolBox;
 import com.iflytek.astron.console.toolkit.entity.tool.AgentToolDefinition;
@@ -48,6 +49,7 @@ public class AgentToolRuntimeService {
 
     private final ToolBoxMapper toolBoxMapper;
     private final CommonConfig commonConfig;
+    private final BizConfig bizConfig;
     private final ToolServiceCallHandler toolServiceCallHandler;
 
     /** Load the latest version of each tool id and build an agent-callable definition per tool. */
@@ -105,6 +107,7 @@ public class AgentToolRuntimeService {
             }
             boolean accessible = Boolean.TRUE.equals(toolBox.getIsPublic())
                     || StringUtils.equals(uid, toolBox.getUserId())
+                    || StringUtils.equals(toolBox.getUserId(), bizConfig.getAdminUid())
                     || (spaceId != null && spaceId.equals(toolBox.getSpaceId()));
             if (!accessible) {
                 log.warn("Reject bot tool, not accessible by uid {}: {}", uid, id);

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/tool/AgentToolRuntimeServiceTest.java
@@ -3,6 +3,7 @@ package com.iflytek.astron.console.toolkit.service.tool;
 import cn.hutool.core.codec.Base64;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.config.properties.BizConfig;
 import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
 import com.iflytek.astron.console.toolkit.entity.table.tool.ToolBox;
 import com.iflytek.astron.console.toolkit.entity.tool.AgentToolDefinition;
@@ -49,7 +50,9 @@ class AgentToolRuntimeServiceTest {
     private AgentToolRuntimeService newService(ToolBoxMapper mapper, ToolServiceCallHandler handler) {
         CommonConfig commonConfig = new CommonConfig();
         commonConfig.setAppId("app-123");
-        return new AgentToolRuntimeService(mapper, commonConfig, handler);
+        BizConfig bizConfig = new BizConfig();
+        bizConfig.setAdminUid("1");
+        return new AgentToolRuntimeService(mapper, commonConfig, bizConfig, handler);
     }
 
     @Test
@@ -120,12 +123,13 @@ class AgentToolRuntimeServiceTest {
         ToolBox pub = box("tool@pub", "1000", true, 7L);
         ToolBox own = box("tool@own", "me", false, 7L);
         ToolBox space = box("tool@space", "1000", false, 7L);
+        ToolBox official = box("tool@official", "1", false, 99L); // owned by admin (adminUid=1)
         ToolBox foreign = box("tool@foreign", "1000", false, 99L);
         when(mapper.getToolsLastVersion(anyList()))
-                .thenReturn(List.of(pub, own, space, foreign));
+                .thenReturn(List.of(pub, own, space, official, foreign));
 
         assertThat(service.checkToolsAccessible("me", 7L,
-                List.of("tool@pub", "tool@own", "tool@space"))).isTrue();
+                List.of("tool@pub", "tool@own", "tool@space", "tool@official"))).isTrue();
         // a private tool owned by someone else in another space is rejected
         assertThat(service.checkToolsAccessible("me", 7L, List.of("tool@foreign"))).isFalse();
         // an unknown tool id is rejected


### PR DESCRIPTION
## What

The standard agent ability page persists selected plugins (`tools`) correctly, but the detail API used when reopening the page did not read back the `tools` field. As a result, plugins showed as empty when the ability page was reloaded, and the debug chat could not load the configured plugins.

## Changes

- Add the `tools` field to `BotDetail` and `BotInfoDto`.
- Read back `a.tools AS tools` in `ChatBotBaseMapper.xml` so the bot detail response carries `tools`.
- Relax plugin ownership validation in `AgentToolRuntimeService` to allow importing plugins owned by the admin (official) account.
- Update `AgentToolRuntimeServiceTest` accordingly (new constructor arg + official-plugin case).

## Scope

Backend only (`console/backend` — `commons` and `toolkit`).