### PR TITLE
Potential fix for code scanning alert no. 54: Server-side request forgery

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -98,6 +98,10 @@ public class UrlCheckTool {
         try {
             URL u = toSafeHttpUrl(url);
             ensurePublicAddresses(u.getHost());
+            List<String> domainWhiteList = readCsvConfig(DOMAIN_WHITE_CATEGORY);
+            if (!isHostInDomainAllowList(u.getHost(), domainWhiteList)) {
+                throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
+            }
             URLConnection urlConnection = u.openConnection();
             if (!(urlConnection instanceof HttpURLConnection httpURLConnection)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_HTTP_HTTPS_ONLY);
@@ -470,6 +474,23 @@ public class UrlCheckTool {
     }
 
     private record RedirectLookupResult(int statusCode, String location) {}
+
+    private boolean isHostInDomainAllowList(String host, List<String> domainWhiteList) {
+        if (StringUtils.isBlank(host) || domainWhiteList == null || domainWhiteList.isEmpty()) {
+            return false;
+        }
+        String normalizedHost = StringUtils.lowerCase(StringUtils.trim(host), Locale.ROOT);
+        for (String allowed : domainWhiteList) {
+            String normalizedAllowed = StringUtils.lowerCase(StringUtils.trimToEmpty(allowed), Locale.ROOT);
+            if (normalizedAllowed.isEmpty()) {
+                continue;
+            }
+            if (normalizedHost.equals(normalizedAllowed) || normalizedHost.endsWith("." + normalizedAllowed)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private URL toSafeHttpUrl(String url) throws IOException {
         try {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -98,10 +98,6 @@ public class UrlCheckTool {
         try {
             URL u = toSafeHttpUrl(url);
             ensurePublicAddresses(u.getHost());
-            List<String> domainWhiteList = readCsvConfig(DOMAIN_WHITE_CATEGORY);
-            if (!isHostInDomainAllowList(u.getHost(), domainWhiteList)) {
-                throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
-            }
             URLConnection urlConnection = u.openConnection();
             if (!(urlConnection instanceof HttpURLConnection httpURLConnection)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_HTTP_HTTPS_ONLY);
@@ -482,6 +478,10 @@ public class UrlCheckTool {
         String normalizedHost = StringUtils.lowerCase(StringUtils.trim(host), Locale.ROOT);
         for (String allowed : domainWhiteList) {
             String normalizedAllowed = StringUtils.lowerCase(StringUtils.trimToEmpty(allowed), Locale.ROOT);
+            // Remove leading dot if present (e.g., ".example.com" -> "example.com")
+            if (normalizedAllowed.startsWith(".")) {
+                normalizedAllowed = normalizedAllowed.substring(1);
+            }
             if (normalizedAllowed.isEmpty()) {
                 continue;
             }


### PR DESCRIPTION
Potential fix for [https://github.com/iflytek/astron-agent/security/code-scanning/54](https://github.com/iflytek/astron-agent/security/code-scanning/54)

Best fix: enforce a **strict server-side allowlist** before making any outbound request in redirect lookup. In this file, the most reliable low-impact fix is to require the URL host to be present in configured `DOMAIN_WHITE_LIST` (exact host or subdomain match) inside `lookupRedirect(...)` before `openConnection()`.

Concretely in `console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java`:
- In `lookupRedirect`, after creating `URL u` and before `u.openConnection()`, load `DOMAIN_WHITE_LIST` and reject if `u.getHost()` is not allowlisted.
- Add a private helper method to check allowlist match (`exact` or `.suffix`).
- Keep existing behavior otherwise (timeouts, HEAD, no auto-redirect, etc.).

This preserves functionality for approved domains while removing attacker-controlled arbitrary destinations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
