### PR TITLE
test(console): repair bot chat CI validation

### DIFF
--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
@@ -20,6 +20,7 @@ import com.iflytek.astron.console.commons.service.data.ChatListDataService;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.commons.service.workflow.WorkflowBotChatService;
 import com.iflytek.astron.console.hub.data.ReqKnowledgeRecordsDataService;
+import com.iflytek.astron.console.hub.service.agentmemory.runtime.AgentMemoryRuntimeService;
 import com.iflytek.astron.console.hub.service.chat.ChatListService;
 import com.iflytek.astron.console.hub.service.chat.springai.AgentChatTask;
 import com.iflytek.astron.console.hub.service.chat.springai.SpringAiAgentChatService;
@@ -78,6 +79,8 @@ class BotChatServiceImplUnitTest {
     private com.iflytek.astron.console.hub.util.BotPermissionUtil botPermissionUtil;
     @Mock
     private com.iflytek.astron.console.hub.service.bot.PersonalityConfigService personalityConfigService;
+    @Mock
+    private AgentMemoryRuntimeService agentMemoryRuntimeService;
 
     @InjectMocks
     private BotChatServiceImpl botChatService;
@@ -85,6 +88,8 @@ class BotChatServiceImplUnitTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(botChatService, "maxInputTokens", 8000);
+        lenient().when(agentMemoryRuntimeService.enrichMessages(any(AgentChatTask.class)))
+                .thenAnswer(invocation -> invocation.<AgentChatTask>getArgument(0).getMessages());
     }
 
     @Test

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -351,8 +351,9 @@ const BaseConfig: React.FC<ChatProps> = ({
   const [debugSessionKey, setDebugSessionKey] = useState(0);
   const [debugHistoryLoading, setDebugHistoryLoading] = useState(false);
   const [debugHistorySearchQuery, setDebugHistorySearchQuery] = useState('');
-  const [memoryConfig, setMemoryConfig] =
-    useState<AgentMemoryConfig | null>(null);
+  const [memoryConfig, setMemoryConfig] = useState<AgentMemoryConfig | null>(
+    null
+  );
   const [memoryApiKey, setMemoryApiKey] = useState('');
   const [memoryApiKeyEditing, setMemoryApiKeyEditing] = useState(false);
   const [memoryItems, setMemoryItems] = useState<AgentMemoryItem[]>([]);

--- a/console/frontend/src/services/agent-memory.ts
+++ b/console/frontend/src/services/agent-memory.ts
@@ -45,9 +45,7 @@ export const saveAgentMemoryConfig = (
   return http.put('/agent-memory/config', params);
 };
 
-export const getAgentMemories = (
-  botId: number
-): Promise<AgentMemoryItem[]> => {
+export const getAgentMemories = (botId: number): Promise<AgentMemoryItem[]> => {
   return http.get('/agent-memory/memories', {
     params: { botId },
   });


### PR DESCRIPTION
## Summary
- Mock AgentMemoryRuntimeService in BotChatServiceImplUnitTest so legacy chat task assertions reach SpringAiAgentChatService again
- Apply Prettier formatting to the two frontend files reported by remote check-typescript

## Validation
- Remote CI first pass identified check-typescript formatting failures and BotChatServiceImplUnitTest failures
- superpowers requesting-code-review reviewer returned Ready to merge: Yes, no Critical/Important/Minor issues