### PR TITLE
feat(ci): add boilerplate license header checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,13 +474,33 @@ jobs:
           chmod +x makefiles/check-comments.sh
           ./makefiles/check-comments.sh
 
+  boilerplate-check:
+    name: 📜 Boilerplate Check
+    runs-on: ubuntu-latest
+    needs: [detect-projects]
+    if: needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check license headers
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'origin/main' }}
+        run: |
+          echo "📜 Checking license headers on newly added files..."
+          chmod +x makefiles/check-boilerplate.sh
+          ./makefiles/check-boilerplate.sh
+
   # ============================================================================
   # Stage 5: Summary
   # ============================================================================
   summary:
     name: 📊 Summary
     runs-on: ubuntu-latest
-    needs: [detect-projects, check, test, comment-check]
+    needs: [detect-projects, check, test, comment-check, boilerplate-check]
     if: always() && needs.detect-projects.outputs.has-projects == 'true'
     timeout-minutes: 2
     steps:
@@ -492,13 +512,15 @@ jobs:
           echo "🔍 Quality Checks: ${{ needs.check.result }}"
           echo "🧪 Tests: ${{ needs.test.result }}"
           echo "💬 Comment Check: ${{ needs.comment-check.result }} (temporarily disabled)"
+          echo "📜 Boilerplate Check: ${{ needs.boilerplate-check.result }}"
           echo ""
 
           # Check overall success (comment-check is temporarily disabled, so we accept 'skipped')
           if [[ "${{ needs.detect-projects.result }}" == "success" && \
                 "${{ needs.check.result }}" == "success" && \
                 "${{ needs.test.result }}" == "success" && \
-                ("${{ needs.comment-check.result }}" == "success" || "${{ needs.comment-check.result }}" == "skipped") ]]; then
+                ("${{ needs.comment-check.result }}" == "success" || "${{ needs.comment-check.result }}" == "skipped") && \
+                "${{ needs.boilerplate-check.result }}" == "success" ]]; then
             echo "✅ 🎉 All checks passed! Ready for merge."
           else
             echo "❌ 🚨 Some checks failed. Please review the logs."

