### PR TITLE
fix(workflow): enforce copy permissions

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -4474,6 +4474,9 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         Workflow sourceFlow = this.getOne(new LambdaQueryWrapper<Workflow>().eq(Workflow::getFlowId, sourceFlowId));
         Workflow targetFlow = this.getOne(new LambdaQueryWrapper<Workflow>().eq(Workflow::getFlowId, targetFlowId));
         if (sourceFlow != null && targetFlow != null) {
+            Long spaceId = SpaceInfoUtil.getSpaceId();
+            dataPermissionCheckTool.checkWorkflowVisible(sourceFlow, spaceId);
+            assertWorkflowBelongsToCurrentContext(targetFlow, spaceId);
             log.info("Start copying flow, sourceFlowId{}, targetFlowId{}, targetFlow source data {}", sourceFlowId, targetFlowId, targetFlow.getData());
             targetFlow.setData(sourceFlow.getData());
             targetFlow.setUpdateTime(new Date());

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceCopyFlowPermissionTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceCopyFlowPermissionTest.java
@@ -1,0 +1,99 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.entity.workflow.Workflow;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.util.space.SpaceInfoUtil;
+import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowServiceCopyFlowPermissionTest {
+
+    @Mock
+    private DataPermissionCheckTool dataPermissionCheckTool;
+
+    private WorkflowService workflowService;
+
+    @BeforeEach
+    void setUp() {
+        workflowService = spy(new WorkflowService());
+        ReflectionTestUtils.setField(workflowService, "dataPermissionCheckTool", dataPermissionCheckTool);
+    }
+
+    @Test
+    void copyFlowShouldCheckSourceVisibilityAndTargetOwnership() {
+        Workflow source = workflow("source", 100L, "source-data");
+        Workflow target = workflow("target", 100L, "target-data");
+        doReturn(source, target).when(workflowService).getOne(any(Wrapper.class));
+        doReturn(true).when(workflowService).updateById(target);
+
+        try (MockedStatic<SpaceInfoUtil> space = org.mockito.Mockito.mockStatic(SpaceInfoUtil.class)) {
+            space.when(SpaceInfoUtil::getSpaceId).thenReturn(100L);
+            assertThat(workflowService.copyFlow("source", "target")).isEqualTo(true);
+        }
+
+        verify(dataPermissionCheckTool).checkWorkflowVisible(source, 100L);
+        verify(workflowService).updateById(target);
+        assertThat(target.getData()).isEqualTo("source-data");
+    }
+
+    @Test
+    void copyFlowShouldNotDiscloseInvisibleSource() {
+        Workflow source = workflow("source", 200L, "secret-data");
+        Workflow target = workflow("target", 100L, "target-data");
+        doReturn(source, target).when(workflowService).getOne(any(Wrapper.class));
+        doThrow(new BusinessException(ResponseEnum.INSUFFICIENT_PERMISSIONS))
+                .when(dataPermissionCheckTool).checkWorkflowVisible(source, 100L);
+
+        try (MockedStatic<SpaceInfoUtil> space = org.mockito.Mockito.mockStatic(SpaceInfoUtil.class)) {
+            space.when(SpaceInfoUtil::getSpaceId).thenReturn(100L);
+            assertThatThrownBy(() -> workflowService.copyFlow("source", "target"))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        verify(workflowService, never()).updateById(any(Workflow.class));
+        assertThat(target.getData()).isEqualTo("target-data");
+    }
+
+    @Test
+    void copyFlowShouldNotOverwriteTargetFromAnotherSpace() {
+        Workflow source = workflow("source", 100L, "source-data");
+        Workflow target = workflow("target", 200L, "target-data");
+        target.setIsPublic(true);
+        doReturn(source, target).when(workflowService).getOne(any(Wrapper.class));
+
+        try (MockedStatic<SpaceInfoUtil> space = org.mockito.Mockito.mockStatic(SpaceInfoUtil.class)) {
+            space.when(SpaceInfoUtil::getSpaceId).thenReturn(100L);
+            assertThatThrownBy(() -> workflowService.copyFlow("source", "target"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("code")
+                    .isEqualTo(ResponseEnum.INSUFFICIENT_PERMISSIONS.getCode());
+        }
+
+        verify(dataPermissionCheckTool).checkWorkflowVisible(source, 100L);
+        verify(workflowService, never()).updateById(any(Workflow.class));
+        assertThat(target.getData()).isEqualTo("target-data");
+    }
+
+    private Workflow workflow(String flowId, Long spaceId, String data) {
+        Workflow workflow = new Workflow();
+        workflow.setFlowId(flowId);
+        workflow.setSpaceId(spaceId);
+        workflow.setData(data);

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceCopyFlowPermissionTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceCopyFlowPermissionTest.java
@@ -60,7 +60,8 @@ class WorkflowServiceCopyFlowPermissionTest {
         Workflow target = workflow("target", 100L, "target-data");
         doReturn(source, target).when(workflowService).getOne(any(Wrapper.class));
         doThrow(new BusinessException(ResponseEnum.INSUFFICIENT_PERMISSIONS))
-                .when(dataPermissionCheckTool).checkWorkflowVisible(source, 100L);
+                .when(dataPermissionCheckTool)
+                .checkWorkflowVisible(source, 100L);
 
         try (MockedStatic<SpaceInfoUtil> space = org.mockito.Mockito.mockStatic(SpaceInfoUtil.class)) {
             space.when(SpaceInfoUtil::getSpaceId).thenReturn(100L);

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceCopyFlowPermissionTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceCopyFlowPermissionTest.java
@@ -97,3 +97,6 @@ class WorkflowServiceCopyFlowPermissionTest {
         workflow.setFlowId(flowId);
         workflow.setSpaceId(spaceId);
         workflow.setData(data);
+        return workflow;
+    }
+}


### PR DESCRIPTION
## Summary

- require read visibility on the source workflow before copying its definition
- require the target workflow to belong to the current user or space before updating it
- add regression coverage for allowed copies, private-source disclosure attempts, and cross-space target overwrites

## Why

`GET /workflow/copy-flow` previously loaded source and target workflows by caller-controlled IDs and copied the complete workflow data without authorization checks. An authenticated user could disclose a private workflow by copying it into their own flow or overwrite another tenant's workflow.

The target uses the service's strict current-context ownership check instead of `checkWorkflowBelong`, because the latter also permits public workflows and is therefore insufficient for a write target.

Fixes #1590.

## Validation

- `git diff --check` passed
- added `WorkflowServiceCopyFlowPermissionTest` with three permission scenarios
- local Maven test execution was attempted twice, but first-time dependency resolution exceeded the 10-minute command limit both times; no compilation or test failure was reported before timeout

## Impact

Authorized same-space copies continue to work. Cross-tenant reads and writes through `copy-flow` now fail with the existing permission errors before workflow data is modified.
