### PR TITLE
fix(agent): send space-id on the debug chat SSE request

### DIFF
--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -14,6 +14,7 @@ import { getLanguageCode } from '@/utils/http';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import eventBus from '@/utils/event-bus';
 import { baseURL } from '@/utils/http';
+import useSpaceStore from '@/store/space-store';
 import { ModelListData } from '@/services/spark-common';
 import {
   hasInvalidMcpServerUrls,
@@ -267,10 +268,20 @@ const PromptTry = forwardRef<
       let toolsName: string = ''; //工具名称
       const controller = new AbortController();
       controllerRef.current = controller;
-      const headerConfig = {
+      const headerConfig: Record<string, string> = {
         'Accept-Language': getLanguageCode(),
         authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       };
+      // Carry the current space context, mirroring the axios interceptor in
+      // utils/http.ts. Without space-id the backend resolves models in the
+      // personal scope and a space-scoped custom model reports "模型不存在".
+      const { spaceId, spaceType, enterpriseId } = useSpaceStore.getState();
+      if (spaceType === 'team' && enterpriseId) {
+        headerConfig['enterprise-id'] = enterpriseId;
+      }
+      if (spaceId) {
+        headerConfig['space-id'] = spaceId;
+      }
       setIsLoading(true);
       setIsCompleted(false);
       // 先追加用户消息


### PR DESCRIPTION
Fixes #1547

## Root cause

The agent debug chat opens its SSE stream with `fetchEventSource` in `console/frontend/src/components/prompt-try/index.tsx` and constructs its **own** header object:

```ts
const headerConfig = {
  'Accept-Language': getLanguageCode(),
  authorization: `Bearer ${localStorage.getItem('accessToken')}`,
};
```

Because it doesn't go through the axios instance, it bypasses the request interceptor in `utils/http.ts` that normally attaches `space-id` (and `enterprise-id` for team spaces) to every request. With no `space-id`, the backend resolves the model in the personal / no-space scope, so a model created inside a space is reported as `模型不存在` — exactly the reproduction in #1547.

## Fix

Attach the space context to the SSE headers, mirroring the interceptor's logic (`space-id` whenever a space is active, `enterprise-id` additionally for `team` spaces):

```ts
const { spaceId, spaceType, enterpriseId } = useSpaceStore.getState();
if (spaceType === 'team' && enterpriseId) {
  headerConfig['enterprise-id'] = enterpriseId;
}
if (spaceId) {
  headerConfig['space-id'] = spaceId;
}
```

Personal-scope behaviour is unchanged (`spaceId` empty → no header added, same as before).

## Scope

One file, frontend only. No API or backend change — the backend already reads `space-id` from other flows; this just makes the debug SSE request send it like every other request does.
