### PR TITLE
fix(agent): harden CoT parsing and avoid duplicate LLM calls

### DIFF
--- a/core/agent/domain/models/base.py
+++ b/core/agent/domain/models/base.py
@@ -19,22 +19,17 @@ class BaseLLMModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     async def create_completion(self, messages: list, stream: bool) -> Any:
-        llm_object = await self.llm.chat.completions.create(
-            messages=messages,
-            stream=stream,
-            model=self.name,
-            timeout=int(os.getenv("DEFAULT_LLM_TIMEOUT", "90")),
-        )
-        if os.getenv("DEFAULT_LLM_MAX_TOKEN"):
-            llm_object = await self.llm.chat.completions.create(
-                messages=messages,
-                stream=stream,
-                model=self.name,
-                timeout=int(os.getenv("DEFAULT_LLM_TIMEOUT", "90")),
-                max_tokens=int(os.getenv("DEFAULT_LLM_MAX_TOKEN", "8000")),
-            )
+        request_kwargs = {
+            "messages": messages,
+            "stream": stream,
+            "model": self.name,
+            "timeout": int(os.getenv("DEFAULT_LLM_TIMEOUT", "90")),
+        }
+        max_tokens = os.getenv("DEFAULT_LLM_MAX_TOKEN")
+        if max_tokens:
+            request_kwargs["max_tokens"] = int(max_tokens)
 
-        return llm_object
+        return await self.llm.chat.completions.create(**request_kwargs)
 
     def _log_messages_to_span(self, sp: Span, messages: list) -> None:
         for message in messages:

--- a/core/agent/engine/nodes/cot/cot_runner.py
+++ b/core/agent/engine/nodes/cot/cot_runner.py
@@ -1,6 +1,7 @@
 import json
+import re
 import time
-from typing import Any, AsyncIterator, Union
+from typing import Any, AsyncIterator, Match, Union
 
 from common.otlp.log_trace.base import Usage
 
@@ -8,6 +9,7 @@ from common.otlp.log_trace.base import Usage
 from common.otlp.log_trace.node_log import Data, NodeLog
 from common.otlp.log_trace.node_trace_log import NodeTraceLog
 from common.otlp.trace.span import Span
+from loguru import logger
 from pydantic import Field
 
 from agent.api.schemas.agent_response import AgentResponse, CotStep
@@ -28,6 +30,36 @@ from agent.service.plugin.mcp import McpPlugin
 from agent.service.plugin.workflow import WorkflowPlugin
 
 default_cot_step = CotStep(empty=True)
