### PR TITLE
fix(console): avoid nullable workflow response dereference

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowChatRunClient.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowChatRunClient.java
@@ -8,6 +8,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +47,8 @@ public class WorkflowChatRunClient {
             if (!response.isSuccessful()) {
                 throw new IOException("Workflow chat HTTP " + response.code());
             }
-            return response.body() == null ? "" : response.body().string();
+            ResponseBody body = response.body();
+            return body == null ? "" : body.string();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Store the OkHttp workflow response body in a local before reading it to satisfy SpotBugs null analysis.
- Preserve the existing empty-body behavior for workflow chat responses.

## Validation
- Remote quality before this fix: check-java failed on NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE; check-typescript, check-go, and check-python passed.
- Remote test matrix before this fix: all targets passed.
- Code review: no issues found.