### PR TITLE
feat(agent): add OpenClaw workflow trigger intake

### DIFF
--- a/core/agent/api/router.py
+++ b/core/agent/api/router.py
@@ -6,6 +6,7 @@ It sets up the common prefix '/agent/v1' for all agent API endpoints.
 
 from fastapi import APIRouter
 
+from agent.api.v1.openclaw_trigger import openclaw_trigger_router
 from agent.api.v1.skill_sandbox_api import skill_sandbox_router
 from agent.api.v1.workflow_agent import workflow_agent_router
 
@@ -14,3 +15,4 @@ router_v1 = APIRouter(
 )
 router_v1.include_router(workflow_agent_router)
 router_v1.include_router(skill_sandbox_router)
+router_v1.include_router(openclaw_trigger_router)

--- a/core/agent/api/schemas/openclaw_trigger.py
+++ b/core/agent/api/schemas/openclaw_trigger.py
@@ -1,0 +1,55 @@
+"""Schemas for controlled OpenClaw-to-Astron workflow triggers."""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class OpenClawTriggerInputs(BaseModel):
+    """Webhook payload accepted from an OpenClaw trigger."""
+
+    trigger_id: str = Field(..., min_length=1, max_length=128)
+    workflow_id: str = Field(..., min_length=1, max_length=128)
+    operator_uid: str = Field(..., min_length=1, max_length=64)
+    scenario: str = Field(..., min_length=1, max_length=128)
+    action: str = Field(..., min_length=1, max_length=128)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    safety_level: Literal["low", "medium", "high"] = "high"
+    approval_required: bool = True
+    idempotency_key: str = Field(default="", max_length=128)
+    audit_tags: list[str] = Field(default_factory=list)
+
+    @field_validator("audit_tags")
+    @classmethod
+    def limit_audit_tags(cls, value: list[str]) -> list[str]:
+        """Keep audit metadata bounded for logs and traces."""
+
+        if len(value) > 16:
+            raise ValueError("audit_tags cannot contain more than 16 items")
+        return value
+
+
+class OpenClawTriggerAuditEvent(BaseModel):
+    """Audit record returned and logged for each trigger request."""
+
+    event_id: str
+    trigger_id: str
+    workflow_id: str
+    operator_uid: str
+    scenario: str
+    action: str
+    safety_level: str
+    approval_required: bool
+    auth_mode: str
+    status: str
+    audit_tags: list[str] = Field(default_factory=list)
+
+
+class OpenClawTriggerResponse(BaseModel):
+    """Response for a controlled OpenClaw trigger request."""
+
+    code: int = 0
+    message: str = "success"
+    status: Literal["pending_approval", "accepted"]
+    audit_event: OpenClawTriggerAuditEvent
+    dispatch_payload: dict[str, Any]

--- a/core/agent/api/v1/openclaw_trigger.py
+++ b/core/agent/api/v1/openclaw_trigger.py
@@ -1,0 +1,40 @@
+"""OpenClaw controlled trigger API."""
+
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+from agent.api.schemas.openclaw_trigger import OpenClawTriggerInputs
+from agent.service.openclaw_trigger import (
+    OpenClawSignatureError,
+    create_openclaw_trigger_response,
+    verify_openclaw_signature,
+)
+
+openclaw_trigger_router = APIRouter(prefix="/openclaw", tags=["openclaw"])
+
+
+@openclaw_trigger_router.post(  # type: ignore[misc]
+    "/triggers/workflows",
+    description="Accept a controlled OpenClaw trigger for an Astron workflow.",
+)
+async def trigger_workflow_from_openclaw(
+    request: Request,
+    x_openclaw_signature: Annotated[str | None, Header()] = None,
+) -> JSONResponse:
+    """Validate, audit, and stage an OpenClaw-triggered Astron workflow."""
+
+    raw_body = await request.body()
+    try:
+        auth_mode = verify_openclaw_signature(raw_body, x_openclaw_signature)
+        inputs = OpenClawTriggerInputs.model_validate(json.loads(raw_body or b"{}"))
+    except OpenClawSignatureError as exc:
+        return JSONResponse(status_code=401, content={"code": 401, "message": str(exc)})
+    except (json.JSONDecodeError, UnicodeDecodeError, ValidationError) as exc:
+        return JSONResponse(status_code=422, content={"code": 422, "message": str(exc)})
+
+    response = create_openclaw_trigger_response(inputs, auth_mode)
+    return JSONResponse(content=response.model_dump())