--- a/makefiles/boilerplate/boilerplate.go.txt
+++ b/makefiles/boilerplate/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright YEAR iFlytek Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/makefiles/boilerplate/boilerplate.java.txt
+++ b/makefiles/boilerplate/boilerplate.java.txt
@@ -1,0 +1,15 @@
+/*
+Copyright YEAR iFlytek Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/makefiles/boilerplate/boilerplate.py.txt
+++ b/makefiles/boilerplate/boilerplate.py.txt
@@ -1,0 +1,13 @@
+# Copyright YEAR iFlytek Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/makefiles/boilerplate/boilerplate.sh.txt
+++ b/makefiles/boilerplate/boilerplate.sh.txt
@@ -1,0 +1,13 @@
+# Copyright YEAR iFlytek Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/makefiles/boilerplate/boilerplate.ts.txt
+++ b/makefiles/boilerplate/boilerplate.ts.txt
@@ -1,0 +1,15 @@
+/*
+Copyright YEAR iFlytek Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/makefiles/check-boilerplate.sh
+++ b/makefiles/check-boilerplate.sh
@@ -75,11 +75,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Paths that are vendored, generated or otherwise not ours to license
+# Paths that are vendored, generated or otherwise not ours to license.
+# Each directory is listed twice so it matches at the repository root as well
+# as nested, because '*/name/*' cannot match a path that starts with 'name/'.
 is_excluded() {
     case "$1" in
-        */node_modules/*|*/dist/*|*/build/*|*/target/*|*/.venv/*|*/venv/*) return 0 ;;
-        */__pycache__/*|*/migrations/*|helm/*|*/generated/*|*.min.js) return 0 ;;
+        node_modules/*|*/node_modules/*) return 0 ;;
+        dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*) return 0 ;;
+        .venv/*|*/.venv/*|venv/*|*/venv/*) return 0 ;;
+        __pycache__/*|*/__pycache__/*) return 0 ;;
+        migrations/*|*/migrations/*|generated/*|*/generated/*) return 0 ;;
+        helm/*|*.min.js) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -104,11 +110,15 @@ collect_files() {
         git -C "$REPO_ROOT" ls-files
     else
         local merge_base
-        if merge_base="$(git -C "$REPO_ROOT" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
-            git -C "$REPO_ROOT" diff --diff-filter=A --name-only "$merge_base" HEAD
-        else
-            echo -e "${YELLOW}⚠️  Cannot resolve $BASE_REF, nothing to check${RESET}" >&2
+        if ! merge_base="$(git -C "$REPO_ROOT" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
+            # Failing closed matters: a shallow clone would otherwise check
+            # nothing and report success, silently disabling the CI gate
+            echo -e "${RED}❌ Cannot resolve a merge base with $BASE_REF.${RESET}" >&2
+            echo -e "${YELLOW}   Fetch the base branch first (fetch-depth: 0 in GitHub Actions),${RESET}" >&2
+            echo -e "${YELLOW}   or pass --all to scan every tracked file instead.${RESET}" >&2
+            return 1
         fi
+        git -C "$REPO_ROOT" diff --diff-filter=A --name-only "$merge_base" HEAD
     fi
 }
 
@@ -195,6 +205,12 @@ missing=0
 checked=0
 fixed=0
 
+# Collect first rather than piping through process substitution: a subshell
+# would swallow a non-zero exit from collect_files and report a false pass
+if ! files_list="$(collect_files)"; then
+    exit 1
+fi
+
 while IFS= read -r file; do
     [[ -z "$file" || ! -f "$REPO_ROOT/$file" ]] && continue
     is_excluded "$file" && continue
@@ -215,7 +231,7 @@ while IFS= read -r file; do
         echo -e "${RED}  ✗ missing header: $file${RESET}"
         missing=$((missing + 1))
     fi
-done < <(collect_files)
+done <<< "$files_list"
 
 echo ""
 echo -e "${BLUE}   Files inspected: $checked${RESET}"

--- a/makefiles/check-boilerplate.sh
+++ b/makefiles/check-boilerplate.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Copyright 2026 iFlytek Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# Boilerplate Checker - License Header Enforcement
+# =============================================================================
+#
+# Usage:
+#   ./makefiles/check-boilerplate.sh                 Check files added in this
+#                                                    branch (default)
+#   ./makefiles/check-boilerplate.sh --all           Check every tracked file
+#   ./makefiles/check-boilerplate.sh --fix [--all]   Insert missing headers
+#   ./makefiles/check-boilerplate.sh path/to/file    Check the given files only
+#
+# The default mode only looks at files ADDED relative to the base branch, so
+# existing files without a header never fail the build. Run with --all to see
+# the full backlog.
+#
+# Base branch for the added-files diff can be overridden with BASE_REF.
+# =============================================================================
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RESET='\033[0m'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BOILERPLATE_DIR="$REPO_ROOT/makefiles/boilerplate"
+BASE_REF="${BASE_REF:-origin/main}"
+
+MODE="changed"
+FIX=false
+EXPLICIT_FILES=()
+
+usage() {
+    cat <<'USAGE'
+Boilerplate Checker - License Header Enforcement
+
+Usage:
+  ./makefiles/check-boilerplate.sh                 Check files added in this
+                                                   branch (default)
+  ./makefiles/check-boilerplate.sh --all           Check every tracked file
+  ./makefiles/check-boilerplate.sh --fix [--all]   Insert missing headers
+  ./makefiles/check-boilerplate.sh path/to/file    Check the given files only
+
+The default mode only looks at files ADDED relative to the base branch, so
+existing files without a header never fail the build. Run with --all to see
+the full backlog. Override the diff base with BASE_REF.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --all) MODE="all"; shift ;;
+        --fix) FIX=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo -e "${RED}Unknown option: $1${RESET}" >&2; exit 2 ;;
+        *) EXPLICIT_FILES+=("$1"); shift ;;
+    esac
+done
+
+# Paths that are vendored, generated or otherwise not ours to license
+is_excluded() {
+    case "$1" in
+        */node_modules/*|*/dist/*|*/build/*|*/target/*|*/.venv/*|*/venv/*) return 0 ;;
+        */__pycache__/*|*/migrations/*|helm/*|*/generated/*|*.min.js) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Map a file to its boilerplate template, empty when the type is not covered
+template_for() {
+    case "$1" in
+        *.go) echo "$BOILERPLATE_DIR/boilerplate.go.txt" ;;
+        *.java) echo "$BOILERPLATE_DIR/boilerplate.java.txt" ;;
+        *.py) echo "$BOILERPLATE_DIR/boilerplate.py.txt" ;;
+        *.sh) echo "$BOILERPLATE_DIR/boilerplate.sh.txt" ;;
+        *.ts|*.tsx|*.js|*.jsx) echo "$BOILERPLATE_DIR/boilerplate.ts.txt" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Collect the files to inspect
+collect_files() {
+    if [[ ${#EXPLICIT_FILES[@]} -gt 0 ]]; then
+        printf '%s\n' "${EXPLICIT_FILES[@]}"
+    elif [[ "$MODE" == "all" ]]; then
+        git -C "$REPO_ROOT" ls-files
+    else
+        local merge_base
+        if merge_base="$(git -C "$REPO_ROOT" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
+            git -C "$REPO_ROOT" diff --diff-filter=A --name-only "$merge_base" HEAD
+        else
+            echo -e "${YELLOW}⚠️  Cannot resolve $BASE_REF, nothing to check${RESET}" >&2
+        fi
+    fi
+}
+
+# Compare the head of a file against its template, ignoring the copyright year
+has_boilerplate() {
+    local file="$1" template="$2"
+    python3 - "$file" "$template" <<'PYTHON'
+import re
+import sys
+
+file_path, template_path = sys.argv[1], sys.argv[2]
+
+with open(template_path, encoding="utf-8") as handle:
+    template = handle.read().strip().splitlines()
+
+try:
+    with open(file_path, encoding="utf-8") as handle:
+        content = handle.read()
+except (UnicodeDecodeError, FileNotFoundError):
+    # Unreadable files are reported as compliant; other tooling owns them
+    sys.exit(0)
+
+lines = content.splitlines()
+
+# A shebang and any encoding cookie legally precede the header
+while lines and (lines[0].startswith("#!") or "coding" in lines[0][:40]):
+    lines.pop(0)
+while lines and not lines[0].strip():
+    lines.pop(0)
+
+if len(lines) < len(template):
+    sys.exit(1)
+
+for expected, actual in zip(template, lines):
+    pattern = re.escape(expected).replace("YEAR", r"\d{4}(-\d{4})?")
+    if not re.fullmatch(pattern, actual.rstrip()):
+        sys.exit(1)
+
+sys.exit(0)
+PYTHON
+}
+
+# Insert the rendered template above the existing content
+insert_boilerplate() {
+    local file="$1" template="$2"
+    python3 - "$file" "$template" <<'PYTHON'
+import datetime
+import os
+import shutil
+import sys
+
+file_path, template_path = sys.argv[1], sys.argv[2]
+
+with open(template_path, encoding="utf-8") as handle:
+    header = handle.read().strip()
+header = header.replace("YEAR", str(datetime.date.today().year))
+
+with open(file_path, encoding="utf-8") as handle:
+    lines = handle.read().splitlines(keepends=True)
+
+prefix = []
+while lines and (lines[0].startswith("#!") or "coding" in lines[0][:40]):
+    prefix.append(lines.pop(0))
+
+body = "".join(lines).lstrip("\n")
+
+# Write through a temp file and rename, so rewriting a script that is
+# currently executing cannot corrupt the running interpreter's read
+temp_path = file_path + ".boilerplate.tmp"
+with open(temp_path, "w", encoding="utf-8") as handle:
+    handle.write("".join(prefix))
+    handle.write(header + "\n\n")
+    handle.write(body)
+shutil.copymode(file_path, temp_path)
+os.replace(temp_path, file_path)
+PYTHON
+}
+
+echo -e "${BLUE}📜 Checking license headers...${RESET}"
+[[ "$MODE" == "all" ]] && echo -e "${BLUE}   Scope: all tracked files${RESET}" \
+    || echo -e "${BLUE}   Scope: files added against $BASE_REF${RESET}"
+
+missing=0
+checked=0
+fixed=0
+
+while IFS= read -r file; do
+    [[ -z "$file" || ! -f "$REPO_ROOT/$file" ]] && continue
+    is_excluded "$file" && continue
+
+    template="$(template_for "$file")"
+    [[ -z "$template" ]] && continue
+
+    checked=$((checked + 1))
+    if has_boilerplate "$REPO_ROOT/$file" "$template"; then
+        continue
+    fi
+
+    if [[ "$FIX" == true ]]; then
+        insert_boilerplate "$REPO_ROOT/$file" "$template"
+        echo -e "${GREEN}  ✚ added header: $file${RESET}"
+        fixed=$((fixed + 1))
+    else
+        echo -e "${RED}  ✗ missing header: $file${RESET}"
+        missing=$((missing + 1))
+    fi
+done < <(collect_files)
+
+echo ""
+echo -e "${BLUE}   Files inspected: $checked${RESET}"
+
+if [[ "$FIX" == true ]]; then
+    echo -e "${GREEN}✅ Added headers to $fixed file(s)${RESET}"
+    exit 0
+fi
+
+if [[ $missing -gt 0 ]]; then
+    echo -e "${RED}❌ $missing file(s) are missing the license header${RESET}"
+    echo -e "${YELLOW}   Run './makefiles/check-boilerplate.sh --fix' to add them${RESET}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ All inspected files carry the license header${RESET}"


### PR DESCRIPTION
Fixes #621

## Summary

Adds a `boilerplate.txt` license-header checker and wires it into the CI pipeline as its own `📜 Boilerplate Check` job.

## Why the check is scoped to added files

No source file in the repository currently carries a license header (only `LICENSE` and `NOTICE` contain the Apache text). A repo-wide gate would therefore fail every build on day one, and back-filling headers across the whole multi-language tree in one PR would be an unreviewable diff.

So the checker defaults to files **added** against the base branch:

- Existing files are never touched — modifying a legacy file does not fail the build.
- New code has to comply, so the gap closes going forward instead of growing.
- `--all` shows the full backlog whenever the team wants to do a sweep.
- `--fix` inserts the header (stamping the current year) so back-filling is mechanical.

## What's included

- `makefiles/boilerplate/boilerplate.{go,java,py,sh,ts}.txt` — Apache 2.0 templates matching `NOTICE`, with a `YEAR` placeholder.
- `makefiles/check-boilerplate.sh` — the checker, following the existing `makefiles/check-comments.sh` conventions.
- `.github/workflows/ci.yml` — new job plus the summary gate.

Details worth noting:

- Shebangs and encoding cookies are preserved; the header is inserted after them.
- The year is matched as a wildcard (`YEAR` → `\d{4}` or `2024-2026`), so headers do not go stale.
- Vendored/generated paths (`node_modules`, `dist`, `target`, `migrations`, `helm/`, `*.min.js`, …) are excluded.
- `--fix` writes through a temp file and `os.replace`, so rewriting a script that is currently executing cannot corrupt the running interpreter.

## Validation

Exercised end to end in a scratch git repo:

| Case | Result |
| --- | --- |
| `--all` over files without headers | 3 violations reported, exit 1 |
| `--fix --all` then re-check | headers inserted, second run clean, exit 0 |
| Python file with shebang | shebang kept on line 1, header below |
| Modified legacy file + one new file | only the **new** file is flagged |
| Re-run after fix (idempotency) | no duplicate headers |
| `bash -n` on the checker, `yaml.safe_load` on `ci.yml` | both pass |

## Follow-ups (not in this PR)

Back-filling headers across existing files can be done incrementally per module with `--fix`; once a tree is clean it can be promoted to `--all` in CI.
