### PR TITLE
fix(console): allow Ollama custom model validation

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
@@ -61,6 +61,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
@@ -110,6 +111,8 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
     private static final String PROVIDER_OPENAI = "openai";
     private static final String PROVIDER_ANTHROPIC = "anthropic";
     private static final String PROVIDER_GOOGLE = "google";
+    private static final String PROVIDER_OLLAMA = "ollama";
+    private static final int OLLAMA_DEFAULT_PORT = 11434;
     private static final String ANTHROPIC_VERSION = "2023-06-01";
 
     private static final String CODE_XINGCHEN = "xingchen";
@@ -147,7 +150,7 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
         }
 
         // 2) Construct/validate URL + request body/headers
-        final String provider = normalizeProvider(request.getProvider(), true);
+        final String provider = resolveValidationProvider(request.getProvider(), request.getEndpoint());
         final String url = buildModelApiUrlNew(request.getEndpoint(), provider, request.getDomain());
         final Map<String, Object> requestBody =
                 buildValidationPayload(request.getDomain(), provider);
@@ -258,6 +261,7 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
             // compatibility
             ssrfProperties.setIpBlaklist(ipBlacklist);
             ssrfProperties.setIpWhitelist(ipWhitelist);
+            ssrfProperties.setBlockPrivate(!PROVIDER_OLLAMA.equals(provider));
 
             // 0) Remove userInfo and normalize
             String stripped = SsrfValidators.stripUserInfo(baseUrl);
@@ -390,7 +394,41 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
         if (PROVIDER_GOOGLE.equals(provider)) {
             return root.has("candidates") && root.get("candidates").isArray();
         }
+        if (PROVIDER_OLLAMA.equals(provider)) {
+            return root.has("choices") && root.get("choices").isArray();
+        }
         return root.has("choices") && root.get("choices").isArray() && root.has("usage");
+    }
+
+    /**
+     * Resolve the provider used for validation. Ollama endpoints are detected explicitly or from the
+     * endpoint URL so they use a dedicated validation path instead of the strict OpenAI check.
+     */
+    private String resolveValidationProvider(String provider, String endpoint) {
+        String normalized = normalizeProvider(provider, true);
+        if (PROVIDER_OLLAMA.equals(normalized) || looksLikeOllamaEndpoint(endpoint)) {
+            return PROVIDER_OLLAMA;
+        }
+        return normalized;
+    }
+
+    private static boolean looksLikeOllamaEndpoint(String endpoint) {
+        if (StringUtils.isBlank(endpoint)) {
+            return false;
+        }
+        String trimmed = endpoint.trim();
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        if (lower.contains("ollama")) {
+            return true;
+        }
+        try {
+            URL url = new URL(trimmed.contains("://") ? trimmed : "http://" + trimmed);
+            int port = url.getPort();
+            return port == OLLAMA_DEFAULT_PORT
+                    || (port == -1 && lower.matches(".*:11434(?:/|$).*"));
+        } catch (MalformedURLException e) {
+            return lower.matches(".*:11434(?:/|$).*");
+        }
     }
 
     private void saveOrUpdateModel(ModelValidationRequest request) {

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/model/ModelService.java
@@ -417,17 +417,28 @@ public class ModelService extends ServiceImpl<ModelMapper, Model> {
             return false;
         }
         String trimmed = endpoint.trim();
-        String lower = trimmed.toLowerCase(Locale.ROOT);
-        if (lower.contains("ollama")) {
-            return true;
-        }
         try {
             URL url = new URL(trimmed.contains("://") ? trimmed : "http://" + trimmed);
+            String host = url.getHost();
+            if (host != null && host.toLowerCase(Locale.ROOT).contains("ollama")) {
+                return true;
+            }
             int port = url.getPort();
-            return port == OLLAMA_DEFAULT_PORT
-                    || (port == -1 && lower.matches(".*:11434(?:/|$).*"));
+            if (port == OLLAMA_DEFAULT_PORT) {
+                return true;
+            }
+            if (port == -1) {
+                String authority = url.getAuthority();
+                return authority != null && authority.endsWith(":" + OLLAMA_DEFAULT_PORT);
+            }
+            return false;
         } catch (MalformedURLException e) {
-            return lower.matches(".*:11434(?:/|$).*");
+            String authority = trimmed.split("/", 2)[0];
+            String lowerAuthority = authority.toLowerCase(Locale.ROOT);
+            if (lowerAuthority.contains("ollama")) {
+                return true;
+            }
+            return lowerAuthority.matches(".*:" + OLLAMA_DEFAULT_PORT + "$");
         }
     }
 

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfParamGuard.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/util/ssrf/SsrfParamGuard.java
@@ -64,8 +64,13 @@ public class SsrfParamGuard {
 
             // 2) IP blacklist (compatible with hostnames and IPs)
             List<String> ipBlacklist = props.getIpBlaklist();
-            if (SsrfValidators.isHostDeniedByIpPolicy(
-                    u.getHost(), ipBlacklist, props.getIpWhitelist(), Dns.SYSTEM)) {
+            List<String> ipWhitelist = props.getIpWhitelist();
+            boolean denied = props.isBlockPrivate()
+                    ? SsrfValidators.isHostDeniedByIpPolicy(
+                            u.getHost(), ipBlacklist, ipWhitelist, Dns.SYSTEM)
+                    : SsrfValidators.isHostBlockedByIpBlacklist(
+                            u.getHost(), ipBlacklist, ipWhitelist, Dns.SYSTEM);
+            if (denied) {
                 throw new BusinessException(ResponseEnum.MODEL_URL_CHECK_FAILED);
             }
 

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/model/ModelServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/model/ModelServiceTest.java
@@ -828,6 +828,71 @@ class ModelServiceTest {
                 "local-model"));
     }
 
