### PR TITLE
Add A2A agent card discovery

### DIFF
--- a/core/agent/api/router.py
+++ b/core/agent/api/router.py
@@ -6,6 +6,7 @@ It sets up the common prefix '/agent/v1' for all agent API endpoints.
 
 from fastapi import APIRouter
 
+from agent.api.v1.a2a import a2a_router
 from agent.api.v1.skill_sandbox_api import skill_sandbox_router
 from agent.api.v1.workflow_agent import workflow_agent_router
 
@@ -14,3 +15,4 @@ router_v1 = APIRouter(
 )
 router_v1.include_router(workflow_agent_router)
 router_v1.include_router(skill_sandbox_router)
+router_v1.include_router(a2a_router)

--- a/core/agent/api/schemas/a2a.py
+++ b/core/agent/api/schemas/a2a.py
@@ -1,0 +1,118 @@
+"""A2A protocol schemas used by the core agent adapter."""
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class A2ABaseModel(BaseModel):
+    """Base model that accepts Python names and emits A2A camelCase names."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class A2APart(A2ABaseModel):
+    """A single A2A message or artifact part."""
+
+    text: Optional[str] = None
+    raw: Optional[str] = None
+    url: Optional[str] = None
+    data: Any = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    filename: str = ""
+    media_type: str = Field(default="text/plain", alias="mediaType")
+
+
+class A2AAgentInterface(A2ABaseModel):
+    """A declared A2A transport interface."""
+
+    url: str
+    protocol_binding: str = Field(alias="protocolBinding")
+    tenant: str = ""
+    protocol_version: str = Field(alias="protocolVersion")
+
+
+class A2AAgentProvider(A2ABaseModel):
+    """A2A AgentCard provider."""
+
+    url: str
+    organization: str
+
+
+class A2AAgentCapabilities(A2ABaseModel):
+    """A2A AgentCard capability declaration."""
+
+    streaming: bool = False
+    push_notifications: bool = Field(default=False, alias="pushNotifications")
+    extended_agent_card: bool = Field(default=False, alias="extendedAgentCard")
+
+
+class A2AAuthentication(A2ABaseModel):
+    """Legacy A2A AgentCard authentication declaration."""
+
+    schemes: list[str] = Field(default_factory=list)
+    credentials: str = ""
+
+
+class A2AStringList(A2ABaseModel):
+    """A2A list wrapper used by security requirements."""
+
+    values: list[str] = Field(default_factory=list, alias="list")
+
+
+class A2ASecurityRequirement(A2ABaseModel):
+    """A2A security requirement declaration."""
+
+    schemes: dict[str, A2AStringList]
+
+
+class A2AAPIKeySecurityScheme(A2ABaseModel):
+    """A2A API key security scheme."""
+
+    description: str = ""
+    location: Literal["query", "header", "cookie"]
+    name: str
+
+
+class A2ASecurityScheme(A2ABaseModel):
+    """A2A security scheme union."""
+
+    api_key_security_scheme: A2AAPIKeySecurityScheme = Field(
+        alias="apiKeySecurityScheme"
+    )
+
+
+class A2AAgentSkill(A2ABaseModel):
+    """A2A AgentCard skill declaration."""
+
+    id: str
+    name: str
+    description: str
+    tags: list[str]
+    examples: list[str] = Field(default_factory=list)
+    input_modes: list[str] = Field(default_factory=list, alias="inputModes")
+    output_modes: list[str] = Field(default_factory=list, alias="outputModes")
+
+
+class A2AAgentCard(A2ABaseModel):
+    """A2A discovery card."""
+
+    protocol_version: str = Field(default="0.3.0", alias="protocolVersion")
+    name: str
+    description: str
+    url: str = ""
+    preferred_transport: str = Field(default="HTTP+JSON", alias="preferredTransport")
+    supported_interfaces: list[A2AAgentInterface] = Field(alias="supportedInterfaces")
+    provider: A2AAgentProvider
+    version: str
+    capabilities: A2AAgentCapabilities
+    authentication: A2AAuthentication = Field(default_factory=A2AAuthentication)
+    security_schemes: dict[str, A2ASecurityScheme] = Field(
+        default_factory=dict, alias="securitySchemes"
+    )
+    security_requirements: list[A2ASecurityRequirement] = Field(
+        default_factory=list, alias="securityRequirements"
+    )
+    default_input_modes: list[str] = Field(alias="defaultInputModes")
+    default_output_modes: list[str] = Field(alias="defaultOutputModes")
+    skills: list[A2AAgentSkill]

--- a/core/agent/api/schemas/a2a.py
+++ b/core/agent/api/schemas/a2a.py
@@ -70,15 +70,17 @@ class A2AAPIKeySecurityScheme(A2ABaseModel):
     """A2A API key security scheme."""
 
     description: str = ""
-    location: Literal["query", "header", "cookie"]
+    type: Literal["apiKey"] = "apiKey"
+    in_: Literal["query", "header", "cookie"] = Field(alias="in")
     name: str
 
 
 class A2ASecurityScheme(A2ABaseModel):
     """A2A security scheme union."""
 
-    api_key_security_scheme: A2AAPIKeySecurityScheme = Field(
-        alias="apiKeySecurityScheme"
+    api_key_security_scheme: Optional[A2AAPIKeySecurityScheme] = Field(
+        default=None,
+        alias="apiKeySecurityScheme",
     )
 
 

--- a/core/agent/api/v1/a2a.py
+++ b/core/agent/api/v1/a2a.py
@@ -72,7 +72,7 @@ def build_agent_card() -> A2AAgentCard:
             "astronConsumer": A2ASecurityScheme(
                 apiKeySecurityScheme=A2AAPIKeySecurityScheme(
                     description="Astron gateway consumer header.",
-                    location="header",
+                    in_="header",
                     name="x-consumer-username",
                 )
             )

--- a/core/agent/api/v1/a2a.py
+++ b/core/agent/api/v1/a2a.py
@@ -1,0 +1,116 @@
+"""A2A discovery adapter for the core agent service."""
+
+import os
+
+from fastapi import APIRouter
+
+from agent.api.schemas.a2a import (
+    A2AAgentCapabilities,
+    A2AAgentCard,
+    A2AAgentInterface,
+    A2AAgentProvider,
+    A2AAgentSkill,
+    A2AAPIKeySecurityScheme,
+    A2AAuthentication,
+    A2ASecurityRequirement,
+    A2ASecurityScheme,
+    A2AStringList,
+)
+
+A2A_PROTOCOL_VERSION = "0.3.0"
+ASTRON_AGENT_VERSION = "1.0.9"
+
+a2a_discovery_router = APIRouter()
+a2a_router = APIRouter(prefix="/a2a")
+
+
+def _public_base_url() -> str:
+    configured_url = (
+        os.getenv("A2A_PUBLIC_BASE_URL")
+        or os.getenv("AGENT_BASE_URL")
+        or f"http://localhost:{os.getenv('SERVICE_PORT', '8700')}"
+    )
+    return configured_url.rstrip("/")
+
+
+def _agent_version() -> str:
+    return os.getenv("ASTRON_AGENT_VERSION", ASTRON_AGENT_VERSION).removeprefix("v")
+
+
+def build_agent_card() -> A2AAgentCard:
+    """Build public A2A discovery metadata for the core agent service."""
+
+    interface_url = f"{_public_base_url()}/agent/v1/a2a"
+    return A2AAgentCard(
+        protocolVersion=A2A_PROTOCOL_VERSION,
+        name="Astron Agent",
+        description="Astron Agent core runtime exposed through an A2A text adapter.",
+        url=interface_url,
+        preferredTransport="HTTP+JSON",
+        supportedInterfaces=[
+            A2AAgentInterface(
+                url=interface_url,
+                protocolBinding="HTTP+JSON",
+                protocolVersion=A2A_PROTOCOL_VERSION,
+            )
+        ],
+        provider=A2AAgentProvider(
+            organization="iFLYTEK",
+            url="https://github.com/iflytek/astron-agent",
+        ),
+        version=_agent_version(),
+        capabilities=A2AAgentCapabilities(
+            streaming=False,
+            pushNotifications=False,
+            extendedAgentCard=False,
+        ),
+        authentication=A2AAuthentication(
+            schemes=["ApiKey"],
+            credentials="x-consumer-username header",
+        ),
+        securitySchemes={
+            "astronConsumer": A2ASecurityScheme(
+                apiKeySecurityScheme=A2AAPIKeySecurityScheme(
+                    description="Astron gateway consumer header.",
+                    location="header",
+                    name="x-consumer-username",
+                )
+            )
+        },
+        securityRequirements=[
+            A2ASecurityRequirement(schemes={"astronConsumer": A2AStringList(list=[])})
+        ],
+        defaultInputModes=["text/plain"],
+        defaultOutputModes=["text/plain"],
+        skills=[
+            A2AAgentSkill(
+                id="astron-agent-chat",
+                name="Astron Agent Chat",
+                description="Send text to the configured Astron Agent runtime.",
+                tags=["agent", "chat", "astron"],
+                examples=["Summarize this workflow result."],
+                inputModes=["text/plain"],
+                outputModes=["text/plain"],
+            )
+        ],
+    )
+
+
+@a2a_discovery_router.get(  # type: ignore[misc]
+    "/.well-known/agent-card.json",
+    response_model=A2AAgentCard,
+)
+async def get_well_known_agent_card() -> A2AAgentCard:
+    """Return the public A2A discovery card."""
+
+    return build_agent_card()
+
+
+@a2a_router.get(  # type: ignore[misc]
+    "/agent-card.json",
+    response_model=A2AAgentCard,
+)
+async def get_agent_card() -> A2AAgentCard:
+    """Return the public A2A discovery card from the versioned API path."""
+
+    return build_agent_card()

--- a/core/agent/main.py
+++ b/core/agent/main.py
@@ -26,6 +26,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from agent.api import router
 from agent.api.schemas.completion_chunk import ReasonChatCompletionChunk
+from agent.api.v1.a2a import a2a_discovery_router
 from agent.exceptions.agent_exc import AgentExc
 
 
@@ -67,6 +68,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(create_health_router("core-agent", service_manager))
+    app.include_router(a2a_discovery_router)
     app.include_router(router.router_v1)
 
     @app.exception_handler(AgentExc)  # type: ignore[misc]

--- a/core/agent/tests/test_a2a.py
+++ b/core/agent/tests/test_a2a.py
@@ -1,0 +1,60 @@
+"""Tests for the A2A adapter surface."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agent.api.v1 import a2a
+
+
+def test_build_agent_card_uses_a2a_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Agent card should expose spec-shaped capabilities and skills."""
+    monkeypatch.setenv("A2A_PUBLIC_BASE_URL", "https://agent.example.com/")
+
+    card = a2a.build_agent_card()
+    dumped = card.model_dump(by_alias=True)
+
+    assert dumped["supportedInterfaces"][0]["url"] == (
+        "https://agent.example.com/agent/v1/a2a"
+    )
+    assert dumped["supportedInterfaces"][0]["protocolBinding"] == "HTTP+JSON"
+    assert dumped["protocolVersion"] == "0.3.0"
+    assert dumped["version"] == "1.0.9"
+    assert dumped["authentication"] == {
+        "schemes": ["ApiKey"],
+        "credentials": "x-consumer-username header",
+    }
+    assert dumped["capabilities"] == {
+        "streaming": False,
+        "pushNotifications": False,
+        "extendedAgentCard": False,
+    }
+    assert dumped["securitySchemes"]["astronConsumer"]["apiKeySecurityScheme"] == {
+        "description": "Astron gateway consumer header.",
+        "location": "header",
+        "name": "x-consumer-username",
+    }
+    assert dumped["securityRequirements"][0]["schemes"] == {
+        "astronConsumer": {"list": []}
+    }
+    assert dumped["skills"][0]["id"] == "astron-agent-chat"
+    assert dumped["skills"][0]["inputModes"] == ["text/plain"]
+
+
+def test_agent_card_routes_expose_discovery_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both well-known and versioned routes should return the same agent card."""
+    monkeypatch.setenv("A2A_PUBLIC_BASE_URL", "https://agent.example.com")
+
+    app = FastAPI()
+    app.include_router(a2a.a2a_discovery_router)
+    app.include_router(a2a.a2a_router, prefix="/agent/v1")
+    client = TestClient(app)
+
+    well_known = client.get("/.well-known/agent-card.json")
+    versioned = client.get("/agent/v1/a2a/agent-card.json")
+
+    assert well_known.status_code == 200
+    assert versioned.status_code == 200
+    assert well_known.json() == versioned.json()