--- a/core/agent/service/openclaw_trigger.py
+++ b/core/agent/service/openclaw_trigger.py
@@ -1,0 +1,105 @@
+"""OpenClaw trigger intake service.
+
+The service intentionally separates intake, audit, and dispatch planning. High
+risk RPA scenarios default to human approval instead of direct execution.
+"""
+
+import hashlib
+import hmac
+import os
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from agent.api.schemas.openclaw_trigger import (
+    OpenClawTriggerAuditEvent,
+    OpenClawTriggerInputs,
+    OpenClawTriggerResponse,
+)
+
+SIGNATURE_HEADER_PREFIX = "sha256="
+
+
+class OpenClawSignatureError(ValueError):
+    """Raised when the OpenClaw webhook signature is missing or invalid."""
+
+
+def verify_openclaw_signature(raw_body: bytes, signature: str | None) -> str:
+    """Verify optional HMAC-SHA256 signature for OpenClaw webhooks.
+
+    If OPENCLAW_WEBHOOK_SECRET is not configured, unsigned requests are allowed
+    only when OPENCLAW_ALLOW_UNSIGNED_DEV=true is set for local development.
+    """
+
+    secret = os.getenv("OPENCLAW_WEBHOOK_SECRET", "")
+    if not secret:
+        if os.getenv("OPENCLAW_ALLOW_UNSIGNED_DEV", "").lower() == "true":
+            return "unsigned-dev"
+        raise OpenClawSignatureError("OPENCLAW_WEBHOOK_SECRET is not configured")
+    if not signature:
+        raise OpenClawSignatureError("missing OpenClaw signature")
+
+    digest = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+    expected = f"{SIGNATURE_HEADER_PREFIX}{digest}"
+    if not hmac.compare_digest(signature, expected):
+        raise OpenClawSignatureError("invalid OpenClaw signature")
+    return "hmac-sha256"
+
+
+def build_dispatch_payload(inputs: OpenClawTriggerInputs) -> dict[str, Any]:
+    """Build the workflow-agent request body for the accepted trigger."""
+
+    prompt = (
+        f"OpenClaw triggered controlled action `{inputs.action}` for scenario "
+        f"`{inputs.scenario}`. Execute only the configured workflow and preserve "
+        "the supplied audit context."
+    )
+    return {
+        "uid": inputs.operator_uid,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": True,
+        "model_config": {"domain": "", "api": "", "provider": "", "api_key": ""},
+        "plugin": {"workflow_ids": [inputs.workflow_id]},
+        "max_loop_count": 1,
+        "meta_data": {
+            "caller": "openclaw_trigger",
+            "caller_sid": inputs.trigger_id,
+            "workflow_id": inputs.workflow_id,
+        },
+        "openclaw_context": {
+            "trigger_id": inputs.trigger_id,
+            "scenario": inputs.scenario,
+            "action": inputs.action,
+            "payload": inputs.payload,
+            "idempotency_key": inputs.idempotency_key,
+        },
+    }
+
+
+def create_openclaw_trigger_response(
+    inputs: OpenClawTriggerInputs, auth_mode: str
+) -> OpenClawTriggerResponse:
+    """Create an auditable response and dispatch plan for an OpenClaw trigger."""
+
+    requires_approval = inputs.approval_required or inputs.safety_level == "high"
+    status = "pending_approval" if requires_approval else "accepted"
+    audit_event = OpenClawTriggerAuditEvent(
+        event_id=f"openclaw-{uuid4()}",
+        trigger_id=inputs.trigger_id,
+        workflow_id=inputs.workflow_id,
+        operator_uid=inputs.operator_uid,
+        scenario=inputs.scenario,
+        action=inputs.action,
+        safety_level=inputs.safety_level,
+        approval_required=requires_approval,
+        auth_mode=auth_mode,
+        status=status,
+        audit_tags=inputs.audit_tags,
+    )
+    logger.bind(openclaw_audit=True).info(audit_event.model_dump())
+    return OpenClawTriggerResponse(
+        status=status,
+        audit_event=audit_event,
+        dispatch_payload=build_dispatch_payload(inputs),
+    )

