### PR TITLE
docs: refine release workflow instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,92 +59,23 @@ Astron Agent is an enterprise-grade Agentic Workflow development platform. It in
 - Console Backend -> Core Services: HTTP/REST
 - Core Services -> Core Services: Kafka event-driven communication
 
-## Behavioral Guidelines to Reduce Common LLM Coding Mistakes
-
-Merge these with project-specific instructions as needed.
-
-Tradeoff: These guidelines prioritize caution over speed. Use judgment for trivial tasks.
-
-### 1. Think Before Coding
-
-Do not assume. Do not hide confusion. Surface tradeoffs.
-
-Before implementing:
-
-- State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them instead of choosing silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Identify what is confusing and ask.
-
-### 2. Simplicity First
-
-Write the minimum code that solves the problem. Nothing speculative.
-
-- Do not add features beyond what was asked.
-- Do not add abstractions for single-use code.
-- Do not add "flexibility" or "configurability" that was not requested.
-- Do not add error handling for impossible scenarios.
-- If you write 200 lines and the same result could be achieved in 50, rewrite it.
-- Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
-
-### 3. Surgical Changes
-
-Touch only what you must. Clean up only your own mess.
-
-When editing existing code:
-
-- Do not "improve" adjacent code, comments, or formatting.
-- Do not refactor things that are not broken.
-- Match the existing style, even if you would normally do it differently.
-- If you notice unrelated dead code, mention it. Do not delete it.
-
-When your changes create orphans:
-
-- Remove imports, variables, or functions that become unused because of your changes.
-- Do not remove pre-existing dead code unless asked.
-- Use this test: every changed line should trace directly to the user's request.
-
-### 4. Goal-Driven Execution
-
-Define success criteria. Iterate until verified.
-
-Turn tasks into verifiable goals:
-
-- "Add validation" -> "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" -> "Write a test that reproduces it, then make it pass"
-- "Refactor X" -> "Ensure tests pass before and after"
-
-For multi-step tasks, state a brief plan:
-
-1. [Step] -> verify: [check]
-2. [Step] -> verify: [check]
-3. [Step] -> verify: [check]
-
-Strong success criteria allow you to work independently in a loop. Weak criteria such as "make it work" require constant clarification.
-
-These guidelines are working if there are fewer unnecessary changes in diffs, fewer rewrites caused by overcomplication, and more clarifying questions before implementation rather than after mistakes.
-
-## Modification Recommendations
-
-- Before making changes, first identify the target module. Do not modify shared layers directly before understanding the call chain.
-- If a change involves multiple services, make the call chain and dependency direction explicit.
-- If Kafka, Redis, MinIO, or authentication is involved, evaluate the impact on other services first.
-
 ## Important Notes
 
-- Before implementation, first confirm the target module, upstream and downstream dependencies, and the verification approach.
+- Before making any changes, clearly identify the target module along with its complete call chain and upstream/downstream dependencies. For cross‑service changes, explicitly document the invocation path and dependency direction. Direct modifications to shared layers are strictly prohibited without a thorough impact assessment.
+- If Kafka, Redis, MinIO, or authentication is involved, evaluate the impact on other services first.
 - **Always prioritize official frameworks, SDKs, and APIs.** When an official framework, SDK, or API exists for a task, you MUST use it instead of hand-rolling a custom implementation, reimplementing existing capabilities, or calling lower-level interfaces directly. Only fall back to a custom approach when no official option covers the need, and state explicitly why the official option was insufficient.
 - If it is a complete feature request or a complex bug, add logs at key points as much as reasonably possible to help with troubleshooting, but do not add excessive logging.
 
 ## Key Workflow Expectations
 
