### PR TITLE
fix(workflow): prevent SSE request replay on disconnect

### DIFF
--- a/console/frontend/_tests_/sse-request.test.js
+++ b/console/frontend/_tests_/sse-request.test.js
@@ -1,6 +1,16 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { fetchSseWithContext } from '../src/utils/sse-request.ts';
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowChatSource = readFileSync(
+  resolve(frontendRoot, 'src/components/workflow/store/flow-chat-function.ts'),
+  'utf8'
+);
 
 const originalDocument = globalThis.document;
 const originalWindow = globalThis.window;
@@ -11,8 +21,8 @@ globalThis.document = {
   hidden: false,
 };
 globalThis.window = {
-  clearTimeout,
-  setTimeout,
+  clearTimeout: globalThis.clearTimeout,
+  setTimeout: globalThis.setTimeout,
 };
 
 test.after(() => {
@@ -48,10 +58,10 @@ const captureRequest = async (path, getContext) => {
     fetch: async (input, init) => {
       capturedRequest = {
         input: input.toString(),
-        headers: new Headers(init?.headers),
+        headers: new globalThis.Headers(init?.headers),
       };
 
-      return new Response('data: {}\n\n', {
+      return new globalThis.Response('data: {}\n\n', {
         headers: { 'content-type': 'text/event-stream' },
       });
     },
@@ -119,4 +129,61 @@ test('non-team SSE requests omit stale enterprise context', async () => {
 
   assert.equal(requestWithoutSpace.headers.get('space-id'), null);
   assert.equal(requestWithoutSpace.headers.get('enterprise-id'), null);
+});
+
+test('throwing from an SSE error callback prevents POST request replay', async () => {
+  const transportError = new Error('socket closed');
+  let requestCount = 0;
+
+  await assert.rejects(
+    fetchEventSource('/workflow/chat', {
+      method: 'POST',
+      openWhenHidden: true,
+      fetch: async () => {
+        requestCount += 1;
+        throw transportError;
+      },
+      onerror(error) {
+        throw error;
+      },
+    }),
+    transportError
+  );
+
+  assert.equal(requestCount, 1);
+});
+
+test('workflow POST streams stop retries and finalize active UI state', () => {
+  assert.doesNotMatch(
+    workflowChatSource,
+    /onerror\(\)\s*\{\s*get\(\)\.controllerRef\?\.abort\(\);\s*\}/,
+    'aborting and returning from onerror still schedules the default retry'
+  );
+  assert.equal(
+    workflowChatSource.match(/handleWorkflowSseError\(error, get/g)?.length,
+    3,
+    'chat, resume, and interrupt-abort POST streams must share no-retry handling'
+  );
+  assert.match(
+    workflowChatSource,
+    /get\(\)\.wsMessageStatus\s*!==\s*'end'[\s\S]*handleFlowStop\([\s\S]*throw requestError/,
+    'transport failures must finalize an active workflow before rejecting'
+  );
+  assert.equal(
+    workflowChatSource.match(/void fetchEventSource\(/g)?.length,
+    3,
+    'all workflow POST stream promises must be handled explicitly'
+  );
+  assert.equal(
+    workflowChatSource.match(
+      /onclose\(\) \{\s*handleWorkflowSseClose\(get\);\s*\}/g
+    )?.length,
+    2,
+    'chat and resume streams must finalize when the connection closes early'
+  );
+  assert.equal(
+    workflowChatSource.match(/\.catch\(\(\) => undefined\);/g)?.length,
+    3,
+    'expected workflow SSE rejections must not become unhandled promises'
+  );
 });

--- a/console/frontend/src/components/workflow/store/flow-chat-function.ts
+++ b/console/frontend/src/components/workflow/store/flow-chat-function.ts
@@ -520,6 +520,41 @@ const handleMessageEnd = (data: WebSocketMessageData, get): void => {
   get().setInterruptChat({ ...initInterruptChat });
   handleRunningNodeStatus();
 };
+const handleWorkflowSseError = (
+  error: unknown,
+  get,
+  finalizeExecution = true
+): never => {
+  const requestError =
+    error instanceof Error ? error : new Error(String(error));
+  console.error('[Workflow SSE] Request failed', requestError);
+  if (finalizeExecution && get().wsMessageStatus !== 'end') {
+    handleFlowStop(
+      {
+        code: -1,
+        message: i18n.t(
+          'workflow.nodes.chatDebugger.workflowConnectionInterrupted'
+        ),
+      },
+      get
+    );
+  }
+  throw requestError;
+};
+const handleWorkflowSseClose = (get): void => {
+  if (get().wsMessageStatus === 'end') return;
+
+  console.error('[Workflow SSE] Connection closed before completion');
+  handleFlowStop(
+    {
+      code: -1,
+      message: i18n.t(
+        'workflow.nodes.chatDebugger.workflowConnectionInterrupted'
+      ),
+    },
+    get
+  );
+};
 const handleResumeChat = (content, get, set): void => {
   const currentFlow = useFlowsManager.getState().currentFlow;
   const nodes = useFlowStore.getState().nodes;
@@ -560,7 +595,7 @@ const handleResumeChat = (content, get, set): void => {
     params.version = get().versionId;
     params.promptDebugger = true;
   }
-  fetchEventSource(url, {
+  void fetchEventSource(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -569,13 +604,16 @@ const handleResumeChat = (content, get, set): void => {
     body: JSON.stringify(params),
     signal: get().controllerRef?.signal,
     openWhenHidden: true,
-    onerror() {
-      get().controllerRef?.abort();
+    onerror(error) {
+      handleWorkflowSseError(error, get);
+    },
+    onclose() {
+      handleWorkflowSseClose(get);
     },
     onmessage(e) {
       handleMessage(nodes, edges, e, get, set);
     },
-  });
+  }).catch(() => undefined);
   clearNodeStatus(get);
 };
 const runDebugger = (obj: unknown): void => {
@@ -614,7 +652,7 @@ const runDebugger = (obj: unknown): void => {
     params.version = get().versionId;
     params.promptDebugger = true;
   }
-  fetchEventSource(url, {
+  void fetchEventSource(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -623,13 +661,16 @@ const runDebugger = (obj: unknown): void => {
     body: JSON.stringify(params),
     signal: get().controllerRef?.signal,
     openWhenHidden: true,
-    onerror() {
-      get().controllerRef?.abort();
+    onerror(error) {
+      handleWorkflowSseError(error, get);
+    },
+    onclose() {
+      handleWorkflowSseClose(get);
     },
     onmessage(e) {
       handleMessage(nodes, edges, e, get, set);
     },
-  });
+  }).catch(() => undefined);
   clearNodeStatus(get);
 };
 const advancedConfig = (): unknown => {
@@ -899,19 +940,18 @@ const handleStopConversation = (get): void => {
       eventId: get().interruptChat?.eventId,
       eventType: 'abort',
     };
-    fetchEventSource(url, {
+    void fetchEventSource(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: getAuthorization(),
       },
       body: JSON.stringify(params),
-      signal: get().controllerRef?.signal,
       openWhenHidden: true,
-      onerror() {
-        get().controllerRef?.abort();
+      onerror(error) {
+        handleWorkflowSseError(error, get, false);
       },
-    });
+    }).catch(() => undefined);
   }
   get().setChatList(chatList => [
     ...chatList,

--- a/console/frontend/src/locales/en-En/workflow.ts
+++ b/console/frontend/src/locales/en-En/workflow.ts
@@ -747,6 +747,8 @@ const translation = {
       userIgnoredQuestion: 'User ignored this question',
       userCurrentRoundInput: 'User current round dialogue input content',
       workflowTerminated: 'Workflow terminated',
+      workflowConnectionInterrupted:
+        'Workflow connection interrupted. Try again.',
       startNewConversation: 'Start New Conversation',
       deepThinking: 'Deep Thinking',
       generating: 'Generating',

--- a/console/frontend/src/locales/zh-ZH/workflow.ts
+++ b/console/frontend/src/locales/zh-ZH/workflow.ts
@@ -717,6 +717,7 @@ const translation = {
       userIgnoredQuestion: '用户已忽略此次问答',
       userCurrentRoundInput: '用户本轮对话输入内容',
       workflowTerminated: '工作流终止运行',
+      workflowConnectionInterrupted: '工作流连接中断，请重试',
       startNewConversation: '开启新对话',
       deepThinking: '已深度思考',
       generating: '生成中',

--- a/core/workflow/consts/engine/timeout.py
+++ b/core/workflow/consts/engine/timeout.py
@@ -3,4 +3,5 @@ from enum import Enum
 
 class QueueTimeout(Enum):
     AsyncQT = 600
-    PingQT = 30
+    # Keep the SSE connection active before the 30-second proxy idle boundary.
+    PingQT = 15

--- a/core/workflow/tests/service/test_chat_service_response_filter.py
+++ b/core/workflow/tests/service/test_chat_service_response_filter.py
@@ -1,4 +1,10 @@
+import asyncio
+
+import pytest
+
+from workflow.consts.app_audit import AppAuditPolicy
 from workflow.consts.engine.chat_status import ChatStatus
+from workflow.consts.engine.timeout import QueueTimeout
 from workflow.engine.callbacks.openai_types_sse import (
     Choice,
     Delta,
@@ -6,7 +12,7 @@ from workflow.engine.callbacks.openai_types_sse import (
     NodeInfo,
     WorkflowStep,
 )
-from workflow.service.chat_service import _filter_response_frame
+from workflow.service.chat_service import _filter_response_frame, _get_response
 
 
 def test_release_filter_keeps_end_node_variable_content() -> None:
@@ -65,3 +71,28 @@ def test_release_filter_keeps_workflow_end_content() -> None:
     assert filtered.workflow_step.node is None
     assert filtered.workflow_step.seq == 4
     assert filtered.choices[0].delta.content == '{"output":[{"name":"test"}]}'
+
+
+@pytest.mark.asyncio
+async def test_idle_workflow_sends_heartbeat_before_30_seconds(
+    monkeypatch,
+) -> None:
+    observed_timeouts: list[float] = []
+
+    async def timeout_immediately(awaitable, *, timeout: float):
+        observed_timeouts.append(timeout)
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", timeout_immediately)
+
+    response = await _get_response(
+        app_audit_policy=AppAuditPolicy.DEFAULT,
+        audit_strategy=None,
+        response_queue=asyncio.Queue(),
+        last_response=None,
+    )
+
+    assert observed_timeouts == [15]
+    assert QueueTimeout.PingQT.value == 15
+    assert response.choices[0].finish_reason == "ping"


### PR DESCRIPTION
Reduce workflow SSE heartbeat interval below the proxy idle timeout, prevent automatic replay of state-changing POST streams, finalize interrupted UI state, and add regression coverage.