### PR TITLE
fix(console): send selected plugin tools in bot-debug chat request

### DIFF
--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -1661,6 +1661,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 choosedAlltool={effectiveToolConfig}
                 mcpServerUrls={mcpServerUrls}
                 skills={skills}
+                tools={tools}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1722,6 +1723,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                 choosedAlltool={effectiveToolConfig}
                 mcpServerUrls={mcpServerUrls}
                 skills={skills}
+                tools={tools}
                 findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                 personalityConfig={
                   personalityData.enablePersonality
@@ -1756,6 +1758,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         choosedAlltool={effectiveToolConfig}
         mcpServerUrls={mcpServerUrls}
         skills={skills}
+        tools={tools}
         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
         personalityConfig={
           personalityData.enablePersonality
@@ -2902,6 +2905,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                       choosedAlltool={effectiveToolConfig}
                       mcpServerUrls={mcpServerUrls}
                       skills={skills}
+                      tools={tools}
                       findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                       personalityConfig={
                         personalityData.enablePersonality
@@ -2947,6 +2951,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                           choosedAlltool={effectiveToolConfig}
                           mcpServerUrls={mcpServerUrls}
                           skills={skills}
+                          tools={tools}
                           findModelOptionByUniqueKey={
                             findModelOptionByUniqueKey
                           }
@@ -3022,6 +3027,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                         choosedAlltool={effectiveToolConfig}
                         mcpServerUrls={mcpServerUrls}
                         skills={skills}
+                        tools={tools}
                         findModelOptionByUniqueKey={findModelOptionByUniqueKey}
                         personalityConfig={
                           personalityData.enablePersonality

--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -20,6 +20,7 @@ import {
   normalizeMcpServerUrls,
 } from '@/components/config-page-component/config-base/mcp-url-config';
 import type { AgentSkill } from '@/types/skill';
+import type { AgentTool } from '@/types/plugin-store';
 
 // PromptTry组件暴露的方法接口
 export interface PromptTryRef {
@@ -67,6 +68,7 @@ const PromptTry = forwardRef<
     };
     mcpServerUrls?: string[];
     skills?: AgentSkill[];
+    tools?: AgentTool[];
     findModelOptionByUniqueKey: (
       uniqueKey: string
     ) => ModelListData | undefined;
@@ -90,6 +92,7 @@ const PromptTry = forwardRef<
       choosedAlltool,
       mcpServerUrls,
       skills,
+      tools,
       initialMessages,
       onMessagesChange,
       showHeaderAndRecommend = true,
@@ -231,6 +234,9 @@ const PromptTry = forwardRef<
       }
       if (skills && skills.length > 0) {
         form.append('skills', JSON.stringify(skills));
+      }
+      if (tools && tools.length > 0) {
+        form.append('tools', JSON.stringify(tools));
       }
 
       // 添加人设配置信息


### PR DESCRIPTION
## What

Standard agent debug chat ("全新对话", via /chat-message/bot-debug) did not carry the introduced plugin tools, so the running conversation had no access to the plugins and could not invoke them.

## Changes

- `prompt-try`: accept a `tools` prop and append it (JSON) to the request form when present.
- `config-base`: pass `tools={tools}` to all PromptTry instances.

Net +12 lines, frontend only.