### PR TITLE
fix(console): prevent blank workflow history poisoning

### DIFF
--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImpl.java
@@ -107,6 +107,12 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
         String url = chatBotReqDto.getUrl();
         Integer botId = chatBotReqDto.getBotId();
 
+        if (StrUtil.isBlank(ask)) {
+            log.warn("Rejecting workflow chat request with empty user input, uid: {}, chatId: {}, botId: {}",
+                    uid, chatId, botId);
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+
         JSONObject inputs = new JSONObject();
         inputs.put("AGENT_USER_INPUT", ask);
 
@@ -210,26 +216,35 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
         LinkedList<ChatRequestDto> filteredMessages = new LinkedList<>();
         boolean removeNext = false;
         for (ChatRequestDto dto : requestDtoList.getMessages()) {
+            if (removeNext) {
+                removeNext = false;
+                continue;
+            }
+
             Object content = dto.getContent();
             if (content instanceof List<?> list) {
+                boolean textFound = false;
                 // Type-safe iteration without unchecked cast
                 for (Object item : list) {
-                    if (item instanceof ChatModelMeta itemJson) {
-                        String type = itemJson.getType();
-                        if ("text".equals(type)) {
-                            ChatRequestDto filteredDto = new ChatRequestDto();
-                            filteredDto.setRole(dto.getRole());
-                            filteredDto.setContent(itemJson.getText());
-                            filteredDto.setContent_type(dto.getContent_type());
-                            filteredMessages.add(filteredDto);
-                            break;
-                        }
+                    if (item instanceof ChatModelMeta itemJson
+                            && "text".equals(itemJson.getType())
+                            && StrUtil.isNotBlank(itemJson.getText())) {
+                        ChatRequestDto filteredDto = new ChatRequestDto();
+                        filteredDto.setRole(dto.getRole());
+                        filteredDto.setContent(itemJson.getText());
+                        filteredDto.setContent_type(dto.getContent_type());
+                        filteredMessages.add(filteredDto);
+                        textFound = true;
+                        break;
                     }
+                }
+                if (!textFound && "user".equals(dto.getRole())) {
+                    removeNext = true;
                 }
             } else {
                 // Determine if this item should be removed when passed to large model
                 boolean remove = shouldRemove(content);
-                if (!removeNext && !remove) {
+                if (!remove) {
                     // Non-list type, keep directly
                     filteredMessages.add(dto);
                 }

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImplTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImplTest.java
@@ -1,6 +1,8 @@
 package com.iflytek.astron.console.commons.service.workflow.impl;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.dto.chat.ChatModelMeta;
 import com.iflytek.astron.console.commons.dto.chat.ChatReqModelDto;
@@ -26,6 +28,9 @@ import okio.Buffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RBucket;
@@ -307,6 +312,77 @@ class WorkflowBotChatServiceImplTest {
         assertEquals(ResponseEnum.BOT_CHAIN_SUBMIT_ERROR, exception.getResponseEnum());
         verify(userLangChainDataService).findOneByBotId(456);
         verifyNoInteractions(chatDataService);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\u00A0", "\uFEFF", "\u3000"})
+    void testChatWorkflowBot_WithBlankQuestion_ShouldRejectBeforePersistence(String ask) {
+        // Given
+        chatBotReqDto.setAsk(ask);
+
+        // When & Then
+        try (MockedConstruction<WorkflowClient> mockWorkflowClient = mockConstruction(WorkflowClient.class)) {
+            BusinessException exception = assertThrows(BusinessException.class, () ->
+                    workflowBotChatService.chatWorkflowBot(
+                            chatBotReqDto, sseEmitter, sseId, workflowOperation, workflowVersion));
+
+            assertEquals(ResponseEnum.PARAMETER_ERROR, exception.getResponseEnum());
+            verify(chatDataService, never()).createRequest(any());
+            assertTrue(mockWorkflowClient.constructed().isEmpty());
+        }
+    }
+
+    @Test
+    void testChatWorkflowBot_WithFileOnlyHistory_ShouldOmitWholeRoundFromRequest() throws Exception {
+        when(userLangChainDataService.findOneByBotId(456)).thenReturn(userLangChainInfo);
+        when(chatDataService.createRequest(any(ChatReqRecords.class))).thenReturn(chatReqRecords);
+        when(workflowBotParamService.handleMultiFileParam(
+                anyString(), anyLong(), isNull(), any(), any(), anyLong())).thenReturn(false);
+
+        List<ChatReqModelDto> reqList = new ArrayList<>();
+        when(chatDataService.getReqModelBotHistoryByChatId("testUser", 123L)).thenReturn(reqList);
+
+        ChatModelMeta imageMeta = new ChatModelMeta();
+        imageMeta.setType("image_url");
+        JSONObject imageUrl = new JSONObject();
+        imageUrl.put("url", "encoded-image-url");
+        imageMeta.setImage_url(imageUrl);
+        ChatRequestDto<List<ChatModelMeta>> fileOnlyUser = new ChatRequestDto<>(
+                "user", List.of(imageMeta));
+        ChatRequestDto<String> orphanedAnswer = new ChatRequestDto<>("assistant", "Image answer");
+        ChatRequestDto<String> earlierUser = new ChatRequestDto<>("user", "Earlier question");
+        ChatRequestDto<String> earlierAssistant = new ChatRequestDto<>("assistant", "Earlier answer");
+        ChatRequestDto<String> laterUser = new ChatRequestDto<>("user", "Later question");
+        ChatRequestDto<String> laterAssistant = new ChatRequestDto<>("assistant", "Later answer");
+        ChatRequestDtoList requestDtoList = new ChatRequestDtoList();
+        requestDtoList.setMessages(new LinkedList<>(List.of(
+                earlierUser, earlierAssistant, fileOnlyUser, orphanedAnswer, laterUser, laterAssistant)));
+        when(chatHistoryService.getHistory("testUser", 123L, reqList)).thenReturn(requestDtoList);
+        when(chatBotDataService.findMarketBotByBotId(456)).thenReturn(null);
+
+        List<List<?>> constructorArgs = new ArrayList<>();
+        try (MockedConstruction<WorkflowClient> mockWorkflowClient = mockConstruction(
+                WorkflowClient.class,
+                (mock, context) -> constructorArgs.add(context.arguments()))) {
+            workflowBotChatService.chatWorkflowBot(
+                    chatBotReqDto, sseEmitter, sseId, workflowOperation, workflowVersion);
+
+            assertEquals(1, mockWorkflowClient.constructed().size());
+            RequestBody requestBody = (RequestBody) constructorArgs.get(0).get(4);
+            Buffer buffer = new Buffer();
+            requestBody.writeTo(buffer);
+            JSONArray history = JSON.parseObject(buffer.readUtf8()).getJSONArray("history");
+            assertEquals(4, history.size());
+            assertEquals("user", history.getJSONObject(0).getString("role"));
+            assertEquals("Earlier question", history.getJSONObject(0).getString("content"));
+            assertEquals("assistant", history.getJSONObject(1).getString("role"));
+            assertEquals("Earlier answer", history.getJSONObject(1).getString("content"));
+            assertEquals("user", history.getJSONObject(2).getString("role"));
+            assertEquals("Later question", history.getJSONObject(2).getString("content"));
+            assertEquals("assistant", history.getJSONObject(3).getString("role"));
+            assertEquals("Later answer", history.getJSONObject(3).getString("content"));
+        }
     }
 
     @Test

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageController.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.hub.controller.chat;
 
 import cn.hutool.core.util.RandomUtil;
+import cn.hutool.core.util.StrUtil;
 import com.alibaba.fastjson2.JSON;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.entity.bot.ChatBotBase;
@@ -82,6 +83,12 @@ public class ChatMessageController {
 
         log.info("Establishing SSE connection, sseId: {}, chatId: {}", sseId, chatId);
 
+        // Validate before any conversation lookup so invalid input has no downstream side effects.
+        ValidationResult validation = validateChatRequest(chatId, text, sseId, sseEmitter);
+        if (!validation.isValid()) {
+            return sseEmitter;
+        }
+
         // Get the latest chat_id
         List<ChatTreeIndex> chatTreeIndexList = chatListDataService.findChatTreeIndexByChatIdOrderById(chatId);
         if (chatTreeIndexList.isEmpty()) {
@@ -92,9 +99,9 @@ public class ChatMessageController {
         }
         Long lastChatId = chatTreeIndexList.getFirst().getChildChatId();
 
-        // Validate request parameters
-        ValidationResult validation = validateChatRequest(lastChatId, text, sseId, sseEmitter);
-        if (!validation.isValid()) {
+        // Preserve validation of the resolved child ID in case stored tree data is incomplete.
+        ValidationResult resolvedChatValidation = validateChatRequest(lastChatId, text, sseId, sseEmitter);
+        if (!resolvedChatValidation.isValid()) {
             return sseEmitter;
         }
 
@@ -124,7 +131,7 @@ public class ChatMessageController {
             return ValidationResult.invalid();
         }
 
-        if (StringUtils.isBlank(text)) {
+        if (StrUtil.isBlank(text)) {
             log.warn("Chat content is empty, sseId: {}, chatId: {}", sseId, chatId);
             SseEmitterUtil.sendError(sseEmitter, "Please enter chat content");
             SseEmitterUtil.sendEndAndComplete(sseEmitter);

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImpl.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.hub.service.chat.impl;
 
 import cn.hutool.core.collection.CollectionUtil;
+import cn.hutool.core.util.StrUtil;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
@@ -127,6 +128,13 @@ public class BotChatServiceImpl implements BotChatService {
     @Override
     public void chatMessageBot(ChatBotReqDto chatBotReqDto, SseEmitter sseEmitter, String sseId, String workflowOperation, String workflowVersion) {
         try {
+            if (StrUtil.isBlank(chatBotReqDto.getAsk())) {
+                log.warn("Rejecting chat request with empty user input, sseId: {}, chatId: {}, uid: {}",
+                        sseId, chatBotReqDto.getChatId(), chatBotReqDto.getUid());
+                SseEmitterUtil.completeWithError(sseEmitter, "Please enter chat content");
+                return;
+            }
+
             log.info("Processing chat request, sseId: {}, chatId: {}, uid: {}", sseId, chatBotReqDto.getChatId(), chatBotReqDto.getUid());
             Long spaceId = SpaceInfoUtil.getSpaceId();
 

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.iflytek.astron.console.hub.service.chat.impl;
 
+import cn.hutool.core.util.StrUtil;
 import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.commons.dto.chat.*;
 import com.iflytek.astron.console.commons.dto.llm.SparkChatRequest;
@@ -108,6 +109,7 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
         List<ChatRespModelDto> respList = chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, reqIdList);
         ChatRequestDtoList chatRecordList = new ChatRequestDtoList();
         int tempLength = 0;
+        int skippedInvalidRounds = 0;
 
         // Group answer history by reqId
         Map<Long, ChatRespModelDto> respMap = new HashMap<>();
@@ -124,6 +126,11 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
 
             // Skip if no response found for this request
             if (respDto == null) {
+                continue;
+            }
+
+            if (StrUtil.isBlank(reqDto.getMessage()) && !hasUsableFileUrl(reqDto.getUrl())) {
+                skippedInvalidRounds++;
                 continue;
             }
 
@@ -156,23 +163,25 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
             // Historical length concatenation
             tempLength = tempLength + answerLength;
             if (tempLength > MAX_HISTORY_NUMBERS) {
+                logSkippedInvalidRounds(chatId, skippedInvalidRounds);
                 return chatRecordList;
             }
             /*** Add question ***/
             String ask = reqDto.getMessage();
             int askLength = ask == null ? 0 : ask.length();
             // If the question is an image, set length to 800 to prevent history from exceeding 10 images
-            if (StringUtils.isNotBlank(reqDto.getUrl())) {
+            if (hasUsableFileUrl(reqDto.getUrl())) {
                 askLength = 800;
             }
             tempLength = tempLength + askLength;
             if (tempLength > MAX_HISTORY_NUMBERS) {
+                logSkippedInvalidRounds(chatId, skippedInvalidRounds);
                 return chatRecordList;
             }
 
             // If there is data in multimodal content, it means this is multimodal input, append history in
             // multimodal design QQA format
-            if (StringUtils.isNotBlank(reqDto.getUrl())) {
+            if (hasUsableFileUrl(reqDto.getUrl())) {
                 String url = reqDto.getUrl();
                 List<ChatModelMeta> metaList = urlToArray(url, ask);
                 chatRecordList.getMessages().addFirst(new ChatRequestDto("user", metaList));
@@ -180,6 +189,7 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
                 chatRecordList.getMessages().addFirst(new ChatRequestDto("user", ask));
             }
         }
+        logSkippedInvalidRounds(chatId, skippedInvalidRounds);
         chatRecordList.setLength(tempLength);
         return chatRecordList;
     }
@@ -191,17 +201,17 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
     public List<ChatModelMeta> urlToArray(String url, String ask) {
         List<ChatModelMeta> metaList = new ArrayList<>();
         // Image address concatenation
-        if (StringUtils.isNotBlank(url)) {
+        if (hasUsableFileUrl(url)) {
             String[] urls = url.split(",");
             // Assemble images
             for (String tempUrl : urls) {
                 // Skip if image address is empty
-                if (StringUtils.isBlank(tempUrl) || "null".equals(tempUrl)) {
+                if (!isUsableFileUrl(tempUrl)) {
                     continue;
                 }
                 ChatModelMeta meta = new ChatModelMeta();
                 JSONObject jb = new JSONObject();
-                jb.put("url", Base64Util.encode(tempUrl));
+                jb.put("url", Base64Util.encode(tempUrl.trim()));
                 meta.setType("image_url");
                 meta.setImage_url(jb);
                 metaList.add(meta);
@@ -209,13 +219,31 @@ public class ChatHistoryServiceImpl implements ChatHistoryService {
         }
 
         // Text must be placed at the end of the array
-        if (StringUtils.isNotBlank(ask)) {
+        if (StrUtil.isNotBlank(ask)) {
             ChatModelMeta meta = new ChatModelMeta();
             meta.setType("text");
             meta.setText(ask);
             metaList.add(meta);
         }
         return metaList;
+    }
+
+    private boolean hasUsableFileUrl(String url) {
+        if (StrUtil.isBlank(url)) {
+            return false;
+        }
+        return Arrays.stream(url.split(",")).anyMatch(this::isUsableFileUrl);
+    }
+
+    private boolean isUsableFileUrl(String url) {
+        return StrUtil.isNotBlank(url) && !"null".equalsIgnoreCase(url.trim());
+    }
+
+    private void logSkippedInvalidRounds(Long chatId, int skippedInvalidRounds) {
+        if (skippedInvalidRounds > 0) {
+            log.warn("Skipped {} invalid chat history round(s) with empty user content, chatId: {}",
+                    skippedInvalidRounds, chatId);
+        }
     }
 
     /**

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageControllerTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/controller/chat/ChatMessageControllerTest.java
@@ -4,6 +4,7 @@ import com.iflytek.astron.console.commons.service.bot.ChatBotDataService;
 import com.iflytek.astron.console.commons.service.data.ChatDataService;
 import com.iflytek.astron.console.commons.service.data.ChatListDataService;
 import com.iflytek.astron.console.commons.dto.bot.DebugChatBotReqDto;
+import com.iflytek.astron.console.commons.entity.chat.ChatTreeIndex;
 import com.iflytek.astron.console.commons.util.RequestContextUtil;
 import com.iflytek.astron.console.commons.util.SseEmitterUtil;
 import com.iflytek.astron.console.commons.util.space.SpaceInfoUtil;
@@ -14,6 +15,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -21,6 +25,8 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RedissonClient;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -30,6 +36,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +58,45 @@ class ChatMessageControllerTest {
 
     @InjectMocks
     private ChatMessageController controller;
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\u00A0", "\uFEFF", "\u3000"})
+    void chatRejectsBlankTextBeforeLookingUpConversation(String text) {
+        SseEmitter emitter = mock(SseEmitter.class);
+
+        try (MockedStatic<SseEmitterUtil> sse = mockStatic(SseEmitterUtil.class)) {
+            sse.when(SseEmitterUtil::createSseEmitter).thenReturn(emitter);
+
+            SseEmitter result = controller.chat(1L, text, null, null, null);
+
+            assertSame(emitter, result);
+            verifyNoInteractions(chatListDataService, botChatService);
+            sse.verify(() -> SseEmitterUtil.sendError(eq(emitter), eq("Please enter chat content")));
+            sse.verify(() -> SseEmitterUtil.sendEndAndComplete(emitter));
+        }
+    }
+
+    @Test
+    void chatRejectsNullResolvedChatIdBeforeLookingUpContext() {
+        SseEmitter emitter = mock(SseEmitter.class);
+        ChatTreeIndex invalidIndex = ChatTreeIndex.builder().childChatId(null).build();
+        when(chatListDataService.findChatTreeIndexByChatIdOrderById(1L))
+                .thenReturn(List.of(invalidIndex));
+
+        try (MockedStatic<SseEmitterUtil> sse = mockStatic(SseEmitterUtil.class)) {
+            sse.when(SseEmitterUtil::createSseEmitter).thenReturn(emitter);
+
+            SseEmitter result = controller.chat(1L, "hello", null, null, null);
+
+            assertSame(emitter, result);
+            verify(chatListDataService).findChatTreeIndexByChatIdOrderById(1L);
+            verifyNoMoreInteractions(chatListDataService);
+            verifyNoInteractions(botChatService);
+            sse.verify(() -> SseEmitterUtil.sendError(eq(emitter), eq("Chat ID cannot be empty")));
+            sse.verify(() -> SseEmitterUtil.sendEndAndComplete(emitter));
+        }
+    }
 
     @Test
     void botDebugRejectsSpaceHeaderFromNonMemberBeforeUsingSpaceResources() {

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/BotChatServiceImplUnitTest.java
@@ -18,6 +18,7 @@ import com.iflytek.astron.console.commons.service.data.ChatHistoryService;
 import com.iflytek.astron.console.commons.service.data.ChatListDataService;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.commons.service.workflow.WorkflowBotChatService;
+import com.iflytek.astron.console.commons.util.SseEmitterUtil;
 import com.iflytek.astron.console.commons.util.space.SpaceInfoUtil;
 import com.iflytek.astron.console.hub.data.ReqKnowledgeRecordsDataService;
 import com.iflytek.astron.console.hub.service.agentmemory.runtime.AgentMemoryRuntimeService;
@@ -33,6 +34,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -121,6 +125,23 @@ class BotChatServiceImplUnitTest {
 
         verify(workflowBotChatService).chatWorkflowBot(eq(chatBotReqDto), eq(sseEmitter), eq("sse"), eq("op"), eq("v1"));
         verify(springAiAgentChatService, never()).chat(any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\u00A0", "\uFEFF", "\u3000"})
+    void testChatMessageBot_BlankQuestion_DoesNotQueryOrInvokeServices(String ask) {
+        ChatBotReqDto chatBotReqDto = createChatBotReqDto();
+        chatBotReqDto.setAsk(ask);
+        SseEmitter sseEmitter = new SseEmitter();
+
+        try (MockedStatic<SseEmitterUtil> sse = mockStatic(SseEmitterUtil.class)) {
+            botChatService.chatMessageBot(chatBotReqDto, sseEmitter, "sse", null, null);
+
+            verifyNoInteractions(chatBotDataService, chatDataService, workflowService,
+                    workflowBotChatService, springAiAgentChatService);
+            sse.verify(() -> SseEmitterUtil.completeWithError(sseEmitter, "Please enter chat content"));
+        }
     }
 
     @Test

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/chat/impl/ChatHistoryServiceImplTest.java
@@ -13,6 +13,9 @@ import org.apache.logging.log4j.util.Base64Util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -227,6 +230,104 @@ class ChatHistoryServiceImplTest {
         assertTrue(result.getLength() > 0);
 
         verify(chatDataService).getChatRespModelBotHistoryByChatId(uid, chatId, reqIds);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\u00A0", "\uFEFF", "\u3000"})
+    void testGetHistory_WithFailedBlankRequest_ShouldSkipOnlyInvalidRound(String invalidMessage) {
+        // Given
+        ChatReqModelDto currentRequest = new ChatReqModelDto();
+        currentRequest.setId(3L);
+        currentRequest.setMessage("Follow-up question");
+
+        ChatReqModelDto failedRequest = new ChatReqModelDto();
+        failedRequest.setId(2L);
+        failedRequest.setMessage(invalidMessage);
+
+        ChatReqModelDto completedRequest = new ChatReqModelDto();
+        completedRequest.setId(1L);
+        completedRequest.setMessage("Earlier question");
+
+        ChatRespModelDto failedResponse = new ChatRespModelDto();
+        failedResponse.setReqId(2L);
+        failedResponse.setMessage("x".repeat(ChatHistoryServiceImpl.MAX_HISTORY_NUMBERS + 1));
+
+        ChatRespModelDto completedResponse = new ChatRespModelDto();
+        completedResponse.setReqId(1L);
+        completedResponse.setMessage("Earlier answer");
+
+        List<ChatReqModelDto> requests = Arrays.asList(currentRequest, failedRequest, completedRequest);
+        List<Long> requestIds = Arrays.asList(3L, 2L, 1L);
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, requestIds))
+                .thenReturn(Arrays.asList(failedResponse, completedResponse));
+
+        // When
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, requests);
+
+        // Then
+        assertEquals(2, result.getMessages().size());
+        assertEquals("user", result.getMessages().get(0).getRole());
+        assertEquals("Earlier question", result.getMessages().get(0).getContent());
+        assertEquals("assistant", result.getMessages().get(1).getRole());
+        assertEquals("Earlier answer", result.getMessages().get(1).getContent());
+        assertEquals(completedRequest.getMessage().length() + completedResponse.getMessage().length(),
+                result.getLength());
+    }
+
+    @Test
+    void testGetHistory_WithOnlyInvalidFileUrls_ShouldSkipInvalidRound() {
+        ChatReqModelDto failedRequest = new ChatReqModelDto();
+        failedRequest.setId(2L);
+        failedRequest.setMessage(null);
+        failedRequest.setUrl("null, NULL , ,\t,\u00A0,\uFEFF,null");
+
+        ChatReqModelDto completedRequest = new ChatReqModelDto();
+        completedRequest.setId(1L);
+        completedRequest.setMessage("Earlier question");
+
+        ChatRespModelDto failedResponse = new ChatRespModelDto();
+        failedResponse.setReqId(2L);
+        failedResponse.setMessage("x".repeat(ChatHistoryServiceImpl.MAX_HISTORY_NUMBERS + 1));
+
+        ChatRespModelDto completedResponse = new ChatRespModelDto();
+        completedResponse.setReqId(1L);
+        completedResponse.setMessage("Earlier answer");
+
+        List<ChatReqModelDto> requests = Arrays.asList(failedRequest, completedRequest);
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(2L, 1L)))
+                .thenReturn(Arrays.asList(failedResponse, completedResponse));
+
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, requests);
+
+        assertEquals(2, result.getMessages().size());
+        assertEquals("Earlier question", result.getMessages().get(0).getContent());
+        assertEquals("Earlier answer", result.getMessages().get(1).getContent());
+        assertEquals(completedRequest.getMessage().length() + completedResponse.getMessage().length(),
+                result.getLength());
+    }
+
+    @Test
+    void testGetHistory_WithFileOnlyRequest_ShouldKeepRound() {
+        ChatReqModelDto fileRequest = new ChatReqModelDto();
+        fileRequest.setId(1L);
+        fileRequest.setMessage(null);
+        fileRequest.setUrl("http://example.com/image.jpg");
+
+        ChatRespModelDto response = new ChatRespModelDto();
+        response.setReqId(1L);
+        response.setMessage("Image answer");
+
+        when(chatDataService.getChatRespModelBotHistoryByChatId(uid, chatId, Arrays.asList(1L)))
+                .thenReturn(Arrays.asList(response));
+
+        ChatRequestDtoList result = chatHistoryService.getHistory(uid, chatId, Arrays.asList(fileRequest));
+
+        assertEquals(2, result.getMessages().size());
+        assertEquals("user", result.getMessages().get(0).getRole());
+        assertInstanceOf(List.class, result.getMessages().get(0).getContent());
+        assertEquals("assistant", result.getMessages().get(1).getRole());
+        assertEquals("Image answer", result.getMessages().get(1).getContent());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1539

- reject blank workflow chat input before persistence and downstream calls
- skip legacy invalid history rounds without deleting stored records
- preserve valid multimodal history and remove unrepresentable file-only workflow rounds as pairs
- add regression coverage for blank, Unicode whitespace, invalid URLs, and history ordering