### PR TITLE
fix(console): satisfy bot service spotless formatting

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/bot/impl/BotServiceImpl.java
@@ -619,7 +619,8 @@ public class BotServiceImpl implements BotService {
 
         if (botTypeListService != null) {
             try {
-                return botTypeListService.getBotTypeList().stream()
+                return botTypeListService.getBotTypeList()
+                        .stream()
                         .map(BotTypeList::getTypeKey)
                         .filter(typeKey -> typeKey != null && typeKey > 0)
                         .findFirst()


### PR DESCRIPTION
## Summary
- Fix Java Spotless formatting in BotServiceImpl by splitting the stream call chain as required.

## Verification
- Remote quality checks before publish: check-typescript, check-go, check-python passed; check-java failed only on this Spotless violation.
- Remote test matrix passed all targets before publish.