### PR TITLE
fix(knowledge): load platform config from persistent storage

### DIFF
--- a/core/knowledge/domain/platform_account_config.py
+++ b/core/knowledge/domain/platform_account_config.py
@@ -1,14 +1,186 @@
+import json
+import os
 from contextvars import ContextVar
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from loguru import logger
+
+KNOWLEDGE_PLATFORM_CACHE_KEY = "platform_account_text:knowledge_platform"
+PLATFORM_ACCOUNT_CATEGORY = "PLATFORM_ACCOUNT"
+KNOWLEDGE_PLATFORM_CODE = "KNOWLEDGE_PLATFORM"
 
 _PLATFORM_ACCOUNT_CONFIG: ContextVar[Dict[str, Any]] = ContextVar(
     "platform_account_config", default={}
 )
+_PLATFORM_ACCOUNT_FALLBACK: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "platform_account_fallback", default=None
+)
+_REDIS_CLIENT = None
 
 
 def set_platform_account_config(config: Dict[str, Any]) -> None:
     _PLATFORM_ACCOUNT_CONFIG.set(config)
+    _PLATFORM_ACCOUNT_FALLBACK.set(None)
 
 
 def get_config_value(section: str, key: str, default: Optional[Any] = None) -> Any:
-    return _PLATFORM_ACCOUNT_CONFIG.get({}).get(section, {}).get(key, default)
+    value = _section_value(_PLATFORM_ACCOUNT_CONFIG.get({}), section, key)
+    if value not in (None, ""):
+        return value
+
+    fallback = _PLATFORM_ACCOUNT_FALLBACK.get()
+    if fallback is None:
+        fallback = _load_from_redis() or _load_from_database() or {}
+        _PLATFORM_ACCOUNT_FALLBACK.set(fallback)
+    value = _section_value(fallback, section, key)
+    return default if value in (None, "") else value
+
+
+def _section_value(config: Dict[str, Any], section: str, key: str) -> Any:
+    section_config = config.get(section, {})
+    if not isinstance(section_config, dict):
+        return None
+    if key in section_config:
+        return section_config[key]
+    camel_key = _snake_to_camel(key)
+    return section_config.get(camel_key)
+
+
+def _snake_to_camel(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(part.capitalize() for part in tail)
+
+
+def _load_from_redis() -> Optional[Dict[str, Any]]:
+    try:
+        client = _redis_client()
+        if client is None:
+            return None
+        raw_config = client.get(KNOWLEDGE_PLATFORM_CACHE_KEY)
+        if isinstance(raw_config, bytes):
+            raw_config = raw_config.decode("utf-8")
+        if not raw_config:
+            return None
+        config = json.loads(raw_config)
+        return config if isinstance(config, dict) else None
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning(f"Invalid knowledge platform config in Redis: {exc}")
+        return None
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning(f"Failed to read knowledge platform config from Redis: {exc}")
+        return None
+
+
+def _load_from_database() -> Optional[Dict[str, Any]]:
+    try:
+        import pymysql  # type: ignore[import-untyped]
+
+        connection = pymysql.connect(
+            host=os.getenv("MYSQL_HOST", "mysql"),
+            port=int(os.getenv("MYSQL_PORT", "3306")),
+            user=os.getenv("MYSQL_USER", "root"),
+            password=os.getenv("MYSQL_PASSWORD", ""),
+            database=_console_mysql_database(),
+            charset="utf8mb4",
+            cursorclass=pymysql.cursors.DictCursor,
+        )
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT `value`
+                    FROM config_info
+                    WHERE category = %s AND code = %s AND is_valid = 1
+                    ORDER BY update_time DESC
+                    LIMIT 1
+                    """,
+                    (PLATFORM_ACCOUNT_CATEGORY, KNOWLEDGE_PLATFORM_CODE),
+                )
+                row = cursor.fetchone()
+                raw_config = row.get("value") if row else None
+                if not raw_config:
+                    return None
+                config = json.loads(raw_config)
+                if not isinstance(config, dict):
+                    return None
+                _store_to_redis(raw_config)
+                return config
+        finally:
+            connection.close()
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning(f"Invalid knowledge platform config in database: {exc}")
+        return None
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning(f"Failed to read knowledge platform config from database: {exc}")
+        return None
+
+
+def _store_to_redis(raw_config: str) -> None:
+    try:
+        client = _redis_client()
+        if client is not None:
+            client.set(KNOWLEDGE_PLATFORM_CACHE_KEY, raw_config)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning(f"Failed to cache knowledge platform config in Redis: {exc}")
+
+
+def _redis_client():  # type: ignore[no-untyped-def]
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        return _REDIS_CLIENT
+
+    redis_cluster_addr = os.getenv("REDIS_CLUSTER_ADDR", "")
+    redis_addr = os.getenv("REDIS_ADDR", "redis:6379")
+    redis_password = os.getenv("REDIS_PASSWORD") or None
+
+    if redis_cluster_addr:
+        from rediscluster import RedisCluster
+
+        startup_nodes = []
+        for item in redis_cluster_addr.split(","):
+            host, port = item.strip().split(":", 1)
+            startup_nodes.append({"host": host, "port": port})
+        _REDIS_CLIENT = RedisCluster(
+            startup_nodes=startup_nodes,
+            password=redis_password,
+            decode_responses=True,
+        )
+        return _REDIS_CLIENT
+
+    if redis_addr:
+        import redis
+
+        host, port = redis_addr.split(":", 1)
+        _REDIS_CLIENT = redis.Redis(
+            host=host,
+            port=int(port),
+            password=redis_password,
+            db=_redis_database(),
+            decode_responses=True,
+        )
+        return _REDIS_CLIENT
+
+    return None
+
+
+def _redis_database() -> int:
+    value = os.getenv("REDIS_DATABASE_CONSOLE") or os.getenv("REDIS_DATABASE") or "0"
+    try:
+        return int(value)
+    except ValueError:
+        return 0
+
+
+def _console_mysql_database() -> str:
+    explicit = os.getenv("CONSOLE_MYSQL_DB")
+    if explicit:
+        return explicit
+
+    mysql_url = os.getenv("MYSQL_URL", "")
+    if mysql_url.startswith("jdbc:"):
+        mysql_url = mysql_url[5:]
+    parsed = urlparse(mysql_url)
+    if parsed.path and parsed.path != "/":
+        return parsed.path.lstrip("/")
+    return "astron_console"

--- a/core/knowledge/pyproject.toml
+++ b/core/knowledge/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pydantic==2.9.2",
     "pydantic-settings==2.10.1",
     "pylint>=3.3.8",
+    "pymysql>=1.1.1",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",

--- a/core/knowledge/tests/domain/platform_account_config_test.py
+++ b/core/knowledge/tests/domain/platform_account_config_test.py
@@ -1,0 +1,128 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from knowledge.domain import platform_account_config
+
+
+def setup_function() -> None:
+    platform_account_config._REDIS_CLIENT = None
+    platform_account_config.set_platform_account_config({})
+
+
+def test_request_header_config_takes_precedence_over_redis() -> None:
+    platform_account_config.set_platform_account_config(
+        {"ragflow": {"base_url": "http://request-ragflow"}}
+    )
+
+    with patch.object(platform_account_config, "_load_from_redis") as loader:
+        value = platform_account_config.get_config_value("ragflow", "base_url")
+
+    assert value == "http://request-ragflow"
+    loader.assert_not_called()
+
+
+def test_missing_request_headers_fall_back_to_shared_platform_account_config() -> None:
+    redis_client = MagicMock()
+    redis_client.get.return_value = json.dumps(
+        {
+            "ragflow": {
+                "baseUrl": "http://managed-ragflow",
+                "apiToken": "managed-token",
+                "timeout": 45,
+                "defaultGroup": "managed-group",
+            }
+        }
+    )
+    platform_account_config.set_platform_account_config(
+        {"ragflow": {"base_url": "", "api_token": ""}}
+    )
+
+    with patch.object(
+        platform_account_config, "_redis_client", return_value=redis_client
+    ):
+        assert (
+            platform_account_config.get_config_value("ragflow", "base_url")
+            == "http://managed-ragflow"
+        )
+        assert (
+            platform_account_config.get_config_value("ragflow", "api_token")
+            == "managed-token"
+        )
+        assert platform_account_config.get_config_value("ragflow", "timeout") == 45
+        assert (
+            platform_account_config.get_config_value("ragflow", "default_group")
+            == "managed-group"
+        )
+
+    redis_client.get.assert_called_once_with(
+        platform_account_config.KNOWLEDGE_PLATFORM_CACHE_KEY
+    )
+
+
+def test_redis_miss_falls_back_to_persistent_database_config() -> None:
+    database_config = {
+        "ragflow": {
+            "baseUrl": "http://database-ragflow",
+            "apiToken": "database-token",
+        }
+    }
+
+    with patch.object(
+        platform_account_config, "_load_from_redis", return_value=None
+    ), patch.object(
+        platform_account_config,
+        "_load_from_database",
+        return_value=database_config,
+    ) as database_loader:
+        assert (
+            platform_account_config.get_config_value("ragflow", "base_url")
+            == "http://database-ragflow"
+        )
+        assert (
+            platform_account_config.get_config_value("ragflow", "api_token")
+            == "database-token"
+        )
+
+    database_loader.assert_called_once_with()
+
+
+def test_database_loader_reads_console_config_and_backfills_redis() -> None:
+    raw_config = json.dumps(
+        {
+            "ragflow": {
+                "baseUrl": "http://database-ragflow",
+                "apiToken": "database-token",
+            }
+        }
+    )
+    cursor = MagicMock()
+    cursor.fetchone.return_value = {"value": raw_config}
+    connection = MagicMock()
+    connection.cursor.return_value.__enter__.return_value = cursor
+
+    with patch("pymysql.connect", return_value=connection), patch.object(
+        platform_account_config, "_store_to_redis"
+    ) as cache_store:
+        config = platform_account_config._load_from_database()
+
+    assert config == json.loads(raw_config)
+    assert cursor.execute.call_args.args[1] == (
+        platform_account_config.PLATFORM_ACCOUNT_CATEGORY,
+        platform_account_config.KNOWLEDGE_PLATFORM_CODE,
+    )
+    cache_store.assert_called_once_with(raw_config)
+    connection.close.assert_called_once_with()
+
+
+def test_invalid_redis_config_preserves_caller_default() -> None:
+    redis_client = MagicMock()
+    redis_client.get.return_value = "not-json"
+
+    with patch.object(
+        platform_account_config, "_redis_client", return_value=redis_client
+    ), patch.object(platform_account_config, "_load_from_database", return_value=None):
+        value = platform_account_config.get_config_value(
+            "ragflow", "base_url", "legacy-default"
+        )
+
+    assert value == "legacy-default"

--- a/core/knowledge/uv.lock
+++ b/core/knowledge/uv.lock
@@ -830,6 +830,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pylint" },
+    { name = "pymysql" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -872,6 +873,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.9.2" },
     { name = "pydantic-settings", specifier = "==2.10.1" },
     { name = "pylint", specifier = ">=3.3.8" },
+    { name = "pymysql", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -1446,6 +1448,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/58/1f614a84d3295c542e9f6e2c764533eea3f318f4592dc1ea06c797114767/pylint-3.3.8.tar.gz", hash = "sha256:26698de19941363037e2937d3db9ed94fb3303fdadf7d98847875345a8bb6b05", size = 1523947, upload-time = "2025-08-09T09:12:57.234Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/1a/711e93a7ab6c392e349428ea56e794a3902bb4e0284c1997cff2d7efdbc1/pylint-3.3.8-py3-none-any.whl", hash = "sha256:7ef94aa692a600e82fabdd17102b73fc226758218c97473c7ad67bd4cb905d83", size = 523153, upload-time = "2025-08-09T09:12:54.836Z" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
 ]
 
 [[package]]

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -414,6 +414,16 @@ services:
     environment:
       SERVICE_PORT: "${CORE_KNOWLEDGE_PORT:-20010}"
       OTLP_ENABLE: "${OTLP_ENABLE:-0}"
+      REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
+      REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_DATABASE_CONSOLE: "${REDIS_DATABASE_CONSOLE:-0}"
+      MYSQL_HOST: "${MYSQL_HOST:-mysql}"
+      MYSQL_PORT: "${MYSQL_PORT:-3306}"
+      MYSQL_USER: "${MYSQL_USER:-root}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      CONSOLE_MYSQL_DB: "${CONSOLE_MYSQL_DB:-astron_console}"
+      MYSQL_URL: "${MYSQL_URL:-jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true}"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Summary:
- load knowledge-platform account settings from request context, Redis, then the persistent Console database
- repopulate Redis from persistent configuration after cache loss
- add runtime connectivity settings and focused regression tests