### PR TITLE
fix(console): avoid blocking AES IV generation

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/util/AESUtil.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/util/AESUtil.java
@@ -21,6 +21,7 @@ public class AESUtil {
     private static final int IV_LENGTH = 12; // GCM recommended 96 bits (12 bytes)
     private static final int TAG_LENGTH = 128; // GCM authentication tag length 128 bits
     private static final HexFormat HEX_FORMAT = HexFormat.of();
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     // Private constructor to prevent instantiation
     private AESUtil() {
@@ -99,7 +100,7 @@ public class AESUtil {
 
             // Generate random IV
             byte[] iv = new byte[IV_LENGTH];
-            SecureRandom.getInstanceStrong().nextBytes(iv);
+            SECURE_RANDOM.nextBytes(iv);
             GCMParameterSpec gcmSpec = new GCMParameterSpec(TAG_LENGTH, iv);
 
             cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmSpec);

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/util/AESUtilTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/util/AESUtilTest.java
@@ -1,0 +1,27 @@
+package com.iflytek.astron.console.hub.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+class AESUtilTest {
+
+    private static final String KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void encryptShouldRoundTripWithoutBlockingStrongRandom() {
+        String plainText = "enterprise invitation";
+
+        String firstCipherText = AESUtil.encrypt(plainText, KEY);
+        String secondCipherText = AESUtil.encrypt(plainText, KEY);
+
+        assertEquals(plainText, AESUtil.decrypt(firstCipherText, KEY));
+        assertEquals(plainText, AESUtil.decrypt(secondCipherText, KEY));
+        assertNotEquals(firstCipherText, secondCipherText);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace per-call SecureRandom.getInstanceStrong() with a reusable non-blocking SecureRandom for AES-GCM IV generation.
- Add AESUtil round-trip/non-deterministic ciphertext test with timeout guard.

## Root Cause
- Remote test-console-backend repeatedly hung in InviteRecordBizServiceImplTest.
- jstack showed the main test thread blocked in AESUtil.encryptBytes -> SecureRandom.getInstanceStrong().nextBytes(iv) -> NativePRNG blocking random source.

## Verification
- Code review completed: no Critical/Important issues; minor feedback applied.
- Previous remote quality checks passed all check-* targets before backend test hang.