+
+FORMAT_CORRECTION_PROMPT = """
+
+上一次输出格式无法解析。请仅重新输出当前步骤，并严格采用以下两种格式之一：
+Thought: <当前思考>
+Action: <一个可访问工具名>
+Action Input: <单行合法 JSON>
+或
+Thought: <当前思考>
+Final Answer: <最终回答>
+不要省略上述英文标识字段，也不要用 Markdown 包裹标识字段。
+"""
+
+
+def _protocol_marker(label: str) -> re.Pattern[str]:
+    """Match common provider variations without matching prose mid-line."""
+    return re.compile(
+        rf"(?<![\w\"'])[ \t]*(?:(?:[-*]|\d+[.)])[ \t]+)?(?:\*\*)?{label}"
+        rf"(?:\*\*)?[ \t]*[:：](?:\*\*)?[ \t]*",
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+
+PROTOCOL_MARKERS = {
+    "thought": _protocol_marker(r"thought"),
+    "action": _protocol_marker(r"action"),
+    "action_input": _protocol_marker(r"action[ \t_-]+input"),
+    "observation": _protocol_marker(r"observation"),
+    "final_answer": _protocol_marker(r"final[ \t_-]+answer"),
+}
 
 
 class CotRunner(RunnerBase):
@@ -70,78 +102,112 @@ class CotRunner(RunnerBase):
 
     async def _parse_action_input(self, action_input_raw: str) -> dict[str, Any]:
         """解析并验证 action_input JSON 格式"""
+        normalized_input = action_input_raw.strip()
+        normalized_input = re.sub(
+            r"^```(?:json)?\s*", "", normalized_input, flags=re.IGNORECASE
+        )
+        normalized_input = re.sub(r"\s*```$", "", normalized_input)
         try:
-            return json.loads(action_input_raw.strip())
+            return json.loads(normalized_input)
         except json.decoder.JSONDecodeError:
             raise cot_exc.CotFormatIncorrectExc(
                 f"无效的插件参数JSON格式: {action_input_raw}"
             )
 
+    @staticmethod
+    def _find_marker(step_content: str, marker: str) -> Match[str] | None:
+        return PROTOCOL_MARKERS[marker].search(step_content)
+
+    def _has_complete_action(self, step_content: str) -> bool:
+        action = self._find_marker(step_content, "action")
+        action_input = self._find_marker(step_content, "action_input")
+        return bool(action and action_input and action.end() <= action_input.start())
+
+    def _extract_final_answer(self, step_content: str) -> str | None:
+        marker = self._find_marker(step_content, "final_answer")
+        if marker is None:
+            return None
+        return step_content[marker.end() :]
+
+    def _marker_presence(self, step_content: str) -> dict[str, bool]:
+        return {
+            marker: self._find_marker(step_content, marker) is not None
+            for marker in PROTOCOL_MARKERS
+        }
+
     async def _parse_action_and_input(
-        self, step_content: str, has_thought: bool = False
+        self, step_content: str
     ) -> tuple[str, str, dict[str, Any]]:
         """解析 action、action_input 和 thought"""
-        if has_thought:
-            thought_raw, right = step_content.split("Action:")
-            thought = thought_raw.split("Thought:")[1].strip()
-        else:
-            thought = ""
-            _, right = step_content.split("Action:")
+        action_marker = self._find_marker(step_content, "action")
+        action_input_marker = self._find_marker(step_content, "action_input")
+        if (
+            action_marker is None
+            or action_input_marker is None
+            or action_marker.end() > action_input_marker.start()
+        ):
+            raise cot_exc.CotFormatIncorrectExc("无效的推理格式，Action字段不完整")
 
-        action_raw, right = right.split("Action Input:")
-        action = action_raw.strip()
+        thought = ""
+        thought_marker = self._find_marker(step_content, "thought")
+        if thought_marker is not None and thought_marker.end() <= action_marker.start():
+            thought = step_content[thought_marker.end() : action_marker.start()].strip()
+
+        action = step_content[action_marker.end() : action_input_marker.start()].strip()
+        action = action.strip("`*_")
 
         if not await self.is_valid_plugin(action):
             raise cot_exc.CotFormatIncorrectExc(f"无效的插件名称'{action}'")
 
-        action_input_raw = right.split("Observation:")[0].strip()
+        action_input_end = len(step_content)
+        observation_marker = self._find_marker(step_content, "observation")
+        if (
+            observation_marker is not None
+            and observation_marker.start() >= action_input_marker.end()
+        ):
+            action_input_end = observation_marker.start()
+        action_input_raw = step_content[
+            action_input_marker.end() : action_input_end
+        ].strip()
         action_input = await self._parse_action_input(action_input_raw)
         return thought, action, action_input
 
-    async def parse_cot_step(self, step_content: str) -> CotStep:
-        # 处理包含 Thought 和 Final Answer 的情况
-        if all([k in step_content for k in ("Thought:", "Final Answer:")]):
-            thought = step_content.split("Final Answer:")[0].split("Thought:")[1]
+    async def parse_cot_step(
+        self, step_content: str, allow_plain_final_answer: bool = False
+    ) -> CotStep:
+        final_answer_marker = self._find_marker(step_content, "final_answer")
+        if final_answer_marker is not None:
+            thought = ""
+            thought_marker = self._find_marker(step_content, "thought")
+            if (
+                thought_marker is not None
+                and thought_marker.end() <= final_answer_marker.start()
+            ):
+                thought = step_content[
+                    thought_marker.end() : final_answer_marker.start()
+                ].strip()
             return CotStep(thought=thought, finished_cot=True)
 
-        # 处理只有 Final Answer 的情况
-        if "Final Answer:" in step_content:
-            return CotStep(finished_cot=True)
+        if self._has_complete_action(step_content):
+            thought, action, action_input = await self._parse_action_and_input(
+                step_content
+            )
+            return CotStep(thought=thought, action=action, action_input=action_input)
 
-        # 处理包含 Thought、Action、Action Input 和 Observation 的情况
-        if all(
-            [
-                k in step_content
-                for k in ("Thought:", "Action:", "Action Input:", "Observation:")
-            ]
+        normalized_content = step_content.strip()
+        if (
+            allow_plain_final_answer
+            and normalized_content
+            and not any(self._marker_presence(normalized_content).values())
         ):
-            thought, action, action_input = await self._parse_action_and_input(
-                step_content, has_thought=True
+            logger.warning(
+                "Recovering unmarked final answer after {} completed tool steps; "
+                "model={}, content_length={}",
+                len(self.scratchpad.steps),
+                self.model.name,
+                len(normalized_content),
             )
-            return CotStep(thought=thought, action=action, action_input=action_input)
-
-        # 处理包含 Thought、Action 和 Action Input 的情况
-        if all([k in step_content for k in ("Thought:", "Action:", "Action Input:")]):
-            thought, action, action_input = await self._parse_action_and_input(
-                step_content, has_thought=True
-            )
-            return CotStep(thought=thought, action=action, action_input=action_input)
-
-        # 处理包含 Action、Action Input 和 Observation 的情况
-        if all(
-            [k in step_content for k in ("Action:", "Action Input:", "Observation:")]
-        ):
-            thought, action, action_input = await self._parse_action_and_input(
-                step_content, has_thought=False
-            )
-            return CotStep(thought=thought, action=action, action_input=action_input)
-
-        # 处理包含 Action 和 Action Input 的情况
-        if all([k in step_content for k in ("Action:", "Action Input:")]):
-            thought, action, action_input = await self._parse_action_and_input(
-                step_content, has_thought=False
-            )
-            return CotStep(thought=thought, action=action, action_input=action_input)
+            return CotStep(thought=normalized_content, finished_cot=True)
 
         # 其他情况都视为无效格式
         raise cot_exc.CotFormatIncorrectExc("无效的推理格式，缺少必要的标识字段")
@@ -152,6 +218,7 @@ class CotRunner(RunnerBase):
         first_loop: bool,
         span: Span,
         node_trace_log: NodeTraceLog,
+        allow_plain_final_answer: bool = False,
     ) -> AsyncIterator[AgentResponse]:
 
         with span.start("MakingStep") as sp:
@@ -216,17 +283,17 @@ class CotRunner(RunnerBase):
                     continue
 
                 step_content += content
-                if first_loop:
-                    if "Final Answer:" in step_content:
-                        yield AgentResponse(
-                            typ="content",
-                            content=step_content.split("Final Answer:")[1],
-                            model=self.model.name,
-                        )
-                        final_answer = True
-                        continue
+                extracted_final_answer = self._extract_final_answer(step_content)
+                if extracted_final_answer is not None:
+                    yield AgentResponse(
+                        typ="content",
+                        content=extracted_final_answer,
+                        model=self.model.name,
+                    )
+                    final_answer = True
+                    continue
 
-                if "Observation:" in step_content or "Final Answer:" in step_content:
+                if self._find_marker(step_content, "observation") is not None:
                     step_content_complete = True
 
             node_end_time = int(round(time.time() * 1000))
@@ -257,9 +324,94 @@ class CotRunner(RunnerBase):
 
             if not final_answer:
                 # 解析 step_content
+                protocol_content = step_content
+                reasoning_action_complete = self._has_complete_action(thinks)
+                content_action_complete = self._has_complete_action(step_content)
+                reasoning_final_answer = self._extract_final_answer(thinks)
+
+                if reasoning_action_complete and not content_action_complete:
+                    protocol_content = thinks
+                    logger.warning(
+                        "Using reasoning_content as CoT action protocol; model={}, "
+                        "content_length={}, reasoning_length={}, completed_steps={}",
+                        self.model.name,
+                        len(step_content),
+                        len(thinks),
+                        len(self.scratchpad.steps),
+                    )
+
+                if (
+                    not content_action_complete
+                    and reasoning_final_answer is not None
+                    and step_content.strip()
+                ):
+                    yield AgentResponse(
+                        typ="content",
+                        content=step_content,
+                        model=self.model.name,
+                    )
+                    return
+
+                if (
+                    not content_action_complete
+                    and not reasoning_action_complete
+                    and allow_plain_final_answer
+                    and step_content.strip()
+                    and not any(self._marker_presence(step_content).values())
+                ):
+                    logger.warning(
+                        "Recovering unmarked final answer; model={}, "
+                        "content_length={}, completed_steps={}",
+                        self.model.name,
+                        len(step_content.strip()),
+                        len(self.scratchpad.steps),
+                    )
+                    yield AgentResponse(
+                        typ="content",
+                        content=step_content,
+                        model=self.model.name,
+                    )
+                    return
+
+                if (
+                    not step_content.strip()
+                    and reasoning_final_answer is not None
+                    and reasoning_final_answer.strip()
+                ):
+                    logger.warning(
+                        "Using final answer from reasoning_content because content is "
+                        "empty; model={}, reasoning_length={}, completed_steps={}",
+                        self.model.name,
+                        len(thinks),
+                        len(self.scratchpad.steps),
+                    )
+                    yield AgentResponse(
+                        typ="content",
+                        content=reasoning_final_answer,
+                        model=self.model.name,
+                    )
+                    return
+
+                try:
+                    cot_step = await self.parse_cot_step(
+                        protocol_content,
+                        allow_plain_final_answer=allow_plain_final_answer,
+                    )
+                except cot_exc.CotExc:
+                    logger.warning(
+                        "CoT response format validation failed; model={}, "
+                        "content_length={}, reasoning_length={}, completed_steps={}, "
+                        "markers={}",
+                        self.model.name,
+                        len(protocol_content),
+                        len(thinks),
+                        len(self.scratchpad.steps),
+                        self._marker_presence(protocol_content),
+                    )
+                    raise
                 yield AgentResponse(
                     typ="cot_step",
-                    content=await self.parse_cot_step(step_content),
+                    content=cot_step,
                     model=self.model.name,
                 )
 
@@ -269,13 +421,18 @@ class CotRunner(RunnerBase):
         first_loop: bool,
         span: Span,
         node_trace_log: NodeTraceLog,
+        allow_plain_final_answer: bool = False,
     ) -> AsyncIterator[tuple[AgentResponse | None, CotStep, bool]]:
         """处理 agent 响应，yield (agent_response, cot_step, yield_answer)"""
         cot_step: CotStep = default_cot_step
         yield_answer = False
 
         async for agent_response in self.read_response(
-            msgs, first_loop, span, node_trace_log
+            msgs,
+            first_loop,
+            span,
+            node_trace_log,
+            allow_plain_final_answer=allow_plain_final_answer,
         ):
             if agent_response.typ in ["reasoning_content", "log"]:
                 yield agent_response, cot_step, yield_answer
@@ -322,11 +479,14 @@ class CotRunner(RunnerBase):
             user_prompt_template = await self.create_user_prompt()
 
             loop_count = 0
+            format_retry_used = False
+            format_correction = ""
             while self.max_loop > loop_count:
                 loop_count += 1
                 user_prompt = user_prompt_template.replace(
                     "{scratchpad}", await self.scratchpad.template()
                 )
+                user_prompt += format_correction
 
                 msgs = LLMMessages(
                     messages=[
@@ -337,17 +497,39 @@ class CotRunner(RunnerBase):
 
                 cot_step = default_cot_step
                 yield_answer = False
-                async for (
-                    agent_response,
-                    step,
-                    answer_flag,
-                ) in self._process_agent_responses(
-                    msgs, loop_count == 1, sp, node_trace_log
-                ):
-                    if agent_response is not None:
-                        yield agent_response
-                    cot_step = step
-                    yield_answer = answer_flag
+                try:
+                    async for (
+                        agent_response,
+                        step,
+                        answer_flag,
+                    ) in self._process_agent_responses(
+                        msgs,
+                        loop_count == 1,
+                        sp,
+                        node_trace_log,
+                        allow_plain_final_answer=bool(self.scratchpad.steps)
+                        or format_retry_used,
+                    ):
+                        if agent_response is not None:
+                            yield agent_response
+                        cot_step = step
+                        yield_answer = answer_flag
+                except cot_exc.CotExc:
+                    if format_retry_used:
+                        raise
+                    format_retry_used = True
+                    format_correction = FORMAT_CORRECTION_PROMPT
+                    loop_count -= 1
+                    logger.warning(
+                        "Retrying CoT step once with format correction; "
+                        "model={}, completed_steps={}",
+                        self.model.name,
+                        len(self.scratchpad.steps),
+                    )
+                    continue
+
+                format_retry_used = False
+                format_correction = ""
 
                 if yield_answer:
                     return

--- a/core/agent/tests/test_base_llm_model.py
+++ b/core/agent/tests/test_base_llm_model.py
@@ -55,8 +55,11 @@ class TestBaseLLMModel:
         return Span(app_id="test_app", uid="test_uid")
 
     @pytest.mark.asyncio
-    async def test_create_completion(self, model: BaseLLMModel) -> None:
+    async def test_create_completion(
+        self, model: BaseLLMModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test creating completion request"""
+        monkeypatch.delenv("DEFAULT_LLM_MAX_TOKEN", raising=False)
         mock_response = AsyncMock()
         model.llm.chat.completions.create = AsyncMock(return_value=mock_response)
 
@@ -68,6 +71,27 @@ class TestBaseLLMModel:
             stream=True,
             model="test_model",
             timeout=90,
+        )
+        assert result == mock_response
+
+    @pytest.mark.asyncio
+    async def test_create_completion_with_max_tokens_sends_one_request(
+        self, model: BaseLLMModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A configured token limit must not duplicate the upstream request."""
+        monkeypatch.setenv("DEFAULT_LLM_MAX_TOKEN", "2048")
+        mock_response = AsyncMock()
+        model.llm.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        messages = [{"role": "user", "content": "test"}]
+        result = await model.create_completion(messages, stream=True)
+
+        model.llm.chat.completions.create.assert_awaited_once_with(
+            messages=messages,
+            stream=True,
+            model="test_model",
+            timeout=90,
+            max_tokens=2048,
         )
         assert result == mock_response
 

--- a/core/agent/tests/test_runner_base_and_chat_cot.py
+++ b/core/agent/tests/test_runner_base_and_chat_cot.py
@@ -149,17 +149,294 @@ class ReasoningActionThenFinalAnswerLLM(BaseLLMModel):
                 "reasoning_content": "",
                 "content": (
                     "Thought: The sensor reading is available.\n"
-                    "Final Answer: Ready to answer."
+                    "Final Answer: Current temperature: 26.2°C"
+                ),
+            }
+        else:
+            raise AssertionError("Unexpected extra model stream call")
+
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class PlainFinalAnswerAfterActionLLM(BaseLLMModel):
+    """Fake a provider that omits Final Answer after a successful tool call."""
+
+    stream_call_count: int = 0
+    received_user_prompts: list[str] = []
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        self.received_user_prompts.append(messages[-1]["content"])
+        if self.stream_call_count == 1:
+            delta_data = {
+                "reasoning_content": "",
+                "content": (
+                    "Thought: Read the current temperature.\n"
+                    "Action: tool1\n"
+                    'Action Input: {"scenario": "normal"}'
+                ),
+            }
+        elif self.stream_call_count == 2:
+            delta_data = {
+                "reasoning_content": "",
+                "content": "The tool succeeded and the temperature is 26.2°C.",
+            }
+        else:
+            raise AssertionError("Unexpected extra model stream call")
+
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class InvalidThenCorrectedActionLLM(BaseLLMModel):
+    """Fake one malformed first step followed by a corrected ReAct step."""
+
+    stream_call_count: int = 0
+    received_user_prompts: list[str] = []
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        self.received_user_prompts.append(messages[-1]["content"])
+        if self.stream_call_count == 1:
+            delta_data = {
+                "reasoning_content": "",
+                "content": "I should read the current temperature first.",
+            }
+        elif self.stream_call_count == 2:
+            delta_data = {
+                "reasoning_content": "",
+                "content": (
+                    "Thought: Read the current temperature.\n"
+                    "Action: tool1\n"
+                    'Action Input: {"scenario": "normal"}'
                 ),
             }
         elif self.stream_call_count == 3:
             delta_data = {
                 "reasoning_content": "",
-                "content": "Current temperature: 26.2°C",
+                "content": (
+                    "Thought: The reading is available.\n"
+                    "Final Answer: Current temperature: 26.2°C"
+                ),
             }
         else:
             raise AssertionError("Unexpected extra model stream call")
 
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class PartialActionAfterSuccessfulActionLLM(BaseLLMModel):
+    """Fake a truncated post-tool step followed by a corrected final answer."""
+
+    stream_call_count: int = 0
+    received_user_prompts: list[str] = []
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        self.received_user_prompts.append(messages[-1]["content"])
+        if self.stream_call_count == 1:
+            content = (
+                "Thought: Read the current temperature.\n"
+                "Action: tool1\n"
+                'Action Input: {"scenario": "normal"}'
+            )
+        elif self.stream_call_count == 2:
+            content = "Thought: Continue with another tool.\nAction: tool1"
+        elif self.stream_call_count == 3:
+            content = (
+                "Thought: The previous tool result is sufficient.\n"
+                "Final Answer: Current temperature: 26.2°C"
+            )
+        else:
+            raise AssertionError("Unexpected extra model stream call")
+
+        delta_data = {"reasoning_content": "", "content": content}
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class ReasoningOnlyProtocolLLM(BaseLLMModel):
+    """Fake a provider that puts a complete ReAct step in reasoning_content."""
+
+    stream_call_count: int = 0
+    received_user_prompts: list[str] = []
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        self.received_user_prompts.append(messages[-1]["content"])
+        if self.stream_call_count == 1:
+            delta_data = {
+                "reasoning_content": (
+                    "Thought: Read the current temperature.\n"
+                    "Action: tool1\n"
+                    'Action Input: {"scenario": "normal"}'
+                ),
+                "content": "",
+            }
+        elif self.stream_call_count == 2:
+            delta_data = {
+                "reasoning_content": "",
+                "content": (
+                    "Thought: The reading is available.\n"
+                    "Final Answer: Current temperature: 26.2°C"
+                ),
+            }
+        else:
+            raise AssertionError("Unexpected extra model stream call")
+
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class AlwaysInvalidProtocolLLM(BaseLLMModel):
+    """Fake a provider that answers in plain text even after format correction."""
+
+    stream_call_count: int = 0
+    received_user_prompts: list[str] = []
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        self.received_user_prompts.append(messages[-1]["content"])
+        delta_data = {
+            "reasoning_content": "",
+            "content": "I will not follow the required protocol.",
+        }
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class AlwaysPartialProtocolLLM(BaseLLMModel):
+    """Fake a provider that returns an unsafe partial action twice."""
+
+    stream_call_count: int = 0
+    received_user_prompts: list[str] = []
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        self.received_user_prompts.append(messages[-1]["content"])
+        delta_data = {
+            "reasoning_content": "",
+            "content": "Thought: I should call a tool.\nAction: tool1",
+        }
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class MixedReasoningActionContentLLM(BaseLLMModel):
+    """Fake a provider that puts the action in reasoning and prose in content."""
+
+    stream_call_count: int = 0
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        self.stream_call_count += 1
+        if self.stream_call_count == 1:
+            delta_data = {
+                "reasoning_content": (
+                    "Thought: Read the current temperature.\n"
+                    "Action: tool1\n"
+                    'Action Input: {"scenario": "normal"}'
+                ),
+                "content": "I will check the sensor now.",
+            }
+        elif self.stream_call_count == 2:
+            delta_data = {
+                "reasoning_content": "",
+                "content": "Final Answer: Current temperature: 26.2°C",
+            }
+        else:
+            raise AssertionError("Unexpected extra model stream call")
+
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class ReasoningFinalWithContentLLM(BaseLLMModel):
+    """Fake a reasoning model that emits its user-facing answer in content."""
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        delta_data = {
+            "reasoning_content": "Thought: Enough context.\nFinal Answer: internal",
+            "content": "User-facing answer",
+        }
+        delta = MagicMock()
+        delta.dict.return_value = delta_data
+        delta.model_dump.return_value = delta_data
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        yield chunk
+
+
+class ReasoningOnlyFinalLLM(BaseLLMModel):
+    """Fake a provider that places the whole final protocol in reasoning."""
+
+    async def stream(  # type: ignore[override]
+        self, messages: list, stream: bool, span: Optional[Span] = None
+    ) -> AsyncIterator[Any]:
+        delta_data = {
+            "reasoning_content": (
+                "Thought: Enough context.\nFinal Answer: Reasoning-channel answer"
+            ),
+            "content": "",
+        }
         delta = MagicMock()
         delta.dict.return_value = delta_data
         delta.model_dump.return_value = delta_data
@@ -357,6 +634,36 @@ class TestCotRunnerParseStep:
         assert step.action_input == {"x": 1}
 
     @pytest.mark.asyncio
+    async def test_parse_cot_step_accepts_common_marker_variations(
+        self, cot_runner: CotRunner
+    ) -> None:
+        content = (
+            "**thought**： read the sensor\n"
+            "**ACTION**： tool1\n"
+            "**Action_Input**： ```json\n"
+            '{"x": 1}\n'
+            "```"
+        )
+
+        step = await cot_runner.parse_cot_step(content)
+
+        assert step.thought == "read the sensor"
+        assert step.action == "tool1"
+        assert step.action_input == {"x": 1}
+
+    @pytest.mark.asyncio
+    async def test_parse_cot_step_accepts_inline_markers(
+        self, cot_runner: CotRunner
+    ) -> None:
+        content = "Thought: read the sensor Action: tool1 " 'Action Input: {"x": 1}'
+
+        step = await cot_runner.parse_cot_step(content)
+
+        assert step.thought == "read the sensor"
+        assert step.action == "tool1"
+        assert step.action_input == {"x": 1}
+
+    @pytest.mark.asyncio
     async def test_parse_cot_step_invalid_format(self, cot_runner: CotRunner) -> None:
         from agent.exceptions import cot_exc
 
@@ -387,7 +694,7 @@ class TestCotRunnerParseStep:
         ]
 
         assert [(response.typ, response.content) for response in responses] == [
-            ("content", " 26.2°C")
+            ("content", "26.2°C")
         ]
         usage = node_trace.trace[-1].data.usage
         assert usage.prompt_tokens == 12
@@ -417,10 +724,9 @@ class TestCotRunnerParseStep:
             )
         ]
 
