### PR TITLE
fix(workflow): handle usage-only OpenAI stream chunks

### DIFF
--- a/core/workflow/infra/providers/llm/openai/openai_chat_llm.py
+++ b/core/workflow/infra/providers/llm/openai/openai_chat_llm.py
@@ -81,11 +81,15 @@ class OpenAIChatAI(ChatAI):
         :param msg: Raw message dictionary from OpenAI API
         :return: Tuple containing (index, status, content, reasoning_content, token_usage)
         """
-        delta = msg["choices"][0]["delta"]
-        status = msg["choices"][0]["finish_reason"]
+        token_usage = msg.get("usage") or {}
+        choices = msg.get("choices") or []
+        if not choices:
+            return "", "", "", token_usage
+
+        delta = choices[0]["delta"]
+        status = choices[0]["finish_reason"]
         content = delta["content"]
         reasoning_content = delta.get("reasoning_content", "")
-        token_usage = {} if not msg["usage"] else msg["usage"]
         return status, content, reasoning_content, token_usage
 
     async def _recv_messages(
@@ -151,6 +155,7 @@ class OpenAIChatAI(ChatAI):
         timeout: float | None = None,
     ) -> AsyncIterator[LLMResponse]:
         last_frame_data = {}
+        latest_usage = {}
         is_first_frame = True
         start_time = None
 
@@ -178,22 +183,47 @@ class OpenAIChatAI(ChatAI):
                     {"recv": json.dumps(chunk.dict(), ensure_ascii=False)}
                 )
 
+                frame_data = chunk.dict()
+                usage = frame_data.get("usage") or {}
+                if usage:
+                    latest_usage = usage
+
+                # Usage-only chunks have no delta and cannot be consumed downstream.
+                if not (frame_data.get("choices") or []):
+                    continue
+
+                if latest_usage and not usage:
+                    frame_data = {**frame_data, "usage": latest_usage}
+
                 # Update last frame data and yield response
-                last_frame_data = chunk.dict()
+                last_frame_data = frame_data
                 yield LLMResponse(
                     msg=last_frame_data,
                 )
 
             except StopAsyncIteration:
                 # Stream ended, mark as finished and yield final response
-                last_frame_data["choices"] = [
-                    {
-                        "finish_reason": ChatStatus.FINISH_REASON.value,
-                        "delta": {"content": "", "reasoning_content": ""},
-                    }
-                ]
+                if not last_frame_data:
+                    raise CustomException(
+                        err_code=CodeEnum.OPEN_AI_REQUEST_ERROR,
+                        err_msg="LLM stream returned no data",
+                        cause_error="LLM stream returned no data",
+                    )
+                if last_frame_data["choices"][0].get("finish_reason"):
+                    break
+
+                final_frame_data = {
+                    **last_frame_data,
+                    "usage": latest_usage or last_frame_data.get("usage"),
+                    "choices": [
+                        {
+                            "finish_reason": ChatStatus.FINISH_REASON.value,
+                            "delta": {"content": "", "reasoning_content": ""},
+                        }
+                    ],
+                }
                 yield LLMResponse(
-                    msg=last_frame_data,
+                    msg=final_frame_data,
                 )
                 break
 

--- a/core/workflow/tests/infra/providers/llm/test_openai_chat_llm.py
+++ b/core/workflow/tests/infra/providers/llm/test_openai_chat_llm.py
@@ -1,0 +1,194 @@
+"""Tests for the OpenAI-compatible chat provider."""
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+from openai.types.chat import ChatCompletionChunk
+
+from workflow.consts.engine.chat_status import SparkLLMStatus
+from workflow.engine.nodes.util.frame_processor import OpenAIFrameProcessor
+from workflow.exception.e import CustomException
+from workflow.exception.errors.err_code import CodeEnum
+
+OPENAI_CHAT_MODULE = "workflow.infra.providers.llm.openai.openai_chat_llm"
+if getattr(sys.modules.get(OPENAI_CHAT_MODULE), "__spec__", None) is None:
+    # The factory tests install a spec-less fake module during test collection.
+    sys.modules.pop(OPENAI_CHAT_MODULE, None)
+OpenAIChatAI = importlib.import_module(OPENAI_CHAT_MODULE).OpenAIChatAI
+
+
+class EmptyAsyncStream:
+    async def __anext__(self) -> None:
+        raise StopAsyncIteration
+
+
+class AsyncChunkStream:
+    def __init__(self, chunks: list[ChatCompletionChunk]) -> None:
+        self._chunks = iter(chunks)
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class RecordingSpan:
+    async def add_info_events_async(self, _: dict[str, Any]) -> None:
+        pass
+
+
+def build_openai_chat_ai() -> OpenAIChatAI:
+    return OpenAIChatAI(
+        model_url="https://example.com/v1/chat/completions",
+        model_name="openai/test-model",
+        temperature=1,
+        app_id="",
+        api_key="test-key",
+        api_secret="",
+        max_tokens=256,
+        top_k=1,
+        uid="test-user",
+    )
+
+
+def build_chunk(
+    choices: list[dict[str, Any]],
+    usage: dict[str, int] | None = None,
+) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chatcmpl-test",
+        choices=choices,
+        created=0,
+        model="openai/test-model",
+        object="chat.completion.chunk",
+        usage=usage,
+    )
+
+
+async def process_frames(
+    chat_ai: OpenAIChatAI,
+    chunks: list[ChatCompletionChunk],
+) -> list[tuple[dict[str, Any], Any]]:
+    processor = OpenAIFrameProcessor()
+    processed = []
+    async for response in chat_ai._process_stream(  # noqa: SLF001
+        AsyncChunkStream(chunks),
+        span=RecordingSpan(),  # type: ignore[arg-type]
+    ):
+        processed.append((response.msg, processor.process_frame(response.msg)))
+    return processed
+
+
+def test_decode_message_accepts_usage_only_stream_chunk() -> None:
+    usage = {
+        "prompt_tokens": 8,
+        "completion_tokens": 4,
+        "total_tokens": 12,
+    }
+
+    (
+        status,
+        content,
+        reasoning_content,
+        token_usage,
+    ) = build_openai_chat_ai().decode_message(
+        {
+            "choices": [],
+            "usage": usage,
+        }
+    )
+
+    assert status == ""
+    assert content == ""
+    assert reasoning_content == ""
+    assert token_usage == usage
+
+
+@pytest.mark.asyncio
+async def test_process_stream_normalizes_usage_chunk_before_stop() -> None:
+    usage = {
+        "prompt_tokens": 8,
+        "completion_tokens": 4,
+        "total_tokens": 12,
+    }
+
+    processed = await process_frames(
+        build_openai_chat_ai(),
+        [
+            build_chunk(
+                [
+                    {
+                        "delta": {"content": "Hello"},
+                        "finish_reason": None,
+                        "index": 0,
+                    }
+                ]
+            ),
+            build_chunk([], usage),
+            build_chunk(
+                [
+                    {
+                        "delta": {},
+                        "finish_reason": "stop",
+                        "index": 0,
+                    }
+                ]
+            ),
+        ],
+    )
+
+    assert [frame.text["content"] for _, frame in processed] == ["Hello", ""]
+    assert processed[-1][1].status == SparkLLMStatus.END.value
+    assert processed[-1][0]["usage"]["total_tokens"] == 12
+    assert all(message["choices"] for message, _ in processed)
+
+
+@pytest.mark.asyncio
+async def test_process_stream_normalizes_usage_chunk_before_eof() -> None:
+    processed = await process_frames(
+        build_openai_chat_ai(),
+        [
+            build_chunk(
+                [
+                    {
+                        "delta": {"content": "Hello"},
+                        "finish_reason": None,
+                        "index": 0,
+                    }
+                ]
+            ),
+            build_chunk(
+                [],
+                {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 4,
+                    "total_tokens": 12,
+                },
+            ),
+        ],
+    )
+
+    assert [frame.text["content"] for _, frame in processed] == ["Hello", ""]
+    assert processed[-1][1].status == SparkLLMStatus.END.value
+    assert processed[-1][0]["usage"]["total_tokens"] == 12
+    assert all(message["choices"] for message, _ in processed)
+
+
+@pytest.mark.asyncio
+async def test_process_stream_rejects_response_without_sse_chunks() -> None:
+    chat_ai = build_openai_chat_ai()
+
+    with pytest.raises(CustomException) as exc_info:
+        [
+            response
+            async for response in chat_ai._process_stream(  # noqa: SLF001
+                EmptyAsyncStream(),
+                span=None,  # type: ignore[arg-type]
+            )
+        ]
+
+    assert exc_info.value.code == CodeEnum.OPEN_AI_REQUEST_ERROR.code
+    assert exc_info.value.cause_error == "LLM stream returned no data"


### PR DESCRIPTION
Handle OpenAI-compatible streaming responses that include usage-only chunks, preserve token usage on the terminal frame, and report empty SSE streams explicitly. Includes regression coverage for usage-only chunks and empty streams.