### PR TITLE
fix(console): include space context in debug SSE requests

### DIFF
--- a/console/frontend/_tests_/prompt-try-sse-headers.test.ts
+++ b/console/frontend/_tests_/prompt-try-sse-headers.test.ts
@@ -1,0 +1,52 @@
+import { deepStrictEqual } from 'node:assert/strict';
+import { buildDebugSseHeaders } from '../src/components/prompt-try/request-headers';
+
+const baseContext = {
+  languageCode: 'zh-CN',
+  accessToken: 'test-token',
+};
+
+deepStrictEqual(
+  buildDebugSseHeaders({
+    ...baseContext,
+    spaceId: '42',
+    spaceType: 'team',
+    enterpriseId: '7',
+  }),
+  {
+    'Accept-Language': 'zh-CN',
+    authorization: 'Bearer test-token',
+    'space-id': '42',
+    'enterprise-id': '7',
+  },
+  'team-space debug requests should carry space and enterprise context'
+);
+
+deepStrictEqual(
+  buildDebugSseHeaders({
+    ...baseContext,
+    spaceId: '42',
+    spaceType: 'personal',
+    enterpriseId: '7',
+  }),
+  {
+    'Accept-Language': 'zh-CN',
+    authorization: 'Bearer test-token',
+    'space-id': '42',
+  },
+  'non-team debug requests should not carry stale enterprise context'
+);
+
+deepStrictEqual(
+  buildDebugSseHeaders({
+    ...baseContext,
+    spaceId: '',
+    spaceType: 'personal',
+    enterpriseId: '',
+  }),
+  {
+    'Accept-Language': 'zh-CN',
+    authorization: 'Bearer test-token',
+  },
+  'personal debug requests should omit empty space context'
+);

--- a/console/frontend/src/components/prompt-try/index.tsx
+++ b/console/frontend/src/components/prompt-try/index.tsx
@@ -22,6 +22,8 @@ import {
 import type { AgentSkill } from '@/types/skill';
 import type { AgentTool } from '@/types/plugin-store';
 import type { AgentWorkflow } from '@/types/agent-workflow';
+import useSpaceStore from '@/store/space-store';
+import { buildDebugSseHeaders } from './request-headers';
 
 // PromptTry组件暴露的方法接口
 export interface PromptTryRef {
@@ -267,10 +269,14 @@ const PromptTry = forwardRef<
       let toolsName: string = ''; //工具名称
       const controller = new AbortController();
       controllerRef.current = controller;
-      const headerConfig = {
-        'Accept-Language': getLanguageCode(),
-        authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      };
+      const { spaceId, spaceType, enterpriseId } = useSpaceStore.getState();
+      const headerConfig = buildDebugSseHeaders({
+        languageCode: getLanguageCode(),
+        accessToken: localStorage.getItem('accessToken'),
+        spaceId,
+        spaceType,
+        enterpriseId,
+      });
       setIsLoading(true);
       setIsCompleted(false);
       // 先追加用户消息

--- a/console/frontend/src/components/prompt-try/request-headers.ts
+++ b/console/frontend/src/components/prompt-try/request-headers.ts
@@ -1,0 +1,22 @@
+export interface DebugSseHeaderContext {
+  languageCode: string;
+  accessToken: string | null;
+  spaceId: string;
+  spaceType: string;
+  enterpriseId: string;
+}
+
+export const buildDebugSseHeaders = ({
+  languageCode,
+  accessToken,
+  spaceId,
+  spaceType,
+  enterpriseId,
+}: DebugSseHeaderContext): Record<string, string> => ({
+  'Accept-Language': languageCode,
+  authorization: `Bearer ${accessToken}`,
+  ...(spaceId ? { 'space-id': spaceId } : {}),
+  ...(spaceType === 'team' && enterpriseId
+    ? { 'enterprise-id': enterpriseId }
+    : {}),
+});


### PR DESCRIPTION
Forward space and enterprise context headers in prompt debug SSE requests, with regression coverage for team and personal spaces. Relates to #1547.