### PR TITLE
chore(console): format hub CI repair files

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/bot/BotCreateController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/bot/BotCreateController.java
@@ -78,7 +78,8 @@ public class BotCreateController {
         if (bot.getTools() == null) {
             return Collections.emptyList();
         }
-        return bot.getTools().stream()
+        return bot.getTools()
+                .stream()
                 .filter(tool -> tool != null && tool.getToolId() != null && !tool.getToolId().trim().isEmpty())
                 .map(tool -> tool.getToolId().trim())
                 .toList();

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolver.java
@@ -49,7 +49,9 @@ public class AgentToolCallbackResolver {
         return callbacks;
     }
 
-    /** Extract the {@code toolId} list from the saved plugin tools JSON; tolerant of malformed input. */
+    /**
+     * Extract the {@code toolId} list from the saved plugin tools JSON; tolerant of malformed input.
+     */
     private List<String> parseToolIds(String tools) {
         if (StringUtils.isBlank(tools)) {
             return List.of();

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/springai/AgentToolCallbackResolverTest.java
@@ -61,8 +61,12 @@ class AgentToolCallbackResolverTest {
         when(mcp.listTools(any())).thenReturn(List.of());
         AgentToolRuntimeService link = mock(AgentToolRuntimeService.class);
         when(link.resolveTools(List.of("tool@a", "tool@b"))).thenReturn(List.of(
-                AgentToolDefinition.builder().toolId("tool@a").functionName("getWeather")
-                        .description("d").inputSchema("{\"type\":\"object\",\"properties\":{}}").build()));
+                AgentToolDefinition.builder()
+                        .toolId("tool@a")
+                        .functionName("getWeather")
+                        .description("d")
+                        .inputSchema("{\"type\":\"object\",\"properties\":{}}")
+                        .build()));
 
         String toolsJson = "[{\"toolId\":\"tool@a\",\"name\":\"A\"},{\"toolId\":\"tool@b\"},{\"toolId\":\"tool@a\"}]";
         List<ToolCallback> tools =


### PR DESCRIPTION
## Summary
- apply Spotless-compatible wrapping to hub Java formatter violations surfaced after toolkit formatting passed

## Verification
- remote check-java after PR #1446 reported only these hub Spotless violations
- required code review completed with no Critical or Important issues
- remote validation will be rerun after merge per astron-agent-remote-ci-check