### PR TITLE
docs: register ja locale in VitePress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -191,14 +191,14 @@ export default defineConfig({
     ja: {
       label: "日本語",
       lang: "ja-JP",
-      link: "/ja/",
+      link: "/ja/README",
       title: "Astron Agent",
       description: "エンタープライズ向け・商用フレンドリーな Agentic Workflow 開発プラットフォームのドキュメントサイト。",
       themeConfig: {
         logo: "/logo-square.png",
         siteTitle: "Astron Agent",
         nav: [
-          { text: "ホーム", link: "/ja/" },
+          { text: "ホーム", link: "/ja/README" },
           { text: "プロジェクト概要", link: "/ja/README" }
         ],
         sidebar: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -187,6 +187,52 @@ export default defineConfig({
           copyright: "Copyright © iFLYTEK Astron Agent"
         }
       }
+    },
+    ja: {
+      label: "日本語",
+      lang: "ja-JP",
+      link: "/ja/",
+      title: "Astron Agent",
+      description: "エンタープライズ向け・商用フレンドリーな Agentic Workflow 開発プラットフォームのドキュメントサイト。",
+      themeConfig: {
+        logo: "/logo-square.png",
+        siteTitle: "Astron Agent",
+        nav: [
+          { text: "ホーム", link: "/ja/" },
+          { text: "プロジェクト概要", link: "/ja/README" }
+        ],
+        sidebar: [
+          {
+            text: "はじめに",
+            items: [
+              { text: "プロジェクト概要", link: "/ja/README" }
+            ]
+          }
+        ],
+        socialLinks,
+        search: {
+          provider: "local"
+        },
+        editLink: {
+          pattern: editLinkPattern,
+          text: "GitHub でこのページを編集"
+        },
+        langMenuLabel: "言語",
+        returnToTopLabel: "ページトップに戻る",
+        sidebarMenuLabel: "メニュー",
+        darkModeSwitchLabel: "テーマ",
+        outline: {
+          label: "ページ内ナビゲーション"
+        },
+        docFooter: {
+          prev: "前のページ",
+          next: "次のページ"
+        },
+        footer: {
+          message: "Apache 2.0 Licensed.",
+          copyright: "Copyright © iFLYTEK Astron Agent"
+        }
+      }
     }
   }
 });

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,5 +1,0 @@
----
-layout: astron-home
-title: Astron Agent
-description: エンタープライズ向け・商用フレンドリーな Agentic Workflow 開発プラットフォームのドキュメントサイト。
----

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,5 @@
+---
+layout: astron-home
+title: Astron Agent
+description: エンタープライズ向け・商用フレンドリーな Agentic Workflow 開発プラットフォームのドキュメントサイト。
+---


### PR DESCRIPTION
## What this PR does

Registers the Japanese locale in the VitePress config so that `docs/ja/` pages appear in the language switcher.

## Changes

1. **`docs/.vitepress/config.mts`** — Added `ja` locale block with:
   - Language label: 日本語 (`ja-JP`)
   - Minimal nav and sidebar pointing only to `/ja/README` (the only page that currently exists under `docs/ja/`)
   - All UI strings translated to Japanese

2. **`docs/ja/index.md`** — Created the locale index page (mirrors `docs/zh/index.md` structure)

## Why minimal nav/sidebar?

The issue notes that `docs/ja/` currently only has `README.md`. Copying the full `zh` nav/sidebar would produce 404s for all untranslated pages. The nav/sidebar can be expanded as more pages are translated in follow-up PRs.

## Verification

- [ ] `pnpm docs:build` succeeds with no dead-link errors
- [ ] Language switcher shows English / 简体中文 / 日本語
- [ ] Selecting 日本語 lands on the Japanese page with `lang="ja-JP"`
- [ ] All nav/sidebar entries resolve to existing files

Fixes #1542