### PR TITLE
fix(workflow): allow zero LLM temperature

### DIFF
--- a/core/workflow/engine/nodes/base_node.py
+++ b/core/workflow/engine/nodes/base_node.py
@@ -1037,7 +1037,7 @@ class BaseLLMNode(BaseNode):
     apiSecret: str = Field(default="")
 
     url: str = Field(default="")
-    temperature: float = Field(gt=0, le=1, default=1.0)
+    temperature: float = Field(ge=0, le=1, default=1.0)
     maxTokens: int = Field(gt=0, default=2048)
     uid: str = Field(default="")
     template: str = Field(default="")

--- a/core/workflow/tests/engine/nodes/test_llm_node_validation.py
+++ b/core/workflow/tests/engine/nodes/test_llm_node_validation.py
@@ -1,0 +1,27 @@
+import pytest
+from pydantic import ValidationError
+
+from workflow.consts.engine.model_provider import ModelProviderEnum
+from workflow.engine.nodes.llm.spark_llm_node import SparkLLMNode
+
+
+def build_anthropic_node(temperature: float) -> SparkLLMNode:
+    return SparkLLMNode(
+        input_identifier=[],
+        output_identifier=["output"],
+        domain="test-model",
+        appId="test-app",
+        source=ModelProviderEnum.ANTHROPIC.value,
+        temperature=temperature,
+    )
+
+
+def test_anthropic_compatible_node_accepts_zero_temperature() -> None:
+    node = build_anthropic_node(0)
+
+    assert node.temperature == 0
+
+
+def test_llm_node_rejects_negative_temperature() -> None:
+    with pytest.raises(ValidationError):
+        build_anthropic_node(-0.1)


### PR DESCRIPTION
## Summary
- allow workflow LLM nodes to accept a zero temperature
- add regression coverage for zero and negative temperature values

## Verification
- not run locally, per user request