### PR TITLE
feat: add OpenClaw workflow node

### DIFF
--- a/console/backend/hub/src/main/resources/db/migration/V1.43__add_openclaw_node_template.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.43__add_openclaw_node_template.sql
@@ -1,0 +1,177 @@
+-- Add OpenClaw / ChatClaw workflow node templates.
+
+INSERT INTO config_info (
+    category, code, name, value, is_valid, remarks, create_time, update_time, order_no
+)
+SELECT category, '1,2', '工具',
+       JSON_OBJECT(
+           'idType', 'openclaw',
+           'nodeType', '工具',
+           'aliasName', 'OpenClaw',
+           'description', '通过拖拽式画布配置 OpenClaw / ChatClaw Skill，支持应用构建和可视化微调参数。',
+           'data', JSON_OBJECT(
+               'nodeMeta', JSON_OBJECT('nodeType', '工具节点', 'aliasName', 'OpenClaw'),
+               'nodeParam', JSON_OBJECT(
+                   'mcpServerId', '',
+                   'mcpServerUrl', '',
+                   'toolName', 'run_skill',
+                   'skillName', 'chatclaw-builder',
+                   'executionMode', 'chatclaw',
+                   'preCondition', '',
+                   'postCondition', '',
+                   'tuningParams', JSON_OBJECT(
+                       'temperature', 0.2,
+                       'max_steps', 8
+                   )
+               ),
+               'inputs', JSON_ARRAY(
+                   JSON_OBJECT(
+                       'id', '',
+                       'name', 'instruction',
+                       'required', true,
+                       'schema', JSON_OBJECT(
+                           'type', 'string',
+                           'default', '用户对 ChatClaw 应用的构建或微调需求',
+                           'value', JSON_OBJECT('type', 'ref', 'content', JSON_OBJECT())
+                       )
+                   ),
+                   JSON_OBJECT(
+                       'id', '',
+                       'name', 'context',
+                       'required', false,
+                       'schema', JSON_OBJECT(
+                           'type', 'object',
+                           'default', '应用上下文、领域知识或已有配置',
+                           'value', JSON_OBJECT('type', 'ref', 'content', JSON_OBJECT())
+                       )
+                   )
+               ),
+               'outputs', JSON_ARRAY(JSON_OBJECT(
+                   'id', '',
+                   'name', 'result',
+                   'schema', JSON_OBJECT(
+                       'type', 'object',
+                       'default', 'OpenClaw Skill 执行结果',
+                       'properties', JSON_ARRAY(
+                           JSON_OBJECT('id', '', 'name', 'application', 'type', 'object', 'default', 'ChatClaw 应用配置', 'required', false, 'nameErrMsg', ''),
+                           JSON_OBJECT('id', '', 'name', 'workflow', 'type', 'object', 'default', '生成或微调后的工作流配置', 'required', false, 'nameErrMsg', ''),
+                           JSON_OBJECT('id', '', 'name', 'message', 'type', 'string', 'default', '执行摘要', 'required', false, 'nameErrMsg', '')
+                       )
+                   ),
+                   'required', false,
+                   'nameErrMsg', ''
+               )),
+               'references', JSON_ARRAY(),
+               'allowInputReference', true,
+               'allowOutputReference', true,
+               'icon', 'https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/mcp-new.png'
+           )
+       ),
+       1, 'OpenClaw', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 12
+FROM (
+    SELECT 'WORKFLOW_NODE_TEMPLATE' AS category
+    UNION ALL SELECT 'WORKFLOW_NODE_TEMPLATE_PRE'
+    UNION ALL SELECT 'WORKFLOW_NODE_TEMPLATE_INNER'
+    UNION ALL SELECT 'WORKFLOW_NODE_TEMPLATE_INNER_PRE'
+) categories;
+
+INSERT INTO config_info_en (
+    category, code, name, value, is_valid, remarks, create_time, update_time, order_no
+)
+SELECT category, '1,2', 'Tools',
+       JSON_OBJECT(
+           'idType', 'openclaw',
+           'nodeType', 'Tool',
+           'aliasName', 'OpenClaw',
+           'description', 'Configure OpenClaw / ChatClaw skills in the drag-and-drop canvas for app building and visual fine-tuning parameters.',
+           'data', JSON_OBJECT(
+               'nodeMeta', JSON_OBJECT('nodeType', 'Tool Node', 'aliasName', 'OpenClaw'),
+               'nodeParam', JSON_OBJECT(
+                   'mcpServerId', '',
+                   'mcpServerUrl', '',
+                   'toolName', 'run_skill',
+                   'skillName', 'chatclaw-builder',
+                   'executionMode', 'chatclaw',
+                   'preCondition', '',
+                   'postCondition', '',
+                   'tuningParams', JSON_OBJECT(
+                       'temperature', 0.2,
+                       'max_steps', 8
+                   )
+               ),
+               'inputs', JSON_ARRAY(
+                   JSON_OBJECT(
+                       'id', '',
+                       'name', 'instruction',
+                       'required', true,
+                       'schema', JSON_OBJECT(
+                           'type', 'string',
+                           'default', 'User requirement for building or fine-tuning a ChatClaw application',
+                           'value', JSON_OBJECT('type', 'ref', 'content', JSON_OBJECT())
+                       )
+                   ),
+                   JSON_OBJECT(
+                       'id', '',
+                       'name', 'context',
+                       'required', false,
+                       'schema', JSON_OBJECT(
+                           'type', 'object',
+                           'default', 'Application context, domain knowledge, or existing configuration',
+                           'value', JSON_OBJECT('type', 'ref', 'content', JSON_OBJECT())
+                       )
+                   )
+               ),
+               'outputs', JSON_ARRAY(JSON_OBJECT(
+                   'id', '',
+                   'name', 'result',
+                   'schema', JSON_OBJECT(
+                       'type', 'object',
+                       'default', 'OpenClaw skill execution result',
+                       'properties', JSON_ARRAY(
+                           JSON_OBJECT('id', '', 'name', 'application', 'type', 'object', 'default', 'ChatClaw application configuration', 'required', false, 'nameErrMsg', ''),
+                           JSON_OBJECT('id', '', 'name', 'workflow', 'type', 'object', 'default', 'Generated or fine-tuned workflow configuration', 'required', false, 'nameErrMsg', ''),
+                           JSON_OBJECT('id', '', 'name', 'message', 'type', 'string', 'default', 'Execution summary', 'required', false, 'nameErrMsg', '')
+                       )
+                   ),
+                   'required', false,
+                   'nameErrMsg', ''
+               )),
+               'references', JSON_ARRAY(),
+               'allowInputReference', true,
+               'allowOutputReference', true,
+               'icon', 'https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/mcp-new.png'
+           )
+       ),
+       1, 'OpenClaw', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 12
+FROM (
+    SELECT 'WORKFLOW_NODE_TEMPLATE' AS category
+    UNION ALL SELECT 'WORKFLOW_NODE_TEMPLATE_PRE'
+    UNION ALL SELECT 'WORKFLOW_NODE_TEMPLATE_INNER'
+    UNION ALL SELECT 'WORKFLOW_NODE_TEMPLATE_INNER_PRE'
+) categories;
+
+UPDATE config_info
+SET value = JSON_ARRAY_APPEND(
+    value,
+    '$',
+    JSON_OBJECT(
+        'idType', 'openclaw',
+        'icon', 'https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/mcp-new.png',
+        'name', 'OpenClaw',
+        'markdown', '## 用途\n通过拖拽式画布配置 OpenClaw / ChatClaw Skill。节点会把画布输入和可视化配置合并为 MCP 工具参数，用于构建 ChatClaw 应用、执行 Skill 或调整微调参数。\n\n## 输入\n- instruction：用户的应用构建或微调需求。\n- context：可选的上下文、领域知识或已有应用配置。\n\n## 配置\n填写 MCP 服务地址或服务 ID、工具名、Skill 名称、执行模式、前置/后置条件和微调参数。\n\n## 输出\nresult：OpenClaw Skill 返回的应用配置、工作流配置或执行摘要。'
+    )
+)
+WHERE category = 'TEMPLATE' AND code = 'node';
+
+UPDATE config_info_en
+SET value = JSON_ARRAY_APPEND(
+    value,
+    '$',
+    JSON_OBJECT(
+        'idType', 'openclaw',
+        'icon', 'https://oss-beijing-m8.openstorage.cn/SparkBotProd/icon/common/mcp-new.png',
+        'name', 'OpenClaw',
+        'markdown', '## Purpose\nConfigure OpenClaw / ChatClaw skills in the drag-and-drop canvas. The node merges workflow inputs and visual configuration into MCP tool arguments for ChatClaw app building, skill execution, or fine-tuning adjustments.\n\n## Inputs\n- instruction: User requirement for app building or fine-tuning.\n- context: Optional context, domain knowledge, or existing app configuration.\n\n## Configuration\nSet MCP server URL or server ID, tool name, skill name, execution mode, pre/post conditions, and tuning parameters.\n\n## Output\nresult: Application configuration, workflow configuration, or execution summary returned by the OpenClaw skill.'
+    )
+)
+WHERE category = 'TEMPLATE' AND code = 'node';