--- a/core/agent/tests/test_a2a.py
+++ b/core/agent/tests/test_a2a.py
@@ -31,7 +31,8 @@ def test_build_agent_card_uses_a2a_shapes(monkeypatch: pytest.MonkeyPatch) -> No
     }
     assert dumped["securitySchemes"]["astronConsumer"]["apiKeySecurityScheme"] == {
         "description": "Astron gateway consumer header.",
-        "location": "header",
+        "type": "apiKey",
+        "in": "header",
         "name": "x-consumer-username",
     }
     assert dumped["securityRequirements"][0]["schemes"] == {


### PR DESCRIPTION
## Summary
- Add A2A AgentCard schemas and discovery metadata for Astron Agent
- Register the well-known and versioned A2A agent-card routes
- Add focused tests for AgentCard serialization and route exposure

Part 1/3 of the split requested on PR #1456.

## Stack
1. A2A schemas + Agent Card discovery/registration: #1480
2. A2A core task modules/runtime: https://github.com/Rajesh270712/astron-agent/pull/1
3. Auth/message execution + E2E tests: https://github.com/Rajesh270712/astron-agent/pull/2

Part 2 and 3 are stacked in my fork to keep their diffs focused until this upstream base lands.

## Validation
- `uv run pytest tests/test_a2a.py -q`
- `uv run isort --profile black --check-only api/schemas/a2a.py api/v1/a2a.py tests/test_a2a.py`
- `uv run black --check api/schemas/a2a.py api/v1/a2a.py tests/test_a2a.py`
- `uv run flake8 --extend-ignore=E501 api/schemas/a2a.py api/v1/a2a.py tests/test_a2a.py`