--- a/core/agent/tests/test_openclaw_trigger.py
+++ b/core/agent/tests/test_openclaw_trigger.py
@@ -1,0 +1,133 @@
+"""Tests for OpenClaw controlled trigger intake."""
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from agent.api.schemas.openclaw_trigger import OpenClawTriggerInputs
+from agent.api.v1.openclaw_trigger import openclaw_trigger_router
+from agent.service.openclaw_trigger import build_dispatch_payload
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "trigger_id": "oc-001",
+        "workflow_id": "finance-reimbursement-rpa",
+        "operator_uid": "alice",
+        "scenario": "finance-reimbursement",
+        "action": "submit-reimbursement",
+        "payload": {"amount": 128.5, "currency": "CNY"},
+        "safety_level": "high",
+        "approval_required": True,
+        "audit_tags": ["openclaw", "rpa"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    test_app = FastAPI()
+    test_app.include_router(openclaw_trigger_router)
+    return test_app
+
+
+@pytest.mark.asyncio
+async def test_high_risk_trigger_defaults_to_pending_approval(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENCLAW_ALLOW_UNSIGNED_DEV", "true")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/openclaw/triggers/workflows", json=_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "pending_approval"
+    assert body["audit_event"]["approval_required"] is True
+    assert body["audit_event"]["auth_mode"] == "unsigned-dev"
+    assert body["dispatch_payload"]["plugin"]["workflow_ids"] == [
+        "finance-reimbursement-rpa"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_low_risk_trigger_can_be_accepted(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENCLAW_ALLOW_UNSIGNED_DEV", "true")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/openclaw/triggers/workflows",
+            json=_payload(safety_level="low", approval_required=False),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "accepted"
+    assert body["audit_event"]["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_hmac_signature_is_required_when_secret_configured(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENCLAW_WEBHOOK_SECRET", "secret")
+    raw_body = json.dumps(_payload()).encode("utf-8")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        unsigned = await client.post(
+            "/openclaw/triggers/workflows",
+            content=raw_body,
+            headers={"content-type": "application/json"},
+        )
+        digest = hmac.new(b"secret", raw_body, hashlib.sha256).hexdigest()
+        signed = await client.post(
+            "/openclaw/triggers/workflows",
+            content=raw_body,
+            headers={
+                "content-type": "application/json",
+                "x-openclaw-signature": f"sha256={digest}",
+            },
+        )
+
+    assert unsigned.status_code == 401
+    assert signed.status_code == 200
+    assert signed.json()["audit_event"]["auth_mode"] == "hmac-sha256"
+
+
+@pytest.mark.asyncio
+async def test_malformed_utf8_body_returns_422(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENCLAW_ALLOW_UNSIGNED_DEV", "true")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/openclaw/triggers/workflows",
+            content=b"\xff",
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["code"] == 422
+
+
+def test_dispatch_payload_preserves_audit_context() -> None:
+    inputs = OpenClawTriggerInputs.model_validate(_payload(idempotency_key="idem-1"))
+
+    dispatch_payload = build_dispatch_payload(inputs)
+
+    assert dispatch_payload["uid"] == "alice"
+    assert dispatch_payload["meta_data"]["caller"] == "openclaw_trigger"
+    assert dispatch_payload["meta_data"]["caller_sid"] == "oc-001"
+    assert dispatch_payload["openclaw_context"]["idempotency_key"] == "idem-1"


### PR DESCRIPTION
## Summary
- add an `/agent/v1/openclaw/triggers/workflows` intake endpoint for OpenClaw-triggered Astron workflows
- require HMAC-SHA256 webhook signatures by default, with an explicit unsigned-dev mode for local testing
- return a structured audit event and workflow-agent dispatch payload, while defaulting high-risk RPA actions to pending human approval
- add unit tests for approval gating, HMAC verification, and audit context preservation

Closes #1067

## Validation
- `PYTHONPATH=D:\??\work\astron-agent\core\agent .\.venv\Scripts\python.exe -m pytest tests\test_openclaw_trigger.py -q`
- `.\.venv\Scripts\python.exe -m py_compile api\schemas\openclaw_trigger.py service\openclaw_trigger.py api\v1\openclaw_trigger.py tests\test_openclaw_trigger.py`
- `.\.venv\Scripts\python.exe -m black --check api\schemas\openclaw_trigger.py service\openclaw_trigger.py api\v1\openclaw_trigger.py tests\test_openclaw_trigger.py`
- `.\.venv\Scripts\python.exe -m isort --check-only --profile black api\schemas\openclaw_trigger.py service\openclaw_trigger.py api\v1\openclaw_trigger.py tests\test_openclaw_trigger.py`
- `git diff --check`