### PR TITLE
Add core agent A2A adapter

### DIFF
--- a/core/agent/api/router.py
+++ b/core/agent/api/router.py
@@ -6,6 +6,7 @@ It sets up the common prefix '/agent/v1' for all agent API endpoints.
 
 from fastapi import APIRouter
 
+from agent.api.v1.a2a import a2a_router
 from agent.api.v1.skill_sandbox_api import skill_sandbox_router
 from agent.api.v1.workflow_agent import workflow_agent_router
 
@@ -14,3 +15,4 @@ router_v1 = APIRouter(
 )
 router_v1.include_router(workflow_agent_router)
 router_v1.include_router(skill_sandbox_router)
+router_v1.include_router(a2a_router)

--- a/core/agent/api/schemas/a2a.py
+++ b/core/agent/api/schemas/a2a.py
@@ -1,0 +1,191 @@
+"""A2A protocol schemas used by the core agent adapter."""
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class A2ABaseModel(BaseModel):
+    """Base model that accepts Python names and emits A2A camelCase names."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class A2APart(A2ABaseModel):
+    """A single A2A message or artifact part."""
+
+    text: Optional[str] = None
+    raw: Optional[str] = None
+    url: Optional[str] = None
+    data: Any = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    filename: str = ""
+    media_type: str = Field(default="text/plain", alias="mediaType")
+
+
+A2ARole = Literal["ROLE_USER", "ROLE_AGENT", "user", "agent"]
+
+
+class A2AMessage(A2ABaseModel):
+    """A2A message object."""
+
+    message_id: str = Field(alias="messageId")
+    context_id: str = Field(default="", alias="contextId")
+    task_id: str = Field(default="", alias="taskId")
+    role: A2ARole
+    parts: list[A2APart]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    extensions: list[str] = Field(default_factory=list)
+    reference_task_ids: list[str] = Field(
+        default_factory=list, alias="referenceTaskIds"
+    )
+
+
+class A2ASendMessageConfiguration(A2ABaseModel):
+    """Supported subset of A2A SendMessageConfiguration."""
+
+    accepted_output_modes: list[str] = Field(
+        default_factory=list, alias="acceptedOutputModes"
+    )
+    history_length: Optional[int] = Field(default=None, alias="historyLength")
+    return_immediately: bool = Field(default=False, alias="returnImmediately")
+
+
+class A2ASendMessageRequest(A2ABaseModel):
+    """A2A SendMessage request."""
+
+    tenant: str = ""
+    message: A2AMessage
+    configuration: A2ASendMessageConfiguration = Field(
+        default_factory=A2ASendMessageConfiguration
+    )
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2AAgentInterface(A2ABaseModel):
+    """A declared A2A transport interface."""
+
+    url: str
+    protocol_binding: str = Field(alias="protocolBinding")
+    tenant: str = ""
+    protocol_version: str = Field(alias="protocolVersion")
+
+
+class A2AAgentProvider(A2ABaseModel):
+    """A2A AgentCard provider."""
+
+    url: str
+    organization: str
+
+
+class A2AAgentCapabilities(A2ABaseModel):
+    """A2A AgentCard capability declaration."""
+
+    streaming: bool = False
+    push_notifications: bool = Field(default=False, alias="pushNotifications")
+    extended_agent_card: bool = Field(default=False, alias="extendedAgentCard")
+
+
+class A2AStringList(A2ABaseModel):
+    """A2A list wrapper used by security requirements."""
+
+    values: list[str] = Field(default_factory=list, alias="list")
+
+
+class A2ASecurityRequirement(A2ABaseModel):
+    """A2A security requirement declaration."""
+
+    schemes: dict[str, A2AStringList]
+
+
+class A2AAPIKeySecurityScheme(A2ABaseModel):
+    """A2A API key security scheme."""
+
+    description: str = ""
+    location: Literal["query", "header", "cookie"]
+    name: str
+
+
+class A2ASecurityScheme(A2ABaseModel):
+    """A2A security scheme union."""
+
+    api_key_security_scheme: A2AAPIKeySecurityScheme = Field(
+        alias="apiKeySecurityScheme"
+    )
+
+
+class A2AAgentSkill(A2ABaseModel):
+    """A2A AgentCard skill declaration."""
+
+    id: str
+    name: str
+    description: str
+    tags: list[str]
+    examples: list[str] = Field(default_factory=list)
+    input_modes: list[str] = Field(default_factory=list, alias="inputModes")
+    output_modes: list[str] = Field(default_factory=list, alias="outputModes")
+
+
+class A2AAgentCard(A2ABaseModel):
+    """A2A discovery card."""
+
+    name: str
+    description: str
+    supported_interfaces: list[A2AAgentInterface] = Field(alias="supportedInterfaces")
+    provider: A2AAgentProvider
+    version: str
+    capabilities: A2AAgentCapabilities
+    security_schemes: dict[str, A2ASecurityScheme] = Field(
+        default_factory=dict, alias="securitySchemes"
+    )
+    security_requirements: list[A2ASecurityRequirement] = Field(
+        default_factory=list, alias="securityRequirements"
+    )
+    default_input_modes: list[str] = Field(alias="defaultInputModes")
+    default_output_modes: list[str] = Field(alias="defaultOutputModes")
+    skills: list[A2AAgentSkill]
+
+
+class A2ATaskStatus(A2ABaseModel):
+    """A2A task status."""
+
+    state: Literal[
+        "TASK_STATE_SUBMITTED",
+        "TASK_STATE_WORKING",
+        "TASK_STATE_COMPLETED",
+        "TASK_STATE_FAILED",
+        "TASK_STATE_CANCELED",
+        "TASK_STATE_INPUT_REQUIRED",
+        "TASK_STATE_REJECTED",
+        "TASK_STATE_AUTH_REQUIRED",
+    ]
+    message: Optional[A2AMessage] = None
+    timestamp: Optional[str] = None
+
+
+class A2AArtifact(A2ABaseModel):
+    """A2A task artifact."""
+
+    artifact_id: str = Field(alias="artifactId")
+    name: str = ""
+    description: str = ""
+    parts: list[A2APart]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2ATask(A2ABaseModel):
+    """A2A task response."""
+
+    id: str
+    context_id: str = Field(alias="contextId")
+    status: A2ATaskStatus
+    artifacts: list[A2AArtifact] = Field(default_factory=list)
+    history: list[A2AMessage] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2ASendMessageResponse(A2ABaseModel):
+    """A2A SendMessage response payload."""
+
+    task: Optional[A2ATask] = None
+    message: Optional[A2AMessage] = None

--- a/core/agent/api/schemas/a2a.py
+++ b/core/agent/api/schemas/a2a.py
@@ -86,6 +86,13 @@ class A2AAgentCapabilities(A2ABaseModel):
     extended_agent_card: bool = Field(default=False, alias="extendedAgentCard")
 
 
+class A2AAuthentication(A2ABaseModel):
+    """Legacy A2A AgentCard authentication declaration."""
+
+    schemes: list[str] = Field(default_factory=list)
+    credentials: str = ""
+
+
 class A2AStringList(A2ABaseModel):
     """A2A list wrapper used by security requirements."""
 
@@ -129,12 +136,16 @@ class A2AAgentSkill(A2ABaseModel):
 class A2AAgentCard(A2ABaseModel):
     """A2A discovery card."""
 
+    protocol_version: str = Field(default="0.3.0", alias="protocolVersion")
     name: str
     description: str
+    url: str = ""
+    preferred_transport: str = Field(default="HTTP+JSON", alias="preferredTransport")
     supported_interfaces: list[A2AAgentInterface] = Field(alias="supportedInterfaces")
     provider: A2AAgentProvider
     version: str
     capabilities: A2AAgentCapabilities
+    authentication: A2AAuthentication = Field(default_factory=A2AAuthentication)
     security_schemes: dict[str, A2ASecurityScheme] = Field(
         default_factory=dict, alias="securitySchemes"
     )
@@ -189,3 +200,48 @@ class A2ASendMessageResponse(A2ABaseModel):
 
     task: Optional[A2ATask] = None
     message: Optional[A2AMessage] = None
+
+
+class A2ATaskSendParams(A2ABaseModel):
+    """A2A task send request used by task-oriented HTTP clients."""
+
+    id: str = ""
+    tenant: str = ""
+    session_id: str = Field(default="", alias="sessionId")
+    context_id: str = Field(default="", alias="contextId")
+    message: A2AMessage
+    configuration: A2ASendMessageConfiguration = Field(
+        default_factory=A2ASendMessageConfiguration
+    )
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2ATaskStatusUpdateEvent(A2ABaseModel):
+    """A2A task status update event."""
+
+    task_id: str = Field(alias="taskId")
+    context_id: str = Field(alias="contextId")
+    kind: Literal["status-update"] = "status-update"
+    status: A2ATaskStatus
+    final: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2ATaskArtifactUpdateEvent(A2ABaseModel):
+    """A2A task artifact update event."""
+
+    task_id: str = Field(alias="taskId")
+    context_id: str = Field(alias="contextId")
+    kind: Literal["artifact-update"] = "artifact-update"
+    artifact: A2AArtifact
+    append: bool = False
+    last_chunk: bool = Field(default=True, alias="lastChunk")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2ATaskEvents(A2ABaseModel):
+    """Recorded task runtime events."""
+
+    events: list[A2ATaskStatusUpdateEvent | A2ATaskArtifactUpdateEvent] = Field(
+        default_factory=list
+    )

--- a/core/agent/api/v1/a2a.py
+++ b/core/agent/api/v1/a2a.py
@@ -148,6 +148,36 @@ def _metadata_mapping(metadata: dict[str, Any], key: str) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _max_loop_count(metadata: dict[str, Any]) -> int:
+    parsed_metadata = _optional_int(metadata.get("max_loop_count"))
+    if parsed_metadata is not None:
+        return parsed_metadata
+
+    parsed_env = _optional_int(os.getenv("A2A_MAX_LOOP_COUNT"))
+    if parsed_env is not None:
+        return parsed_env
+
+    return 5
+
+
+def _request_uid(request: A2ASendMessageRequest, metadata: dict[str, Any]) -> str:
+    return (
+        _metadata_string(metadata, "uid")
+        or _metadata_string(request.message.metadata, "uid")
+        or request.message.context_id
+        or request.message.message_id
+        or request.message.task_id
+        or str(uuid.uuid4())
+    )[:64]
+
+
 def _completion_inputs_from_a2a(
     request: A2ASendMessageRequest,
     text: str,
@@ -161,15 +191,8 @@ def _completion_inputs_from_a2a(
     }
     model_config.update(_metadata_mapping(metadata, "model_config"))
 
-    max_loop_count = metadata.get("max_loop_count", os.getenv("A2A_MAX_LOOP_COUNT", 5))
-
     return CustomCompletionInputs(
-        uid=(
-            _metadata_string(metadata, "uid")
-            or _metadata_string(request.message.metadata, "uid")
-            or request.message.context_id
-            or request.message.message_id
-        )[:64],
+        uid=_request_uid(request, metadata),
         messages=[LLMMessage(role="user", content=text)],
         stream=False,
         meta_data={
@@ -182,7 +205,7 @@ def _completion_inputs_from_a2a(
         model_config=model_config,
         instruction=_metadata_mapping(metadata, "instruction"),
         plugin=_metadata_mapping(metadata, "plugin"),
-        max_loop_count=int(max_loop_count),
+        max_loop_count=_max_loop_count(metadata),
     )
 
 
@@ -252,7 +275,11 @@ def _parse_sse_payload(chunk: str) -> dict[str, Any] | None:
         payload = line.removeprefix("data:").strip()
         if not payload or payload == "[DONE]":
             return None
-        return json.loads(payload)
+        try:
+            parsed_payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        return parsed_payload if isinstance(parsed_payload, dict) else None
     return None
 
 
@@ -267,6 +294,7 @@ async def _collect_completion_text(completion: CustomChatCompletion) -> tuple[st
 
         if payload.get("code", 0) != 0:
             error_message = str(payload.get("message") or "A2A agent execution failed")
+            break
 
         for choice in payload.get("choices", []):
             delta = choice.get("delta") or {}

--- a/core/agent/api/v1/a2a.py
+++ b/core/agent/api/v1/a2a.py
@@ -4,7 +4,7 @@ import json
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Annotated, Any
+from typing import Annotated, Any, TypeAlias
 
 from common.otlp.trace.span import Span
 from fastapi import APIRouter, Header, HTTPException, Query
@@ -44,7 +44,7 @@ _TERMINAL_TASK_STATES = {
     "TASK_STATE_CANCELED",
     "TASK_STATE_REJECTED",
 }
-_TaskEvent = A2ATaskStatusUpdateEvent | A2ATaskArtifactUpdateEvent
+_TaskEvent: TypeAlias = A2ATaskStatusUpdateEvent | A2ATaskArtifactUpdateEvent
 _TASKS: dict[str, A2ATask] = {}
 _TASK_EVENTS: dict[str, list[_TaskEvent]] = {}
 

--- a/core/agent/api/v1/a2a.py
+++ b/core/agent/api/v1/a2a.py
@@ -1,0 +1,314 @@
+"""A2A protocol adapter for the core agent service."""
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from common.otlp.trace.span import Span
+from fastapi import APIRouter, Header, HTTPException
+
+from agent.api.schemas.a2a import (
+    A2AAgentCapabilities,
+    A2AAgentCard,
+    A2AAgentInterface,
+    A2AAgentProvider,
+    A2AAgentSkill,
+    A2AAPIKeySecurityScheme,
+    A2AArtifact,
+    A2AMessage,
+    A2APart,
+    A2ASecurityRequirement,
+    A2ASecurityScheme,
+    A2ASendMessageRequest,
+    A2ASendMessageResponse,
+    A2AStringList,
+    A2ATask,
+    A2ATaskStatus,
+)
+from agent.api.schemas.llm_message import LLMMessage
+from agent.api.schemas.workflow_agent_inputs import CustomCompletionInputs
+from agent.api.v1.workflow_agent import CustomChatCompletion
+
+A2A_PROTOCOL_VERSION = "0.3"
+
+a2a_discovery_router = APIRouter()
+a2a_router = APIRouter(prefix="/a2a")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _public_base_url() -> str:
+    configured_url = (
+        os.getenv("A2A_PUBLIC_BASE_URL")
+        or os.getenv("AGENT_BASE_URL")
+        or f"http://localhost:{os.getenv('SERVICE_PORT', '8700')}"
+    )
+    return configured_url.rstrip("/")
+
+
+def build_agent_card() -> A2AAgentCard:
+    """Build public A2A discovery metadata for the core agent service."""
+
+    interface_url = f"{_public_base_url()}/agent/v1/a2a"
+    return A2AAgentCard(
+        name="Astron Agent",
+        description="Astron Agent core runtime exposed through an A2A text adapter.",
+        supportedInterfaces=[
+            A2AAgentInterface(
+                url=interface_url,
+                protocolBinding="HTTP+JSON",
+                protocolVersion=A2A_PROTOCOL_VERSION,
+            )
+        ],
+        provider=A2AAgentProvider(
+            organization="iFLYTEK",
+            url="https://github.com/iflytek/astron-agent",
+        ),
+        version="0.1.0",
+        capabilities=A2AAgentCapabilities(
+            streaming=False,
+            pushNotifications=False,
+            extendedAgentCard=False,
+        ),
+        securitySchemes={
+            "astronConsumer": A2ASecurityScheme(
+                apiKeySecurityScheme=A2AAPIKeySecurityScheme(
+                    description="Astron gateway consumer header.",
+                    location="header",
+                    name="x-consumer-username",
+                )
+            )
+        },
+        securityRequirements=[
+            A2ASecurityRequirement(schemes={"astronConsumer": A2AStringList(list=[])})
+        ],
+        defaultInputModes=["text/plain"],
+        defaultOutputModes=["text/plain"],
+        skills=[
+            A2AAgentSkill(
+                id="astron-agent-chat",
+                name="Astron Agent Chat",
+                description="Send text to the configured Astron Agent runtime.",
+                tags=["agent", "chat", "astron"],
+                examples=["Summarize this workflow result."],
+                inputModes=["text/plain"],
+                outputModes=["text/plain"],
+            )
+        ],
+    )
+
+
+@a2a_discovery_router.get(  # type: ignore[misc]
+    "/.well-known/agent-card.json",
+    response_model=A2AAgentCard,
+)
+async def get_well_known_agent_card() -> A2AAgentCard:
+    """Return the public A2A discovery card."""
+
+    return build_agent_card()
+
+
+@a2a_router.get(  # type: ignore[misc]
+    "/agent-card.json",
+    response_model=A2AAgentCard,
+)
+async def get_agent_card() -> A2AAgentCard:
+    """Return the public A2A discovery card from the versioned API path."""
+
+    return build_agent_card()
+
+
+def extract_message_text(message: A2AMessage) -> str:
+    """Return the text content from a client A2A message."""
+
+    if message.role not in {"ROLE_USER", "user"}:
+        raise HTTPException(status_code=400, detail="A2A message role must be user")
+
+    text_parts = [part.text.strip() for part in message.parts if part.text]
+    text = "\n".join(part for part in text_parts if part)
+    if not text:
+        raise HTTPException(
+            status_code=400,
+            detail="A2A message must include at least one non-empty text part",
+        )
+    return text
+
+
+def _metadata_string(metadata: dict[str, Any], key: str, default: str = "") -> str:
+    value = metadata.get(key, default)
+    return value if isinstance(value, str) else default
+
+
+def _metadata_mapping(metadata: dict[str, Any], key: str) -> dict[str, Any]:
+    value = metadata.get(key, {})
+    return value if isinstance(value, dict) else {}
+
+
+def _completion_inputs_from_a2a(
+    request: A2ASendMessageRequest,
+    text: str,
+) -> CustomCompletionInputs:
+    metadata = request.metadata
+    model_config = {
+        "domain": os.getenv("A2A_MODEL_DOMAIN", ""),
+        "api": os.getenv("A2A_MODEL_API", ""),
+        "provider": os.getenv("A2A_MODEL_PROVIDER", ""),
+        "api_key": os.getenv("A2A_MODEL_API_KEY", ""),
+    }
+    model_config.update(_metadata_mapping(metadata, "model_config"))
+
+    max_loop_count = metadata.get("max_loop_count", os.getenv("A2A_MAX_LOOP_COUNT", 5))
+
+    return CustomCompletionInputs(
+        uid=(
+            _metadata_string(metadata, "uid")
+            or _metadata_string(request.message.metadata, "uid")
+            or request.message.context_id
+            or request.message.message_id
+        )[:64],
+        messages=[LLMMessage(role="user", content=text)],
+        stream=False,
+        meta_data={
+            "caller": "a2a_http_json",
+            "caller_sid": request.message.message_id,
+            "workflow_id": _metadata_string(metadata, "workflow_id"),
+            "run_id": request.message.task_id,
+            "node_id": _metadata_string(metadata, "node_id"),
+        },
+        model_config=model_config,
+        instruction=_metadata_mapping(metadata, "instruction"),
+        plugin=_metadata_mapping(metadata, "plugin"),
+        max_loop_count=int(max_loop_count),
+    )
+
+
+def _history_message(
+    request: A2ASendMessageRequest, task_id: str, context_id: str
+) -> A2AMessage:
+    return request.message.model_copy(
+        update={
+            "task_id": task_id,
+            "context_id": context_id,
+            "role": "ROLE_USER",
+        }
+    )
+
+
+def _status_message(task_id: str, context_id: str, text: str) -> A2AMessage:
+    return A2AMessage(
+        messageId=str(uuid.uuid4()),
+        contextId=context_id,
+        taskId=task_id,
+        role="ROLE_AGENT",
+        parts=[A2APart(text=text, mediaType="text/plain")],
+    )
+
+
+def _task_response(
+    request: A2ASendMessageRequest,
+    state: str,
+    output_text: str = "",
+    error_text: str = "",
+) -> A2ASendMessageResponse:
+    task_id = request.message.task_id or str(uuid.uuid4())
+    context_id = request.message.context_id or str(uuid.uuid4())
+    history = [_history_message(request, task_id=task_id, context_id=context_id)]
+    artifacts = []
+    status_message = None
+
+    if state == "TASK_STATE_COMPLETED":
+        artifacts.append(
+            A2AArtifact(
+                artifactId=str(uuid.uuid4()),
+                name="result",
+                parts=[A2APart(text=output_text, mediaType="text/plain")],
+            )
+        )
+    elif error_text:
+        status_message = _status_message(task_id, context_id, error_text)
+
+    return A2ASendMessageResponse(
+        task=A2ATask(
+            id=task_id,
+            contextId=context_id,
+            status=A2ATaskStatus(
+                state=state, message=status_message, timestamp=_utc_now()
+            ),
+            artifacts=artifacts,
+            history=history,
+            metadata={"source": "astron-agent-core"},
+        )
+    )
+
+
+def _parse_sse_payload(chunk: str) -> dict[str, Any] | None:
+    for line in chunk.splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if not payload or payload == "[DONE]":
+            return None
+        return json.loads(payload)
+    return None
+
+
+async def _collect_completion_text(completion: CustomChatCompletion) -> tuple[str, str]:
+    text_parts = []
+    error_message = ""
+
+    async for chunk in completion.do_complete():
+        payload = _parse_sse_payload(chunk)
+        if not payload:
+            continue
+
+        if payload.get("code", 0) != 0:
+            error_message = str(payload.get("message") or "A2A agent execution failed")
+
+        for choice in payload.get("choices", []):
+            delta = choice.get("delta") or {}
+            content = delta.get("content")
+            if content:
+                text_parts.append(str(content))
+
+    return "".join(text_parts), error_message
+
+
+@a2a_router.post(  # type: ignore[misc]
+    "/message:send",
+    response_model=A2ASendMessageResponse,
+)
+async def send_message(
+    x_consumer_username: Annotated[str, Header()],
+    request: A2ASendMessageRequest,
+) -> A2ASendMessageResponse:
+    """Map an A2A text message onto the existing core agent completion runner."""
+
+    text = extract_message_text(request.message)
+    if request.configuration.return_immediately:
+        return _task_response(request, "TASK_STATE_SUBMITTED")
+
+    completion_inputs = _completion_inputs_from_a2a(request, text)
+    span = Span(app_id=x_consumer_username, uid=completion_inputs.uid)
+    completion = CustomChatCompletion(
+        app_id=x_consumer_username,
+        inputs=completion_inputs,
+        log_caller=completion_inputs.meta_data.caller,
+        span=span,
+        bot_id="",
+        uid=completion_inputs.uid,
+        question=text,
+    )
+    output_text, error_message = await _collect_completion_text(completion)
+
+    if error_message:
+        return _task_response(
+            request,
+            "TASK_STATE_FAILED",
+            error_text=error_message,
+        )
+
+    return _task_response(request, "TASK_STATE_COMPLETED", output_text=output_text)

--- a/core/agent/api/v1/a2a.py
+++ b/core/agent/api/v1/a2a.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Any
 
 from common.otlp.trace.span import Span
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Query
 
 from agent.api.schemas.a2a import (
     A2AAgentCapabilities,
@@ -17,6 +17,7 @@ from agent.api.schemas.a2a import (
     A2AAgentSkill,
     A2AAPIKeySecurityScheme,
     A2AArtifact,
+    A2AAuthentication,
     A2AMessage,
     A2APart,
     A2ASecurityRequirement,
@@ -25,13 +26,27 @@ from agent.api.schemas.a2a import (
     A2ASendMessageResponse,
     A2AStringList,
     A2ATask,
+    A2ATaskArtifactUpdateEvent,
+    A2ATaskEvents,
+    A2ATaskSendParams,
     A2ATaskStatus,
+    A2ATaskStatusUpdateEvent,
 )
 from agent.api.schemas.llm_message import LLMMessage
 from agent.api.schemas.workflow_agent_inputs import CustomCompletionInputs
 from agent.api.v1.workflow_agent import CustomChatCompletion
 
-A2A_PROTOCOL_VERSION = "0.3"
+A2A_PROTOCOL_VERSION = "0.3.0"
+ASTRON_AGENT_VERSION = "1.0.9"
+_TERMINAL_TASK_STATES = {
+    "TASK_STATE_COMPLETED",
+    "TASK_STATE_FAILED",
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_REJECTED",
+}
+_TaskEvent = A2ATaskStatusUpdateEvent | A2ATaskArtifactUpdateEvent
+_TASKS: dict[str, A2ATask] = {}
+_TASK_EVENTS: dict[str, list[_TaskEvent]] = {}
 
 a2a_discovery_router = APIRouter()
 a2a_router = APIRouter(prefix="/a2a")
@@ -50,13 +65,20 @@ def _public_base_url() -> str:
     return configured_url.rstrip("/")
 
 
+def _agent_version() -> str:
+    return os.getenv("ASTRON_AGENT_VERSION", ASTRON_AGENT_VERSION).removeprefix("v")
+
+
 def build_agent_card() -> A2AAgentCard:
     """Build public A2A discovery metadata for the core agent service."""
 
     interface_url = f"{_public_base_url()}/agent/v1/a2a"
     return A2AAgentCard(
+        protocolVersion=A2A_PROTOCOL_VERSION,
         name="Astron Agent",
         description="Astron Agent core runtime exposed through an A2A text adapter.",
+        url=interface_url,
+        preferredTransport="HTTP+JSON",
         supportedInterfaces=[
             A2AAgentInterface(
                 url=interface_url,
@@ -68,11 +90,15 @@ def build_agent_card() -> A2AAgentCard:
             organization="iFLYTEK",
             url="https://github.com/iflytek/astron-agent",
         ),
-        version="0.1.0",
+        version=_agent_version(),
         capabilities=A2AAgentCapabilities(
             streaming=False,
             pushNotifications=False,
             extendedAgentCard=False,
+        ),
+        authentication=A2AAuthentication(
+            schemes=["ApiKey"],
+            credentials="x-consumer-username header",
         ),
         securitySchemes={
             "astronConsumer": A2ASecurityScheme(
@@ -268,6 +294,57 @@ def _task_response(
     )
 
 
+def _record_task(task: A2ATask) -> None:
+    """Store task state and the latest task runtime events in process memory."""
+
+    _TASKS[task.id] = task
+    final = task.status.state in _TERMINAL_TASK_STATES
+    events: list[_TaskEvent] = [
+        A2ATaskStatusUpdateEvent(
+            taskId=task.id,
+            contextId=task.context_id,
+            status=task.status,
+            final=final,
+        )
+    ]
+    events.extend(
+        A2ATaskArtifactUpdateEvent(
+            taskId=task.id,
+            contextId=task.context_id,
+            artifact=artifact,
+            append=False,
+            lastChunk=True,
+        )
+        for artifact in task.artifacts
+    )
+    _TASK_EVENTS[task.id] = events
+
+
+def _stored_response(response: A2ASendMessageResponse) -> A2ASendMessageResponse:
+    if response.task is not None:
+        _record_task(response.task)
+    return response
+
+
+def _request_from_task_send_params(
+    params: A2ATaskSendParams,
+) -> A2ASendMessageRequest:
+    task_id = params.id or params.message.task_id
+    context_id = params.context_id or params.session_id or params.message.context_id
+    message = params.message.model_copy(
+        update={
+            "task_id": task_id,
+            "context_id": context_id,
+        }
+    )
+    return A2ASendMessageRequest(
+        tenant=params.tenant,
+        message=message,
+        configuration=params.configuration,
+        metadata=params.metadata,
+    )
+
+
 def _parse_sse_payload(chunk: str) -> dict[str, Any] | None:
     for line in chunk.splitlines():
         if not line.startswith("data:"):
@@ -317,7 +394,7 @@ async def send_message(
 
     text = extract_message_text(request.message)
     if request.configuration.return_immediately:
-        return _task_response(request, "TASK_STATE_SUBMITTED")
+        return _stored_response(_task_response(request, "TASK_STATE_SUBMITTED"))
 
     completion_inputs = _completion_inputs_from_a2a(request, text)
     span = Span(app_id=x_consumer_username, uid=completion_inputs.uid)
@@ -333,10 +410,68 @@ async def send_message(
     output_text, error_message = await _collect_completion_text(completion)
 
     if error_message:
-        return _task_response(
-            request,
-            "TASK_STATE_FAILED",
-            error_text=error_message,
+        return _stored_response(
+            _task_response(
+                request,
+                "TASK_STATE_FAILED",
+                error_text=error_message,
+            )
         )
 
-    return _task_response(request, "TASK_STATE_COMPLETED", output_text=output_text)
+    return _stored_response(
+        _task_response(request, "TASK_STATE_COMPLETED", output_text=output_text)
+    )
+
+
+@a2a_router.post(  # type: ignore[misc]
+    "/tasks:send",
+    response_model=A2ATask,
+)
+async def send_task(
+    x_consumer_username: Annotated[str, Header()],
+    params: A2ATaskSendParams,
+) -> A2ATask:
+    """Run a task-oriented A2A request through the core agent runtime."""
+
+    response = await send_message(
+        x_consumer_username=x_consumer_username,
+        request=_request_from_task_send_params(params),
+    )
+    if response.task is None:
+        raise HTTPException(status_code=500, detail="A2A runtime did not create a task")
+    return response.task
+
+
+@a2a_router.get(  # type: ignore[misc]
+    "/tasks/{task_id}",
+    response_model=A2ATask,
+)
+async def get_task(
+    x_consumer_username: Annotated[str, Header()],
+    task_id: str,
+    history_length: Annotated[int | None, Query(alias="historyLength")] = None,
+) -> A2ATask:
+    """Return the latest recorded task runtime state."""
+
+    task = _TASKS.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="A2A task not found")
+    if history_length is None:
+        return task
+    history = [] if history_length <= 0 else task.history[-history_length:]
+    return task.model_copy(update={"history": history})
+
+
+@a2a_router.get(  # type: ignore[misc]
+    "/tasks/{task_id}/events",
+    response_model=A2ATaskEvents,
+)
+async def get_task_events(
+    x_consumer_username: Annotated[str, Header()],
+    task_id: str,
+) -> A2ATaskEvents:
+    """Return recorded task status and artifact events."""
+
+    if task_id not in _TASKS:
+        raise HTTPException(status_code=404, detail="A2A task not found")
+    return A2ATaskEvents(events=_TASK_EVENTS.get(task_id, []))

--- a/core/agent/main.py
+++ b/core/agent/main.py
@@ -26,6 +26,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from agent.api import router
 from agent.api.schemas.completion_chunk import ReasonChatCompletionChunk
+from agent.api.v1.a2a import a2a_discovery_router
 from agent.exceptions.agent_exc import AgentExc
 
 
@@ -67,6 +68,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(create_health_router("core-agent", service_manager))
+    app.include_router(a2a_discovery_router)
     app.include_router(router.router_v1)
 
     @app.exception_handler(AgentExc)  # type: ignore[misc]

--- a/core/agent/tests/test_a2a.py
+++ b/core/agent/tests/test_a2a.py
@@ -1,0 +1,158 @@
+"""Tests for the A2A adapter surface."""
+
+from dataclasses import dataclass
+from typing import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from common.otlp import sid as sid_module
+from fastapi import HTTPException
+
+from agent.api.schemas.a2a import A2ASendMessageRequest
+from agent.api.v1 import a2a
+
+
+@dataclass
+class _DummySidGen:
+    """Simple sid generator for tests that construct Span."""
+
+    value: str = "test-sid"
+
+    def gen(self) -> str:
+        return self.value
+
+
+@pytest.fixture(autouse=True)
+def _setup_test_environment() -> None:
+    """Ensure Span can be created in the isolated test environment."""
+    if sid_module.sid_generator2 is None:
+        sid_module.sid_generator2 = _DummySidGen()  # type: ignore[assignment]
+
+
+def test_build_agent_card_uses_a2a_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Agent card should expose spec-shaped capabilities and skills."""
+    monkeypatch.setenv("A2A_PUBLIC_BASE_URL", "https://agent.example.com/")
+
+    card = a2a.build_agent_card()
+    dumped = card.model_dump(by_alias=True)
+
+    assert dumped["supportedInterfaces"][0]["url"] == (
+        "https://agent.example.com/agent/v1/a2a"
+    )
+    assert dumped["supportedInterfaces"][0]["protocolBinding"] == "HTTP+JSON"
+    assert dumped["capabilities"] == {
+        "streaming": False,
+        "pushNotifications": False,
+        "extendedAgentCard": False,
+    }
+    assert dumped["securitySchemes"]["astronConsumer"]["apiKeySecurityScheme"] == {
+        "description": "Astron gateway consumer header.",
+        "location": "header",
+        "name": "x-consumer-username",
+    }
+    assert dumped["securityRequirements"][0]["schemes"] == {
+        "astronConsumer": {"list": []}
+    }
+    assert dumped["skills"][0]["id"] == "astron-agent-chat"
+    assert dumped["skills"][0]["inputModes"] == ["text/plain"]
+
+
+def test_extract_message_text_rejects_empty_text() -> None:
+    """A2A send needs a non-empty text part for the current core-agent adapter."""
+    request = A2ASendMessageRequest.model_validate(
+        {
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "   "}],
+            }
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        a2a.extract_message_text(request.message)
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_message_maps_text_to_custom_completion() -> None:
+    """message:send should route A2A text into the existing completion runner."""
+    request = A2ASendMessageRequest.model_validate(
+        {
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "Say hello."}],
+            },
+            "metadata": {
+                "uid": "user-1",
+                "model_config": {
+                    "domain": "model",
+                    "api": "https://llm.example.com",
+                    "provider": "openai",
+                    "api_key": "test-key",
+                },
+                "max_loop_count": 3,
+            },
+        }
+    )
+
+    mock_completion = MagicMock()
+
+    async def fake_complete() -> AsyncIterator[str]:
+        yield (
+            'data: {"choices":[{"delta":{"content":"Hello"}}],'
+            '"code":0,"message":"success","object":"chat.completion.chunk"}\n\n'
+        )
+        yield (
+            'data: {"choices":[{"delta":{"content":"!"}}],'
+            '"code":0,"message":"success","object":"chat.completion.chunk"}\n\n'
+        )
+        yield "data: [DONE]\n\n"
+
+    mock_completion.do_complete = fake_complete
+
+    with patch("agent.api.v1.a2a.CustomChatCompletion", return_value=mock_completion):
+        response = await a2a.send_message(
+            x_consumer_username="tenant-1",
+            request=request,
+        )
+
+    assert response.task is not None
+    assert response.task.status.state == "TASK_STATE_COMPLETED"
+    assert response.task.history[0].parts[0].text == "Say hello."
+    assert response.task.artifacts[0].parts[0].text == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_send_message_can_return_immediately_without_running_agent() -> None:
+    """returnImmediately should create a submitted task without invoking the runner."""
+    request = A2ASendMessageRequest.model_validate(
+        {
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "Start work."}],
+            },
+            "configuration": {"returnImmediately": True},
+            "metadata": {
+                "model_config": {
+                    "domain": "model",
+                    "api": "https://llm.example.com",
+                },
+                "max_loop_count": 1,
+            },
+        }
+    )
+
+    with patch("agent.api.v1.a2a.CustomChatCompletion") as completion:
+        response = await a2a.send_message(
+            x_consumer_username="tenant-1",
+            request=request,
+        )
+
+    completion.assert_not_called()
+    assert response.task is not None
+    assert response.task.status.state == "TASK_STATE_SUBMITTED"
+    assert response.task.artifacts == []

