### PR TITLE
fix(workflow): satisfy OpenAI stream type checks

### DIFF
--- a/core/workflow/infra/providers/llm/openai/openai_chat_llm.py
+++ b/core/workflow/infra/providers/llm/openai/openai_chat_llm.py
@@ -154,8 +154,8 @@ class OpenAIChatAI(ChatAI):
         span: Span,
         timeout: float | None = None,
     ) -> AsyncIterator[LLMResponse]:
-        last_frame_data = {}
-        latest_usage = {}
+        last_frame_data: dict[str, Any] = {}
+        latest_usage: dict[str, Any] = {}
         is_first_frame = True
         start_time = None
 
@@ -221,8 +221,8 @@ class OpenAIChatAI(ChatAI):
 
     @staticmethod
     def _normalize_stream_frame(
-        frame_data: dict, latest_usage: dict
-    ) -> tuple[dict | None, dict]:
+        frame_data: dict[str, Any], latest_usage: dict[str, Any]
+    ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
         usage = frame_data.get("usage") or {}
         if usage:
             latest_usage = usage
@@ -237,8 +237,8 @@ class OpenAIChatAI(ChatAI):
 
     @staticmethod
     def _build_final_stream_frame(
-        last_frame_data: dict, latest_usage: dict
-    ) -> dict | None:
+        last_frame_data: dict[str, Any], latest_usage: dict[str, Any]
+    ) -> dict[str, Any] | None:
         if not last_frame_data:
             raise CustomException(
                 err_code=CodeEnum.OPEN_AI_REQUEST_ERROR,

--- a/core/workflow/tests/infra/providers/llm/test_openai_chat_llm.py
+++ b/core/workflow/tests/infra/providers/llm/test_openai_chat_llm.py
@@ -2,7 +2,7 @@
 
 import importlib
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from openai.types.chat import ChatCompletionChunk
@@ -16,7 +16,10 @@ OPENAI_CHAT_MODULE = "workflow.infra.providers.llm.openai.openai_chat_llm"
 if getattr(sys.modules.get(OPENAI_CHAT_MODULE), "__spec__", None) is None:
     # The factory tests install a spec-less fake module during test collection.
     sys.modules.pop(OPENAI_CHAT_MODULE, None)
-OpenAIChatAI = importlib.import_module(OPENAI_CHAT_MODULE).OpenAIChatAI
+if TYPE_CHECKING:
+    from workflow.infra.providers.llm.openai.openai_chat_llm import OpenAIChatAI
+else:
+    OpenAIChatAI = importlib.import_module(OPENAI_CHAT_MODULE).OpenAIChatAI
 
 
 class EmptyAsyncStream:


### PR DESCRIPTION
## Summary
- annotate OpenAI stream state and helper dictionaries for strict mypy inference
- expose the real provider class to mypy through TYPE_CHECKING
- preserve the existing runtime dynamic import used by tests

## Validation
- independent code review passed with no findings
- final remote quality and test validation will run after merge