### PR TITLE
chore(ci): satisfy Python quality checks

### DIFF
--- a/core/agent/engine/nodes/cot/cot_runner.py
+++ b/core/agent/engine/nodes/cot/cot_runner.py
@@ -212,7 +212,8 @@ class CotRunner(RunnerBase):
         # 其他情况都视为无效格式
         raise cot_exc.CotFormatIncorrectExc("无效的推理格式，缺少必要的标识字段")
 
-    async def read_response(
+    # Keep the streaming protocol transitions together as one state machine.
+    async def read_response(  # noqa: C901
         self,
         messages: LLMMessages,
         first_loop: bool,
@@ -468,7 +469,8 @@ class CotRunner(RunnerBase):
             cot_step.action_output = plugin_response.result
             yield AgentResponse(typ="cot_step", content=cot_step, model=self.model.name)
 
-    async def run(
+    # Keep the retry, tool-execution, and completion transitions together.
+    async def run(  # noqa: C901
         self, span: Span, node_trace_log: NodeTraceLog
     ) -> AsyncIterator[AgentResponse]:
         """cot run"""

--- a/core/workflow/tests/service/test_chat_service_response_filter.py
+++ b/core/workflow/tests/service/test_chat_service_response_filter.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -75,11 +76,11 @@ def test_release_filter_keeps_workflow_end_content() -> None:
 
 @pytest.mark.asyncio
 async def test_idle_workflow_sends_heartbeat_before_30_seconds(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed_timeouts: list[float] = []
 
-    async def timeout_immediately(awaitable, *, timeout: float):
+    async def timeout_immediately(awaitable: Any, *, timeout: float) -> None:
         observed_timeouts.append(timeout)
         awaitable.close()
         raise asyncio.TimeoutError


### PR DESCRIPTION
Resolve the remote Python quality findings for the intelligent-decision/SSE fix by documenting the intentional CoT state-machine complexity exemptions and typing the workflow heartbeat test helpers. Production behavior is unchanged.