### PR TITLE
fix(chat): skip blank exchanges when building chat history

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
@@ -127,6 +127,17 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
                 continue;
             }
 
+            // Skip failed or empty exchanges. A request that carries no content (for
+            // example an API call rejected for a missing required input) must not be
+            // replayed, otherwise the blank message fails validation on every
+            // following turn and permanently breaks the chat
+            if (StringUtils.isBlank(reqDto.getMessage()) && StringUtils.isBlank(reqDto.getUrl())) {
+                continue;
+            }
+            if (StringUtils.isBlank(respDto.getMessage()) && StringUtils.isBlank(respDto.getContent())) {
+                continue;
+            }
+
             // Add answer, history records answer first then question
             String answer = respDto.getMessage();
             int answerLength = answer == null ? 0 : answer.length();

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
@@ -201,8 +201,30 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
      */
     private boolean isBlankExchange(ChatReqModelDto reqDto, ChatRespModelDto respDto) {
         boolean blankRequest = StringUtils.isBlank(reqDto.getMessage()) && StringUtils.isBlank(reqDto.getUrl());
-        boolean blankResponse = StringUtils.isBlank(respDto.getMessage()) && StringUtils.isBlank(respDto.getContent());
-        return blankRequest || blankResponse;
+        return blankRequest || !addsAssistantMessage(respDto);
+    }
+
+    /**
+     * Determine whether this response actually contributes an assistant message
+     *
+     * <p>
+     * Mirrors the branches that append the assistant turn below. Multimodal responses only append
+     * for {@code needHis} 0 and 2, so a response can be non-empty and still add nothing. Replaying
+     * such a pair would append the question without its answer, leaving two consecutive user
+     * messages that the model API rejects.
+     *
+     * @param respDto Response record of the exchange
+     * @return Returns true when an assistant message with content will be appended
+     */
+    private boolean addsAssistantMessage(ChatRespModelDto respDto) {
+        if (StringUtils.isBlank(respDto.getContent())) {
+            return StringUtils.isNotBlank(respDto.getMessage());
+        }
+        int needHis = respDto.getNeedHis();
+        if (needHis == 0) {
+            return true;
+        }
+        return needHis == 2 && StringUtils.isNotBlank(respDto.getMessage());
     }
 
     /**

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
@@ -131,10 +131,7 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
             // example an API call rejected for a missing required input) must not be
             // replayed, otherwise the blank message fails validation on every
             // following turn and permanently breaks the chat
-            if (StringUtils.isBlank(reqDto.getMessage()) && StringUtils.isBlank(reqDto.getUrl())) {
-                continue;
-            }
-            if (StringUtils.isBlank(respDto.getMessage()) && StringUtils.isBlank(respDto.getContent())) {
+            if (isBlankExchange(reqDto, respDto)) {
                 continue;
             }
 
@@ -193,6 +190,19 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
         }
         chatRecordList.setLength(tempLength);
         return chatRecordList;
+    }
+
+    /**
+     * Determine whether a question/answer pair carries no usable content
+     *
+     * @param reqDto Request record of the exchange
+     * @param respDto Response record of the exchange
+     * @return Returns true when either side is empty and the pair should not be replayed
+     */
+    private boolean isBlankExchange(ChatReqModelDto reqDto, ChatRespModelDto respDto) {
+        boolean blankRequest = StringUtils.isBlank(reqDto.getMessage()) && StringUtils.isBlank(reqDto.getUrl());
+        boolean blankResponse = StringUtils.isBlank(respDto.getMessage()) && StringUtils.isBlank(respDto.getContent());
+        return blankRequest || blankResponse;
     }
 
     /**

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
@@ -208,10 +208,10 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
      * Determine whether this response actually contributes an assistant message
      *
      * <p>
-     * Mirrors the branches that append the assistant turn below. Multimodal responses only append
-     * for {@code needHis} 0 and 2, so a response can be non-empty and still add nothing. Replaying
-     * such a pair would append the question without its answer, leaving two consecutive user
-     * messages that the model API rejects.
+     * Mirrors the branches that append the assistant turn below. Multimodal responses only append for
+     * {@code needHis} 0 and 2, so a response can be non-empty and still add nothing. Replaying such a
+     * pair would append the question without its answer, leaving two consecutive user messages that the
+     * model API rejects.
      *
      * @param respDto Response record of the exchange
      * @return Returns true when an assistant message with content will be appended

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
@@ -230,6 +230,60 @@ class ChatHistoryServiceImplTest {
     }
 
     @Test
+    void testGetHistory_WithBlankRequestMessage_ShouldSkipExchange() {
+        // Given: a failed exchange whose request has no content, followed by a normal one
+        ChatReqModelDto blankReq = new ChatReqModelDto();
+        blankReq.setId(3L);
+        blankReq.setMessage("");
+
+        ChatRespModelDto errorResp = new ChatRespModelDto();
+        errorResp.setReqId(3L);
+        errorResp.setMessage("Workflow error: required input is missing");
+
+        ChatReqModelDto normalReq = new ChatReqModelDto();
+        normalReq.setId(4L);
+        normalReq.setMessage("Normal question");
+
+        ChatRespModelDto normalResp = new ChatRespModelDto();
+        normalResp.setReqId(4L);
+        normalResp.setMessage("Normal answer");
+
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(4L, 3L)))
+                .thenReturn(Arrays.asList(errorResp, normalResp));
+
+        // When
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(normalReq, blankReq));
+
+        // Then: the blank exchange is dropped, the normal one is kept
+        assertEquals(2, result.getMessages().size());
+        assertEquals("user", result.getMessages().get(0).getRole());
+        assertEquals("Normal question", result.getMessages().get(0).getContent());
+        assertEquals("assistant", result.getMessages().get(1).getRole());
+        assertEquals("Normal answer", result.getMessages().get(1).getContent());
+    }
+
+    @Test
+    void testGetHistory_WithBlankResponse_ShouldSkipExchange() {
+        // Given: a response that saved no content at all
+        ChatReqModelDto req = new ChatReqModelDto();
+        req.setId(5L);
+        req.setMessage("Question with lost answer");
+
+        ChatRespModelDto blankResp = new ChatRespModelDto();
+        blankResp.setReqId(5L);
+        blankResp.setMessage("");
+
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(5L)))
+                .thenReturn(Arrays.asList(blankResp));
+
+        // When
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(req));
+
+        // Then
+        assertTrue(result.getMessages().isEmpty());
+    }
+
+    @Test
     void testGetHistory_WithNullReqList_ShouldReturnEmptyList() {
         // When
         ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, null);

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
@@ -352,10 +352,10 @@ class ChatHistoryServiceImplTest {
         // When
         ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(req));
 
-        // Then
+        // Then: both turns survive; the question is inserted last so it leads
         assertEquals(2, result.getMessages().size());
-        assertEquals("assistant", result.getMessages().get(0).getRole());
-        assertEquals("user", result.getMessages().get(1).getRole());
+        assertEquals("user", result.getMessages().get(0).getRole());
+        assertEquals("assistant", result.getMessages().get(1).getRole());
     }
 
     @Test

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
@@ -284,6 +284,81 @@ class ChatHistoryServiceImplTest {
     }
 
     @Test
+    void testGetHistory_WithMultimodalContentAndNeedHis1_ShouldSkipExchange() {
+        // Given: needHis == 1 appends no assistant message at all, so replaying the
+        // question alone would leave two consecutive user turns
+        ChatReqModelDto req = new ChatReqModelDto();
+        req.setId(6L);
+        req.setMessage("Question");
+
+        ChatRespModelDto resp = new ChatRespModelDto();
+        resp.setReqId(6L);
+        resp.setMessage("Answer");
+        resp.setContent("multimodal content");
+        resp.setNeedHis(1);
+
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(6L)))
+                .thenReturn(Arrays.asList(resp));
+
+        // When
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(req));
+
+        // Then
+        assertTrue(result.getMessages().isEmpty());
+    }
+
+    @Test
+    void testGetHistory_WithMultimodalContentAndNeedHis2ButBlankMessage_ShouldSkipExchange() {
+        // Given: needHis == 2 appends respDto.getMessage(), which is blank here
+        ChatReqModelDto req = new ChatReqModelDto();
+        req.setId(7L);
+        req.setMessage("Question");
+
+        ChatRespModelDto resp = new ChatRespModelDto();
+        resp.setReqId(7L);
+        resp.setMessage("");
+        resp.setContent("multimodal content");
+        resp.setNeedHis(2);
+
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(7L)))
+                .thenReturn(Arrays.asList(resp));
+
+        // When
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(req));
+
+        // Then
+        assertTrue(result.getMessages().isEmpty());
+    }
+
+    @Test
+    void testGetHistory_WithMultimodalContentAndNeedHis0_ShouldKeepExchange() {
+        // Given: needHis == 0 appends the multimodal assistant turn, so it must survive
+        ChatReqModelDto req = new ChatReqModelDto();
+        req.setId(8L);
+        req.setMessage("Question");
+
+        ChatRespModelDto resp = new ChatRespModelDto();
+        resp.setReqId(8L);
+        resp.setMessage("");
+        resp.setContent("multimodal content");
+        resp.setUrl("http://example.com/response.jpg");
+        resp.setType("image");
+        resp.setDataId("data456");
+        resp.setNeedHis(0);
+
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(8L)))
+                .thenReturn(Arrays.asList(resp));
+
+        // When
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(req));
+
+        // Then
+        assertEquals(2, result.getMessages().size());
+        assertEquals("assistant", result.getMessages().get(0).getRole());
+        assertEquals("user", result.getMessages().get(1).getRole());
+    }
+
+    @Test
     void testGetHistory_WithNullReqList_ShouldReturnEmptyList() {
         // When
         ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, null);


### PR DESCRIPTION
Fixes #1539

## Summary

- Skip history exchanges whose request carries no content (blank message and no attachment) and exchanges whose response saved no content, when building the chat history that is replayed to the workflow service.

## Root cause

When a workflow chat request comes in with an empty `AGENT_USER_INPUT`, the request record is persisted **before** the workflow call (`WorkflowBotChatServiceImpl.chatWorkflowBot`). The workflow service then rejects the run for the missing required input, and `WorkflowListener` appends the fallback error text and saves it as the response on the end frame. That leaves a durable pair in this chat's history: an **empty user message** + an error answer.

`ChatHistoryServiceImpl.getHistory` replayed that pair on every subsequent request, the workflow service rejected the blank user message each time, and the session became permanently unusable — exactly the behavior reported in #1539.

## Fix

`getHistory` already skips requests that have no response; this change extends the same guard to blank exchanges, so one failed request no longer poisons the rest of the session. This also heals already-poisoned sessions, since the history is rebuilt from records on every request.

## Tests

- `testGetHistory_WithBlankRequestMessage_ShouldSkipExchange` — the failed pair is dropped, the surrounding normal exchange is kept intact.
- `testGetHistory_WithBlankResponse_ShouldSkipExchange` — a pair whose response saved no content is dropped.
