### PR TITLE
docs: add external workflow integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ After startup, you can access the services at the following addresses:
 
 ## 📚 Documentation
 
+- [🔌 Integration Guide](docs/guide/integration.md) — call published workflows from an existing project via HTTP/SSE
 - [🚀 Deployment Guide](docs/DEPLOYMENT_GUIDE.md)
 - [🔧 Configuration](docs/CONFIGURATION.md)
 - [🚀 Quick Start](https://www.xfyun.cn/doc/spark/Agent02-%E5%BF%AB%E9%80%9F%E5%BC%80%E5%A7%8B.html)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<!-- osai-verify: 47a03548c83092cc7722 -->
+
 [![Astron Agent Logo](./logo.svg)](https://iflytek.github.io/astron-agent/)
 
 [![Astron_Readme](./docs/imgs/Astron_Readme.png)](https://agent.xfyun.cn)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -26,6 +26,7 @@ export default defineConfig({
         nav: [
           { text: "Home", link: "/" },
           { text: "Quick Start", link: "/guide/quick-start" },
+          { text: "Integration", link: "/guide/integration" },
           { text: "Deployment", link: "/guide/deploy" },
           { text: "Case Studies", link: "/cases/" },
           { text: "Examples", link: "/examples" },
@@ -38,6 +39,7 @@ export default defineConfig({
             items: [
               { text: "Project Overview", link: "/README" },
               { text: "Quick Start", link: "/guide/quick-start" },
+              { text: "Integrate Into Your App", link: "/guide/integration" },
               { text: "FAQ", link: "/faq" }
             ]
           },
@@ -113,6 +115,7 @@ export default defineConfig({
         nav: [
           { text: "首页", link: "/zh/" },
           { text: "快速开始", link: "/zh/guide/quick-start" },
+          { text: "集成指南", link: "/zh/guide/integration" },
           { text: "部署与配置", link: "/zh/guide/deploy" },
           { text: "案例实践", link: "/zh/cases/" },
           { text: "工作流示例", link: "/zh/examples" },
@@ -125,6 +128,7 @@ export default defineConfig({
             items: [
               { text: "项目概览", link: "/zh/README" },
               { text: "快速开始", link: "/zh/guide/quick-start" },
+              { text: "集成到现有项目", link: "/zh/guide/integration" },
               { text: "FAQ", link: "/zh/faq" }
             ]
           },

--- a/docs/.vitepress/theme/AstronHomePage.vue
+++ b/docs/.vitepress/theme/AstronHomePage.vue
@@ -16,6 +16,7 @@ const { lang } = useData();
 const zhContent = {
   nav: {
     quickStart: "快速开始",
+    integration: "集成指南",
     deploy: "部署指南",
     cases: "案例实践",
     config: "配置说明",
@@ -107,6 +108,11 @@ const zhContent = {
   resourcesText: "从首页进入稳定的信息架构，把说明文档和社区入口统一收敛到 Pages 文档站。",
   resourceCards: [
     {
+      title: "集成到现有项目",
+      description: "通过公开 HTTP/SSE API 调用已发布工作流，了解鉴权、请求参数、流式响应与生产边界。",
+      href: "/guide/integration"
+    },
+    {
       title: "快速开始",
       description: "两步完成本地体验，先拉起 Docker Compose 环境再进入控制台。",
       href: "/guide/quick-start"
@@ -151,6 +157,7 @@ const zhContent = {
 const enContent = {
   nav: {
     quickStart: "Quick Start",
+    integration: "Integration",
     deploy: "Deployment",
     cases: "Case Studies",
     config: "Configuration",
@@ -245,6 +252,11 @@ const enContent = {
     "Move from the landing page into a stable information architecture that keeps documentation and community entry points in one place.",
   resourceCards: [
     {
+      title: "Integrate Into Your App",
+      description: "Call published workflows through the public HTTP/SSE API, with authentication, payload, streaming, and production guidance.",
+      href: "/guide/integration"
+    },
+    {
       title: "Quick Start",
       description: "Get a local experience running in two steps before diving deeper into the platform.",
       href: "/guide/quick-start"
@@ -329,6 +341,7 @@ onBeforeUnmount(() => {
         </a>
         <div class="astron-home__nav-links">
           <a :href="localizePath('/guide/quick-start')">{{ content.nav.quickStart }}</a>
+          <a :href="localizePath('/guide/integration')">{{ content.nav.integration }}</a>
           <a :href="localizePath('/guide/deploy')">{{ content.nav.deploy }}</a>
           <a :href="localizePath('/cases/')">{{ content.nav.cases }}</a>
           <a :href="localizePath('/guide/config')">{{ content.nav.config }}</a>
@@ -349,7 +362,7 @@ onBeforeUnmount(() => {
             {{ content.heroText }}
           </p>
           <div class="astron-home__actions">
-            <a class="astron-home__button astron-home__button--primary" href="https://github.com/iflytek/astron-agent" target="_blank" rel="noreferrer">{{ content.primaryAction }}</a>
+            <a class="astron-home__button astron-home__button--primary" :href="localizePath('/guide/integration')">{{ content.nav.integration }}</a>
             <a class="astron-home__button astron-home__button--secondary" href="https://agent.xfyun.cn" target="_blank" rel="noreferrer">{{ content.secondaryAction }}</a>
           </div>
           <ul class="astron-home__metrics">

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ After startup, you can access the services at the following addresses:
 
 ## 📚 Documentation
 
+- [🔌 Integration Guide](/guide/integration) — call published workflows from an existing project via HTTP/SSE
 - [🚀 Deployment Guide](/DEPLOYMENT_GUIDE)
 - [🔧 Configuration](/CONFIGURATION)
 - [🏢 Case Studies](/cases/)

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -1,0 +1,320 @@
+# Integrate Astron Agent into Your Application
+
+Astron Agent can run workflows for another application through its published workflow API. Your application stays responsible for its own UI and business logic, while Astron Agent provides the workflow, model, knowledge, tool, and RPA orchestration behind an HTTP/SSE boundary.
+
+> This is a service integration, not an in-process library integration. The supported consumer boundary is the public workflow API exposed by Astron Agent's gateway. Internal Python and Java modules are implementation details and are not published as stable SDK packages.
+
+## When to use this integration
+
+Use the workflow API when you want to:
+
+- add an AI workflow to an existing web, mobile, backend, or automation project;
+- keep model and tool orchestration in Astron Agent instead of rebuilding it in every application;
+- stream intermediate output to a user interface;
+- reuse one published workflow from multiple services while keeping application credentials separate.
+
+If you only want to evaluate or operate the full platform, start with [Quick Start](./quick-start.md) or [Deployment](./deploy.md) instead.
+
+## Integration boundary
+
+```text
+Your application
+    │  POST /workflow/v1/chat/completions
+    │  Authorization: Bearer <application-key>:<application-secret>
+    ▼
+Astron Agent gateway (Nginx)
+    │  validates the application and forwards its App ID
+    ▼
+Published workflow
+    └─ models · knowledge · tools/MCP · RPA
+```
+
+Call the gateway address shown after publishing. Do not call `core-workflow:7880`, `/internal/gateway/auth/**`, or other container-only endpoints directly: those routes are internal, and direct calls bypass the supported gateway boundary.
+
+## 1. Publish a workflow as an API
+
+1. Create and debug a workflow in the Astron Agent console.
+2. Select **Publish** in the workflow editor.
+3. Choose **Publish as API** and open its configuration.
+4. Create or select an application, then complete the publication flow.
+5. Copy the generated values:
+   - **Service URL**
+   - **Flow ID**
+   - **API Key**
+   - **API Secret**
+
+Keep the API Secret in a server-side secret store. Do not put it in browser code, mobile packages, source control, screenshots, or client-visible logs.
+
+## 2. Call the published workflow
+
+The public endpoint is:
+
+```text
+POST <ASTRON_BASE_URL>/workflow/v1/chat/completions
+```
+
+Use the exact Service URL displayed by the console when it differs from the path above. Authentication uses the application credentials in one header:
+
+```http
+Authorization: Bearer <application-key>:<application-secret>
+Content-Type: application/json
+```
+
+A minimal request is:
+
+```json
+{
+  "flow_id": "<FLOW_ID>",
+  "uid": "user-123",
+  "stream": true,
+  "parameters": {
+    "query": "Summarize this support request"
+  }
+}
+```
+
+`flow_id` and `parameters` are required. The available keys inside `parameters` come from the workflow's Start node, so replace `query` with the inputs defined by your published workflow.
+
+Optional request fields:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `uid` | string | Your end-user identifier (up to 40 characters). |
+| `stream` | boolean | `true` for SSE streaming; `false` for one JSON response. Defaults to `true`. |
+| `chat_id` | string | Your conversation identifier (up to 128 characters). Reuse it when continuing a conversation. |
+| `history` | array | Earlier messages as `{ "role": "user" | "assistant", "content": "...", "content_type": "text" }`. |
+| `ext` | object | Integration-specific metadata forwarded with the request. |
+| `version` | string | Published workflow version when your environment requires one. |
+
+### cURL
+
+```bash
+export ASTRON_BASE_URL="https://astron.example.com"
+export ASTRON_API_KEY="replace-me"
+export ASTRON_API_SECRET="replace-me"
+export ASTRON_FLOW_ID="replace-me"
+
+curl --no-buffer \
+  --request POST "$ASTRON_BASE_URL/workflow/v1/chat/completions" \
+  --header "Authorization: Bearer $ASTRON_API_KEY:$ASTRON_API_SECRET" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"flow_id\": \"$ASTRON_FLOW_ID\",
+    \"uid\": \"user-123\",
+    \"chat_id\": \"conversation-456\",
+    \"stream\": true,
+    \"parameters\": {
+      \"query\": \"Summarize this support request\"
+    }
+  }"
+```
+
+### Python
+
+This example uses only the Python standard library. Run it in a backend service, not in browser-delivered code.
+
+```python
+import json
+import os
+import urllib.request
+
+base_url = os.environ["ASTRON_BASE_URL"].rstrip("/")
+credential = f'{os.environ["ASTRON_API_KEY"]}:{os.environ["ASTRON_API_SECRET"]}'
+payload = {
+    "flow_id": os.environ["ASTRON_FLOW_ID"],
+    "uid": "user-123",
+    "chat_id": "conversation-456",
+    "stream": True,
+    "parameters": {"query": "Summarize this support request"},
+}
+
+request = urllib.request.Request(
+    f"{base_url}/workflow/v1/chat/completions",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={
+        "Authorization": f"Bearer {credential}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    },
+    method="POST",
+)
+
+with urllib.request.urlopen(request, timeout=1800) as response:
+    for raw_line in response:
+        line = raw_line.decode("utf-8").strip()
+        if not line.startswith("data:"):
+            continue
+        event = json.loads(line.removeprefix("data:").strip())
+        if event.get("code") != 0:
+            raise RuntimeError(event.get("message", "workflow failed"))
+
+        choice = (event.get("choices") or [{}])[0]
+        delta = choice.get("delta") or {}
+        if delta.get("content"):
+            print(delta["content"], end="", flush=True)
+
+        finish_reason = choice.get("finish_reason")
+        if finish_reason == "stop":
+            break
+        if finish_reason == "interrupt":
+            print("\nWorkflow paused and requires a reply.")
+            break
+```
+
+### Node.js 18+
+
+```js
+const baseUrl = process.env.ASTRON_BASE_URL.replace(/\/$/, "");
+const authorization = `Bearer ${process.env.ASTRON_API_KEY}:${process.env.ASTRON_API_SECRET}`;
+
+const response = await fetch(`${baseUrl}/workflow/v1/chat/completions`, {
+  method: "POST",
+  headers: {
+    Authorization: authorization,
+    "Content-Type": "application/json",
+    Accept: "text/event-stream"
+  },
+  body: JSON.stringify({
+    flow_id: process.env.ASTRON_FLOW_ID,
+    uid: "user-123",
+    chat_id: "conversation-456",
+    stream: true,
+    parameters: { query: "Summarize this support request" }
+  })
+});
+
+if (!response.ok || !response.body) {
+  throw new Error(`Astron request failed: ${response.status} ${await response.text()}`);
+}
+
+const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+let buffer = "";
+let finished = false;
+
+while (!finished) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buffer += value;
+
+  const frames = buffer.split("\n\n");
+  buffer = frames.pop() ?? "";
+
+  for (const frame of frames) {
+    const dataLine = frame.split("\n").find((line) => line.startsWith("data:"));
+    if (!dataLine) continue;
+
+    const event = JSON.parse(dataLine.slice(5).trim());
+    if (event.code !== 0) throw new Error(event.message || "workflow failed");
+
+    const choice = event.choices?.[0];
+    if (choice?.delta?.content) process.stdout.write(choice.delta.content);
+    if (choice?.finish_reason === "interrupt") {
+      console.log("\nWorkflow paused and requires a reply.");
+      finished = true;
+    }
+    if (choice?.finish_reason === "stop") finished = true;
+  }
+}
+```
+
+## 3. Handle the response
+
+### Streaming mode
+
+With `stream: true`, the response media type is `text/event-stream`. Each frame contains a `data:` line whose value is JSON. Useful fields include:
+
+```json
+{
+  "code": 0,
+  "message": "Success",
+  "id": "request-or-session-id",
+  "choices": [
+    {
+      "delta": {
+        "role": "assistant",
+        "content": "incremental output",
+        "reasoning_content": ""
+      },
+      "finish_reason": null
+    }
+  ],
+  "workflow_step": {
+    "seq": 3,
+    "progress": 0.5
+  }
+}
+```
+
+Consumer rules:
+
+- append `choices[0].delta.content` when it is non-empty;
+- treat `code != 0` as a workflow error even if the HTTP connection was established successfully;
+- ignore heartbeat frames with `finish_reason: "ping"`;
+- finish on `finish_reason: "stop"`;
+- handle `finish_reason: "interrupt"` only if your workflow contains an interactive pause;
+- do not depend on every intermediate `workflow_step` field as a stable business contract.
+
+### Non-streaming mode
+
+Set `stream` to `false` to receive one JSON response. The response uses the same top-level shape; inspect `code`, `message`, `choices`, and `usage` rather than assuming a plain text body.
+
+## 4. Resume an interrupted workflow
+
+If a frame has `finish_reason: "interrupt"`, save `event_data.event_id`. After collecting the user's answer, call:
+
+```text
+POST <ASTRON_BASE_URL>/workflow/v1/resume
+```
+
+Use the same Authorization header:
+
+```bash
+curl --no-buffer \
+  --request POST "$ASTRON_BASE_URL/workflow/v1/resume" \
+  --header "Authorization: Bearer $ASTRON_API_KEY:$ASTRON_API_SECRET" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "event_id": "<EVENT_ID>",
+    "event_type": "resume",
+    "content": "The user reply"
+  }'
+```
+
+The resume response follows the mode of the interrupted request. Event IDs are runtime state: resume promptly and handle an expired or already-resumed event as an error.
+
+## Production checklist
+
+- **Use HTTPS.** The default local deployment listens on HTTP; terminate TLS at Nginx or an upstream ingress before exposing the API outside a trusted network.
+- **Keep credentials server-side.** If a browser or mobile app needs the capability, call your own backend first and let that backend call Astron Agent.
+- **Separate applications and credentials.** Use different Astron applications for environments or consumers that need independent rotation and revocation.
+- **Set streaming-aware timeouts.** The bundled gateway allows long-lived workflow streams, but every proxy and client in front of it must also disable buffering and allow suitable read timeouts.
+- **Use stable IDs.** Generate `uid` and `chat_id` from your system; do not put secrets or sensitive personal data in either value.
+- **Validate workflow inputs.** Treat `parameters` as untrusted input and constrain it before passing values to tools, databases, or RPA actions.
+- **Record trace IDs safely.** The response `id` is useful for troubleshooting. Log it with the status and duration, but redact credentials and sensitive prompts.
+- **Plan for workflow changes.** Start-node inputs and End-node outputs are the consumer contract. Review them before publishing a new version and test clients against the published workflow.
+
+## What is not a supported dependency contract
+
+The following can be useful when contributing to Astron Agent itself, but external applications should not depend on them as stable APIs:
+
+- importing packages directly from `core/agent`, `core/workflow`, or `core/common`;
+- calling container DNS names or internal service ports;
+- sending `X-Consumer-Username` yourself;
+- calling `/internal/gateway/auth/**` or unpublished `/workflow/v1/**` routes;
+- reading or writing Astron Agent databases directly.
+
+For repository-level extension work, see [Project Modules](../PROJECT_MODULES.md). For reusable workflow definitions, see [Workflow Examples](../examples.md).
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `401` or a missing/malformed credential error | Header must be exactly `Authorization: Bearer <application-key>:<application-secret>`. Confirm neither value is empty. |
+| `Failed to get application` | Confirm the API Key and Secret belong to the application selected at publication time. |
+| Workflow not found or not authorized | Use the Flow ID shown for the published API, not the App ID or an editor-only ID. |
+| Parameter validation error | Send a `parameters` object whose keys and value types match the Start node. |
+| Output arrives all at once | Disable response buffering in every reverse proxy and use an SSE-capable HTTP client. |
+| Stream stays open without text | Heartbeat frames are normal while a long-running node executes; enforce your own overall deadline. |
+| Works inside Docker but not externally | Call the published gateway host and exposed port, then check DNS, firewall, TLS, and proxy routing. |
+
+See the [FAQ](../faq.md), [Configuration Reference](../CONFIGURATION.md), and [Deployment Guide](./deploy.md) for additional operational guidance.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -123,6 +123,7 @@ docker compose -f docker-compose-with-auth.yaml up -d
 
 ## 📚 文档
 
+- [🔌 集成指南](guide/integration.md) — 通过 HTTP/SSE 在现有项目中调用已发布工作流
 - [🚀 部署指南](DEPLOYMENT_GUIDE.md)
 - [🔧 配置说明](CONFIGURATION.md)
 - [🏗️ 模块说明](PROJECT_MODULES.md)

--- a/docs/zh/guide/integration.md
+++ b/docs/zh/guide/integration.md
@@ -1,0 +1,320 @@
+# 在现有项目中集成 Astron Agent
+
+Astron Agent 可以通过已发布的工作流 API，为其他应用提供工作流执行能力。你的项目继续负责自己的界面和业务逻辑，Astron Agent 则在 HTTP/SSE 边界后提供工作流、模型、知识库、工具和 RPA 编排。
+
+> 这里描述的是**服务集成**，不是进程内依赖。当前面向消费者的稳定边界是 Astron Agent 网关暴露的公开工作流 API；仓库内部的 Python、Java 模块属于实现细节，并未作为稳定 SDK 包发布。
+
+## 适用场景
+
+以下情况适合使用工作流 API：
+
+- 为已有 Web、移动端、后端或自动化项目补充 AI 工作流能力；
+- 将模型和工具编排集中在 Astron Agent 中，避免每个业务项目重复实现；
+- 向用户界面流式返回中间结果；
+- 让多个服务复用同一条已发布工作流，同时按应用隔离凭据。
+
+如果只是评估或运行完整平台，请先阅读[快速开始](./quick-start.md)或[部署说明](./deploy.md)。
+
+## 集成边界
+
+```text
+你的应用
+    │  POST /workflow/v1/chat/completions
+    │  Authorization: Bearer <application-key>:<application-secret>
+    ▼
+Astron Agent 网关（Nginx）
+    │  校验应用身份并转发 App ID
+    ▼
+已发布工作流
+    └─ 模型 · 知识库 · 工具/MCP · RPA
+```
+
+请调用发布后显示的网关地址。不要直接调用 `core-workflow:7880`、`/internal/gateway/auth/**` 或其他容器内部端点：这些路由属于内部实现，直连会绕过受支持的网关边界。
+
+## 1. 将工作流发布为 API
+
+1. 在 Astron Agent 控制台创建并调试工作流。
+2. 在工作流编辑器中点击**发布**。
+3. 选择**发布为 API**并进入配置。
+4. 新建或选择应用，完成发布流程。
+5. 保存生成的信息：
+   - **服务地址（Service URL）**
+   - **Flow ID**
+   - **API Key**
+   - **API Secret**
+
+请将 API Secret 保存在服务端密钥管理系统中，不要写入浏览器代码、移动端安装包、源码仓库、截图或客户端可见日志。
+
+## 2. 调用已发布工作流
+
+公开端点为：
+
+```text
+POST <ASTRON_BASE_URL>/workflow/v1/chat/completions
+```
+
+如果控制台展示的 Service URL 与上述路径不同，请以控制台生成的完整地址为准。鉴权信息通过一个请求头传入：
+
+```http
+Authorization: Bearer <application-key>:<application-secret>
+Content-Type: application/json
+```
+
+最小请求示例：
+
+```json
+{
+  "flow_id": "<FLOW_ID>",
+  "uid": "user-123",
+  "stream": true,
+  "parameters": {
+    "query": "总结这条客户工单"
+  }
+}
+```
+
+`flow_id` 和 `parameters` 为必填项。`parameters` 内可用的字段来自工作流的开始节点，请将示例中的 `query` 替换为已发布工作流实际定义的输入。
+
+可选请求字段：
+
+| 字段 | 类型 | 用途 |
+| --- | --- | --- |
+| `uid` | string | 业务系统中的终端用户标识，最长 40 个字符。 |
+| `stream` | boolean | `true` 返回 SSE 流，`false` 返回单个 JSON；默认 `true`。 |
+| `chat_id` | string | 业务系统中的会话标识，最长 128 个字符；继续同一会话时可复用。 |
+| `history` | array | 历史消息，格式为 `{ "role": "user" | "assistant", "content": "...", "content_type": "text" }`。 |
+| `ext` | object | 随请求传入的扩展元数据。 |
+| `version` | string | 环境要求指定发布版本时使用。 |
+
+### cURL
+
+```bash
+export ASTRON_BASE_URL="https://astron.example.com"
+export ASTRON_API_KEY="replace-me"
+export ASTRON_API_SECRET="replace-me"
+export ASTRON_FLOW_ID="replace-me"
+
+curl --no-buffer \
+  --request POST "$ASTRON_BASE_URL/workflow/v1/chat/completions" \
+  --header "Authorization: Bearer $ASTRON_API_KEY:$ASTRON_API_SECRET" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"flow_id\": \"$ASTRON_FLOW_ID\",
+    \"uid\": \"user-123\",
+    \"chat_id\": \"conversation-456\",
+    \"stream\": true,
+    \"parameters\": {
+      \"query\": \"总结这条客户工单\"
+    }
+  }"
+```
+
+### Python
+
+以下示例只使用 Python 标准库。请在后端服务中运行，不要把密钥放进浏览器端代码。
+
+```python
+import json
+import os
+import urllib.request
+
+base_url = os.environ["ASTRON_BASE_URL"].rstrip("/")
+credential = f'{os.environ["ASTRON_API_KEY"]}:{os.environ["ASTRON_API_SECRET"]}'
+payload = {
+    "flow_id": os.environ["ASTRON_FLOW_ID"],
+    "uid": "user-123",
+    "chat_id": "conversation-456",
+    "stream": True,
+    "parameters": {"query": "总结这条客户工单"},
+}
+
+request = urllib.request.Request(
+    f"{base_url}/workflow/v1/chat/completions",
+    data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+    headers={
+        "Authorization": f"Bearer {credential}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    },
+    method="POST",
+)
+
+with urllib.request.urlopen(request, timeout=1800) as response:
+    for raw_line in response:
+        line = raw_line.decode("utf-8").strip()
+        if not line.startswith("data:"):
+            continue
+        event = json.loads(line.removeprefix("data:").strip())
+        if event.get("code") != 0:
+            raise RuntimeError(event.get("message", "工作流执行失败"))
+
+        choice = (event.get("choices") or [{}])[0]
+        delta = choice.get("delta") or {}
+        if delta.get("content"):
+            print(delta["content"], end="", flush=True)
+
+        finish_reason = choice.get("finish_reason")
+        if finish_reason == "stop":
+            break
+        if finish_reason == "interrupt":
+            print("\n工作流已暂停，需要用户回复。")
+            break
+```
+
+### Node.js 18+
+
+```js
+const baseUrl = process.env.ASTRON_BASE_URL.replace(/\/$/, "");
+const authorization = `Bearer ${process.env.ASTRON_API_KEY}:${process.env.ASTRON_API_SECRET}`;
+
+const response = await fetch(`${baseUrl}/workflow/v1/chat/completions`, {
+  method: "POST",
+  headers: {
+    Authorization: authorization,
+    "Content-Type": "application/json",
+    Accept: "text/event-stream"
+  },
+  body: JSON.stringify({
+    flow_id: process.env.ASTRON_FLOW_ID,
+    uid: "user-123",
+    chat_id: "conversation-456",
+    stream: true,
+    parameters: { query: "总结这条客户工单" }
+  })
+});
+
+if (!response.ok || !response.body) {
+  throw new Error(`Astron 请求失败：${response.status} ${await response.text()}`);
+}
+
+const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+let buffer = "";
+let finished = false;
+
+while (!finished) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buffer += value;
+
+  const frames = buffer.split("\n\n");
+  buffer = frames.pop() ?? "";
+
+  for (const frame of frames) {
+    const dataLine = frame.split("\n").find((line) => line.startsWith("data:"));
+    if (!dataLine) continue;
+
+    const event = JSON.parse(dataLine.slice(5).trim());
+    if (event.code !== 0) throw new Error(event.message || "工作流执行失败");
+
+    const choice = event.choices?.[0];
+    if (choice?.delta?.content) process.stdout.write(choice.delta.content);
+    if (choice?.finish_reason === "interrupt") {
+      console.log("\n工作流已暂停，需要用户回复。");
+      finished = true;
+    }
+    if (choice?.finish_reason === "stop") finished = true;
+  }
+}
+```
+
+## 3. 处理响应
+
+### 流式模式
+
+当 `stream: true` 时，响应类型为 `text/event-stream`。每一帧包含一行 `data:`，其值为 JSON。常用字段如下：
+
+```json
+{
+  "code": 0,
+  "message": "Success",
+  "id": "request-or-session-id",
+  "choices": [
+    {
+      "delta": {
+        "role": "assistant",
+        "content": "增量输出",
+        "reasoning_content": ""
+      },
+      "finish_reason": null
+    }
+  ],
+  "workflow_step": {
+    "seq": 3,
+    "progress": 0.5
+  }
+}
+```
+
+客户端处理规则：
+
+- `choices[0].delta.content` 非空时，将其追加到当前输出；
+- 即使 HTTP 连接已经成功建立，只要 `code != 0`，仍应按工作流错误处理；
+- `finish_reason: "ping"` 是心跳帧，可以忽略；
+- `finish_reason: "stop"` 表示执行结束；
+- 仅当工作流包含交互式暂停时，才需要处理 `finish_reason: "interrupt"`；
+- 不要将每个中间帧中的 `workflow_step` 全部字段视为稳定业务协议。
+
+### 非流式模式
+
+将 `stream` 设为 `false` 可获得单个 JSON 响应。返回值仍使用相同的顶层结构，应读取 `code`、`message`、`choices` 和 `usage`，不要假设响应正文是纯文本。
+
+## 4. 恢复被中断的工作流
+
+如果某一帧的 `finish_reason` 为 `interrupt`，请保存 `event_data.event_id`。收集用户回复后调用：
+
+```text
+POST <ASTRON_BASE_URL>/workflow/v1/resume
+```
+
+使用相同的 Authorization 请求头：
+
+```bash
+curl --no-buffer \
+  --request POST "$ASTRON_BASE_URL/workflow/v1/resume" \
+  --header "Authorization: Bearer $ASTRON_API_KEY:$ASTRON_API_SECRET" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "event_id": "<EVENT_ID>",
+    "event_type": "resume",
+    "content": "用户回复内容"
+  }'
+```
+
+恢复后的响应模式与被中断的请求一致。Event ID 属于运行时状态，应尽快恢复，并将过期或已经恢复过的事件按错误处理。
+
+## 生产接入检查清单
+
+- **启用 HTTPS。** 默认本地部署监听 HTTP；在可信网络之外暴露 API 前，应在 Nginx 或上层 Ingress 终止 TLS。
+- **凭据只放服务端。** 浏览器或移动端需要使用该能力时，先调用你自己的后端，再由后端调用 Astron Agent。
+- **按环境和消费者拆分应用。** 对需要独立轮换和撤销权限的环境或调用方，分别创建 Astron 应用和凭据。
+- **配置流式超时。** 内置网关允许长连接，但链路中的其他反向代理和客户端也必须关闭缓冲并设置合适的读取超时。
+- **使用稳定业务标识。** 从业务系统生成 `uid` 和 `chat_id`，不要在其中放入密钥或敏感个人信息。
+- **校验工作流输入。** 将 `parameters` 视为不可信输入；传给工具、数据库或 RPA 动作前先约束类型和范围。
+- **安全记录追踪 ID。** 响应中的 `id` 可用于排障；可以记录它以及状态和耗时，但必须脱敏凭据和敏感提示词。
+- **管理工作流变更。** 开始节点的输入和结束节点的输出就是消费者协议；发布新版本前应审查字段，并用真实客户端验证。
+
+## 不属于稳定依赖协议的内容
+
+以下内容适合贡献 Astron Agent 本身时使用，但外部应用不应将其视为稳定 API：
+
+- 直接导入 `core/agent`、`core/workflow` 或 `core/common` 中的包；
+- 直连容器 DNS 名称或内部服务端口；
+- 由客户端自行传入 `X-Consumer-Username`；
+- 调用 `/internal/gateway/auth/**` 或未公开的 `/workflow/v1/**` 路由；
+- 直接读写 Astron Agent 数据库。
+
+如需扩展仓库内部模块，请阅读[模块说明](../PROJECT_MODULES.md)；如需复用工作流定义，请查看[工作流示例](../examples.md)。
+
+## 故障排查
+
+| 现象 | 检查项 |
+| --- | --- |
+| 返回 `401` 或提示凭据缺失/格式错误 | 请求头必须严格为 `Authorization: Bearer <application-key>:<application-secret>`，并确认两个值都非空。 |
+| 提示 `Failed to get application` | 确认 API Key 和 API Secret 属于发布时选择的同一个应用。 |
+| 工作流不存在或无权访问 | 使用已发布 API 显示的 Flow ID，不要误用 App ID 或仅供编辑器使用的 ID。 |
+| 参数校验失败 | `parameters` 的字段名和类型必须与开始节点定义一致。 |
+| 输出直到最后才一次性返回 | 关闭所有反向代理的响应缓冲，并使用支持 SSE 的 HTTP 客户端。 |
+| 长时间没有文本但连接未断 | 长节点运行期间出现心跳帧属于正常现象；调用方仍应设置整体超时。 |
+| Docker 内可用但外部不可用 | 调用对外暴露的网关主机和端口，并检查 DNS、防火墙、TLS 与代理路由。 |
+
+更多运维信息请参考 [FAQ](../faq.md)、[配置参考](../CONFIGURATION.md)和[部署说明](./deploy.md)。


### PR DESCRIPTION
## Summary

- add standalone English and Chinese guides for integrating published Astron Agent workflows into existing applications
- document the supported public HTTP/SSE boundary, application authentication, request fields, streaming events, interrupt/resume flow, production safeguards, and unsupported internal dependencies
- provide runnable cURL, Python, and Node.js examples
- add prominent Integration entries to the VitePress top navigation, sidebar, homepage hero/resources, root README, and bilingual overview pages

## Why

The existing documentation is strong on deploying the full platform, but consumers also need a clear path for using Astron Agent as a capability from another project. This change separates that service-integration workflow from deployment guidance and avoids presenting internal Python/Java modules as stable SDK packages.

## Validation

- `npm run docs:build` ✅
  - build used a temporary local compatibility copy for the pre-existing broken `docs/ja/README.md` image reference (`./imgs/WeCom_Group.png`); that unrelated file is not part of this PR
- all JSON examples parsed successfully
- all Python snippets compiled successfully
- all Node.js snippets passed `node --check`
- relative links in both new guides resolve
- `git diff --cached --check` passed before commit
- independent review completed; its only blocking finding (English guide incorrectly saying Start-node outputs) was fixed to "Start-node inputs and End-node outputs"

## Scope

Documentation only. No runtime API or behavior changes.
