### PR TITLE
feat: add OpenClaw RPA trigger controls

### DIFF
--- a/console/frontend/src/components/workflow/nodes/rpa/index.tsx
+++ b/console/frontend/src/components/workflow/nodes/rpa/index.tsx
@@ -1,14 +1,217 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
+import { Switch } from 'antd';
 import FixedOutputs from '../components/fixed-outputs';
 import ExceptionHandling from '../components/exception-handling';
 import SingleInput from '../components/single-input';
 import { NodeCommonProps } from '../../types';
+import {
+  FlowInput,
+  FlowSelect,
+  FlowTextArea,
+  FLowCollapse,
+} from '@/components/workflow/ui';
+import { useNodeCommon } from '@/components/workflow/hooks/use-node-common';
+
+const readString = (
+  nodeParam: Record<string, unknown> | null | undefined,
+  key: string
+): string => {
+  const value = nodeParam?.[key];
+  return typeof value === 'string' ? value : '';
+};
+
+const readStringList = (
+  nodeParam: Record<string, unknown> | null | undefined,
+  key: string
+): string => {
+  const value = nodeParam?.[key];
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  return '';
+};
+
+const ControlRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-1">
+    <div className="text-sm text-[#333]">{label}</div>
+    {children}
+  </div>
+);
+
+const OpenClawControlConfig = memo(({ id, data }: NodeCommonProps) => {
+  const { handleChangeNodeParam, nodeParam, canvasesDisabled } = useNodeCommon({
+    id,
+    data,
+  });
+
+  const setNodeParamValue = (
+    key: string,
+    value: unknown,
+    formatter?: (value: unknown) => unknown
+  ) => {
+    handleChangeNodeParam(
+      (data, value) => {
+        data.nodeParam = data.nodeParam || {};
+        data.nodeParam[key] = formatter ? formatter(value) : value;
+      },
+      value
+    );
+  };
+
+  return (
+    <FLowCollapse
+      label={<div className="text-base font-medium">OpenClaw 安全触发</div>}
+      content={
+        <div
+          className="rounded-md px-[18px] pb-3 pointer-events-auto flex flex-col gap-3"
+          style={{ pointerEvents: canvasesDisabled ? 'none' : 'auto' }}
+        >
+          <ControlRow label="触发来源">
+            <FlowSelect
+              value={readString(nodeParam, 'triggerSource')}
+              placeholder="默认关闭"
+              options={[
+                { label: '默认 RPA 调用', value: '' },
+                { label: 'OpenClaw 安全触发', value: 'openclaw' },
+              ]}
+              onChange={(value: string) =>
+                setNodeParamValue('triggerSource', value)
+              }
+            />
+          </ControlRow>
+          <ControlRow label="固定场景">
+            <FlowInput
+              value={readString(nodeParam, 'scenario')}
+              placeholder="financial_reimbursement"
+              onChange={e => setNodeParamValue('scenario', e.target.value)}
+            />
+            {readString(nodeParam, 'scenarioErrMsg') && (
+              <p className="text-xs text-[#F74E43]">
+                {readString(nodeParam, 'scenarioErrMsg')}
+              </p>
+            )}
+          </ControlRow>
+          <ControlRow label="允许场景白名单">
+            <FlowTextArea
+              value={readStringList(nodeParam, 'allowedScenarios')}
+              placeholder="多个场景用英文逗号分隔"
+              onChange={e =>
+                setNodeParamValue(
+                  'allowedScenarios',
+                  e.target.value,
+                  value =>
+                    String(value)
+                      .split(',')
+                      .map(item => item.trim())
+                      .filter(Boolean)
+                )
+              }
+            />
+          </ControlRow>
+          <div className="grid grid-cols-2 gap-3">
+            <ControlRow label="校验触发签名">
+              <Switch
+                checked={Boolean(nodeParam?.triggerAuthRequired)}
+                onChange={checked =>
+                  setNodeParamValue('triggerAuthRequired', checked)
+                }
+              />
+            </ControlRow>
+            <ControlRow label="需要人工审批">
+              <Switch
+                checked={Boolean(nodeParam?.approvalRequired)}
+                onChange={checked =>
+                  setNodeParamValue('approvalRequired', checked)
+                }
+              />
+            </ControlRow>
+          </div>
+          <ControlRow label="签名密钥环境变量">
+            <FlowInput
+              value={
+                readString(nodeParam, 'triggerSecretEnv') ||
+                'OPENCLAW_RPA_TRIGGER_SECRET'
+              }
+              placeholder="OPENCLAW_RPA_TRIGGER_SECRET"
+              onChange={e =>
+                setNodeParamValue('triggerSecretEnv', e.target.value)
+              }
+            />
+            {readString(nodeParam, 'triggerSecretEnvErrMsg') && (
+              <p className="text-xs text-[#F74E43]">
+                {readString(nodeParam, 'triggerSecretEnvErrMsg')}
+              </p>
+            )}
+          </ControlRow>
+          <ControlRow label="签名输入变量">
+            <FlowInput
+              value={
+                readString(nodeParam, 'triggerSignatureInput') ||
+                'trigger_signature'
+              }
+              placeholder="trigger_signature"
+              onChange={e =>
+                setNodeParamValue('triggerSignatureInput', e.target.value)
+              }
+            />
+            {readString(nodeParam, 'triggerSignatureInputErrMsg') && (
+              <p className="text-xs text-[#F74E43]">
+                {readString(nodeParam, 'triggerSignatureInputErrMsg')}
+              </p>
+            )}
+          </ControlRow>
+          <div className="grid grid-cols-2 gap-3">
+            <ControlRow label="审批状态">
+              <FlowSelect
+                value={readString(nodeParam, 'approvalStatus')}
+                placeholder="pending"
+                options={[
+                  { label: '待审批', value: 'pending' },
+                  { label: '已批准', value: 'approved' },
+                  { label: '已拒绝', value: 'rejected' },
+                ]}
+                onChange={(value: string) =>
+                  setNodeParamValue('approvalStatus', value)
+                }
+              />
+            </ControlRow>
+            <ControlRow label="审批人">
+              <FlowInput
+                value={readString(nodeParam, 'approver')}
+                placeholder="finance-lead"
+                onChange={e => setNodeParamValue('approver', e.target.value)}
+              />
+            </ControlRow>
+          </div>
+          <ControlRow label="风险等级">
+            <FlowSelect
+              value={readString(nodeParam, 'riskLevel') || 'high'}
+              options={[
+                { label: '高风险', value: 'high' },
+                { label: '中风险', value: 'medium' },
+                { label: '低风险', value: 'low' },
+              ]}
+              onChange={(value: string) => setNodeParamValue('riskLevel', value)}
+            />
+          </ControlRow>
+        </div>
+      }
+    />
+  );
+});
 
 export const RpaDetail = memo((props: NodeCommonProps) => {
   const { id, data } = props;
 
   return (
     <div className="p-[14px] pb-[6px]">
+      <OpenClawControlConfig id={id} data={data} />
       <SingleInput id={id} data={data} />
       <FixedOutputs id={id} data={data} />
       <ExceptionHandling id={id} data={data} />

--- a/console/frontend/src/components/workflow/utils/reactflowUtils.ts
+++ b/console/frontend/src/components/workflow/utils/reactflowUtils.ts
@@ -753,6 +753,77 @@ function validateRetryConfig(currentCheckNode: unknown): boolean {
   return true;
 }
 
+function isOpenClawRpaControlEnabled(nodeParam: unknown): boolean {
+  return Boolean(
+    nodeParam?.triggerSource === 'openclaw' ||
+      nodeParam?.triggerAuthRequired ||
+      nodeParam?.approvalRequired ||
+      nodeParam?.allowedScenarios?.length
+  );
+}
+
+function validateRpaOpenClawParams(currentCheckNode: unknown): boolean {
+  if (currentCheckNode?.nodeType !== 'rpa') {
+    return true;
+  }
+
+  const nodeParam = currentCheckNode?.data?.nodeParam;
+  if (!nodeParam || !isOpenClawRpaControlEnabled(nodeParam)) {
+    if (nodeParam) {
+      nodeParam.scenarioErrMsg = '';
+      nodeParam.triggerSecretEnvErrMsg = '';
+      nodeParam.triggerSignatureInputErrMsg = '';
+    }
+    return true;
+  }
+
+  const valueCannotBeEmpty = i18next.t(
+    'workflow.nodes.validation.valueCannotBeEmpty'
+  );
+  let passFlag = true;
+  if (!nodeParam?.scenario?.trim()) {
+    nodeParam.scenarioErrMsg = valueCannotBeEmpty;
+    passFlag = false;
+  } else {
+    nodeParam.scenarioErrMsg = '';
+  }
+
+  if (
+    nodeParam?.triggerAuthRequired &&
+    Object.hasOwn(nodeParam, 'triggerSecretEnv') &&
+    !nodeParam?.triggerSecretEnv?.trim()
+  ) {
+    nodeParam.triggerSecretEnvErrMsg = valueCannotBeEmpty;
+    passFlag = false;
+  } else {
+    nodeParam.triggerSecretEnvErrMsg = '';
+  }
+
+  if (nodeParam?.triggerAuthRequired) {
+    const signatureInput =
+      nodeParam?.triggerSignatureInput?.trim() || 'trigger_signature';
+    const hasSignatureInput = currentCheckNode?.data?.inputs?.some(
+      (input: unknown) =>
+        Boolean(
+          input &&
+            typeof input === 'object' &&
+            'name' in input &&
+            input.name === signatureInput
+        )
+    );
+    if (!hasSignatureInput) {
+      nodeParam.triggerSignatureInputErrMsg = valueCannotBeEmpty;
+      passFlag = false;
+    } else {
+      nodeParam.triggerSignatureInputErrMsg = '';
+    }
+  } else {
+    nodeParam.triggerSignatureInputErrMsg = '';
+  }
+
+  return passFlag;
+}
+
 export const checkedNodeParams = (currentCheckNode: unknown): boolean => {
   const validations = [
     validateTemplateParams,
@@ -768,6 +839,7 @@ export const checkedNodeParams = (currentCheckNode: unknown): boolean => {
     validateDatabaseParams,
     validateServiceIdParams,
     validateRetryConfig,
+    validateRpaOpenClawParams,
     validateVariableAggregationNode,
   ];
 

--- a/core/workflow/engine/nodes/rpa/rpa_node.py
+++ b/core/workflow/engine/nodes/rpa/rpa_node.py
@@ -1,3 +1,5 @@
+import hashlib
+import hmac
 import json
 import os
 from typing import Any, Dict
@@ -37,6 +39,184 @@ class RPANode(BaseNode):
     source: str = ""
     version: int | None = None
     rpaParams: Dict[str, Any] = Field(default_factory=dict)
+    triggerSource: str = ""
+    triggerAuthRequired: bool = False
+    triggerSecretEnv: str = "OPENCLAW_RPA_TRIGGER_SECRET"
+    triggerSignatureInput: str = "trigger_signature"
+    scenario: str = ""
+    allowedScenarios: list[str] = Field(default_factory=list)
+    approvalRequired: bool = False
+    approvalStatus: str = ""
+    approver: str = ""
+    riskLevel: str = "high"
+    auditTags: list[str] = Field(default_factory=list)
+
+    def openclaw_control_enabled(self) -> bool:
+        return (
+            (self.triggerSource or "").lower() == "openclaw"
+            or self.triggerAuthRequired
+            or self.approvalRequired
+            or bool(self.allowedScenarios)
+        )
+
+    def _sanitize_control_inputs(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in inputs.items()
+            if key != self.triggerSignatureInput
+        }
+
+    def build_openclaw_signature_payload(self, inputs: dict[str, Any]) -> str:
+        payload = {
+            "project_id": self.projectId,
+            "trigger_source": self.triggerSource,
+            "scenario": self.scenario,
+            "inputs": self._sanitize_control_inputs(inputs),
+        }
+        return json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+
+    def build_openclaw_signature(self, inputs: dict[str, Any], secret: str) -> str:
+        payload = self.build_openclaw_signature_payload(inputs)
+        return hmac.new(
+            secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+    def build_openclaw_audit_event(
+        self, inputs: dict[str, Any], decision: str
+    ) -> dict[str, Any]:
+        return {
+            "event": "openclaw_rpa_trigger",
+            "decision": decision,
+            "trigger_source": self.triggerSource or "workflow",
+            "project_id": self.projectId,
+            "scenario": self.scenario,
+            "risk_level": self.riskLevel,
+            "approval_required": self.approvalRequired,
+            "approval_status": self.approvalStatus,
+            "approver": self.approver,
+            "input_keys": sorted(self._sanitize_control_inputs(inputs).keys()),
+            "audit_tags": self.auditTags,
+        }
+
+    def build_control_outputs(
+        self, status: str, message: str, audit: dict[str, Any]
+    ) -> dict[str, Any]:
+        output_candidates = {
+            "status": status,
+            "message": message,
+            "audit": audit,
+        }
+        return {
+            output: output_candidates[output]
+            for output in self.output_identifier
+            if output in output_candidates
+        }
+
+    async def _record_openclaw_audit_event(
+        self,
+        span: Span,
+        audit: dict[str, Any],
+        event_log_node_trace: NodeLog | None = None,
+    ) -> None:
+        await span.add_info_events_async({"openclaw_rpa_audit": audit})
+        if event_log_node_trace:
+            event_log_node_trace.append_config_data({"openclaw_rpa_audit": audit})
+
+    async def evaluate_openclaw_controls(
+        self,
+        inputs: dict[str, Any],
+        span: Span,
+        event_log_node_trace: NodeLog | None = None,
+    ) -> NodeRunResult | dict[str, Any] | None:
+        if not self.openclaw_control_enabled():
+            return None
+
+        if not self.scenario:
+            raise CustomException(
+                err_code=CodeEnum.RPA_NODE_ERROR,
+                err_msg="OpenClaw RPA scenario cannot be empty",
+            )
+
+        if self.allowedScenarios and self.scenario not in self.allowedScenarios:
+            audit = self.build_openclaw_audit_event(inputs, "scenario_denied")
+            await self._record_openclaw_audit_event(span, audit, event_log_node_trace)
+            raise CustomException(
+                err_code=CodeEnum.RPA_NODE_ERROR,
+                err_msg=f"OpenClaw RPA scenario {self.scenario} is not allowed",
+            )
+
+        if self.triggerAuthRequired:
+            if self.triggerSignatureInput not in inputs:
+                audit = self.build_openclaw_audit_event(
+                    inputs, "missing_trigger_signature_input"
+                )
+                await self._record_openclaw_audit_event(
+                    span, audit, event_log_node_trace
+                )
+                raise CustomException(
+                    err_code=CodeEnum.RPA_NODE_ERROR,
+                    err_msg=(
+                        "OpenClaw RPA trigger signature input "
+                        f"{self.triggerSignatureInput} is missing"
+                    ),
+                )
+            if not self.triggerSecretEnv:
+                audit = self.build_openclaw_audit_event(
+                    inputs, "missing_trigger_secret_env"
+                )
+                await self._record_openclaw_audit_event(
+                    span, audit, event_log_node_trace
+                )
+                raise CustomException(
+                    err_code=CodeEnum.RPA_NODE_ERROR,
+                    err_msg="OpenClaw RPA trigger secret env cannot be empty",
+                )
+            secret = os.getenv(self.triggerSecretEnv, "")
+            provided_signature = str(inputs.get(self.triggerSignatureInput, ""))
+            if not secret:
+                audit = self.build_openclaw_audit_event(
+                    inputs, "missing_trigger_secret"
+                )
+                await self._record_openclaw_audit_event(
+                    span, audit, event_log_node_trace
+                )
+                raise CustomException(
+                    err_code=CodeEnum.RPA_NODE_ERROR,
+                    err_msg=f"{self.triggerSecretEnv} is not configured",
+                )
+            expected_signature = self.build_openclaw_signature(inputs, secret)
+            if not hmac.compare_digest(provided_signature, expected_signature):
+                audit = self.build_openclaw_audit_event(inputs, "signature_rejected")
+                await self._record_openclaw_audit_event(
+                    span, audit, event_log_node_trace
+                )
+                raise CustomException(
+                    err_code=CodeEnum.RPA_NODE_ERROR,
+                    err_msg="OpenClaw RPA trigger signature is invalid",
+                )
+
+        if self.approvalRequired and (self.approvalStatus or "").lower() != "approved":
+            audit = self.build_openclaw_audit_event(inputs, "approval_required")
+            await self._record_openclaw_audit_event(span, audit, event_log_node_trace)
+            return NodeRunResult(
+                status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                inputs=self._sanitize_control_inputs(inputs),
+                outputs=self.build_control_outputs(
+                    "approval_required",
+                    "OpenClaw RPA trigger is waiting for human approval",
+                    audit,
+                ),
+                process_data={"openclaw_rpa_audit": audit},
+                node_id=self.node_id,
+                node_type=self.node_type,
+                alias_name=self.alias_name,
+            )
+
+        audit = self.build_openclaw_audit_event(inputs, "approved")
+        await self._record_openclaw_audit_event(span, audit, event_log_node_trace)
+        return audit
 
     async def execute(
         self,
@@ -50,7 +230,22 @@ class RPANode(BaseNode):
                 inputs[identifier] = variable_pool.get_variable(
                     node_id=self.node_id, key_name=identifier, span=span
                 )
-            await span.add_info_events_async({"rpa_input": f"{inputs}"})
+            logged_inputs = (
+                self._sanitize_control_inputs(inputs)
+                if self.openclaw_control_enabled()
+                else inputs
+            )
+            await span.add_info_events_async({"rpa_input": f"{logged_inputs}"})
+            openclaw_audit = await self.evaluate_openclaw_controls(
+                inputs, span, event_log_node_trace
+            )
+            if isinstance(openclaw_audit, NodeRunResult):
+                return openclaw_audit
+            rpa_inputs = (
+                self._sanitize_control_inputs(inputs)
+                if self.openclaw_control_enabled()
+                else inputs
+            )
             status = WorkflowNodeExecutionStatus.SUCCEEDED
             url = f"{os.getenv('RPA_BASE_URL')}/rpa/v1/exec"
             variable_ext: dict = variable_pool.system_params.get(
@@ -61,7 +256,7 @@ class RPANode(BaseNode):
                 "project_id": self.projectId,
                 "sid": span.sid,
                 "exec_position": self.rpaParams.get("execPosition", "EXECUTOR"),
-                "params": inputs,
+                "params": rpa_inputs,
                 **({"version": self.version} if self.version else {}),
                 **({"phone_number": phone_number} if phone_number else {}),
             }
@@ -108,10 +303,21 @@ class RPANode(BaseNode):
                     if output in data
                 }
             )
+            if isinstance(openclaw_audit, dict):
+                outputs.update(
+                    self.build_control_outputs(
+                        "executed",
+                        "OpenClaw RPA trigger was approved and executed",
+                        {
+                            **openclaw_audit,
+                            "decision": "executed",
+                        },
+                    )
+                )
 
             return NodeRunResult(
                 status=status,
-                inputs=inputs,
+                inputs=rpa_inputs,
                 outputs=outputs,
                 node_id=self.node_id,
                 node_type=self.node_type,

--- a/core/workflow/tests/engine/nodes/test_rpa_openclaw_controls.py
+++ b/core/workflow/tests/engine/nodes/test_rpa_openclaw_controls.py
@@ -1,0 +1,184 @@
+from typing import Any
+
+import pytest
+
+from workflow.engine.nodes.entities.node_run_result import WorkflowNodeExecutionStatus
+from workflow.engine.nodes.rpa.rpa_node import RPANode
+from workflow.exception.e import CustomException
+
+
+class DummySpan:
+    sid = "sid-1"
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def add_info_event_async(self, event: Any) -> None:
+        self.events.append(event)
+
+    async def add_info_events_async(self, event: Any) -> None:
+        self.events.append(event)
+
+    def record_exception(self, _error: Any) -> None:
+        return None
+
+
+class DummyVariablePool:
+    def get_variable(self, node_id: str, key_name: str, span: DummySpan) -> Any:
+        values = {
+            "trigger_id": "trigger-1",
+            "amount": 1200,
+            "trigger_signature": "do-not-log",
+        }
+        return values[key_name]
+
+
+def build_rpa_node(**overrides: Any) -> RPANode:
+    payload: dict[str, Any] = {
+        "node_id": "rpa::node-1",
+        "alias_name": "Controlled RPA",
+        "node_type": "rpa",
+        "input_identifier": ["trigger_id", "amount", "trigger_signature"],
+        "output_identifier": ["status", "message", "audit"],
+        "projectId": "expense-bot",
+        "header": {"apiKey": "rpa-api-key"},
+        "triggerSource": "openclaw",
+        "scenario": "financial_reimbursement",
+        "allowedScenarios": ["financial_reimbursement"],
+        "riskLevel": "high",
+    }
+    payload.update(overrides)
+    return RPANode(**payload)
+
+
+def test_openclaw_signature_payload_excludes_signature() -> None:
+    node = build_rpa_node(triggerAuthRequired=True)
+    inputs = {
+        "trigger_id": "trigger-1",
+        "amount": 1200,
+        "trigger_signature": "do-not-forward",
+    }
+
+    payload = node.build_openclaw_signature_payload(inputs)
+    audit = node.build_openclaw_audit_event(inputs, "approved")
+
+    assert "do-not-forward" not in payload
+    assert "trigger_signature" not in audit["input_keys"]
+    assert audit["event"] == "openclaw_rpa_trigger"
+
+
+def test_openclaw_control_enabled_handles_null_trigger_source() -> None:
+    node = build_rpa_node(allowedScenarios=[])
+    node.triggerSource = None
+
+    assert node.openclaw_control_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_openclaw_requires_valid_trigger_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = build_rpa_node(triggerAuthRequired=True)
+    inputs = {
+        "trigger_id": "trigger-1",
+        "amount": 1200,
+        "trigger_signature": "invalid",
+    }
+    monkeypatch.setenv("OPENCLAW_RPA_TRIGGER_SECRET", "secret")
+
+    with pytest.raises(CustomException, match="signature is invalid"):
+        await node.evaluate_openclaw_controls(inputs, DummySpan())
+
+
+@pytest.mark.asyncio
+async def test_openclaw_rejects_empty_trigger_secret_env() -> None:
+    node = build_rpa_node(triggerAuthRequired=True, triggerSecretEnv="")
+
+    with pytest.raises(CustomException, match="secret env cannot be empty"):
+        await node.evaluate_openclaw_controls(
+            {"trigger_id": "trigger-1", "trigger_signature": "signature"}, DummySpan()
+        )
+
+
+@pytest.mark.asyncio
+async def test_openclaw_requires_declared_trigger_signature_input() -> None:
+    node = build_rpa_node(triggerAuthRequired=True)
+
+    with pytest.raises(CustomException, match="signature input trigger_signature"):
+        await node.evaluate_openclaw_controls({"trigger_id": "trigger-1"}, DummySpan())
+
+
+@pytest.mark.asyncio
+async def test_openclaw_waits_for_human_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = build_rpa_node(
+        triggerAuthRequired=True,
+        approvalRequired=True,
+        approvalStatus="pending",
+    )
+    inputs = {"trigger_id": "trigger-1", "amount": 1200}
+    inputs["trigger_signature"] = node.build_openclaw_signature(inputs, "secret")
+    monkeypatch.setenv("OPENCLAW_RPA_TRIGGER_SECRET", "secret")
+
+    result = await node.evaluate_openclaw_controls(inputs, DummySpan())
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.inputs == {"trigger_id": "trigger-1", "amount": 1200}
+    assert result.outputs["status"] == "approval_required"
+    assert result.outputs["audit"]["decision"] == "approval_required"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_handles_empty_approval_status() -> None:
+    node = build_rpa_node(approvalRequired=True)
+    node.approvalStatus = None
+
+    result = await node.evaluate_openclaw_controls(
+        {"trigger_id": "trigger-1", "amount": 1200}, DummySpan()
+    )
+
+    assert result.outputs["status"] == "approval_required"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_execute_masks_signature_before_tracing_inputs() -> None:
+    node = build_rpa_node(approvalRequired=True, approvalStatus="pending")
+    span = DummySpan()
+
+    result = await node.execute(DummyVariablePool(), span)
+
+    assert result.outputs["status"] == "approval_required"
+    assert not any("do-not-log" in str(event) for event in span.events)
+
+
+@pytest.mark.asyncio
+async def test_openclaw_approved_trigger_returns_audit_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = build_rpa_node(
+        triggerAuthRequired=True,
+        approvalRequired=True,
+        approvalStatus="approved",
+        approver="finance-lead",
+    )
+    inputs = {"trigger_id": "trigger-1", "amount": 1200}
+    inputs["trigger_signature"] = node.build_openclaw_signature(inputs, "secret")
+    monkeypatch.setenv("OPENCLAW_RPA_TRIGGER_SECRET", "secret")
+
+    audit = await node.evaluate_openclaw_controls(inputs, DummySpan())
+
+    assert audit["decision"] == "approved"
+    assert audit["approver"] == "finance-lead"
+    assert audit["scenario"] == "financial_reimbursement"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_denies_unlisted_scenario() -> None:
+    node = build_rpa_node(
+        scenario="contract_update",
+        allowedScenarios=["financial_reimbursement"],
+    )
+
+    with pytest.raises(CustomException, match="is not allowed"):
+        await node.evaluate_openclaw_controls({"trigger_id": "trigger-1"}, DummySpan())


### PR DESCRIPTION
## Summary
- add optional OpenClaw control fields to the workflow RPA node for fixed high-risk scenarios
- validate scenario allowlists, HMAC trigger signatures, declared signature inputs, and human approval before dispatching RPA execution
- record structured OpenClaw RPA audit events while keeping trigger signatures out of forwarded RPA params and span input traces
- expose the controls in the RPA node detail panel with frontend validation and null-safe helpers

## Context
Related to #1067. This complements #1458 by covering the workflow/RPA-node enforcement path rather than adding another OpenClaw trigger intake endpoint. Legacy RPA execution remains unchanged unless OpenClaw controls are enabled.

## Review fixes
- guard null/undefined RPA node params in frontend helpers and validation
- guard nullable `triggerSource` / `approvalStatus` before lowercasing
- require the configured signature input to exist when trigger auth is enabled
- mask OpenClaw control inputs before writing `rpa_input` span events

## Validation
- `UV_CACHE_DIR=C:\Users\maxjiang\Documents\YY\external\astron-agent\.uv-cache uv run --python 3.11 pytest -q tests\engine\nodes\test_rpa_openclaw_controls.py` (10 passed, warnings only)
- `UV_CACHE_DIR=C:\Users\maxjiang\Documents\YY\external\astron-agent\.uv-cache uv run --python 3.11 black --check engine\nodes\rpa\rpa_node.py tests\engine\nodes\test_rpa_openclaw_controls.py`
- `git diff --check`
- `npm.cmd run type-check` could not run in this checkout because `node_modules` is absent and `tsc` is not installed locally.