--- a/console/frontend/src/components/workflow/constant/index.tsx
+++ b/console/frontend/src/components/workflow/constant/index.tsx
@@ -22,6 +22,7 @@ import { QuestionAnswerDetail } from '@/components/workflow/nodes/question-answe
 import { NodeCommonProps } from '@/components/workflow/types/hooks';
 import { RpaDetail } from '@/components/workflow/nodes/rpa';
 import { McpDetail } from '@/components/workflow/nodes/mcp';
+import { OpenClawDetail } from '@/components/workflow/nodes/openclaw';
 
 // 定义输出类型选项的接口（支持嵌套结构）
 interface OriginOutputType {
@@ -61,6 +62,7 @@ export const nodeTypeComponentMap: Record<
   message: MessageDetail,
   rpa: RpaDetail,
   mcp: McpDetail,
+  openclaw: OpenClawDetail,
 };
 
 export const originOutputTypeList: OriginOutputType[] = [

--- a/console/frontend/src/components/workflow/nodes/openclaw/index.tsx
+++ b/console/frontend/src/components/workflow/nodes/openclaw/index.tsx
@@ -1,0 +1,296 @@
+import React, { memo } from 'react';
+import {
+  FlowInput,
+  FlowInputNumber,
+  FlowSelect,
+  FlowTemplateEditor,
+  FLowCollapse,
+} from '@/components/workflow/ui';
+import Inputs from '@/components/workflow/nodes/components/inputs';
+import FixedOutputs from '@/components/workflow/nodes/components/fixed-outputs';
+import ExceptionHandling from '@/components/workflow/nodes/components/exception-handling';
+import { useNodeCommon } from '@/components/workflow/hooks/use-node-common';
+import {
+  NodeCommonProps,
+  NodeDataType,
+} from '@/components/workflow/types/hooks';
+
+type OpenClawTuningParams = {
+  temperature?: number;
+  max_steps?: number;
+};
+
+type OpenClawNodeParam = {
+  mcpServerId?: string;
+  mcpServerUrl?: string;
+  toolName?: string;
+  skillName?: string;
+  executionMode?: string;
+  preCondition?: string;
+  postCondition?: string;
+  tuningParams?: OpenClawTuningParams;
+  mcpServerIdErrMsg?: string;
+  mcpServerUrlErrMsg?: string;
+  toolNameErrMsg?: string;
+  skillNameErrMsg?: string;
+};
+
+const readString = (
+  nodeParam: Record<string, unknown> | null | undefined,
+  key: keyof OpenClawNodeParam
+): string => {
+  if (!nodeParam) return '';
+  const value = nodeParam[key];
+  return typeof value === 'string' ? value : '';
+};
+
+const readTuningParams = (
+  nodeParam: Record<string, unknown> | null | undefined
+): OpenClawTuningParams => {
+  if (!nodeParam) return {};
+  const value = nodeParam.tuningParams;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as OpenClawTuningParams;
+};
+
+const ensureTuningParams = (
+  data: NodeDataType
+): Record<string, unknown> => {
+  const nodeParam = data.nodeParam || {};
+  if (
+    !nodeParam.tuningParams ||
+    typeof nodeParam.tuningParams !== 'object' ||
+    Array.isArray(nodeParam.tuningParams)
+  ) {
+    nodeParam.tuningParams = {};
+  }
+  data.nodeParam = nodeParam;
+  return nodeParam.tuningParams as Record<string, unknown>;
+};
+
+const ConfigRow = ({
+  label,
+  required = false,
+  children,
+  error,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+  error?: string;
+}): React.ReactElement => (
+  <div className="flex flex-col gap-1">
+    <div className="text-sm text-[#333]">
+      {required && <span className="text-[#F74E43] mr-1">*</span>}
+      {label}
+    </div>
+    {children}
+    {error && <div className="text-[#F74E43] text-xs">{error}</div>}
+  </div>
+);
+
+const RuntimeConfig = ({
+  id,
+  data,
+}: NodeCommonProps): React.ReactElement => {
+  const { handleChangeNodeParam, nodeParam, canvasesDisabled } = useNodeCommon({
+    id,
+    data,
+  });
+  const tuningParams = readTuningParams(nodeParam);
+
+  return (
+    <FLowCollapse
+      label={<div className="text-base font-medium">OpenClaw 配置</div>}
+      content={
+        <div
+          className="rounded-md px-[18px] pb-3 pointer-events-auto flex flex-col gap-3"
+          style={{ pointerEvents: canvasesDisabled ? 'none' : 'auto' }}
+        >
+          <ConfigRow
+            label="MCP 服务地址"
+            required
+            error={readString(nodeParam, 'mcpServerUrlErrMsg')}
+          >
+            <FlowInput
+              value={readString(nodeParam, 'mcpServerUrl')}
+              placeholder="https://example.com/mcp/sse"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.mcpServerUrl = value;
+                  },
+                  e.target.value
+                )
+              }
+            />
+          </ConfigRow>
+          <ConfigRow
+            label="MCP 服务 ID"
+            error={readString(nodeParam, 'mcpServerIdErrMsg')}
+          >
+            <FlowInput
+              value={readString(nodeParam, 'mcpServerId')}
+              placeholder="可选；填写后优先使用已注册服务"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.mcpServerId = value;
+                  },
+                  e.target.value
+                )
+              }
+            />
+          </ConfigRow>
+          <ConfigRow
+            label="工具名"
+            required
+            error={readString(nodeParam, 'toolNameErrMsg')}
+          >
+            <FlowInput
+              value={readString(nodeParam, 'toolName') || 'run_skill'}
+              placeholder="run_skill"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.toolName = value;
+                  },
+                  e.target.value
+                )
+              }
+            />
+          </ConfigRow>
+          <ConfigRow
+            label="Skill 名称"
+            required
+            error={readString(nodeParam, 'skillNameErrMsg')}
+          >
+            <FlowInput
+              value={readString(nodeParam, 'skillName')}
+              placeholder="chatclaw-builder"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.skillName = value;
+                  },
+                  e.target.value
+                )
+              }
+            />
+          </ConfigRow>
+          <ConfigRow label="执行模式">
+            <FlowSelect
+              value={readString(nodeParam, 'executionMode') || 'chatclaw'}
+              onChange={(value: string) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.executionMode = value;
+                  },
+                  value
+                )
+              }
+              options={[
+                { label: 'ChatClaw 应用构建', value: 'chatclaw' },
+                { label: 'OpenClaw Skill 执行', value: 'skill' },
+                { label: '可视化微调', value: 'fine_tune' },
+              ]}
+            />
+          </ConfigRow>
+          <div className="grid grid-cols-2 gap-3">
+            <ConfigRow label="温度">
+              <FlowInputNumber
+                value={tuningParams.temperature}
+                min={0}
+                max={1}
+                step={0.1}
+                precision={2}
+                controls={false}
+                onChange={(value: number | null) =>
+                  handleChangeNodeParam(
+                    (data, value) => {
+                      const params = ensureTuningParams(data);
+                      params.temperature = value;
+                    },
+                    value
+                  )
+                }
+              />
+            </ConfigRow>
+            <ConfigRow label="最大步骤">
+              <FlowInputNumber
+                value={tuningParams.max_steps}
+                min={1}
+                max={100}
+                precision={0}
+                controls={false}
+                onChange={(value: number | null) =>
+                  handleChangeNodeParam(
+                    (data, value) => {
+                      const params = ensureTuningParams(data);
+                      params.max_steps = value;
+                    },
+                    value
+                  )
+                }
+              />
+            </ConfigRow>
+          </div>
+          <ConfigRow label="前置条件">
+            <FlowTemplateEditor
+              id={id}
+              data={data}
+              value={readString(nodeParam, 'preCondition')}
+              placeholder="运行 Skill 前需要满足或补充的条件"
+              onChange={(value: string) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.preCondition = value;
+                  },
+                  value
+                )
+              }
+            />
+          </ConfigRow>
+          <ConfigRow label="后置条件">
+            <FlowTemplateEditor
+              id={id}
+              data={data}
+              value={readString(nodeParam, 'postCondition')}
+              placeholder="运行后对输出进行检查、整理或约束"
+              onChange={(value: string) =>
+                handleChangeNodeParam(
+                  (data, value) => {
+                    data.nodeParam = data.nodeParam || {};
+                    data.nodeParam.postCondition = value;
+                  },
+                  value
+                )
+              }
+            />
+          </ConfigRow>
+        </div>
+      }
+    />
+  );
+};
+
+export const OpenClawDetail = memo(
+  ({ id, data }: NodeCommonProps): React.ReactElement => (
+    <div className="p-[14px] pb-[6px]">
+      <div className="bg-[#fff] rounded-lg flex flex-col gap-2.5">
+        <RuntimeConfig id={id} data={data} />
+        <Inputs id={id} data={data} />
+        <FixedOutputs id={id} data={data} />
+        <ExceptionHandling id={id} data={data} />
+      </div>
+    </div>
+  )
+);