--- a/core/agent/tests/test_a2a.py
+++ b/core/agent/tests/test_a2a.py
@@ -126,6 +126,91 @@ async def test_send_message_maps_text_to_custom_completion() -> None:
 
 
 @pytest.mark.asyncio
+async def test_collect_completion_text_ignores_malformed_sse_payload() -> None:
+    """Malformed upstream SSE data should not fail the A2A request."""
+    mock_completion = MagicMock()
+
+    async def fake_complete() -> AsyncIterator[str]:
+        yield "data: {not-json}\n\n"
+        yield (
+            'data: {"choices":[{"delta":{"content":"Recovered"}}],'
+            '"code":0,"message":"success","object":"chat.completion.chunk"}\n\n'
+        )
+
+    mock_completion.do_complete = fake_complete
+
+    text, error = await a2a._collect_completion_text(mock_completion)
+
+    assert text == "Recovered"
+    assert error == ""
+
+
+def test_completion_inputs_uses_fallback_for_invalid_max_loop_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid metadata/env loop counts should fall back instead of raising."""
+    monkeypatch.setenv("A2A_MAX_LOOP_COUNT", "also-invalid")
+    request = A2ASendMessageRequest.model_validate(
+        {
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "Say hello."}],
+            },
+            "metadata": {"max_loop_count": "not-an-int"},
+        }
+    )
+
+    inputs = a2a._completion_inputs_from_a2a(request, "Say hello.")
+
+    assert inputs.max_loop_count == 5
+
+
+def test_completion_inputs_generates_uid_when_request_ids_are_missing() -> None:
+    """A2A inputs should still have a non-empty uid when IDs are blank."""
+    request = A2ASendMessageRequest.model_validate(
+        {
+            "message": {
+                "messageId": "",
+                "role": "ROLE_USER",
+                "parts": [{"text": "Say hello."}],
+            }
+        }
+    )
+
+    inputs = a2a._completion_inputs_from_a2a(request, "Say hello.")
+
+    assert inputs.uid
+    assert len(inputs.uid) <= 64
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_text_stops_after_error_code() -> None:
+    """Error chunks should stop stream processing before later content chunks."""
+    consumed_chunks = []
+    mock_completion = MagicMock()
+
+    async def fake_complete() -> AsyncIterator[str]:
+        for chunk in [
+            'data: {"code":500,"message":"boom","choices":[]}\n\n',
+            (
+                'data: {"choices":[{"delta":{"content":"ignored"}}],'
+                '"code":0,"message":"success","object":"chat.completion.chunk"}\n\n'
+            ),
+        ]:
+            consumed_chunks.append(chunk)
+            yield chunk
+
+    mock_completion.do_complete = fake_complete
+
+    text, error = await a2a._collect_completion_text(mock_completion)
+
+    assert text == ""
+    assert error == "boom"
+    assert len(consumed_chunks) == 1
+
+
+@pytest.mark.asyncio
 async def test_send_message_can_return_immediately_without_running_agent() -> None:
     """returnImmediately should create a submitted task without invoking the runner."""
     request = A2ASendMessageRequest.model_validate(

--- a/core/agent/tests/test_a2a.py
+++ b/core/agent/tests/test_a2a.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from common.otlp import sid as sid_module
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from agent.api.schemas.a2a import A2ASendMessageRequest
 from agent.api.v1 import a2a
@@ -40,6 +41,12 @@ def test_build_agent_card_uses_a2a_shapes(monkeypatch: pytest.MonkeyPatch) -> No
         "https://agent.example.com/agent/v1/a2a"
     )
     assert dumped["supportedInterfaces"][0]["protocolBinding"] == "HTTP+JSON"
+    assert dumped["protocolVersion"] == "0.3.0"
+    assert dumped["version"] == "1.0.9"
+    assert dumped["authentication"] == {
+        "schemes": ["ApiKey"],
+        "credentials": "x-consumer-username header",
+    }
     assert dumped["capabilities"] == {
         "streaming": False,
         "pushNotifications": False,
@@ -241,3 +248,81 @@ async def test_send_message_can_return_immediately_without_running_agent() -> No
     assert response.task is not None
     assert response.task.status.state == "TASK_STATE_SUBMITTED"
     assert response.task.artifacts == []
+
+
+def test_tasks_send_get_and_events_e2e() -> None:
+    """The HTTP adapter should expose task runtime state and task events."""
+    if hasattr(a2a, "_TASKS"):
+        a2a._TASKS.clear()
+    if hasattr(a2a, "_TASK_EVENTS"):
+        a2a._TASK_EVENTS.clear()
+
+    app = FastAPI()
+    app.include_router(a2a.a2a_router, prefix="/agent/v1")
+    client = TestClient(app)
+    mock_completion = MagicMock()
+
+    async def fake_complete() -> AsyncIterator[str]:
+        yield (
+            'data: {"choices":[{"delta":{"content":"Task"}}],'
+            '"code":0,"message":"success","object":"chat.completion.chunk"}\n\n'
+        )
+        yield (
+            'data: {"choices":[{"delta":{"content":" done"}}],'
+            '"code":0,"message":"success","object":"chat.completion.chunk"}\n\n'
+        )
+
+    mock_completion.do_complete = fake_complete
+    payload = {
+        "id": "task-1",
+        "message": {
+            "messageId": "msg-1",
+            "contextId": "ctx-1",
+            "role": "ROLE_USER",
+            "parts": [{"text": "Run this task."}],
+        },
+        "metadata": {
+            "uid": "user-1",
+            "model_config": {
+                "domain": "model",
+                "api": "https://llm.example.com",
+            },
+        },
+    }
+
+    with patch("agent.api.v1.a2a.CustomChatCompletion", return_value=mock_completion):
+        send_response = client.post(
+            "/agent/v1/a2a/tasks:send",
+            headers={"x-consumer-username": "tenant-1"},
+            json=payload,
+        )
+
+    assert send_response.status_code == 200
+    task = send_response.json()
+    assert task["id"] == "task-1"
+    assert task["contextId"] == "ctx-1"
+    assert task["status"]["state"] == "TASK_STATE_COMPLETED"
+    assert task["artifacts"][0]["parts"][0]["text"] == "Task done"
+
+    get_response = client.get(
+        "/agent/v1/a2a/tasks/task-1",
+        headers={"x-consumer-username": "tenant-1"},
+    )
+
+    assert get_response.status_code == 200
+    assert get_response.json() == task
+
+    events_response = client.get(
+        "/agent/v1/a2a/tasks/task-1/events",
+        headers={"x-consumer-username": "tenant-1"},
+    )
+
+    assert events_response.status_code == 200
+    events = events_response.json()["events"]
+    assert [event["kind"] for event in events] == [
+        "status-update",
+        "artifact-update",
+    ]
+    assert events[0]["status"]["state"] == "TASK_STATE_COMPLETED"
+    assert events[0]["final"] is True
+    assert events[1]["artifact"]["parts"][0]["text"] == "Task done"


### PR DESCRIPTION
## Summary

Adds a focused A2A adapter for the core agent service, including discovery, message sending, runtime task endpoints, and e2e-style task coverage.

## Related Issue

Fixes #709.

## Problem

Issue #709 asks for Astron Agent to expose an A2A-compatible core agent surface so external A2A clients can discover the agent and send messages/tasks. The existing service did not expose an A2A discovery card, `message:send` HTTP adapter, or task runtime endpoints for `core/agent`.

## Change

- Adds A2A Pydantic schemas for agent cards, messages, tasks, artifacts, security schemes, send-message requests/responses, task send params, and task status/artifact events.
- Exposes `/.well-known/agent-card.json` and `/agent/v1/a2a/agent-card.json` with HTTP+JSON interface metadata, capabilities, skills, text I/O modes, and the existing `x-consumer-username` header auth shape.
- Adds `/agent/v1/a2a/message:send` to map A2A text parts into the existing `CustomChatCompletion` runner and return A2A task envelopes for completed, submitted, and failed states.
- Adds runtime task routes under `/agent/v1/a2a`: `POST /tasks:send`, `GET /tasks/{task_id}`, and `GET /tasks/{task_id}/events`.
- Records completed/submitted task state and status/artifact events in an in-process runtime store for retrieval by A2A clients.
- Declares the task event union as an explicit `TypeAlias` so the repo mypy quality check accepts the runtime task event annotations.
- Adds tests for agent card shape, empty text rejection, completed responses, submitted-task behavior, and a FastAPI `TestClient` e2e-style send/get/events task flow.

## Tests

Latest type-only CI fix validation:

- `cd core/agent && .venv/bin/python -m mypy --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --no-implicit-optional --ignore-missing-imports --explicit-package-bases .` -> Success, no issues in 67 source files
- `cd core/agent && PYTHONPATH=.. .venv/bin/python -m pytest tests/test_a2a.py -q` -> 9 passed, 3 warnings
- `flake8` on the touched file -> passed
- `isort --check-only --profile black` on the touched file -> passed
- `black --check` on the touched file -> passed
- `compileall -q api/v1/a2a.py` -> passed
- `git diff --check HEAD~1..HEAD` and `git diff --check` -> passed

Runtime task/e2e follow-up validation before the type-only CI fix:

- `PYTHONPATH=.. .venv/bin/python -m pytest tests/test_a2a.py -q` -> 9 passed, 3 warnings
- `PYTHONPATH=.. .venv/bin/python -m pytest tests/test_router_and_schemas.py tests/test_main.py tests/test_a2a.py -q` -> 22 passed, 5 warnings
- `PYTHONPATH=.. .venv/bin/python -m pytest tests -q` -> 183 passed, 24 warnings
- `.venv/bin/python -m black --check api/v1/a2a.py api/schemas/a2a.py tests/test_a2a.py` -> passed
- `.venv/bin/python -m isort --check-only --profile black api/v1/a2a.py api/schemas/a2a.py tests/test_a2a.py` -> passed
- `.venv/bin/python -m flake8 --extend-ignore=E501 api/v1/a2a.py api/schemas/a2a.py tests/test_a2a.py` -> passed
- `PYTHONPATH=.. .venv/bin/python -m compileall -q api/v1/a2a.py api/schemas/a2a.py tests/test_a2a.py` -> passed

## Risk Notes

- This remains a text-only adapter slice.
- The task runtime store is in-process memory; this PR does not add persistence or cross-worker synchronization.
- The latest public CodeQL/CI workflow runs for head `0e0110f19786c0bb22c8afae03e21f377a8214e8` currently show `action_required`, so their jobs have not run yet.
- I did not run a live Kagent or external A2A client integration test.
- Runtime model/plugin config is still supplied through request metadata or the existing `A2A_MODEL_*` environment defaults.

## Maintainer Attention

Please confirm whether the endpoint placement, auth declaration, A2A schema shape, and in-process task runtime approach match the direction you want for `core/agent`.