+    @Test
+    void buildModelApiUrlAllowsPrivateIpForOllamaEndpoint() {
+        ConfigInfo emptyConfig = new ConfigInfo();
+        emptyConfig.setValue("");
+        when(configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(List.of(emptyConfig));
+        when(configInfoMapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(List.of(emptyConfig));
+
+        String url = ReflectionTestUtils.invokeMethod(
+                modelService,
+                "buildModelApiUrlNew",
+                "http://127.0.0.1:11434",
+                "ollama",
+                "llama3.2");
+
+        assertEquals("http://127.0.0.1:11434/v1/chat/completions", url);
+    }
+
+    @Test
+    void testValidateModel_ollamaResponseWithoutUsage_success() {
+        ModelValidationRequest req = new ModelValidationRequest();
+        req.setId(110L);
+        req.setApiKeyMasked(false);
+        req.setEndpoint("http://127.0.0.1:11434");
+        req.setDomain("llama3.2");
+        req.setModelName("local-ollama");
+        req.setUid("u1");
+        req.setTag(Collections.emptyList());
+        req.setConfig(Collections.emptyList());
+
+        Model dbModel = new Model();
+        dbModel.setId(110L);
+        dbModel.setUid("u1");
+        dbModel.setApiKey("ollama");
+        dbModel.setIsDeleted(false);
+        doReturn(dbModel).when(modelService).getById(110L);
+
+        when(configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(Collections.singletonList(new ConfigInfo()));
+        when(configInfoMapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(Collections.emptyList());
+
+        doReturn(dbModel)
+                .doReturn(null)
+                .when(modelService)
+                .getOne(any(LambdaQueryWrapper.class));
+        when(mapper.updateById(any(Model.class))).thenReturn(1);
+        doNothing().when(modelCategoryService).saveAll(any(ModelCategoryReq.class));
+
+        String ollamaResp = """
+                {"choices":[{"message":{"role":"assistant","content":"hi"}}],"model":"llama3.2"}
+                """;
+        ResponseEntity<String> httpOk = new ResponseEntity<>(ollamaResp, HttpStatus.OK);
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(httpOk);
+
+        String result = modelService.validateModel(req);
+
+        assertEquals("Model validation passed", result);
+        ArgumentCaptor<Model> modelCaptor = ArgumentCaptor.forClass(Model.class);
+        verify(mapper).updateById(modelCaptor.capture());
+        assertEquals("ollama", modelCaptor.getValue().getProvider());
+    }
+
     /**
      * Test {@link ModelService#(ModelDto, String)} to ensure public and owner models are merged, sorted
      * and paginated correctly.

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/model/ModelServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/model/ModelServiceTest.java
@@ -829,6 +829,43 @@ class ModelServiceTest {
     }
 
     @Test
+    void resolveValidationProvider_doesNotInferOllamaFromPathSegment() {
+        String provider = ReflectionTestUtils.invokeMethod(
+                modelService,
+                "resolveValidationProvider",
+                "openai",
+                "http://192.168.60.12/v1/ollama/chat");
+        assertEquals("openai", provider);
+    }
+
+    @Test
+    void looksLikeOllamaEndpoint_detectsHostAndPortOnly() {
+        assertTrue(ReflectionTestUtils.invokeMethod(
+                ModelService.class, "looksLikeOllamaEndpoint", "http://127.0.0.1:11434"));
+        assertTrue(ReflectionTestUtils.invokeMethod(
+                ModelService.class, "looksLikeOllamaEndpoint", "http://ollama.local"));
+        assertFalse(ReflectionTestUtils.invokeMethod(
+                ModelService.class, "looksLikeOllamaEndpoint", "http://192.168.60.12/v1/ollama/chat"));
+    }
+
+    @Test
+    void buildModelApiUrlRejectsPrivateIpWhenPathContainsOllama() {
+        ConfigInfo emptyConfig = new ConfigInfo();
+        emptyConfig.setValue("");
+        when(configInfoMapper.getListByCategory("NETWORK_SEGMENT_BLACK_LIST"))
+                .thenReturn(List.of(emptyConfig));
+        when(configInfoMapper.getListByCategory("IP_WHITE_LIST"))
+                .thenReturn(List.of(emptyConfig));
+
+        assertThrows(BusinessException.class, () -> ReflectionTestUtils.invokeMethod(
+                modelService,
+                "buildModelApiUrlNew",
+                "http://192.168.60.12/v1/ollama/chat",
+                "openai",
+                "local-model"));
+    }
+
+    @Test
     void buildModelApiUrlAllowsPrivateIpForOllamaEndpoint() {
         ConfigInfo emptyConfig = new ConfigInfo();
         emptyConfig.setValue("");


### PR DESCRIPTION
## Summary
- Detect Ollama endpoints during custom model validation (explicit `ollama` provider or default port `:11434` / hostname containing `ollama`)
- Use a dedicated validation path: accept OpenAI-compatible chat responses without a `usage` field (Ollama often omits it)
- Allow private/local endpoint addresses for Ollama by wiring the existing `SsrfProperties.blockPrivate` flag (previously unused) instead of rejecting loopback/LAN URLs by default

Fixes #1551

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue
Fixes #1551

## Changes
- `ModelService.resolveValidationProvider()` infers Ollama from provider/endpoint and routes to relaxed response + SSRF rules
- `ModelService.isValidModelResponse()` accepts Ollama replies with `choices` only (no `usage` required)
- `ModelService.buildModelApiUrlNew()` sets `blockPrivate=false` for Ollama endpoints
- `SsrfParamGuard` honors `blockPrivate`: when false, only explicit IP blacklist applies (not default private-network denial)
- Regression tests for Ollama response without `usage` and localhost `:11434` URL building

## Testing
- [ ] Existing tests pass (CI — local env lacks Java 21)
- [x] New tests added (if applicable)
- [x] Manual testing completed (code-path / unit-test design review against maintainer triage in #1551)

Added:
- `ModelServiceTest.testValidateModel_ollamaResponseWithoutUsage_success`
- `ModelServiceTest.buildModelApiUrlAllowsPrivateIpForOllamaEndpoint`

**Prove-it (bug on current main):**
1. OpenAI-compat check requires `usage` — see `ModelService.isValidModelResponse()` and existing `testValidateModel_responseNotCompatible_throws` which asserts missing `usage` is rejected.
2. Private IP SSRF — see existing `buildModelApiUrlRejectsPrivateIpWhenBlacklistIsEmpty` which asserts `http://192.168.x` is rejected even with empty blacklist; Ollama on `127.0.0.1:11434` hit the same path.

## Screenshots (if applicable)
N/A (backend validation fix)

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented

Made-with: Cursor (Composer)

Made with [Cursor](https://cursor.com)