--- a/console/frontend/src/components/workflow/utils/reactflowUtils.ts
+++ b/console/frontend/src/components/workflow/utils/reactflowUtils.ts
@@ -80,7 +80,7 @@ export function getEdgeId(sourceId: string, targetId: string): string {
 
 export function extractTargetAndSource(inputString: string): string[] | null {
   const regex =
-    /([a-zA-Z]+-(llm|start|end|making|code|base|else|parameter|joiner|aggregation)|plugin|message|iteration|loop|loop-node-start|loop-node-end|loop-exit|variable)::[0-9a-fA-F-]{36}/g;
+    /([a-zA-Z]+-(llm|start|end|making|code|base|else|parameter|joiner|aggregation)|plugin|message|iteration|loop|loop-node-start|loop-node-end|loop-exit|openclaw|variable)::[0-9a-fA-F-]{36}/g;
   return inputString.match(regex);
 }
 
@@ -227,8 +227,7 @@ export const checkedNodeInputData = (
     ) || [];
 
   const noNeedCheckToolInputs =
-    currentCheckNode?.nodeType === 'plugin' ||
-    currentCheckNode?.nodeType === 'flow'
+    ['plugin', 'flow', 'openclaw'].includes(currentCheckNode?.nodeType)
       ? currentCheckNode?.data?.inputs
           ?.filter(input => !input?.required || input?.disabled)
           ?.map(input => input?.id)
@@ -579,6 +578,60 @@ function validateAgentParams(currentCheckNode: unknown): boolean {
   );
 }
 
