### PR TITLE
fix(console): repair agent publish and memory config

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -116,6 +116,7 @@ public class BotServiceImpl implements BotService {
     private String workflowConfigUrl;
 
     public static final String BOT_INPUT_EXAMPLE_SPLIT = "%%split%%";
+    private static final Integer DEFAULT_BOT_TYPE = 10;
 
     private final OkHttpClient httpClient = new OkHttpClient.Builder()
             .connectTimeout(Duration.ofSeconds(10))
@@ -340,9 +341,10 @@ public class BotServiceImpl implements BotService {
     }
 
     private ChatBotBase createWorkflowBotBase(String uid, BotCreateForm bot, Long spaceId, Integer version) {
+        Integer botType = normalizeBotFormType(bot);
         ChatBotBase botBase = new ChatBotBase();
         botBase.setUid(uid);
-        botBase.setBotType(bot.getBotType());
+        botBase.setBotType(botType);
         botBase.setBotName(bot.getName());
         botBase.setAvatar(bot.getAvatar());
         botBase.setPcBackground(bot.getPcBackground());
@@ -369,9 +371,10 @@ public class BotServiceImpl implements BotService {
     }
 
     private ChatBotBase createBasicBotBase(String uid, BotCreateForm bot, Long spaceId) {
+        Integer botType = normalizeBotFormType(bot);
         ChatBotBase botBase = new ChatBotBase();
         botBase.setUid(uid);
-        botBase.setBotType(bot.getBotType());
+        botBase.setBotType(botType);
         botBase.setBotName(bot.getName());
         botBase.setAvatar(bot.getAvatar());
         botBase.setPcBackground(bot.getPcBackground());
@@ -498,10 +501,11 @@ public class BotServiceImpl implements BotService {
     private void updateWorkflowBotInternal(String uid, BotCreateForm bot, HttpServletRequest request, Long spaceId) {
         try {
             Integer botId = bot.getBotId();
+            Integer botType = normalizeBotFormType(bot);
             ChatBotBase botBase = ChatBotBase.builder()
                     .uid(uid)
                     .id(botId)
-                    .botType(bot.getBotType())
+                    .botType(botType)
                     .botName(bot.getName())
                     .avatar(bot.getAvatar())
                     .pcBackground(bot.getPcBackground())
@@ -556,10 +560,11 @@ public class BotServiceImpl implements BotService {
     }
 
     private ChatBotBase createUpdateBotBase(String uid, BotCreateForm bot) {
+        Integer botType = normalizeBotFormType(bot);
         return ChatBotBase.builder()
                 .uid(uid)
                 .id(bot.getBotId())
-                .botType(bot.getBotType())
+                .botType(botType)
                 .botName(bot.getName())
                 .avatar(bot.getAvatar())
                 .pcBackground(bot.getPcBackground())
@@ -599,6 +604,31 @@ public class BotServiceImpl implements BotService {
                 .inputExample(bot.getInputExample() != null && !bot.getInputExample().isEmpty() ? String.join(BOT_INPUT_EXAMPLE_SPLIT, bot.getInputExample()) : null)
                 .modelId(bot.getModelId())
                 .build();
+    }
+
+    private Integer normalizeBotFormType(BotCreateForm bot) {
+        Integer botType = normalizeBotType(bot.getBotType());
+        bot.setBotType(botType);
+        return botType;
+    }
+
+    private Integer normalizeBotType(Integer botType) {
+        if (botType != null && botType > 0) {
+            return botType;
+        }
+
+        if (botTypeListService != null) {
+            try {
+                return botTypeListService.getBotTypeList().stream()
+                        .map(BotTypeList::getTypeKey)
+                        .filter(typeKey -> typeKey != null && typeKey > 0)
+                        .findFirst()
+                        .orElse(DEFAULT_BOT_TYPE);
+            } catch (Exception e) {
+                log.warn("Failed to load default bot type, fallback to {}", DEFAULT_BOT_TYPE, e);
+            }
+        }
+        return DEFAULT_BOT_TYPE;
     }
 
     private void setEnglishInputExamplesIfPresent(ChatBotBase botBase, List<String> inputExampleEn) {

--- a/console/backend/hub/src/main/resources/db/migration/V1.41__repair_memory_config_and_bot_type_defaults.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.41__repair_memory_config_and_bot_type_defaults.sql
@@ -1,0 +1,128 @@
+-- Repair deployments that already executed the early V1.40 migration before
+-- delete_time and space_id normalization were added to agent_memory_config.
+SET @space_id_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'agent_memory_config'
+      AND column_name = 'space_id'
+);
+SET @sql := IF(
+    @space_id_exists = 0,
+    'ALTER TABLE `agent_memory_config` ADD COLUMN `space_id` bigint DEFAULT NULL COMMENT ''Space ID'' AFTER `uid`',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @is_delete_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'agent_memory_config'
+      AND column_name = 'is_delete'
+);
+SET @sql := IF(
+    @is_delete_exists = 0,
+    'ALTER TABLE `agent_memory_config` ADD COLUMN `is_delete` tinyint NOT NULL DEFAULT 0 COMMENT ''Deletion status: 0 not deleted, 1 deleted'' AFTER `min_score`',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @delete_time_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'agent_memory_config'
+      AND column_name = 'delete_time'
+);
+SET @sql := IF(
+    @delete_time_exists = 0,
+    'ALTER TABLE `agent_memory_config` ADD COLUMN `delete_time` bigint NOT NULL DEFAULT 0 COMMENT ''Deletion timestamp, 0 means active'' AFTER `is_delete`',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @drop_unique_indexes := (
+    SELECT GROUP_CONCAT(CONCAT('DROP INDEX `', `index_name`, '`') SEPARATOR ', ')
+    FROM (
+        SELECT DISTINCT `index_name`
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'agent_memory_config'
+          AND non_unique = 0
+          AND index_name <> 'PRIMARY'
+    ) unique_indexes
+);
+SET @sql := IF(
+    @drop_unique_indexes IS NOT NULL,
+    CONCAT('ALTER TABLE `agent_memory_config` ', @drop_unique_indexes),
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+UPDATE `agent_memory_config`
+SET `space_id` = 0
+WHERE `space_id` IS NULL;
+
+ALTER TABLE `agent_memory_config`
+    MODIFY COLUMN `space_id` bigint NOT NULL DEFAULT 0 COMMENT 'Space ID, 0 means no space';
+
+UPDATE `agent_memory_config`
+SET `is_delete` = 0
+WHERE `is_delete` IS NULL;
+
+UPDATE `agent_memory_config` config
+JOIN (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY `bot_id`, `uid`, `space_id`, `provider`
+               ORDER BY `update_time` DESC, `id` DESC
+           ) AS row_num
+    FROM `agent_memory_config`
+    WHERE `is_delete` = 0
+) duplicate_config ON duplicate_config.id = config.id
+SET config.`is_delete` = 1,
+    config.`delete_time` = CAST(UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000 AS UNSIGNED) + config.`id`
+WHERE duplicate_config.row_num > 1;
+
+UPDATE `agent_memory_config`
+SET `delete_time` = CAST(UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000 AS UNSIGNED) + `id`
+WHERE `is_delete` <> 0
+  AND `delete_time` = 0;
+
+UPDATE `agent_memory_config`
+SET `delete_time` = 0
+WHERE `is_delete` = 0;
+
+ALTER TABLE `agent_memory_config`
+    ADD UNIQUE KEY `uk_agent_memory_config_scope` (`bot_id`, `uid`, `space_id`, `provider`, `delete_time`);
+
+-- Existing agents created without a selected category were persisted as bot_type=0,
+-- which makes published agents invisible in category-driven market views.
+SET @default_bot_type := COALESCE((
+    SELECT `type_key`
+    FROM `bot_type_list`
+    WHERE `show_index` = 1
+      AND `is_act` = 1
+      AND `type_key` > 0
+    ORDER BY `order_num` ASC
+    LIMIT 1
+), 10);
+
+UPDATE `chat_bot_base`
+SET `bot_type` = @default_bot_type
+WHERE `is_delete` = 0
+  AND (`bot_type` IS NULL OR `bot_type` <= 0);
+
+UPDATE `chat_bot_market`
+SET `bot_type` = @default_bot_type
+WHERE `is_delete` = 0
+  AND (`bot_type` IS NULL OR `bot_type` <= 0);

--- a/console/frontend/src/components/config-page-component/config-base/index.tsx
+++ b/console/frontend/src/components/config-page-component/config-base/index.tsx
@@ -171,6 +171,33 @@ const buildDefaultMemoryConfig = (botId: number): AgentMemoryConfig => ({
 
 const MEMORY_API_KEY_MASK = '****************';
 
+const normalizeBotTypeValue = (value: unknown): number | undefined => {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return undefined;
+  }
+  return numericValue;
+};
+
+const resolveBotTypeValue = (
+  value: unknown,
+  options: Array<{ value: unknown }> = []
+): number | undefined => {
+  const normalizedValue = normalizeBotTypeValue(value);
+  if (
+    normalizedValue !== undefined &&
+    options.some(item => Number(item.value) === normalizedValue)
+  ) {
+    return normalizedValue;
+  }
+  return normalizeBotTypeValue(options[0]?.value);
+};
+
+const PUBLISHED_BOT_STATUSES = [1, 2, 4];
+
+const isPublishedBotStatus = (botStatus?: number): boolean =>
+  botStatus !== undefined && PUBLISHED_BOT_STATUSES.includes(botStatus);
+
 const baseModelConfig: BaseModelConfig = {
   visible: false,
   isSending: false,
@@ -369,6 +396,29 @@ const BaseConfig: React.FC<ChatProps> = ({
     scope: number;
     promise: Promise<AgentDebugSession | null>;
   } | null>(null);
+  const getEffectiveBotType = useCallback(
+    (value: unknown) => resolveBotTypeValue(value, bottypeList),
+    [bottypeList]
+  );
+  const hasRequiredBaseInfo = useCallback(
+    (info: any = baseinfo) =>
+      Boolean(
+        info?.botName && getEffectiveBotType(info?.botType) && info?.botDesc
+      ),
+    [baseinfo, getEffectiveBotType]
+  );
+  const botTypeRules = useMemo(
+    () => [
+      { required: true, message: '' },
+      {
+        validator: (_: unknown, value: unknown) =>
+          getEffectiveBotType(value)
+            ? Promise.resolve()
+            : Promise.reject(new Error('')),
+      },
+    ],
+    [getEffectiveBotType]
+  );
 
   // 人设相关状态
   const [personalityData, setPersonalityData] = useState({
@@ -549,7 +599,7 @@ const BaseConfig: React.FC<ChatProps> = ({
         navigate('/space/agent');
       } else {
         setIsChanged(false);
-        if (detailInfo.botStatus == 2) {
+        if (isPublishedBotStatus(detailInfo.botStatus)) {
           obj.botName = obj.name;
           return setConfigPageData(obj);
         }
@@ -574,9 +624,9 @@ const BaseConfig: React.FC<ChatProps> = ({
     const name = useFormValues
       ? form.getFieldsValue().botName
       : baseinfo.botName;
-    const botType = useFormValues
-      ? form.getFieldsValue().botType
-      : baseinfo.botType;
+    const botType = getEffectiveBotType(
+      useFormValues ? form.getFieldsValue().botType : baseinfo.botType
+    );
     const botDesc = useFormValues
       ? form.getFieldsValue().botDesc
       : baseinfo.botDesc;
@@ -660,11 +710,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     if (!coverUrl) {
       return message.warning(t('configBase.defaultAvatar'));
     }
-    if (
-      baseinfo?.botName === '' ||
-      baseinfo?.botType === '' ||
-      baseinfo?.botDesc === ''
-    ) {
+    if (!hasRequiredBaseInfo()) {
       return message.warning(t('configBase.requiredInfoNotFilled'));
     }
     if (!validateMcpServerUrls()) return;
@@ -694,7 +740,7 @@ const BaseConfig: React.FC<ChatProps> = ({
     if (!coverUrl) {
       return message.warning(t('configBase.defaultAvatar'));
     }
-    if (!baseinfo?.botName || !baseinfo?.botType || !baseinfo?.botDesc) {
+    if (!hasRequiredBaseInfo()) {
       return message.warning(t('configBase.requiredInfoNotFilled'));
     }
     if (!validateMcpServerUrls()) return;
@@ -860,6 +906,11 @@ const BaseConfig: React.FC<ChatProps> = ({
       });
       const filteredBottypeList = arr.filter(item => item.value !== 25);
       setBottypeList(filteredBottypeList);
+      const withValidBotType = (data: any) => {
+        if (!data) return data;
+        const botType = resolveBotTypeValue(data.botType, filteredBottypeList);
+        return botType ? { ...data, botType } : data;
+      };
       const save = searchParams.get('save');
       const botId = searchParams.get('botId');
 
@@ -867,9 +918,10 @@ const BaseConfig: React.FC<ChatProps> = ({
         sessionStorage.removeItem('botTemplateInfoValue');
 
         getBotInfo({ botId: botId }).then((res: any) => {
+          const normalizedRes = withValidBotType(res);
           setBackgroundImgApp(res.appBackground);
           setBackgroundImg(res.pcBackground);
-          setBotInfo(res);
+          setBotInfo(normalizedRes);
           setBotCreateActiveV({
             cn: save == 'true' ? configPageData?.vcnCn : res.vcnCn,
           });
@@ -896,7 +948,10 @@ const BaseConfig: React.FC<ChatProps> = ({
           } else {
             obj.codeinterpreter = false;
           }
-          const currentConfigData = save == 'true' ? configPageData : res;
+          const currentConfigData =
+            save == 'true'
+              ? withValidBotType(configPageData || res)
+              : normalizedRes;
           setMcpServerUrls(
             normalizeMcpServerUrls(currentConfigData?.mcpServerUrls)
           );
@@ -923,9 +978,13 @@ const BaseConfig: React.FC<ChatProps> = ({
           );
           setPrologue(save == 'true' ? configPageData?.prologue : res.prologue);
           setChoosedAlltool(obj);
-          setBaseinfo(save == 'true' ? configPageData : res);
-          form.setFieldsValue(save == 'true' ? configPageData : res);
-          setDetailInfo(save == 'true' ? { ...res, ...configPageData } : res);
+          setBaseinfo(currentConfigData);
+          form.setFieldsValue(currentConfigData);
+          setDetailInfo(
+            save == 'true'
+              ? { ...normalizedRes, ...currentConfigData }
+              : currentConfigData
+          );
           setCoverUrl(save == 'true' ? configPageData?.avatar : res.avatar);
 
           // 回显人设数据
@@ -1006,6 +1065,10 @@ const BaseConfig: React.FC<ChatProps> = ({
             setSelectSource(arr);
           });
         });
+      } else {
+        const initialBaseInfo = withValidBotType(obj);
+        setBaseinfo(initialBaseInfo);
+        form.setFieldsValue(initialBaseInfo);
       }
     });
     const quickCreate = searchParams.get('quickCreate');
@@ -1682,7 +1745,7 @@ const BaseConfig: React.FC<ChatProps> = ({
       message.warning(t('configBase.defaultAvatar'));
       return;
     }
-    if (!baseinfo?.botName || !baseinfo?.botType || !baseinfo?.botDesc) {
+    if (!hasRequiredBaseInfo()) {
       message.warning(t('configBase.requiredInfoNotFilled'));
       return;
     }
@@ -2112,7 +2175,7 @@ const BaseConfig: React.FC<ChatProps> = ({
               </Form.Item>
               <Form.Item
                 name="botType"
-                rules={[{ required: true, message: '' }]}
+                rules={botTypeRules}
                 colon={false}
                 label={t('configBase.agentCategory')}
               >
@@ -2533,7 +2596,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                   t('configBase.agentName')}
               </div>
               <div className={styles.workbenchAgentStatus}>
-                {detailInfo?.botStatus === 2
+                {isPublishedBotStatus(detailInfo?.botStatus)
                   ? t('configBase.botStatus2')
                   : t('configBase.botStatus0')}
               </div>
@@ -2714,11 +2777,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                     message.warning(t('configBase.defaultAvatar'));
                     return;
                   }
-                  if (
-                    baseinfo?.botName == '' ||
-                    baseinfo?.botType == '' ||
-                    baseinfo?.botDesc == ''
-                  ) {
+                  if (!hasRequiredBaseInfo()) {
                     message.warning(t('configBase.requiredInfoNotFilled'));
                     return;
                   }
@@ -2746,7 +2805,9 @@ const BaseConfig: React.FC<ChatProps> = ({
                       supportContext: supportContextFlag ? 1 : 0,
                       supportSystem: supportSystemFlag ? 1 : 0,
                       name: form.getFieldsValue().botName,
-                      botType: form.getFieldsValue().botType,
+                      botType: getEffectiveBotType(
+                        form.getFieldsValue().botType
+                      ),
                       botDesc: form.getFieldsValue().botDesc,
                       botId: searchParams.get('botId'),
                       promptType: 0,
@@ -2797,7 +2858,9 @@ const BaseConfig: React.FC<ChatProps> = ({
                       supportContext: supportContextFlag ? 1 : 0,
                       supportSystem: supportSystemFlag ? 1 : 0,
                       name: form.getFieldsValue().botName,
-                      botType: form.getFieldsValue().botType,
+                      botType: getEffectiveBotType(
+                        form.getFieldsValue().botType
+                      ),
                       botDesc: form.getFieldsValue().botDesc,
                       botId: searchParams.get('botId'),
                       promptType: 0,
@@ -2849,11 +2912,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                   message.warning(t('configBase.defaultAvatar'));
                   return;
                 }
-                if (
-                  !baseinfo?.botName ||
-                  !baseinfo?.botType ||
-                  !baseinfo?.botDesc
-                ) {
+                if (!hasRequiredBaseInfo()) {
                   message.warning(t('configBase.requiredInfoNotFilled'));
                   return;
                 }
@@ -2878,7 +2937,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                           : backgroundImg,
                     }),
                     name: baseinfo.botName,
-                    botType: baseinfo.botType,
+                    botType: getEffectiveBotType(baseinfo.botType),
                     botDesc: baseinfo.botDesc,
                     supportContext: supportContextFlag ? 1 : 0,
                     supportSystem: supportSystemFlag ? 1 : 0,
@@ -2928,7 +2987,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                           : backgroundImg,
                     }),
                     name: baseinfo.botName,
-                    botType: baseinfo.botType,
+                    botType: getEffectiveBotType(baseinfo.botType),
                     botDesc: baseinfo.botDesc,
                     supportContext: supportContextFlag ? 1 : 0,
                     supportSystem: supportSystemFlag ? 1 : 0,
@@ -3097,7 +3156,7 @@ const BaseConfig: React.FC<ChatProps> = ({
                               <div className={styles.type}>
                                 <Form.Item
                                   name="botType"
-                                  rules={[{ required: true, message: '' }]}
+                                  rules={botTypeRules}
                                   colon={false}
                                   label={t('configBase.agentCategory')}
                                 >

--- a/console/frontend/src/components/config-page-component/config-header/ConfigHeader.tsx
+++ b/console/frontend/src/components/config-page-component/config-header/ConfigHeader.tsx
@@ -32,6 +32,11 @@ interface ConfigHeaderProps {
   children?: React.ReactNode;
 }
 
+const PUBLISHED_BOT_STATUSES = [1, 2, 4];
+
+const isPublishedBotStatus = (botStatus?: number): boolean =>
+  botStatus !== undefined && PUBLISHED_BOT_STATUSES.includes(botStatus);
+
 function ConfigHeader(props: ConfigHeaderProps) {
   const [searchParams] = useSearchParams();
   const { currentRobot, currentTab } = props;
@@ -39,6 +44,7 @@ function ConfigHeader(props: ConfigHeaderProps) {
   const navigate = useNavigate();
   const optionsRef = useRef<HTMLDivElement | null>(null);
   const [showDropList, setShowDropList] = useState(false);
+  const isPublished = isPublishedBotStatus(props.detailInfo?.botStatus);
 
   useEffect(() => {
     document.body.addEventListener('click', clickOutside);
@@ -90,12 +96,10 @@ function ConfigHeader(props: ConfigHeaderProps) {
             <div>
               <span
                 className={`${styles.botStatu_fabu} ${
-                  props.detailInfo?.botStatus === 2
-                    ? ''
-                    : styles.botStatu_weifabu
+                  isPublished ? '' : styles.botStatu_weifabu
                 }`}
               >
-                {props.detailInfo?.botStatus === 2
+                {isPublished
                   ? t('configBase.botStatus2')
                   : t('configBase.botStatus0')}
               </span>
@@ -148,7 +152,7 @@ function ConfigHeader(props: ConfigHeaderProps) {
             }
             if (props.botId) {
               navigate(
-                props.detailInfo?.botStatus === 2
+                isPublished
                   ? `/space/config/base?botId=${props.botId}&save=true`
                   : `/space/config/base?botId=${props.botId}`,
                 {


### PR DESCRIPTION
## Summary
- repair agent memory config schema drift from earlier V1.40 migrations and normalize existing invalid bot categories
- prevent Agent category 0 from persisting in frontend/backend create and update paths
- align config page published status display with published statuses 1/2/4

## Verification
- mvn -pl commons,hub -am -Dtest=AgentMemoryServiceImplTest,AgentMemoryRuntimeServiceImplTest,AgentMemorySecretServiceTest,Mem0MemoryProviderTest,BotServiceImplWorkflowVersionTest -Dsurefire.failIfNoSpecifiedTests=false -Djacoco.skip=true test
- npx eslint src/components/config-page-component/config-base/index.tsx src/components/config-page-component/config-header/ConfigHeader.tsx (warnings only, pre-existing file-level lint debt)
- npm run build
- V1.41 migration dry-run against temporary MySQL schemas for old and current V1.40 shapes