### PR TITLE
fix(console): align trusted tool owner formatting

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/tool/ToolBoxService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/tool/ToolBoxService.java
@@ -590,7 +590,7 @@ public class ToolBoxService extends ServiceImpl<ToolBoxMapper, ToolBox> {
     private boolean isTrustedOfficialToolForCurrentUser(ToolBox toolBox, String currentUserId) {
         boolean trustedOwner = Objects.equals(toolBox.getUserId(), bizConfig.getAdminUid())
                 || (bizConfig.getTrustedToolOwnerUids() != null
-                && bizConfig.getTrustedToolOwnerUids().contains(toolBox.getUserId()));
+                        && bizConfig.getTrustedToolOwnerUids().contains(toolBox.getUserId()));
         boolean officialTool = trustedOwner
                 && Boolean.TRUE.equals(toolBox.getIsPublic())
                 && ToolboxStatusEnum.FORMAL.getCode().equals(toolBox.getStatus());


### PR DESCRIPTION
## Summary
- Align `ToolBoxService` continuation indentation to satisfy Spotless

## Verification
- Remote CI before fix: `check-java` failed only on Spotless for `ToolBoxService.java`
- Remote test matrix before fix: all test targets completed successfully
- Code review: no Critical, Important, or Minor issues