+function validateOpenClawParams(currentCheckNode: unknown): boolean {
+  if (currentCheckNode?.nodeType !== 'openclaw') {
+    return true;
+  }
+
+  const nodeParam = currentCheckNode?.data?.nodeParam;
+  if (!nodeParam) {
+    return false;
+  }
+
+  const valueCannotBeEmpty = i18next.t(
+    'workflow.nodes.validation.valueCannotBeEmpty'
+  );
+  let passFlag = true;
+
+  if (!nodeParam?.mcpServerId?.trim() && !nodeParam?.mcpServerUrl?.trim()) {
+    nodeParam.mcpServerUrlErrMsg = valueCannotBeEmpty;
+    passFlag = false;
+  } else if (
+    nodeParam?.mcpServerUrl?.trim() &&
+    !isValidURL(nodeParam.mcpServerUrl)
+  ) {
+    nodeParam.mcpServerUrlErrMsg = i18next.t(
+      'workflow.nodes.validation.pleaseEnterValidURL'
+    );
+    passFlag = false;
+  } else {
+    nodeParam.mcpServerUrlErrMsg = '';
+  }
+
+  if (!nodeParam?.toolName?.trim()) {
+    nodeParam.toolNameErrMsg = valueCannotBeEmpty;
+    passFlag = false;
+  } else {
+    nodeParam.toolNameErrMsg = '';
+  }
+
+  if (!nodeParam?.skillName?.trim()) {
+    nodeParam.skillNameErrMsg = valueCannotBeEmpty;
+    passFlag = false;
+  } else {
+    nodeParam.skillNameErrMsg = '';
+  }
+
+  if (!nodeParam?.executionMode?.trim()) {
+    nodeParam.executionModeErrMsg = valueCannotBeEmpty;
+    passFlag = false;
+  } else {
+    nodeParam.executionModeErrMsg = '';
+  }
+
+  return passFlag;
+}
+
 function validateQuestionAnswerOptions(currentCheckNode: unknown): boolean {
   if (
     currentCheckNode?.nodeType !== 'question-answer' ||
@@ -764,6 +817,7 @@ export const checkedNodeParams = (currentCheckNode: unknown): boolean => {
     validateLoopParams,
     validateTextJoinerParams,
     validateAgentParams,
+    validateOpenClawParams,
     validateQuestionAnswerOptions,
     validateDatabaseParams,
     validateServiceIdParams,

--- a/core/workflow/engine/entities/node_entities.py
+++ b/core/workflow/engine/entities/node_entities.py
@@ -33,6 +33,7 @@ class NodeType(Enum):
     DATABASE = "database"
     RPA = "rpa"
     MCP = "mcp"
+    OPENCLAW = "openclaw"
     MEMORY_ADD = "memory-add"
     MEMORY_SEARCH = "memory-search"
 
@@ -98,6 +99,7 @@ CONTINUE_ON_ERROR_NOT_STREAM_NODE_TYPE = [
     NodeType.KNOWLEDGE_BASE.value,
     NodeType.PARAMETER_EXTRACTOR.value,
     NodeType.MCP.value,
+    NodeType.OPENCLAW.value,
     NodeType.RPA.value,
     NodeType.MEMORY_ADD.value,
     NodeType.MEMORY_SEARCH.value,

--- a/core/workflow/engine/nodes/cache_node.py
+++ b/core/workflow/engine/nodes/cache_node.py
@@ -36,6 +36,7 @@ from workflow.engine.nodes.loop.loop_node import (
 from workflow.engine.nodes.mcp.mcp_node import MCPNode
 from workflow.engine.nodes.memory import MemoryAddNode, MemorySearchNode
 from workflow.engine.nodes.message.message_node import MessageNode
+from workflow.engine.nodes.openclaw.openclaw_node import OpenClawNode
 from workflow.engine.nodes.params_extractor.pe_node import ParamsExtractorNode
 from workflow.engine.nodes.pgsql.pgsql_node import PGSqlNode
 from workflow.engine.nodes.plugin_tool.plugin_node import PluginNode
@@ -77,6 +78,7 @@ tool_classes = {
     "database": PGSqlNode,  # PostgreSQL database node for data operations
     "rpa": RPANode,
     "mcp": MCPNode,
+    "openclaw": OpenClawNode,
     "memory-add": MemoryAddNode,
     "memory-search": MemorySearchNode,
 }

--- a/core/workflow/engine/nodes/mcp/mcp_node.py
+++ b/core/workflow/engine/nodes/mcp/mcp_node.py
@@ -42,6 +42,30 @@ class MCPNode(BaseNode):
             raise ValueError("toolName cannot be empty")
         return self
 
+    def build_tool_args(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Build MCP tool arguments from resolved workflow inputs."""
+        return inputs
+
+    def build_request_body(self, tool_args: dict[str, Any]) -> dict[str, Any]:
+        """Build the request body sent to the MCP gateway."""
+        return {
+            "mcp_server_id": self.mcpServerId,
+            "mcp_server_url": self.mcpServerUrl,
+            "tool_name": self.toolName,
+            "tool_args": tool_args,
+        }
+
+    async def collect_inputs(
+        self,
+        variable_pool: VariablePool,
+        span: Span,
+    ) -> dict[str, Any]:
+        """Resolve workflow inputs before building MCP tool arguments."""
+        return {
+            k: variable_pool.get_variable(node_id=self.node_id, key_name=k, span=span)
+            for k in self.input_identifier
+        }
+
     async def execute(
         self,
         variable_pool: VariablePool,
@@ -62,14 +86,7 @@ class MCPNode(BaseNode):
         inputs, outputs = {}, {}
         try:
             # Get input variables from variable pool using dictionary comprehension
-            inputs.update(
-                {
-                    k: variable_pool.get_variable(
-                        node_id=self.node_id, key_name=k, span=span
-                    )
-                    for k in self.input_identifier
-                }
-            )
+            inputs.update(await self.collect_inputs(variable_pool, span))
             await span.add_info_events_async(
                 {"mcp_input": json.dumps(inputs, ensure_ascii=False)}
             )
@@ -77,12 +94,7 @@ class MCPNode(BaseNode):
 
             # Prepare MCP tool call request
             url = f"{os.getenv('MCP_BASE_URL')}/api/v1/mcp/call_tool"
-            req_body = {
-                "mcp_server_id": self.mcpServerId,
-                "mcp_server_url": self.mcpServerUrl,
-                "tool_name": self.toolName,
-                "tool_args": inputs,
-            }
+            req_body = self.build_request_body(self.build_tool_args(inputs))
             # Execute MCP tool call
             async with aiohttp.ClientSession(
                 timeout=ClientTimeout(total=5 * 60, sock_connect=30)

--- a/core/workflow/engine/nodes/openclaw/__init__.py
+++ b/core/workflow/engine/nodes/openclaw/__init__.py
@@ -1,0 +1,3 @@
+from workflow.engine.nodes.openclaw.openclaw_node import OpenClawNode
+
+__all__ = ["OpenClawNode"]

--- a/core/workflow/engine/nodes/openclaw/openclaw_node.py
+++ b/core/workflow/engine/nodes/openclaw/openclaw_node.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+from pydantic import Field, model_validator
+
+from workflow.engine.entities.variable_pool import VariablePool
+from workflow.engine.nodes.mcp.mcp_node import MCPNode
+from workflow.extensions.otlp.trace.span import Span
+
+
+class OpenClawNode(MCPNode):
+    """
+    OpenClaw skill execution node.
+
+    The node reuses the existing MCP gateway and adds ChatClaw/OpenClaw runtime
+    metadata to the tool arguments so the canvas can configure skills visually.
+    """
+
+    toolName: str = Field(default="run_skill", description="OpenClaw MCP tool name")
+    skillName: str = Field(default="", description="OpenClaw skill name")
+    executionMode: str = Field(
+        default="chatclaw", description="OpenClaw execution mode"
+    )
+    preCondition: str = Field(default="", description="Pre-run condition or prompt")
+    postCondition: str = Field(default="", description="Post-run condition or prompt")
+    tuningParams: dict[str, Any] = Field(
+        default_factory=dict, description="Visual fine-tuning parameters"
+    )
+    optionalInputIdentifiers: list[str] = Field(
+        default_factory=lambda: ["context"],
+        description="OpenClaw inputs that may be omitted when unresolved",
+    )
+
+    @model_validator(mode="after")
+    def validate_openclaw_fields(self) -> "OpenClawNode":
+        """Validate OpenClaw-specific field constraints."""
+        super().validate_fields()
+        if not self.skillName:
+            raise ValueError("skillName cannot be empty")
+        if not self.executionMode:
+            raise ValueError("executionMode cannot be empty")
+        return self
+
+    def _optional_input_names(self) -> set[str]:
+        return {str(item) for item in self.optionalInputIdentifiers}
+
+    @staticmethod
+    def _is_empty_optional_value(value: Any) -> bool:
+        return value in ("", None, {}, [])
+
+    async def collect_inputs(
+        self,
+        variable_pool: VariablePool,
+        span: Span,
+    ) -> dict[str, Any]:
+        """Resolve inputs while allowing configured optional args to be absent."""
+        inputs: dict[str, Any] = {}
+        optional_inputs = self._optional_input_names()
+        for identifier in self.input_identifier:
+            try:
+                value = variable_pool.get_variable(
+                    node_id=self.node_id, key_name=identifier, span=span
+                )
+            except Exception as err:
+                if identifier in optional_inputs:
+                    await span.add_info_events_async(
+                        {
+                            "openclaw_optional_input_skipped": {
+                                "input": identifier,
+                                "reason": str(err),
+                            }
+                        }
+                    )
+                    continue
+                raise
+            if identifier in optional_inputs and self._is_empty_optional_value(value):
+                continue
+            inputs[identifier] = value
+        return inputs
+
+    def build_tool_args(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Merge workflow inputs with OpenClaw skill execution metadata."""
+        tool_args = {
+            **inputs,
+            "skill_name": self.skillName,
+            "execution_mode": self.executionMode,
+        }
+        if self.preCondition:
+            tool_args["pre_condition"] = self.preCondition
+        if self.postCondition:
+            tool_args["post_condition"] = self.postCondition
+        if self.tuningParams:
+            tuning_params = {
+                key: value
+                for key, value in self.tuningParams.items()
+                if value is not None and value != ""
+            }
+            if tuning_params:
+                tool_args["tuning_params"] = tuning_params
+        return tool_args

--- a/core/workflow/tests/engine/nodes/test_openclaw_node.py
+++ b/core/workflow/tests/engine/nodes/test_openclaw_node.py
@@ -1,0 +1,107 @@
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from workflow.engine.entities.node_entities import (
+    CONTINUE_ON_ERROR_NOT_STREAM_NODE_TYPE,
+    NodeType,
+)
+from workflow.engine.nodes.cache_node import tool_classes
+from workflow.engine.nodes.openclaw.openclaw_node import OpenClawNode
+
+
+class DummySpan:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def add_info_events_async(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class OpenClawInputPool:
+    def get_variable(self, node_id: str, key_name: str, span: DummySpan) -> Any:
+        if key_name == "context":
+            raise Exception("empty reference")
+        return "build a customer support app"
+
+
+def build_openclaw_node(**overrides) -> OpenClawNode:  # type: ignore[no-untyped-def]
+    payload = {
+        "node_id": "openclaw::node-1",
+        "alias_name": "OpenClaw",
+        "node_type": NodeType.OPENCLAW.value,
+        "input_identifier": ["instruction", "context"],
+        "output_identifier": ["result"],
+        "mcpServerUrl": "https://example.test/mcp/sse",
+        "toolName": "run_skill",
+        "skillName": "chatclaw-builder",
+        "executionMode": "chatclaw",
+        "preCondition": "collect user intent",
+        "postCondition": "return application draft",
+        "tuningParams": {"temperature": 0.2},
+    }
+    payload.update(overrides)
+    return OpenClawNode(**payload)
+
+
+def test_openclaw_node_is_registered() -> None:
+    assert tool_classes[NodeType.OPENCLAW.value] is OpenClawNode
+    assert NodeType.OPENCLAW.value in CONTINUE_ON_ERROR_NOT_STREAM_NODE_TYPE
+
+
+def test_openclaw_builds_skill_tool_args() -> None:
+    node = build_openclaw_node()
+
+    tool_args = node.build_tool_args(
+        {
+            "instruction": "build a customer support app",
+            "context": {"industry": "retail"},
+        }
+    )
+
+    assert tool_args == {
+        "instruction": "build a customer support app",
+        "context": {"industry": "retail"},
+        "skill_name": "chatclaw-builder",
+        "execution_mode": "chatclaw",
+        "pre_condition": "collect user intent",
+        "post_condition": "return application draft",
+        "tuning_params": {"temperature": 0.2},
+    }
+
+
+def test_openclaw_uses_mcp_gateway_request_shape() -> None:
+    node = build_openclaw_node(mcpServerId="mcp-server-1", mcpServerUrl="")
+
+    req_body = node.build_request_body({"instruction": "build"})
+
+    assert req_body == {
+        "mcp_server_id": "mcp-server-1",
+        "mcp_server_url": "",
+        "tool_name": "run_skill",
+        "tool_args": {"instruction": "build"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_openclaw_skips_unresolved_optional_input() -> None:
+    node = build_openclaw_node()
+    span = DummySpan()
+
+    inputs = await node.collect_inputs(OpenClawInputPool(), span)
+
+    assert inputs == {"instruction": "build a customer support app"}
+    assert span.events == [
+        {
+            "openclaw_optional_input_skipped": {
+                "input": "context",
+                "reason": "empty reference",
+            }
+        }
+    ]
+
+
+def test_openclaw_requires_skill_name() -> None:
+    with pytest.raises(ValidationError):
+        build_openclaw_node(skillName="")


### PR DESCRIPTION
Closes #1066.

## Summary
- Add an `openclaw` workflow node backed by the existing MCP gateway request shape.
- Add a canvas configuration panel for ChatClaw/OpenClaw runtime options, skill name, tuning params, and pre/post conditions.
- Register OpenClaw node templates through a backend migration and add focused backend tests.
- Address review feedback by guarding missing frontend `nodeParam` values and skipping unresolved optional OpenClaw inputs such as `context` at runtime.

## Validation
- `UV_CACHE_DIR=C:\Users\maxjiang\Documents\YY\external\astron-agent\.uv-cache uv run --python 3.11 pytest tests\engine\nodes\test_openclaw_node.py` (5 passed, warnings only)
- `UV_CACHE_DIR=C:\Users\maxjiang\Documents\YY\external\astron-agent\.uv-cache uv run --python 3.11 black --check engine\nodes\mcp\mcp_node.py engine\nodes\openclaw\openclaw_node.py tests\engine\nodes\test_openclaw_node.py`
- `git diff --check`
- `git diff --cached --check`
- `npm.cmd run type-check` could not run in this checkout because `console/frontend/node_modules` is missing and `tsc` is not available.

## Notes
- The frontend node uses the existing workflow panel patterns and keeps OpenClaw execution routed through the MCP gateway so existing server URL / server ID behavior remains unchanged.
- Cloud checks are currently `action_required` because CLA signing is still pending.