### PR TITLE
feat(console): add unified IP whitelist

### DIFF
--- a/console/backend/hub/src/main/resources/db/migration/V1.43__add_ip_white_list_config.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.43__add_ip_white_list_config.sql
@@ -1,0 +1,35 @@
+INSERT INTO config_info (
+    category, code, name, `value`, is_valid, remarks, create_time, update_time
+)
+SELECT
+    'IP_WHITE_LIST',
+    'ip_white_list',
+    'IP白名单',
+    '',
+    1,
+    '允许URL主机直接填写的精确IP或CIDR，多个值使用英文逗号分隔',
+    NOW(),
+    NOW()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM config_info
+    WHERE category = 'IP_WHITE_LIST' AND code = 'ip_white_list'
+);
+
+INSERT INTO config_info_en (
+    category, code, name, `value`, is_valid, remarks, create_time, update_time
+)
+SELECT
+    'IP_WHITE_LIST',
+    'ip_white_list',
+    'IP whitelist',
+    '',
+    1,
+    'Allowed exact IPs or CIDR ranges for IP-literal URL hosts, separated by commas',
+    NOW(),
+    NOW()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM config_info_en
+    WHERE category = 'IP_WHITE_LIST' AND code = 'ip_white_list'
+);

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
@@ -105,6 +105,7 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
     private static final String CODE_NODE_SWITCH = "switch";
 
     private static final String CAT_IP_BLACKLIST = "NETWORK_SEGMENT_BLACK_LIST";
+    private static final String CAT_IP_WHITELIST = "IP_WHITE_LIST";
     private static final String PROVIDER_OPENAI = "openai";
     private static final String PROVIDER_ANTHROPIC = "anthropic";
     private static final String PROVIDER_GOOGLE = "google";