-Once feature development and testing are complete, run the following release-and-acceptance loop **autonomously, end to end, without asking the user to confirm any step**. Steps 1–3 each dispatch a new subagent to run the named skill under `.codex\skills\`. Step 4 is different: the main agent reads and runs the skill itself, then spawns its own testing subagent as the skill directs — do not hand the whole skill to a single subagent. Repeat the loop until acceptance passes.
+Once the code review is completed and approved, run the following release-and-acceptance loop **autonomously, end to end, without asking the user to confirm any step**. Steps 1, 3, and 5 each dispatch a new subagent to run the named skill under `.codex\skills\` (step 2 is the main agent polling the image build). Step 4 is different: the main agent reads and runs the skill itself, then spawns its own testing subagent as the skill directs — do not hand the whole skill to a single subagent. Repeat the loop until acceptance passes, then run the final CI check as the closing step.
 
 1. **Publish and merge** — Dispatch a subagent to execute the `astron-agent-pr-publish` skill. It commits the eligible local changes, pushes the current branch to `origin`, opens a same-branch pull request into `iflytek/astron-agent`, and merges it once the PR has no conflicts.
 2. **Wait for the image build** — Merging into the upstream branch triggers the image-build workflow `.github/workflows/build-push.yml` in `iflytek/astron-agent`, which builds and pushes all service images to GHCR and takes ~16 minutes. Do not deploy before it finishes. Poll the run with `gh run list` / `gh run watch -R iflytek/astron-agent` on the branch you merged into (rather than sleeping a fixed time), and proceed only when it concludes with `success`. If the build fails, fix the cause and restart from step 1.
 3. **Deploy** — After the build succeeds, dispatch a subagent to execute the `astron-agent-server-deploy` skill, which pulls the new images, restarts the stack, and prunes dangling images on the server. Wait until the deployment completes and all services are up.
 4. **Acceptance test** — Once all services are running, the **main agent itself** reads and runs the `astron-agent-e2e-acceptance` skill (do not delegate the whole skill to a subagent). Following the skill, the main agent selects the feature points to verify, dispatches a testing-only subagent to drive the browser via the Chrome plugin, and uses the returned evidence to judge pass/fail.
-   - **Pass** → the loop is complete; report the result and stop.
-   - **Fail** → the main agent automatically diagnoses and fixes the issues surfaced by the subagent's evidence, then restarts from step 1. Keep iterating until acceptance passes.
+   - **Pass** → proceed to step 5.
+   - **Fail** → The main agent automatically diagnoses the root cause from the subagent's evidence and fixes the issue strictly following the development workflow. After the fix is complete, restart from step 1. Continue iterating until acceptance passes.
+5. **Remote CI check** — After acceptance passes, dispatch a subagent to execute the `astron-agent-remote-ci-check` skill as the final closing step of the whole loop. This entire flow runs **completely within the subagent** — the main agent must not intervene. The subagent has full tool access. **The subagent's sole responsibility is to run CI checks and CI repairs exactly as the skill directs, and then return the result to the main agent — it must not concern itself with anything else** . Once the subagent returns its result, the loop is complete; report the result and stop.
 
 Safety net: if the same failure persists across several full iterations with no progress, stop and report to the user instead of looping indefinitely.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,92 +59,23 @@ Astron Agent is an enterprise-grade Agentic Workflow development platform. It in
 - Console Backend -> Core Services: HTTP/REST
 - Core Services -> Core Services: Kafka event-driven communication
 
-## Behavioral Guidelines to Reduce Common LLM Coding Mistakes
-
-Merge these with project-specific instructions as needed.
-
-Tradeoff: These guidelines prioritize caution over speed. Use judgment for trivial tasks.
-
-### 1. Think Before Coding
-
-Do not assume. Do not hide confusion. Surface tradeoffs.
-
-Before implementing:
-
-- State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them instead of choosing silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Identify what is confusing and ask.
-
-### 2. Simplicity First
-
-Write the minimum code that solves the problem. Nothing speculative.
-
-- Do not add features beyond what was asked.
-- Do not add abstractions for single-use code.
-- Do not add "flexibility" or "configurability" that was not requested.
-- Do not add error handling for impossible scenarios.
-- If you write 200 lines and the same result could be achieved in 50, rewrite it.
-- Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
-
-### 3. Surgical Changes
-
-Touch only what you must. Clean up only your own mess.
-
-When editing existing code:
-
-- Do not "improve" adjacent code, comments, or formatting.
-- Do not refactor things that are not broken.
-- Match the existing style, even if you would normally do it differently.
-- If you notice unrelated dead code, mention it. Do not delete it.
-
-When your changes create orphans:
-
-- Remove imports, variables, or functions that become unused because of your changes.
-- Do not remove pre-existing dead code unless asked.
-- Use this test: every changed line should trace directly to the user's request.
-
-### 4. Goal-Driven Execution
-
-Define success criteria. Iterate until verified.
-
-Turn tasks into verifiable goals:
-
-- "Add validation" -> "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" -> "Write a test that reproduces it, then make it pass"
-- "Refactor X" -> "Ensure tests pass before and after"
-
-For multi-step tasks, state a brief plan:
-
-1. [Step] -> verify: [check]
-2. [Step] -> verify: [check]
-3. [Step] -> verify: [check]
-
-Strong success criteria allow you to work independently in a loop. Weak criteria such as "make it work" require constant clarification.
-
-These guidelines are working if there are fewer unnecessary changes in diffs, fewer rewrites caused by overcomplication, and more clarifying questions before implementation rather than after mistakes.
-
-## Modification Recommendations
-
-- Before making changes, first identify the target module. Do not modify shared layers directly before understanding the call chain.
-- If a change involves multiple services, make the call chain and dependency direction explicit.
-- If Kafka, Redis, MinIO, or authentication is involved, evaluate the impact on other services first.
-
 ## Important Notes
 
-- Before implementation, first confirm the target module, upstream and downstream dependencies, and the verification approach.
+- Before making any changes, clearly identify the target module along with its complete call chain and upstream/downstream dependencies. For cross‑service changes, explicitly document the invocation path and dependency direction. Direct modifications to shared layers are strictly prohibited without a thorough impact assessment.
+- If Kafka, Redis, MinIO, or authentication is involved, evaluate the impact on other services first.
 - **Always prioritize official frameworks, SDKs, and APIs.** When an official framework, SDK, or API exists for a task, you MUST use it instead of hand-rolling a custom implementation, reimplementing existing capabilities, or calling lower-level interfaces directly. Only fall back to a custom approach when no official option covers the need, and state explicitly why the official option was insufficient.
 - If it is a complete feature request or a complex bug, add logs at key points as much as reasonably possible to help with troubleshooting, but do not add excessive logging.
 
 ## Key Workflow Expectations
 
-Once feature development and testing are complete, run the following release-and-acceptance loop **autonomously, end to end, without asking the user to confirm any step**. Steps 1–3 each dispatch a new subagent to run the named skill under `.claude\skills\`. Step 4 is different: the main agent reads and runs the skill itself, then spawns its own testing subagent as the skill directs — do not hand the whole skill to a single subagent. Repeat the loop until acceptance passes.
+Once the code review is completed and approved, run the following release-and-acceptance loop **autonomously, end to end, without asking the user to confirm any step**. Steps 1, 3, and 5 each dispatch a new subagent to run the named skill under `.claude\skills\` (step 2 is the main agent polling the image build). Step 4 is different: the main agent reads and runs the skill itself, then spawns its own testing subagent as the skill directs — do not hand the whole skill to a single subagent. Repeat the loop until acceptance passes, then run the final CI check as the closing step.
 
 1. **Publish and merge** — Dispatch a subagent to execute the `astron-agent-pr-publish` skill. It commits the eligible local changes, pushes the current branch to `origin`, opens a same-branch pull request into `iflytek/astron-agent`, and merges it once the PR has no conflicts.
 2. **Wait for the image build** — Merging into the upstream branch triggers the image-build workflow `.github/workflows/build-push.yml` in `iflytek/astron-agent`, which builds and pushes all service images to GHCR and takes ~16 minutes. Do not deploy before it finishes. Poll the run with `gh run list` / `gh run watch -R iflytek/astron-agent` on the branch you merged into (rather than sleeping a fixed time), and proceed only when it concludes with `success`. If the build fails, fix the cause and restart from step 1.
 3. **Deploy** — After the build succeeds, dispatch a subagent to execute the `astron-agent-server-deploy` skill, which pulls the new images, restarts the stack, and prunes dangling images on the server. Wait until the deployment completes and all services are up.
 4. **Acceptance test** — Once all services are running, the **main agent itself** reads and runs the `astron-agent-e2e-acceptance` skill (do not delegate the whole skill to a subagent). Following the skill, the main agent selects the feature points to verify, dispatches a testing-only subagent (a full-tool type such as `general-purpose`) to drive the browser via the Playwright MCP tools, and uses the returned evidence to judge pass/fail.
-   - **Pass** → the loop is complete; report the result and stop.
-   - **Fail** → the main agent automatically diagnoses and fixes the issues surfaced by the subagent's evidence, then restarts from step 1. Keep iterating until acceptance passes.
+   - **Pass** → proceed to step 5.
+   - **Fail** → The main agent automatically diagnoses the root cause from the subagent's evidence and fixes the issue strictly following the development workflow. After the fix is complete, restart from step 1. Continue iterating until acceptance passes.
+5. **Remote CI check** — After acceptance passes, dispatch a subagent to execute the `astron-agent-remote-ci-check` skill as the final closing step of the whole loop. This entire flow runs **completely within the subagent** — the main agent must not intervene. The subagent has full tool access. **The subagent's sole responsibility is to run CI checks and CI repairs exactly as the skill directs, and then return the result to the main agent — it must not concern itself with anything else** . Once the subagent returns its result, the loop is complete; report the result and stop.
 
 Safety net: if the same failure persists across several full iterations with no progress, stop and report to the user instead of looping indefinitely.


### PR DESCRIPTION
Summary: streamline the project guidance and add the remote CI check as the final release-loop step. Changes are limited to AGENTS.md and CLAUDE.md.