-        assert len(responses) == 1
-        assert responses[0].typ == "cot_step"
-        assert isinstance(responses[0].content, CotStep)
-        assert responses[0].content.finished_cot is True
+        assert [(response.typ, response.content) for response in responses] == [
+            ("content", "26.2°C")
+        ]
         usage = node_trace.trace[-1].data.usage
         assert usage.prompt_tokens == 12
         assert usage.completion_tokens == 8
@@ -451,7 +757,7 @@ class TestCotRunnerParseStep:
         ]
 
         assert [(response.typ, response.content) for response in responses] == [
-            ("content", " done"),
+            ("content", "done"),
             ("reasoning_content", "trailing thought"),
         ]
 
@@ -532,7 +838,307 @@ class TestCotRunnerParseStep:
         )
         assert responses[-1].typ == "content"
         assert responses[-1].content == "Current temperature: 26.2°C"
+        assert model.stream_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_recovers_plain_final_answer_after_successful_action(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = PlainFinalAnswerAfterActionLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+            received_user_prompts=[],
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        plugin_run = AsyncMock(
+            return_value=PluginResponse(
+                result={"temperature": 26.2},
+                log=[],
+            )
+        )
+        cot_runner.plugins[0].run = plugin_run
+
+        responses = [
+            response
+            async for response in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        plugin_run.assert_awaited_once()
+        assert responses[-1].typ == "content"
+        assert (
+            responses[-1].content == "The tool succeeded and the temperature is 26.2°C."
+        )
+        assert model.stream_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_retries_one_invalid_first_step_with_format_correction(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = InvalidThenCorrectedActionLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+            received_user_prompts=[],
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        plugin_run = AsyncMock(
+            return_value=PluginResponse(
+                result={"temperature": 26.2},
+                log=[],
+            )
+        )
+        cot_runner.plugins[0].run = plugin_run
+
+        responses = [
+            response
+            async for response in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        plugin_run.assert_awaited_once()
+        assert "上一次输出格式无法解析" not in model.received_user_prompts[0]
+        assert "上一次输出格式无法解析" in model.received_user_prompts[1]
+        assert all(
+            "上一次输出格式无法解析" not in prompt
+            for prompt in model.received_user_prompts[2:]
+        )
+        assert responses[-1].typ == "content"
+        assert responses[-1].content == "Current temperature: 26.2°C"
         assert model.stream_call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_run_retries_partial_protocol_without_repeating_successful_action(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = PartialActionAfterSuccessfulActionLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+            received_user_prompts=[],
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        plugin_run = AsyncMock(
+            return_value=PluginResponse(
+                result={"temperature": 26.2},
+                log=[],
+            )
+        )
+        cot_runner.plugins[0].run = plugin_run
+
+        responses = [
+            response
+            async for response in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        plugin_run.assert_awaited_once()
+        assert "上一次输出格式无法解析" in model.received_user_prompts[2]
+        assert responses[-1].content == "Current temperature: 26.2°C"
+        assert model.stream_call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_run_parses_complete_protocol_from_reasoning_content(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = ReasoningOnlyProtocolLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+            received_user_prompts=[],
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        plugin_run = AsyncMock(
+            return_value=PluginResponse(
+                result={"temperature": 26.2},
+                log=[],
+            )
+        )
+        cot_runner.plugins[0].run = plugin_run
+
+        responses = [
+            response
+            async for response in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        plugin_run.assert_awaited_once()
+        assert plugin_run.await_args.args[0] == {"scenario": "normal"}
+        assert "上一次输出格式无法解析" not in model.received_user_prompts[1]
+        assert responses[-1].content == "Current temperature: 26.2°C"
+        assert model.stream_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_accepts_plain_answer_after_one_format_correction(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = AlwaysInvalidProtocolLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+            received_user_prompts=[],
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        cot_runner.max_loop = 1
+        plugin_run = AsyncMock()
+        cot_runner.plugins[0].run = plugin_run
+
+        responses = [
+            response
+            async for response in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        plugin_run.assert_not_awaited()
+        assert "上一次输出格式无法解析" not in model.received_user_prompts[0]
+        assert "上一次输出格式无法解析" in model.received_user_prompts[1]
+        assert responses[-1].content == "I will not follow the required protocol."
+        assert model.stream_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_limits_partial_protocol_correction_to_one_retry(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = AlwaysPartialProtocolLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+            received_user_prompts=[],
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        cot_runner.max_loop = 1
+        plugin_run = AsyncMock()
+        cot_runner.plugins[0].run = plugin_run
+
+        with pytest.raises(cot_exc.CotExc):
+            async for _ in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            ):
+                pass
+
+        plugin_run.assert_not_awaited()
+        assert "上一次输出格式无法解析" in model.received_user_prompts[1]
+        assert model.stream_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_prefers_complete_reasoning_action_over_plain_content(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        model = MixedReasoningActionContentLLM.model_construct(
+            name="gpt-5.2-chat",
+            llm=MagicMock(),
+            stream_call_count=0,
+        )
+        cot_runner.model = model
+        cot_runner.process_runner.model = model
+        plugin_run = AsyncMock(
+            return_value=PluginResponse(result={"temperature": 26.2}, log=[])
+        )
+        cot_runner.plugins[0].run = plugin_run
+
+        responses = [
+            response
+            async for response in cot_runner.run(
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        plugin_run.assert_awaited_once()
+        assert plugin_run.await_args.args[0] == {"scenario": "normal"}
+        assert responses[-1].content == "Current temperature: 26.2°C"
+        assert model.stream_call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_read_response_uses_content_when_reasoning_has_final_protocol(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        cot_runner.model = ReasoningFinalWithContentLLM.model_construct(
+            name="gpt-5.2-chat", llm=MagicMock()
+        )
+        messages = MagicMock()
+        messages.list.return_value = []
+
+        responses = [
+            response
+            async for response in cot_runner.read_response(
+                messages,
+                first_loop=False,
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        assert responses[-1].typ == "content"
+        assert responses[-1].content == "User-facing answer"
+
+    @pytest.mark.asyncio
+    async def test_read_response_uses_reasoning_only_final_answer(
+        self,
+        cot_runner: CotRunner,
+        span: Span,
+        node_trace: NodeTraceLog,
+    ) -> None:
+        cot_runner.model = ReasoningOnlyFinalLLM.model_construct(
+            name="gpt-5.2-chat", llm=MagicMock()
+        )
+        messages = MagicMock()
+        messages.list.return_value = []
+
+        responses = [
+            response
+            async for response in cot_runner.read_response(
+                messages,
+                first_loop=False,
+                span=span,
+                node_trace_log=node_trace,
+            )
+        ]
+
+        assert responses[-1].typ == "content"
+        assert responses[-1].content == "Reasoning-channel answer"
 
     @pytest.mark.asyncio
     async def test_is_valid_plugin(self, cot_runner: CotRunner) -> None:


### PR DESCRIPTION
Fix intermittent intelligent-decision workflow failures by tolerating provider ReAct response variants, preserving post-tool completion output, and avoiding duplicate upstream LLM requests. Includes focused regression coverage for the CoT parser and base LLM request path.