@@ -248,22 +249,13 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
      */
     private String buildModelApiUrlNew(String baseUrl, String provider, String modelDomain) {
         try {
-            // Read IP blacklist from database
-            List<ConfigInfo> list = configInfoMapper.getListByCategory(CAT_IP_BLACKLIST);
-            String rawBlacklist = (list != null && !list.isEmpty()) ? list.getFirst().getValue() : "";
-            List<String> databaseBlacklist =
-                    StrUtil.isBlank(rawBlacklist)
-                            ? Collections.emptyList()
-                            : Arrays.stream(rawBlacklist.split(","))
-                                    .map(String::trim)
-                                    .filter(StrUtil::isNotBlank)
-                                    .toList();
-            // Merge database blacklist with default blacklist
-            List<String> mergedBlacklist = new ArrayList<>(databaseBlacklist);
+            List<String> ipBlacklist = loadIpRules(CAT_IP_BLACKLIST);
+            List<String> ipWhitelist = loadIpRules(CAT_IP_WHITELIST);
             SsrfProperties ssrfProperties = new SsrfProperties();
             // Note: The underlying object field name is ipBlaklist (third-party spelling), maintain
             // compatibility
-            ssrfProperties.setIpBlaklist(mergedBlacklist);
+            ssrfProperties.setIpBlaklist(ipBlacklist);
+            ssrfProperties.setIpWhitelist(ipWhitelist);
 
             // 0) Remove userInfo and normalize
             String stripped = SsrfValidators.stripUserInfo(baseUrl);
@@ -307,6 +299,19 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
             log.error("model url check failed: {}", e.getMessage(), e);
             throw new BusinessException(ResponseEnum.MODEL_CHECK_FAILED);
         }
+    }
+
+    private List<String> loadIpRules(String category) {
+        List<ConfigInfo> configs = configInfoMapper.getListByCategory(category);
+        String rawValue = (configs != null && !configs.isEmpty()) ? configs.getFirst().getValue() : "";
+        if (StrUtil.isBlank(rawValue)) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(rawValue.split(","))
+                .map(String::trim)
+                .filter(StrUtil::isNotBlank)
+                .distinct()
+                .toList();
     }
 
     private String appendPathSegment(String basePath, String appendPath) {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -182,6 +182,8 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
     private static final String FIELD_IS_LATEST = "isLatest";
     private static final String FIELD_LATEST_VER = "latestVersion";
     private static final String FIELD_CURR_VER = "currentVersion";
+    private static final String IP_BLACKLIST_CATEGORY = "NETWORK_SEGMENT_BLACK_LIST";
+    private static final String IP_WHITELIST_CATEGORY = "IP_WHITE_LIST";
 
     @Value("${spring.profiles.active}")
     String env;
@@ -1867,9 +1869,9 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
 
     // ========== 5. SSRF/URL validation ==========
     private void validateSsrfForNodes(BizWorkflowData bizWorkflowData) {
-        List<String> ipBlacklist = loadIpBlacklist();
         SsrfProperties ssrfProps = new SsrfProperties();
-        ssrfProps.setIpBlaklist(ipBlacklist);
+        ssrfProps.setIpBlaklist(loadIpRules(IP_BLACKLIST_CATEGORY));
+        ssrfProps.setIpWhitelist(loadIpRules(IP_WHITELIST_CATEGORY));
         SsrfParamGuard ssrfGuard = new SsrfParamGuard(ssrfProps);
 
         for (BizWorkflowNode node : bizWorkflowData.getNodes()) {
@@ -1900,8 +1902,8 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         }
     }
 
-    private List<String> loadIpBlacklist() {
-        List<ConfigInfo> cfgList = configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST");
+    private List<String> loadIpRules(String category) {
+        List<ConfigInfo> cfgList = configInfoMapper.getListByCategory(category);
         if (cfgList == null || cfgList.isEmpty() || StringUtils.isBlank(cfgList.get(0).getValue())) {
             return Collections.emptyList();
         }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -4,6 +4,7 @@ import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.toolkit.entity.table.ConfigInfo;
 import com.iflytek.astron.console.toolkit.mapper.ConfigInfoMapper;
+import com.iflytek.astron.console.toolkit.util.ssrf.SsrfValidators;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -52,6 +53,7 @@ public class UrlCheckTool {
     private static final String IP_CATEGORY = "IP_BLACK_LIST";
     private static final String NETWORK_SEGMENT_CATEGORY = "NETWORK_SEGMENT_BLACK_LIST";
     private static final String DOMAIN_WHITE_CATEGORY = "DOMAIN_WHITE_LIST";
+    private static final String IP_WHITE_CATEGORY = "IP_WHITE_LIST";
 
     // ===== Other constants =====
     private static final int CONNECT_TIMEOUT_MS = (int) Duration.ofSeconds(5).toMillis();
@@ -77,11 +79,15 @@ public class UrlCheckTool {
      * @return the redirected URL if redirect found, otherwise the original URL
      */
     public String getRedirectUrl(String url) {
+        return getRedirectUrl(url, readCsvConfig(IP_WHITE_CATEGORY));
+    }
+
+    protected String getRedirectUrl(String url, List<String> ipWhiteList) {
         if (StringUtils.isBlank(url))
             return url;
 
         try {
-            RedirectLookupResult result = lookupRedirect(url);
+            RedirectLookupResult result = lookupRedirect(url, ipWhiteList);
             if (REDIRECT_STATUS_CODES.contains(result.statusCode)
                     && StringUtils.isNotBlank(result.location)) {
                 return new URL(new URL(url), result.location).toString();
@@ -93,11 +99,11 @@ public class UrlCheckTool {
         return url;
     }
 
-    private RedirectLookupResult lookupRedirect(String url) throws IOException {
+    private RedirectLookupResult lookupRedirect(String url, List<String> ipWhiteList) throws IOException {
         HttpURLConnection conn = null;
         try {
             URL u = toSafeHttpUrl(url);
-            ensurePublicAddresses(u.getHost());
+            ensurePublicAddresses(u.getHost(), ipWhiteList);
             URLConnection urlConnection = u.openConnection();
             if (!(urlConnection instanceof HttpURLConnection httpURLConnection)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_HTTP_HTTPS_ONLY);
@@ -176,16 +182,18 @@ public class UrlCheckTool {
             List<String> ipBlackList = readCsvConfig(IP_CATEGORY);
             List<String> segmentBlackList = readCsvConfig(NETWORK_SEGMENT_CATEGORY);
             List<String> domainWhiteList = readCsvConfig(DOMAIN_WHITE_CATEGORY);
+            List<String> ipWhiteList = readCsvConfig(IP_WHITE_CATEGORY);
 
             String currentUrl = url;
             Set<String> visitedUrls = new HashSet<>();
             for (int i = 0; i <= MAX_REDIRECTS; i++) {
-                validateUrlPolicy(currentUrl, ipBlackList, segmentBlackList, domainWhiteList);
+                validateUrlPolicy(
+                        currentUrl, ipBlackList, segmentBlackList, domainWhiteList, ipWhiteList);
                 if (!visitedUrls.add(currentUrl)) {
                     throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
                 }
 
-                String redirectUrl = getRedirectUrl(currentUrl);
+                String redirectUrl = getRedirectUrl(currentUrl, ipWhiteList);
                 if (currentUrl.equals(redirectUrl)) {
                     return;
                 }
@@ -203,13 +211,15 @@ public class UrlCheckTool {
 
     private void validateUrlPolicy(String url, List<String> ipBlackList,
             List<String> segmentBlackList,
-            List<String> domainWhiteList) throws Exception {
+            List<String> domainWhiteList,
+            List<String> ipWhiteList) throws Exception {
         checkHttpOrHttps(url);
         symbolCheck(url);
         IPv4MappedCheck(url);
         checkUrlForIPv6(url);
         resolveShortLink(url);
-        validateUrlAgainstBlacklist(url, ipBlackList, segmentBlackList, domainWhiteList);
+        validateUrlAgainstBlacklist(
+                url, ipBlackList, segmentBlackList, domainWhiteList, ipWhiteList);
     }
 
     /**
@@ -223,7 +233,8 @@ public class UrlCheckTool {
      */
     private void validateUrlAgainstBlacklist(String url, List<String> ipBlackList,
             List<String> segmentBlackList,
-            List<String> domainWhiteList) throws Exception {
+            List<String> domainWhiteList,
+            List<String> ipWhiteList) throws Exception {
         URI uri = new URI(url);
         String host = uri.getHost();
         if (StringUtils.isBlank(host))
@@ -242,7 +253,12 @@ public class UrlCheckTool {
             throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
         }
         for (InetAddress inet : addresses) {
-            if (isRestrictedAddress(inet)) {
+            if (SsrfValidators.isIpLiteral(asciiHost)
+                    && SsrfValidators.isAddressMatchedByIpRules(inet, ipWhiteList)) {
+                log.debug("URL destination allowed by IP whitelist, host={}, ip={}", asciiHost, inet.getHostAddress());
+                continue;
+            }
+            if (SsrfValidators.isRestrictedAddress(inet)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
             }
             String ip = inet.getHostAddress();
@@ -521,24 +537,13 @@ public class UrlCheckTool {
         }
     }
 
-    private void ensurePublicAddresses(String host) throws UnknownHostException {
+    private void ensurePublicAddresses(String host, List<String> ipWhiteList) throws UnknownHostException {
+        boolean ipLiteral = SsrfValidators.isIpLiteral(host);
         for (InetAddress address : InetAddress.getAllByName(host)) {
-            if (isRestrictedAddress(address)) {
+            if (!(ipLiteral && SsrfValidators.isAddressMatchedByIpRules(address, ipWhiteList))
+                    && SsrfValidators.isRestrictedAddress(address)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
             }
         }
-    }
-
-    private boolean isRestrictedAddress(InetAddress address) {
-        return address.isAnyLocalAddress()
-                || address.isLoopbackAddress()
-                || address.isLinkLocalAddress()
-                || address.isSiteLocalAddress()
-                || address.isMulticastAddress()
-                || address.isMCGlobal()
-                || address.isMCLinkLocal()
-                || address.isMCNodeLocal()
-                || address.isMCOrgLocal()
-                || address.isMCSiteLocal();
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfParamGuard.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfParamGuard.java
@@ -64,10 +64,9 @@ public class SsrfParamGuard {
 
             // 2) IP blacklist (compatible with hostnames and IPs)
             List<String> ipBlacklist = props.getIpBlaklist();
-            if (!ipBlacklist.isEmpty()) {
-                if (SsrfValidators.isHostBlockedByIpBlacklist(u.getHost(), ipBlacklist, Dns.SYSTEM)) {
-                    throw new BusinessException(ResponseEnum.MODEL_URL_CHECK_FAILED);
-                }
+            if (SsrfValidators.isHostDeniedByIpPolicy(
+                    u.getHost(), ipBlacklist, props.getIpWhitelist(), Dns.SYSTEM)) {
+                throw new BusinessException(ResponseEnum.MODEL_URL_CHECK_FAILED);
             }
 
         } catch (BusinessException e) {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfProperties.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfProperties.java
@@ -36,6 +36,15 @@ public class SsrfProperties {
     private List<String> ipBlaklist = new ArrayList<>();
 
     /**
+     * IP addresses or CIDR ranges allowed to bypass IP blacklist checks.
+     *
+     * <p>
+     * The whitelist only affects destination IP policy. URL scheme and syntax validation still apply.
+     * </p>
+     */
+    private List<String> ipWhitelist = new ArrayList<>();
+
+    /**
      * Allowed URL schemes.
      *
      * <p>

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfValidators.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfValidators.java
@@ -33,6 +33,25 @@ public final class SsrfValidators {
     private static final Set<String> ALLOWED_SCHEMES =
             new HashSet<>(Arrays.asList("http", "https", "ws", "wss"));
 
+    private static final IpRules NON_PUBLIC_IP_RULES = parseIpRules(List.of(
+            "0.0.0.0/8",
+            "100.64.0.0/10",
+            "192.0.0.0/24",
+            "192.0.2.0/24",
+            "192.88.99.0/24",
+            "198.18.0.0/15",
+            "198.51.100.0/24",
+            "203.0.113.0/24",
+            "240.0.0.0/4",
+            "::/96",
+            "64:ff9b::/96",
+            "64:ff9b:1::/48",
+            "100::/64",
+            "2001::/23",
+            "2001:db8::/32",
+            "2002::/16",
+            "fc00::/7"));
+
     private SsrfValidators() {}
 
     /**
@@ -65,8 +84,24 @@ public final class SsrfValidators {
     public static boolean isIpLiteral(String host) {
         if (host == null)
             return false;
+        String literal = normalizeHostLiteral(host);
+        if (literal.contains(":")) {
+            try {
+                InetAddress.getByName(literal);
+                return true;
+            } catch (Exception ignore) {
+                return false;
+            }
+        }
+        if (!literal.matches("(?:\\d{1,3}\\.){3}\\d{1,3}")) {
+            return false;
+        }
         try {
-            InetAddress.getByName(host);
+            for (String octet : literal.split("\\.")) {
+                if (Integer.parseInt(octet) > 255) {
+                    return false;
+                }
+            }
             return true;
         } catch (Exception ignore) {
             return false;
@@ -153,6 +188,22 @@ public final class SsrfValidators {
      * @return true if in blacklist, false otherwise
      */
     public static boolean isHostBlockedByIpBlacklist(String host, List<String> ipBlacklist, Dns dns) {
+        return isHostBlockedByIpBlacklist(host, ipBlacklist, Collections.emptyList(), dns);
+    }
+
+    /**
+     * Check whether a host resolves to an IP blocked by the blacklist, with whitelist precedence. Every
+     * resolved address is evaluated independently, so one whitelisted address cannot hide a different
+     * blacklisted address returned by DNS.
+     *
+     * @param host target host or IP literal
+     * @param ipBlacklist blocked exact IPs or CIDR ranges
+     * @param ipWhitelist allowed exact IPs or CIDR ranges
+     * @param dns DNS implementation used for hostnames
+     * @return true if any non-whitelisted destination address is blacklisted
+     */
+    public static boolean isHostBlockedByIpBlacklist(
+            String host, List<String> ipBlacklist, List<String> ipWhitelist, Dns dns) {
         if (host == null || ipBlacklist == null || ipBlacklist.isEmpty())
             return false;
 
@@ -170,38 +221,128 @@ public final class SsrfValidators {
             if (targetIps.isEmpty())
                 return false;
 
-            // 2) Preprocess blacklist
-            Set<String> exactIpSet = new HashSet<>();
-            List<Cidr> cidrList = new ArrayList<>();
-            for (String entry : ipBlacklist) {
-                if (entry == null || entry.trim().isEmpty())
-                    continue;
-                String e = entry.trim();
-                if (e.contains("/")) {
-                    Cidr cidr = parseCidr(e);
-                    if (cidr != null)
-                        cidrList.add(cidr);
-                } else {
-                    String canon = canonicalIp(e);
-                    if (canon != null)
-                        exactIpSet.add(canon);
-                }
-            }
+            IpRules blacklistRules = parseIpRules(ipBlacklist);
+            IpRules whitelistRules = isIpLiteral(literal)
+                    ? parseIpRules(ipWhitelist)
+                    : parseIpRules(Collections.emptyList());
 
-            // 3) Match each IP
+            // 2) Match each IP. Whitelist precedence applies only to the matching address.
             for (InetAddress ip : targetIps) {
-                String canon = canonicalIp(ip);
-                if (canon != null && exactIpSet.contains(canon)) {
+                if (!matchesIpRules(ip, whitelistRules) && matchesIpRules(ip, blacklistRules)) {
                     return true;
-                }
-                for (Cidr cidr : cidrList) {
-                    if (ipInCidr(ip, cidr)) {
-                        return true;
-                    }
                 }
             }
         } catch (Exception ignore) {
             // Resolution failure / DNS exception treated as not hit; stricter handling can return true
+        }
+        return false;
+    }
+
+    /**
+     * Apply the complete destination IP policy used by model and workflow requests. Restricted
+     * addresses are denied by default, and explicit blacklist rules are applied to all other addresses.
+     * IP whitelist rules can only exempt an IP literal in the URL, avoiding a DNS name switching
+     * addresses between validation and connection.
+     *
+     * @param host target host or IP literal
+     * @param ipBlacklist blocked exact IPs or CIDR ranges
+     * @param ipWhitelist allowed exact IPs or CIDR ranges for IP-literal URLs
+     * @param dns DNS implementation used for hostnames
+     * @return true when the destination must be denied
+     */
+    public static boolean isHostDeniedByIpPolicy(
+            String host, List<String> ipBlacklist, List<String> ipWhitelist, Dns dns) {
+        if (host == null) {
+            return true;
+        }
+        try {
+            String literal = normalizeHostLiteral(host);
+            boolean ipLiteral = isIpLiteral(literal);
+            List<InetAddress> targetIps = ipLiteral
+                    ? Collections.singletonList(InetAddress.getByName(literal))
+                    : resolveAll(dns, literal);
+            if (targetIps.isEmpty()) {
+                return true;
+            }
+
+            IpRules blacklistRules = parseIpRules(ipBlacklist);
+            IpRules whitelistRules = ipLiteral
+                    ? parseIpRules(ipWhitelist)
+                    : parseIpRules(Collections.emptyList());
+            for (InetAddress ip : targetIps) {
+                if (matchesIpRules(ip, whitelistRules)) {
+                    continue;
+                }
+                if (isRestrictedAddress(ip) || matchesIpRules(ip, blacklistRules)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    /** Determine whether an address is local, private, link-local, or multicast. */
+    public static boolean isRestrictedAddress(InetAddress address) {
+        return address == null
+                || address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()
+                || address.isMCGlobal()
+                || address.isMCLinkLocal()
+                || address.isMCNodeLocal()
+                || address.isMCOrgLocal()
+                || address.isMCSiteLocal()
+                || matchesIpRules(address, NON_PUBLIC_IP_RULES);
+    }
+
+    /**
+     * Check whether an already resolved address matches an exact IP or CIDR rule. Invalid entries and
+     * hostnames are ignored.
+     *
+     * @param address resolved destination address
+     * @param rules exact IPs or CIDR ranges
+     * @return true when the address matches at least one valid rule
+     */
+    public static boolean isAddressMatchedByIpRules(InetAddress address, List<String> rules) {
+        return address != null && matchesIpRules(address, parseIpRules(rules));
+    }
+
+    private static IpRules parseIpRules(List<String> entries) {
+        Set<String> exactIpSet = new HashSet<>();
+        List<Cidr> cidrList = new ArrayList<>();
+        if (entries == null) {
+            return new IpRules(exactIpSet, cidrList);
+        }
+        for (String entry : entries) {
+            if (entry == null || entry.trim().isEmpty())
+                continue;
+            String value = entry.trim();
+            if (value.contains("/")) {
+                Cidr cidr = parseCidr(value);
+                if (cidr != null)
+                    cidrList.add(cidr);
+            } else {
+                String canonical = canonicalIp(value);
+                if (canonical != null)
+                    exactIpSet.add(canonical);
+            }
+        }
+        return new IpRules(exactIpSet, cidrList);
+    }
+
+    private static boolean matchesIpRules(InetAddress ip, IpRules rules) {
+        String canonical = canonicalIp(ip);
+        if (canonical != null && rules.exactIps.contains(canonical)) {
+            return true;
+        }
+        for (Cidr cidr : rules.cidrs) {
+            if (ipInCidr(ip, cidr)) {
+                return true;
+            }
         }
         return false;
     }
@@ -217,6 +358,9 @@ public final class SsrfValidators {
 
     /** Generate canonical IP string for IPv4/IPv6; return null if invalid. */
     private static String canonicalIp(String ipText) {
+        if (!isIpLiteral(ipText)) {
+            return null;
+        }
         try {
             return canonicalIp(InetAddress.getByName(ipText));
         } catch (Exception e) {
@@ -251,6 +395,8 @@ public final class SsrfValidators {
             String base = s.substring(0, slash).trim();
             int prefix = Integer.parseInt(s.substring(slash + 1).trim());
 
+            if (!isIpLiteral(base))
+                return null;
             InetAddress baseAddr = InetAddress.getByName(base);
             int maxBits = baseAddr.getAddress().length * 8;
             if (prefix < 0 || prefix > maxBits)
@@ -291,6 +437,16 @@ public final class SsrfValidators {
         Cidr(InetAddress network, int prefix) {
             this.network = network;
             this.prefix = prefix;
+        }
+    }
+
+    private static final class IpRules {
+        final Set<String> exactIps;
+        final List<Cidr> cidrs;
+
+        IpRules(Set<String> exactIps, List<Cidr> cidrs) {
+            this.exactIps = exactIps;
+            this.cidrs = cidrs;
         }
     }
 

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/model/ModelServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/model/ModelServiceTest.java
@@ -115,7 +115,7 @@ class ModelServiceTest {
         ModelValidationRequest req = new ModelValidationRequest();
         req.setId(100L);
         req.setApiKeyMasked(false); // Bypass decryptApiKey
-        req.setEndpoint("https://api.example.com"); // Will be appended with /v1/chat/completions
+        req.setEndpoint("https://8.8.8.8"); // Will be appended with /v1/chat/completions
         req.setDomain("gpt-4o-mini");
         req.setModelName("my-model");
         req.setUid("u1");
@@ -178,7 +178,7 @@ class ModelServiceTest {
         ModelValidationRequest req = new ModelValidationRequest();
         req.setId(101L);
         req.setApiKeyMasked(false);
-        req.setEndpoint("https://api.example.com/base");
+        req.setEndpoint("https://8.8.8.8/base");
         req.setDomain("gpt-4o");
         req.setModelName("m2");
         req.setUid("u1");
@@ -217,7 +217,7 @@ class ModelServiceTest {
         ModelValidationRequest req = new ModelValidationRequest();
         req.setId(102L);
         req.setApiKeyMasked(false);
-        req.setEndpoint("https://api.example.com"); // Will be appended with /v1/chat/completions
+        req.setEndpoint("https://8.8.8.8"); // Will be appended with /v1/chat/completions
         req.setDomain("gpt-4o");
         req.setModelName("m3");
         req.setUid("u1");
@@ -509,7 +509,7 @@ class ModelServiceTest {
         req.setId(null);
         req.setApiKeyMasked(null);
         req.setApiKey("ENCRYPTED_BASE64");
-        req.setEndpoint("https://api.example.com"); // Will be appended with /v1/chat/completions
+        req.setEndpoint("https://8.8.8.8"); // Will be appended with /v1/chat/completions
         req.setDomain("gpt-4o-mini");
         req.setModelName("my-new");
         req.setUid("u1");
@@ -649,6 +649,63 @@ class ModelServiceTest {
 
         BusinessException ex = assertThrows(BusinessException.class, () -> modelService.validateModel(req));
         assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void buildModelApiUrlAllowsIpInWhitelist() {
+        ConfigInfo blacklist = new ConfigInfo();
+        blacklist.setValue("192.168.0.0/16");
+        ConfigInfo whitelist = new ConfigInfo();
+        whitelist.setValue("192.168.60.12");
+        when(configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(List.of(blacklist));
+        when(configInfoMapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(List.of(whitelist));
+
+        String url = ReflectionTestUtils.invokeMethod(
+                modelService,
+                "buildModelApiUrlNew",
+                "http://192.168.60.12:5080",
+                "openai",
+                "local-model");
+
+        assertEquals("http://192.168.60.12:5080/v1/chat/completions", url);
+    }
+
+    @Test
+    void buildModelApiUrlRejectsIpOutsideWhitelist() {
+        ConfigInfo blacklist = new ConfigInfo();
+        blacklist.setValue("192.168.0.0/16");
+        ConfigInfo whitelist = new ConfigInfo();
+        whitelist.setValue("192.168.60.12");
+        when(configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(List.of(blacklist));
+        when(configInfoMapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(List.of(whitelist));
+
+        assertThrows(BusinessException.class, () -> ReflectionTestUtils.invokeMethod(
+                modelService,
+                "buildModelApiUrlNew",
+                "http://192.168.60.13:5080",
+                "openai",
+                "local-model"));
+    }
+
+    @Test
+    void buildModelApiUrlRejectsPrivateIpWhenBlacklistIsEmpty() {
+        ConfigInfo emptyConfig = new ConfigInfo();
+        emptyConfig.setValue("");
+        when(configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(List.of(emptyConfig));
+        when(configInfoMapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(List.of(emptyConfig));
+
+        assertThrows(BusinessException.class, () -> ReflectionTestUtils.invokeMethod(
+                modelService,
+                "buildModelApiUrlNew",
+                "http://192.168.60.12:5080",
+                "openai",
+                "local-model"));
     }
 
     /**

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceIpWhitelistTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceIpWhitelistTest.java
@@ -1,0 +1,73 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowData;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowNode;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizNodeData;
+import com.iflytek.astron.console.toolkit.entity.table.ConfigInfo;
+import com.iflytek.astron.console.toolkit.mapper.ConfigInfoMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WorkflowServiceIpWhitelistTest {
+
+    @Test
+    void workflowAllowsModelIpInWhitelist() {
+        WorkflowService service = serviceWithIpRules("192.168.0.0/16", "192.168.60.12");
+
+        assertDoesNotThrow(() -> validate(service, "http://192.168.60.12:5080"));
+    }
+
+    @Test
+    void workflowRejectsModelIpOutsideWhitelist() {
+        WorkflowService service = serviceWithIpRules("192.168.0.0/16", "192.168.60.12");
+
+        assertThrows(BusinessException.class, () -> validate(service, "http://192.168.60.13:5080"));
+    }
+
+    @Test
+    void workflowRejectsPrivateIpWhenBlacklistIsEmpty() {
+        WorkflowService service = serviceWithIpRules("", "");
+
+        assertThrows(BusinessException.class, () -> validate(service, "http://192.168.60.12:5080"));
+    }
+
+    private static WorkflowService serviceWithIpRules(String blacklist, String whitelist) {
+        ConfigInfoMapper mapper = mock(ConfigInfoMapper.class);
+        when(mapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(List.of(config(blacklist)));
+        when(mapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(List.of(config(whitelist)));
+        WorkflowService service = new WorkflowService();
+        ReflectionTestUtils.setField(service, "configInfoMapper", mapper);
+        return service;
+    }
+
+    private static void validate(WorkflowService service, String url) {
+        JSONObject nodeParam = new JSONObject();
+        nodeParam.put("url", url);
+        BizNodeData nodeData = new BizNodeData();
+        nodeData.setNodeParam(nodeParam);
+        BizWorkflowNode node = new BizWorkflowNode();
+        node.setId("http::test");
+        node.setData(nodeData);
+        BizWorkflowData workflowData = new BizWorkflowData();
+        workflowData.setNodes(List.of(node));
+
+        ReflectionTestUtils.invokeMethod(service, "validateSsrfForNodes", workflowData);
+    }
+
+    private static ConfigInfo config(String value) {
+        ConfigInfo config = new ConfigInfo();
+        config.setValue(value);
+        return config;
+    }
+}

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
@@ -78,11 +78,68 @@ class UrlCheckToolTest {
     }
 
     @Test
+    void checkBlackListAllowsWhitelistedRedirectTarget() {
+        ConfigInfoMapper mapper = mockConfigMapper(
+                "", "127.0.0.0/8,169.254.0.0/16", "127.0.0.1,169.254.169.254");
+        UrlCheckTool tool = new RedirectingUrlCheckTool(mapper, Map.of(
+                "http://127.0.0.1/start", "http://169.254.169.254/target"));
+
+        tool.checkBlackList("http://127.0.0.1/start");
+    }
+
+    @Test
+    void checkBlackListRejectsRedirectTargetOutsideWhitelist() {
+        ConfigInfoMapper mapper = mockConfigMapper(
+                "", "127.0.0.0/8,169.254.0.0/16", "127.0.0.1");
+        UrlCheckTool tool = new RedirectingUrlCheckTool(mapper, Map.of(
+                "http://127.0.0.1/start", "http://169.254.169.254/target"));
+
+        assertThrows(BusinessException.class,
+                () -> tool.checkBlackList("http://127.0.0.1/start"));
+    }
+
+    @Test
     void checkUrlRejectsLoopbackAddressDirectly() {
         ConfigInfoMapper mapper = mockConfigMapper("", "");
         UrlCheckTool tool = new UrlCheckTool(mapper);
 
         assertThrows(BusinessException.class, () -> tool.checkUrl("http://127.0.0.1/internal"));
+    }
+
+    @Test
+    void checkUrlAllowsIpInWhitelist() throws Exception {
+        ConfigInfoMapper mapper = mockConfigMapper("", "127.0.0.0/8", "127.0.0.1");
+        UrlCheckTool tool = new UrlCheckTool(mapper);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/allowed", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/allowed";
+            tool.checkUrl(url);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void checkUrlAllowsIpInWhitelistCidr() throws Exception {
+        ConfigInfoMapper mapper = mockConfigMapper("", "127.0.0.0/8", "127.0.0.0/8");
+        UrlCheckTool tool = new UrlCheckTool(mapper);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/allowed", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/allowed";
+            tool.checkUrl(url);
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
@@ -98,10 +155,16 @@ class UrlCheckToolTest {
     }
 
     private static ConfigInfoMapper mockConfigMapper(String ipBlackList, String segmentBlackList) {
+        return mockConfigMapper(ipBlackList, segmentBlackList, "");
+    }
+
+    private static ConfigInfoMapper mockConfigMapper(
+            String ipBlackList, String segmentBlackList, String ipWhiteList) {
         ConfigInfoMapper mapper = mock(ConfigInfoMapper.class);
         when(mapper.getListByCategory("IP_BLACK_LIST")).thenReturn(List.of(config(ipBlackList)));
         when(mapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST")).thenReturn(List.of(config(segmentBlackList)));
         when(mapper.getListByCategory("DOMAIN_WHITE_LIST")).thenReturn(Collections.emptyList());
+        when(mapper.getListByCategory("IP_WHITE_LIST")).thenReturn(List.of(config(ipWhiteList)));
         return mapper;
     }
 
@@ -120,7 +183,7 @@ class UrlCheckToolTest {
         }
 
         @Override
-        public String getRedirectUrl(String url) {
+        protected String getRedirectUrl(String url, List<String> ipWhiteList) {
             return redirects.getOrDefault(url, url);
         }
     }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfValidatorsTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfValidatorsTest.java
@@ -1,0 +1,79 @@
+package com.iflytek.astron.console.toolkit.util.ssrf;
+
+import okhttp3.Dns;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SsrfValidatorsTest {
+
+    @Test
+    void isIpLiteralDoesNotResolveHostname() {
+        assertFalse(SsrfValidators.isIpLiteral("localhost"));
+    }
+
+    @Test
+    void whitelistOverridesBlacklistForMatchingAddress() {
+        assertFalse(SsrfValidators.isHostBlockedByIpBlacklist(
+                "192.168.60.12",
+                List.of("192.168.0.0/16"),
+                List.of("192.168.60.12"),
+                Dns.SYSTEM));
+        assertFalse(SsrfValidators.isHostBlockedByIpBlacklist(
+                "192.168.60.12",
+                List.of("192.168.0.0/16"),
+                List.of("192.168.60.0/24"),
+                Dns.SYSTEM));
+    }
+
+    @Test
+    void privateAddressIsDeniedWithoutBlacklistUnlessLiteralIpIsWhitelisted() {
+        assertTrue(SsrfValidators.isHostDeniedByIpPolicy(
+                "192.168.60.12", List.of(), List.of(), Dns.SYSTEM));
+        assertFalse(SsrfValidators.isHostDeniedByIpPolicy(
+                "192.168.60.12", List.of(), List.of("192.168.60.12"), Dns.SYSTEM));
+    }
+
+    @Test
+    void specialUseAddressesAreDeniedByDefault() throws Exception {
+        assertTrue(SsrfValidators.isRestrictedAddress(InetAddress.getByName("fd00::1")));
+        assertTrue(SsrfValidators.isRestrictedAddress(InetAddress.getByName("100.64.0.1")));
+        assertTrue(SsrfValidators.isRestrictedAddress(InetAddress.getByName("0.1.2.3")));
+        assertTrue(SsrfValidators.isHostDeniedByIpPolicy(
+                "fd00::1", List.of(), List.of(), Dns.SYSTEM));
+        assertFalse(SsrfValidators.isHostDeniedByIpPolicy(
+                "fd00::1", List.of(), List.of("fc00::/7"), Dns.SYSTEM));
+    }
+
+    @Test
+    void hostnameCannotUseIpWhitelistToBypassPrivatePolicy() {
+        Dns dns = hostname -> List.of(InetAddress.getByName("192.168.60.12"));
+
+        assertTrue(SsrfValidators.isHostDeniedByIpPolicy(
+                "model.internal", List.of(), List.of("192.168.60.12"), dns));
+    }
+
+    @Test
+    void whitelistDoesNotHideAnotherBlacklistedDnsAddress() {
+        Dns dns = hostname -> List.of(
+                InetAddress.getByName("192.168.60.12"),
+                InetAddress.getByName("192.168.60.13"));
+
+        assertTrue(SsrfValidators.isHostDeniedByIpPolicy(
+                "model.internal",
+                List.of("192.168.0.0/16"),
+                List.of("192.168.60.12"),
+                dns));
+    }
+
+    @Test
+    void invalidWhitelistEntryDoesNotAllowAddress() throws Exception {
+        assertFalse(SsrfValidators.isAddressMatchedByIpRules(
+                InetAddress.getByName("192.168.60.12"),
+                List.of("model.internal", "192.168.60.0/not-a-prefix")));
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable `IP_WHITE_LIST` setting for exact IPs and CIDR ranges
- apply the same whitelist policy to plugin URLs, workflow validation, and local model endpoints
- keep private and special-use destinations blocked unless an IP-literal destination is explicitly allowed

## Testing
- add focused unit coverage for whitelist precedence, redirects, workflows, and model endpoints