### PR TITLE
fix(toolkit): map workflow response extraction failures to tool errors

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/AgentWorkflowRuntimeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/AgentWorkflowRuntimeService.java
@@ -140,14 +140,13 @@ public class AgentWorkflowRuntimeService {
         body.put("history", new JSONArray());
         body.put("stream", false);
 
-        String responseBody;
         try {
-            responseBody = workflowChatRunClient.chat(body);
+            String responseBody = workflowChatRunClient.chat(body);
+            return extractResult(definition, responseBody);
         } catch (Exception e) {
             log.warn("Workflow run failed, flowId: {}, error: {}", definition.getFlowId(), e.getMessage());
             return errorContent("WORKFLOW_CALL_FAILED", "Workflow call failed: " + e.getMessage());
         }
-        return extractResult(definition, responseBody);
     }
 
     private List<Workflow> selectByFlowIds(List<String> flowIds) {

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/AgentWorkflowRuntimeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/AgentWorkflowRuntimeServiceTest.java
@@ -168,6 +168,23 @@ class AgentWorkflowRuntimeServiceTest {
     }
 
     @Test
+    void runWorkflow_unexpectedResponseShapes_returnReadableErrorInsteadOfThrowing() throws Exception {
+        WorkflowMapper mapper = mock(WorkflowMapper.class);
+        when(mapper.selectList(any())).thenReturn(List.of(sampleWorkflow()));
+        WorkflowChatRunClient client = mock(WorkflowChatRunClient.class);
+        AgentWorkflowRuntimeService service = newService(mapper, client);
+        AgentWorkflowDefinition def = service.resolveWorkflows(List.of("flow123")).get(0);
+
+        // choices is not an array: fastjson2 getJSONArray throws on the invalid inner JSON
+        when(client.chat(any())).thenReturn("{\"code\":0,\"choices\":\"oops\"}");
+        assertThat(service.runWorkflow(def, "u", new JSONObject())).contains("WORKFLOW_CALL_FAILED");
+
+        // code is a non-numeric string: getInteger throws
+        when(client.chat(any())).thenReturn("{\"code\":\"boom\"}");
+        assertThat(service.runWorkflow(def, "u", new JSONObject())).contains("WORKFLOW_CALL_FAILED");
+    }
+
+    @Test
     void runWorkflow_invalidJsonResponse_returnsBadResponseError() throws Exception {
         WorkflowMapper mapper = mock(WorkflowMapper.class);
         when(mapper.selectList(any())).thenReturn(List.of(sampleWorkflow()));


### PR DESCRIPTION
## What

Follow-up to #1483, addressing a post-merge review comment on `AgentWorkflowRuntimeService.runWorkflow`.

`extractResult` was invoked outside the try-catch, so runtime exceptions thrown by fastjson2's typed accessors on unexpected-but-valid JSON (`getJSONArray("choices")` when `choices` is not an array, `getInteger("code")` on a non-numeric string, `getJSONObject(i)` on non-object elements) propagated out of the tool callback and failed the whole agent chat turn, instead of returning a readable tool error to the model.

## Fix

Move `extractResult` inside the existing try block so any extraction failure maps to the `WORKFLOW_CALL_FAILED` error string, preserving the class contract that `runWorkflow` always returns a string for the model.

## Testing

New test `runWorkflow_unexpectedResponseShapes_returnReadableErrorInsteadOfThrowing` (RED before the fix with a propagated `JSONException`, GREEN after): covers `{"code":0,"choices":"oops"}` and `{"code":"boom"}`. Full `AgentWorkflowRuntimeServiceTest` (12) + `WorkflowChatRunClientTest` (3) pass.