### PR TITLE
fix(workflow): persist large LLM protocols safely

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -1630,6 +1630,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         bizOutputs.forEach(bo -> {
             InputOutput o = new InputOutput();
             org.springframework.beans.BeanUtils.copyProperties(bo, o);
+            o.setRequired(Boolean.TRUE.equals(bo.getRequired()));
 
             BizSchema bs = bo.getSchema();
             Schema s = new Schema();
@@ -2636,7 +2637,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
 
         // body = StringEscapeUtils.unescapeJava(body);
 
-        log.info("workflow protocol update, url = {}, body = {}", url, body);
+        logWorkflowProtocolUpdate(url, flowId, body, protocolJson);
         String response = OkHttpUtil.post(url, body);
         log.info("workflow protocol update, response = {}", response);
         Result<?> result = JSON.parseObject(response, Result.class);
@@ -2648,6 +2649,21 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         saveFlowProtocolTemp(flowId,
                 saveDto.getData() == null ? null : JSON.toJSONString(saveDto.getData()),
                 protocolJson == null || protocolJson.get("data") == null ? null : JSON.toJSONString(protocolJson.get("data")));
+    }
+
+    private void logWorkflowProtocolUpdate(String url, String flowId, String body, JSONObject protocolJson) {
+        JSONObject protocolData = protocolJson == null ? null : protocolJson.getJSONObject("data");
+        JSONArray nodes = protocolData == null ? null : protocolData.getJSONArray("nodes");
+        JSONArray edges = protocolData == null ? null : protocolData.getJSONArray("edges");
+        int bodyBytes = body == null ? 0 : body.getBytes(StandardCharsets.UTF_8).length;
+
+        log.info(
+                "workflow protocol update, url = {}, flowId = {}, bodyBytes = {}, nodeCount = {}, edgeCount = {}",
+                url,
+                flowId,
+                bodyBytes,
+                nodes == null ? 0 : nodes.size(),
+                edges == null ? 0 : edges.size());
     }
 
     private void removeWorkflowUiValidationFields(Object value) {

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceProtocolBoundaryTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceProtocolBoundaryTest.java
@@ -1,0 +1,96 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizInputOutput;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizSchema;
+import com.iflytek.astron.console.toolkit.entity.core.workflow.node.InputOutput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkflowServiceProtocolBoundaryTest {
+
+    private WorkflowService workflowService;
+
+    @BeforeEach
+    void setUp() {
+        workflowService = new WorkflowService();
+    }
+
+    @Test
+    void outputCopyDefaultsMissingRequiredToFalseAndPreservesTrue() {
+        List<InputOutput> outputs = new ArrayList<>();
+
+        ReflectionTestUtils.invokeMethod(
+                workflowService,
+                "outputCopy",
+                List.of(output("optional", null), output("required", Boolean.TRUE)),
+                outputs);
+
+        assertThat(outputs).extracting(InputOutput::getRequired).containsExactly(Boolean.FALSE, Boolean.TRUE);
+
+        JSONArray serializedOutputs = JSON.parseArray(JSON.toJSONString(outputs));
+        assertThat(serializedOutputs.getJSONObject(0).containsKey("required")).isTrue();
+        assertThat(serializedOutputs.getJSONObject(0).getBoolean("required")).isFalse();
+        assertThat(serializedOutputs.getJSONObject(1).getBoolean("required")).isTrue();
+    }
+
+    @Test
+    void protocolUpdateLogContainsSafeSummaryWithoutProtocolBody() {
+        String url = "http://workflow/workflow/v1/protocol/update/flow-1";
+        String flowId = "flow-1";
+        String body = "{\"modelApiKey\":\"secret-api-key\",\"prompt\":\"敏感提示词\"}";
+        JSONObject protocolJson = new JSONObject().fluentPut(
+                "data",
+                new JSONObject()
+                        .fluentPut("nodes", new JSONArray(List.of(new JSONObject(), new JSONObject())))
+                        .fluentPut("edges", new JSONArray(List.of(new JSONObject()))));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(WorkflowService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            ReflectionTestUtils.invokeMethod(
+                    workflowService, "logWorkflowProtocolUpdate", url, flowId, body, protocolJson);
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(appender.list).hasSize(1);
+        String message = appender.list.getFirst().getFormattedMessage();
+        assertThat(message)
+                .contains("url = " + url)
+                .contains("flowId = " + flowId)
+                .contains("bodyBytes = " + body.getBytes(StandardCharsets.UTF_8).length)
+                .contains("nodeCount = 2")
+                .contains("edgeCount = 1")
+                .doesNotContain(body)
+                .doesNotContain("secret-api-key")
+                .doesNotContain("敏感提示词");
+    }
+
+    private static BizInputOutput output(String name, Boolean required) {
+        BizSchema schema = new BizSchema();
+        schema.setType("string");
+
+        BizInputOutput output = new BizInputOutput();
+        output.setName(name);
+        output.setRequired(required);
+        output.setSchema(schema);
+        return output;
+    }
+}

--- a/console/frontend/src/components/workflow/nodes/components/model-select/index.tsx
+++ b/console/frontend/src/components/workflow/nodes/components/model-select/index.tsx
@@ -220,6 +220,7 @@ const useModelSelect = (
           customParameterType: 'deepseekr1',
           name: 'REASONING_CONTENT',
           nameErrMsg: '',
+          required: false,
           schema: {
             default: t('workflow.nodes.modelSelect.modelThinkingProcess'),
             type: 'string',

--- a/console/frontend/src/components/workflow/nodes/llm/index.tsx
+++ b/console/frontend/src/components/workflow/nodes/llm/index.tsx
@@ -315,6 +315,7 @@ const OutputSection = ({
                             customParameterType: 'deepseekr1',
                             name: 'REASONING_CONTENT',
                             nameErrMsg: '',
+                            required: false,
                             schema: {
                               default: t(
                                 'workflow.nodes.largeModelNode.modelThinkingProcess'
@@ -325,6 +326,7 @@ const OutputSection = ({
                           {
                             id: uuid(),
                             name: 'output',
+                            required: false,
                             schema: {
                               type: 'string',
                               default: '',
@@ -335,6 +337,7 @@ const OutputSection = ({
                           {
                             id: uuid(),
                             name: 'output',
+                            required: false,
                             schema: {
                               type: 'string',
                               default: '',
@@ -347,6 +350,7 @@ const OutputSection = ({
                       {
                         id: uuid(),
                         name: 'output',
+                        required: false,
                         schema: {
                           type: 'string',
                           default: '',

--- a/core/workflow/alembic/versions/2026_08_06_1742-fdacc27881b5_expand_flow_protocol_columns.py
+++ b/core/workflow/alembic/versions/2026_08_06_1742-fdacc27881b5_expand_flow_protocol_columns.py
@@ -1,0 +1,54 @@
+"""expand flow protocol columns
+
+Use MySQL LONGTEXT for serialized workflow protocols instead of the 64 KiB TEXT
+limit. The Core payload includes wrapper fields and JSON escaping beyond the
+Console's protocol-data byte limit, so LONGTEXT preserves that serialization
+headroom.
+
+Revision ID: fdacc27881b5
+Revises: b13356244aea
+Create Date: 2026-08-06 17:42:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision: str = "fdacc27881b5"
+down_revision: Union[str, None] = "b13356244aea"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_PROTOCOL_COLUMN_COMMENTS = {
+    "data": "编排标准协议",
+    "release_data": "发布后的数据",
+}
+
+
+def upgrade() -> None:
+    for column_name, comment in _PROTOCOL_COLUMN_COMMENTS.items():
+        op.alter_column(
+            "flow",
+            column_name,
+            existing_type=sa.Text(),
+            type_=mysql.LONGTEXT(),
+            existing_nullable=True,
+            existing_server_default=None,
+            existing_comment=comment,
+        )
+
+
+def downgrade() -> None:
+    # Once a protocol larger than 65,535 bytes is stored, shrinking these columns
+    # can fail or truncate data depending on MySQL SQL mode. Keeping LONGTEXT is
+    # backward-compatible with older application code, so this schema migration is
+    # deliberately irreversible rather than risking protocol corruption.
+    raise RuntimeError(
+        "This migration is irreversible: flow.data and flow.release_data may contain "
+        "values that do not fit in MySQL TEXT."
+    )

--- a/core/workflow/api/v1/flow/layout.py
+++ b/core/workflow/api/v1/flow/layout.py
@@ -40,6 +40,14 @@ from workflow.service import app_service, flow_service
 router = APIRouter(tags=["Flows"])
 
 
+def _protocol_validation_exception(error: ValidationError) -> CustomException:
+    """Create a client-safe protocol validation exception."""
+    return CustomException(
+        err_code=CodeEnum.PARAM_ERROR,
+        err_msg=ValidationParse.validation_error(error),
+    )
+
+
 @router.post("/protocol/add", status_code=status.HTTP_200_OK)
 async def add(
     flow: Flow,
@@ -57,7 +65,7 @@ async def add(
         attributes={"flow_id": flow.id},
     ) as current_span:
         try:
-            await current_span.add_info_event_async(f"add flow vo: {flow.json()}")
+            await current_span.add_info_event_async(f"add flow start: {flow.id}")
 
             app_info = await app_service.get_info(flow.app_id, session, current_span)
             db_flow = flow_service.save(flow, app_info, session, current_span)
@@ -73,11 +81,7 @@ async def add(
                     )
                     await current_span.add_info_event_async("Protocol validation end")
                 except ValidationError as err:
-                    current_span.record_exception(err)
-                    raise CustomException(
-                        err_code=CodeEnum.PARAM_ERROR,
-                        err_msg=ValidationParse.validation_error(err),
-                    )
+                    raise _protocol_validation_exception(err) from None
                 except CustomException as err:
                     current_span.record_exception(err)
                     raise err
@@ -152,8 +156,6 @@ async def update(
         try:
             await current_span.add_info_event_async(f"update start: {flow_id}")
             del_flow_by_id(flow_id)
-            update_content = json.dumps(flow.__dict__, ensure_ascii=False)
-            await current_span.add_info_event_async(f"update vo: {update_content}")
             sparkflow_protocol = flow.data
             if sparkflow_protocol:
                 if isinstance(sparkflow_protocol, str):
@@ -166,9 +168,18 @@ async def update(
             if not db_flow:
                 raise CustomException(CodeEnum.FLOW_NOT_FOUND_ERROR)
 
-            flow_service.update(session, db_flow, flow, flow_id, current_span)
+            flow_service.update(session, db_flow, flow)
             m.in_success_count()
             return Resp.success(None, span.sid)
+        except ValidationError as err:
+            validation_err = _protocol_validation_exception(err)
+            current_span.record_exception(validation_err)
+            m.in_error_count(validation_err.code, span=current_span)
+            return Resp.error(
+                validation_err.code,
+                validation_err.message,
+                span.sid,
+            )
         except CustomException as err:
             current_span.record_exception(err)
             m.in_error_count(err.code, span=current_span)

--- a/core/workflow/extensions/fastapi/handler/validation.py
+++ b/core/workflow/extensions/fastapi/handler/validation.py
@@ -40,8 +40,10 @@ async def validation_exception_handler(
 
     The handler formats validation errors into human-readable messages that include:
     - Parameter location in the request structure
-    - The actual input value that caused the error
     - The specific validation error message and type
+
+    Input values and validation context are intentionally omitted because request
+    payloads can contain credentials, prompts, or other sensitive content.
 
     All errors are logged with the tracing system for debugging and monitoring purposes.
 

--- a/core/workflow/extensions/middleware/database/manager.py
+++ b/core/workflow/extensions/middleware/database/manager.py
@@ -82,6 +82,10 @@ class DatabaseService(Service):
         return create_engine(
             url,
             echo=False,
+            # Workflow protocols may contain prompts, credentials, and other
+            # sensitive values. Keep bound parameters out of SQLAlchemy logs and
+            # rendered StatementError/DBAPIError messages.
+            hide_parameters=True,
             pool_size=self.pool_size,
             max_overflow=self.max_overflow,
             pool_recycle=self.pool_recycle,

--- a/core/workflow/service/flow_service.py
+++ b/core/workflow/service/flow_service.py
@@ -10,6 +10,7 @@ import time
 from typing import Any, Optional, cast
 
 from common.utils.snowfake import get_id
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session  # type: ignore
 
 from workflow.cache import flow as flow_cache
@@ -62,15 +63,22 @@ def save(flow: Flow, app_info: App, session: Session, span: Span) -> Flow:
         version="-1",  # Initial version for new flows
     )
 
-    # Persist to database
-    session.add(db_flow)
-    session.commit()
-    session.refresh(db_flow)
+    # Persist to database. DatabaseService configures SQLAlchemy to hide bound
+    # parameters so protocol contents cannot leak through the re-raised exception.
+    try:
+        session.add(db_flow)
+        session.commit()
+        session.refresh(db_flow)
+    except SQLAlchemyError:
+        session.rollback()
+        raise
     return db_flow
 
 
 def update(
-    session: Session, db_flow: Flow, flow: FlowUpdate, flow_id: str, current_span: Span
+    session: Session,
+    db_flow: Flow,
+    flow: FlowUpdate,
 ) -> None:
     """
     Update an existing workflow with new data and clear related cache.
@@ -78,10 +86,8 @@ def update(
     :param session: Database session for transaction management
     :param db_flow: The existing flow object to be updated
     :param flow: The flow update object containing new values
-    :param flow_id: The ID of the flow being updated
-    :param current_span: Tracing span for logging operations
-    :raises Exception: If update fails, transaction is rolled back and exception
-                       is re-raised
+    :raises SQLAlchemyError: If persistence fails, the transaction is rolled back. The
+                             configured engine hides database parameters from logs.
     """
     try:
         # Update flow properties if provided
@@ -97,10 +103,9 @@ def update(
         session.add(db_flow)
         session.commit()
 
-    except Exception as e:
-        current_span.record_exception(e)
+    except SQLAlchemyError:
         session.rollback()
-        raise  # Re-raise the exception to be handled by the main function
+        raise
 
 
 def get(flow_id: str, session: Session, span: Span) -> Flow:

--- a/core/workflow/tests/alembic/test_flow_protocol_column_capacity.py
+++ b/core/workflow/tests/alembic/test_flow_protocol_column_capacity.py
@@ -1,0 +1,118 @@
+"""Regression tests for the flow protocol column capacity migration."""
+
+import importlib.util
+from io import StringIO
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "alembic"
+    / "versions"
+    / "2026_08_06_1742-fdacc27881b5_expand_flow_protocol_columns.py"
+)
+
+EXPECTED_COMMENTS = {
+    "data": "编排标准协议",
+    "release_data": "发布后的数据",
+}
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "expand_flow_protocol_columns", MIGRATION_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Unable to load migration: {MIGRATION_PATH}")
+
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def _capture_alter_column_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    migration: ModuleType,
+    operation_name: str,
+) -> list[tuple[str, str, dict[str, object]]]:
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    def capture(table_name: str, column_name: str, **kwargs: object) -> None:
+        calls.append((table_name, column_name, kwargs))
+
+    monkeypatch.setattr(migration.op, "alter_column", capture)
+    getattr(migration, operation_name)()
+    return calls
+
+
+def test_revision_chain() -> None:
+    migration = _load_migration()
+
+    assert migration.revision == "fdacc27881b5"
+    assert migration.down_revision == "b13356244aea"
+
+
+def test_upgrade_expands_protocol_columns_to_longtext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration()
+    calls = _capture_alter_column_calls(monkeypatch, migration, "upgrade")
+
+    assert [column_name for _, column_name, _ in calls] == [
+        "data",
+        "release_data",
+    ]
+    for table_name, column_name, kwargs in calls:
+        assert table_name == "flow"
+        assert isinstance(kwargs["existing_type"], sa.Text)
+        assert isinstance(kwargs["type_"], mysql.LONGTEXT)
+        assert kwargs["existing_nullable"] is True
+        assert kwargs["existing_server_default"] is None
+        assert kwargs["existing_comment"] == EXPECTED_COMMENTS[column_name]
+
+
+def test_upgrade_compiles_valid_mysql_longtext_ddl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="mysql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    monkeypatch.setattr(migration, "op", Operations(context))
+
+    migration.upgrade()
+
+    sql = output.getvalue()
+    assert sql.count("ALTER TABLE flow MODIFY") == 2
+    assert "data LONGTEXT" in sql
+    assert "release_data LONGTEXT" in sql
+
+
+def test_downgrade_is_explicitly_irreversible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration()
+    alter_calls: list[tuple[str, str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        migration.op,
+        "alter_column",
+        lambda table_name, column_name, **kwargs: alter_calls.append(
+            (table_name, column_name, kwargs)
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        migration.downgrade()
+
+    assert "irreversible" in str(exc_info.value)
+    assert "flow.data" in str(exc_info.value)
+    assert alter_calls == []

--- a/core/workflow/tests/extensions/fastapi/test_flow_layout.py
+++ b/core/workflow/tests/extensions/fastapi/test_flow_layout.py
@@ -1,0 +1,129 @@
+"""Flow layout API regression tests."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from sqlalchemy.exc import StatementError
+
+from workflow.api.v1.flow.layout import update
+from workflow.domain.entities.flow import FlowUpdate
+from workflow.exception.e import CustomException
+from workflow.exception.errors.err_code import CodeEnum
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_update_returns_redacted_parameter_error_for_invalid_protocol() -> None:
+    """Invalid protocol data must not become an opaque or sensitive error."""
+    sensitive_value = "SENTINEL_API_KEY_AND_PROMPT"
+    lone_surrogate = chr(0xD800)
+    flow = FlowUpdate(
+        data={
+            "data": {
+                "nodes": [
+                    {
+                        "id": "llm::test-node",
+                        "data": {
+                            "nodeMeta": sensitive_value,
+                            "nodeParam": {
+                                "systemTemplate": f"bad{lone_surrogate}prompt"
+                            },
+                        },
+                    }
+                ],
+                "edges": [],
+            }
+        }
+    )
+
+    span_context = MagicMock()
+    span_context.__enter__.return_value = span_context
+    span_context.add_info_event_async = AsyncMock(
+        side_effect=lambda value: value.encode("utf-8")
+    )
+    mock_span = Mock(sid="test-sid")
+    mock_span.start.return_value = span_context
+    mock_meter = Mock()
+
+    with (
+        patch("workflow.api.v1.flow.layout.Span", return_value=mock_span),
+        patch("workflow.api.v1.flow.layout.Meter", return_value=mock_meter),
+        patch("workflow.api.v1.flow.layout.del_flow_by_id") as mock_del_flow,
+        patch(
+            "workflow.api.v1.flow.layout.WorkflowEngineFactory.create_engine"
+        ) as mock_create_engine,
+        patch("workflow.api.v1.flow.layout.flow_service.update") as mock_update,
+    ):
+        response = await update("123", flow, Mock())
+
+    payload = json.loads(response.body)
+    assert payload["code"] == CodeEnum.PARAM_ERROR.code
+    assert payload["code"] != CodeEnum.PROTOCOL_UPDATE_ERROR.code
+    assert "nodes->0->data->nodeMeta" in payload["message"]
+    assert sensitive_value not in json.dumps(payload, ensure_ascii=False)
+
+    span_context.record_exception.assert_called_once()
+    recorded_error = span_context.record_exception.call_args.args[0]
+    assert isinstance(recorded_error, CustomException)
+    assert recorded_error.code == CodeEnum.PARAM_ERROR.code
+    assert sensitive_value not in str(recorded_error)
+    assert sensitive_value not in repr(span_context.mock_calls)
+
+    span_context.add_info_event_async.assert_awaited_once_with("update start: 123")
+    assert lone_surrogate not in span_context.add_info_event_async.await_args.args[0]
+
+    mock_del_flow.assert_called_once_with("123")
+    mock_create_engine.assert_not_called()
+    mock_update.assert_not_called()
+    mock_meter.in_error_count.assert_called_once_with(
+        CodeEnum.PARAM_ERROR.code,
+        span=span_context,
+    )
+
+
+async def test_update_records_only_safe_error_when_database_update_fails() -> None:
+    sensitive_value = "SENTINEL_DATABASE_BOUND_PROTOCOL"
+    flow = FlowUpdate(data={"data": {"nodes": [], "edges": []}})
+
+    span_context = MagicMock()
+    span_context.__enter__.return_value = span_context
+    span_context.add_info_event_async = AsyncMock()
+    mock_span = Mock(sid="test-sid")
+    mock_span.start.return_value = span_context
+    mock_meter = Mock()
+    query = MagicMock()
+    query.filter_by.return_value.first.return_value = MagicMock()
+    session = MagicMock()
+    session.query.return_value = query
+
+    database_error = StatementError(
+        "write failed",
+        "UPDATE flow SET data = :data",
+        {"data": sensitive_value},
+        RuntimeError("database rejected value"),
+        hide_parameters=True,
+    )
+    with (
+        patch("workflow.api.v1.flow.layout.Span", return_value=mock_span),
+        patch("workflow.api.v1.flow.layout.Meter", return_value=mock_meter),
+        patch("workflow.api.v1.flow.layout.del_flow_by_id"),
+        patch("workflow.api.v1.flow.layout.WorkflowEngineFactory.create_engine"),
+        patch(
+            "workflow.api.v1.flow.layout.flow_service.update",
+            side_effect=database_error,
+        ),
+    ):
+        response = await update("123", flow, session)
+
+    payload = json.loads(response.body)
+    assert payload["code"] == CodeEnum.PROTOCOL_UPDATE_ERROR.code
+    assert sensitive_value not in json.dumps(payload, ensure_ascii=False)
+    span_context.record_exception.assert_called_once_with(database_error)
+    assert sensitive_value not in str(database_error)
+    assert "SQL parameters hidden" in str(database_error)
+    assert sensitive_value not in repr(span_context.mock_calls)
+    mock_meter.in_error_count.assert_called_once_with(
+        CodeEnum.PROTOCOL_UPDATE_ERROR.code,
+        span=span_context,
+    )

--- a/core/workflow/tests/extensions/fastapi/test_validation.py
+++ b/core/workflow/tests/extensions/fastapi/test_validation.py
@@ -1,0 +1,49 @@
+"""Validation error redaction regression tests."""
+
+import pytest
+from fastapi.exceptions import RequestValidationError
+from pydantic import BaseModel, ValidationError
+
+from workflow.utils.validation import ValidationParse
+
+
+class _Payload(BaseModel):
+    count: int
+
+
+def test_pydantic_validation_error_omits_sensitive_input() -> None:
+    sensitive_value = "SENTINEL_API_KEY_AND_PROMPT"
+
+    with pytest.raises(ValidationError) as exc_info:
+        _Payload.model_validate({"count": sensitive_value})
+
+    message = ValidationParse.validation_error(exc_info.value)
+    assert "count" in message
+    assert "int_parsing" in message
+    assert sensitive_value not in message
+    assert "Input:" not in message
+
+
+def test_request_validation_error_omits_input_context_and_url() -> None:
+    sensitive_value = "SENTINEL_REQUEST_SECRET"
+    context_value = "SENTINEL_VALIDATION_CONTEXT"
+    error_url = "https://errors.example/SENTINEL_ERROR_URL"
+    error = RequestValidationError(
+        [
+            {
+                "type": "string_type",
+                "loc": ("body", "secret"),
+                "msg": "Input should be a valid string",
+                "input": sensitive_value,
+                "ctx": {"expected": context_value},
+                "url": error_url,
+            }
+        ]
+    )
+
+    message = ValidationParse.validation_error(error)
+    assert "body->secret" in message
+    assert "string_type" in message
+    assert sensitive_value not in message
+    assert context_value not in message
+    assert error_url not in message

--- a/core/workflow/tests/extensions/test_database_manager.py
+++ b/core/workflow/tests/extensions/test_database_manager.py
@@ -1,0 +1,26 @@
+"""Database engine privacy configuration tests."""
+
+from unittest.mock import patch
+
+from workflow.extensions.middleware.database.manager import DatabaseService
+
+
+def test_create_engine_hides_bound_parameters() -> None:
+    service = DatabaseService.__new__(DatabaseService)
+    service.pool_size = 10
+    service.max_overflow = 20
+    service.pool_recycle = 30
+
+    with patch(
+        "workflow.extensions.middleware.database.manager.create_engine"
+    ) as create_engine:
+        getattr(service, "_create_engine")("mysql+pymysql://example/test")
+
+    create_engine.assert_called_once_with(
+        "mysql+pymysql://example/test",
+        echo=False,
+        hide_parameters=True,
+        pool_size=10,
+        max_overflow=20,
+        pool_recycle=30,
+    )

--- a/core/workflow/tests/service/test_flow_service_update.py
+++ b/core/workflow/tests/service/test_flow_service_update.py
@@ -1,0 +1,64 @@
+"""Regression tests for persistence failures during protocol writes."""
+
+import traceback
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import StatementError
+
+from workflow.domain.entities.flow import FlowUpdate
+from workflow.service import flow_service
+
+
+def _hidden_statement_error(sensitive_value: str) -> StatementError:
+    return StatementError(
+        "write failed",
+        "UPDATE flow SET data = :data",
+        {"data": sensitive_value},
+        RuntimeError("database rejected value"),
+        hide_parameters=True,
+    )
+
+
+def test_update_rolls_back_and_preserves_redacted_database_exception() -> None:
+    sensitive_value = "SENTINEL_API_KEY_AND_PROMPT"
+    session = MagicMock()
+    database_error = _hidden_statement_error(sensitive_value)
+    session.commit.side_effect = database_error
+    db_flow = MagicMock()
+
+    with pytest.raises(StatementError) as exc_info:
+        flow_service.update(
+            session,
+            db_flow,
+            FlowUpdate(data={"secret": sensitive_value}),
+        )
+
+    error = exc_info.value
+    assert error is database_error
+    rendered_traceback = "".join(
+        traceback.format_exception(type(error), error, error.__traceback__)
+    )
+    assert sensitive_value not in rendered_traceback
+    assert "SQL parameters hidden" in rendered_traceback
+    session.rollback.assert_called_once_with()
+
+
+def test_save_rolls_back_and_preserves_redacted_database_exception() -> None:
+    sensitive_value = "SENTINEL_NEW_PROTOCOL"
+    session = MagicMock()
+    database_error = _hidden_statement_error(sensitive_value)
+    session.commit.side_effect = database_error
+    flow = MagicMock()
+    flow.name = "workflow"
+    flow.data = {"secret": sensitive_value}
+    flow.description = ""
+    flow.app_id = "app-1"
+    app_info = MagicMock(actual_source=0)
+
+    with pytest.raises(StatementError) as exc_info:
+        flow_service.save(flow, app_info, session, MagicMock())
+
+    assert exc_info.value is database_error
+    assert sensitive_value not in str(exc_info.value)
+    session.rollback.assert_called_once_with()

--- a/core/workflow/utils/validation.py
+++ b/core/workflow/utils/validation.py
@@ -15,12 +15,29 @@ class ValidationParse:
         :return: Human-readable string
         """
 
+        if isinstance(error, ValidationError):
+            errors = error.errors(
+                include_input=False,
+                include_url=False,
+                include_context=False,
+            )
+        else:
+            # FastAPI's RequestValidationError.errors() does not accept Pydantic's
+            # redaction flags, so remove the same potentially sensitive fields.
+            errors = [
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key not in {"input", "url", "ctx"}
+                }
+                for item in error.errors()
+            ]
+
         errors_list = [
             (
                 f"Parameter: {'->'.join(map(str, error['loc']))}, "
-                f"Input: {error.get('input')}, "
                 f"Error: {error['msg']} ({error['type']})"
             )
-            for error in error.errors()
+            for error in errors
         ]
         return "\n".join(errors_list)


### PR DESCRIPTION
Expands Core workflow protocol storage to LONGTEXT, normalizes LLM output required defaults, redacts sensitive protocol and database error details, and adds regression coverage across Console and Core.