### PR TITLE
fix(knowledge): prevent RAGFlow parsing jobs from hanging

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/FileInfoV2Service.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/FileInfoV2Service.java
@@ -610,32 +610,40 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
         boolean parseSuccess = false;
         FileInfoV2 fileInfoV2 = this.getById(fileId);
         if (fileInfoV2 != null) {
-            // Type mapping
-            LambdaQueryWrapper<ConfigInfo> wrapper = Wrappers.lambdaQuery(ConfigInfo.class).eq(ConfigInfo::getCategory, "FILE_TYPE_MAPPING").eq(ConfigInfo::getIsValid, 1);
-            String type = fileInfoV2.getType();
-            if (!StringUtils.isEmpty(type)) {
-                wrapper.eq(ConfigInfo::getName, type);
-            }
-
-            ConfigInfo configInfo = configInfoService.getOnly(wrapper);
-            if (configInfo != null) {
-                type = configInfo.getValue();
-            }
-            // Asynchronous knowledge extraction
-            String address = fileInfoV2.getAddress();
-            if (!ProjectContent.HTML_FILE_TYPE.equals(type) && address.startsWith("sparkBot")) {
-                address = s3UtilClient.getS3Url(address);
-            }
-            // CBG-RAG file type validation failed
-            String source = fileInfoV2.getSource();
-            if (ProjectContent.isCbgRagCompatible(source)) {
-                if (!ProjectContent.SUPPORTED_FILE_TYPES.contains(type.toLowerCase())) {
-                    return dealFileResult;
-                }
-            }
-
-
             try {
+                // Keep all preparation inside the terminal-status guard. sliceFiles/retry has
+                // already persisted FILE_PARSE_DOING, so any preparation failure must be closed
+                // as FILE_PARSE_FAILED rather than escaping and leaving the file stuck.
+                LambdaQueryWrapper<ConfigInfo> wrapper = Wrappers.lambdaQuery(ConfigInfo.class)
+                        .eq(ConfigInfo::getCategory, "FILE_TYPE_MAPPING")
+                        .eq(ConfigInfo::getIsValid, 1);
+                String type = fileInfoV2.getType();
+                if (!StringUtils.isEmpty(type)) {
+                    wrapper.eq(ConfigInfo::getName, type);
+                }
+
+                ConfigInfo configInfo = configInfoService.getOnly(wrapper);
+                if (configInfo != null) {
+                    type = configInfo.getValue();
+                }
+                if (StringUtils.isBlank(type)) {
+                    throw new IllegalArgumentException("File type is empty");
+                }
+
+                String source = fileInfoV2.getSource();
+                if (ProjectContent.isCbgRagCompatible(source)
+                        && !ProjectContent.SUPPORTED_FILE_TYPES.contains(type.toLowerCase())) {
+                    throw new IllegalArgumentException("Unsupported file type: " + type);
+                }
+
+                String address = fileInfoV2.getAddress();
+                if (StringUtils.isBlank(address)) {
+                    throw new IllegalArgumentException("File address is empty");
+                }
+                if (!ProjectContent.HTML_FILE_TYPE.equals(type) && address.startsWith("sparkBot")) {
+                    address = s3UtilClient.getS3Url(address);
+                }
+
                 dealFileResult.setTaskId(fileInfoV2.getUuid());
                 ExtractKnowledgeTask extractKnowledgeTask = new ExtractKnowledgeTask();
                 extractKnowledgeTask.setTaskId(fileInfoV2.getUuid());
@@ -653,7 +661,6 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
                 } else {
                     knowledgeService.knowledgeEmbeddingExtractAsync(type, address, sliceConfig, fileInfoV2, extractKnowledgeTask, this);
                 }
-                fileInfoV2.setStatus(ProjectContent.FILE_PARSE_DOING);
                 parseSuccess = true;
             } catch (Exception e) {
                 fileInfoV2.setStatus(ProjectContent.FILE_PARSE_FAILED);
@@ -661,9 +668,15 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
                 dealFileResult.setErrMsg("Knowledge extraction failed:" + e.getMessage());
                 log.error("Knowledge extraction and save failed", e);
             }
-            fileInfoV2.setSliceConfig(JSON.toJSONString(sliceConfig));
-            fileInfoV2.setUpdateTime(new Timestamp(System.currentTimeMillis()));
-            this.updateById(fileInfoV2);
+            // sliceFiles/retry persists FILE_PARSE_DOING and the slice config before
+            // dispatching this task. Never write that stale entity after @Async
+            // dispatch: a fast worker may already have committed SUCCESS/FAILED,
+            // and a late update here would regress the terminal state back to DOING.
+            if (!parseSuccess) {
+                fileInfoV2.setSliceConfig(JSON.toJSONString(sliceConfig));
+                fileInfoV2.setUpdateTime(new Timestamp(System.currentTimeMillis()));
+                this.updateById(fileInfoV2);
+            }
         }
         dealFileResult.setParseSuccess(parseSuccess);
         return dealFileResult;

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/KnowledgeService.java
@@ -459,7 +459,17 @@ public class KnowledgeService {
             SliceConfig sliceConfig,
             FileInfoV2 fileInfoV2,
             ExtractKnowledgeTask extractKnowledgeTask) {
+        try {
+            executeKnowledgeExtract(contentType, url, sliceConfig, fileInfoV2, extractKnowledgeTask);
+        } catch (Exception e) {
+            handleUnexpectedExtractionFailure(fileInfoV2, extractKnowledgeTask, e);
+        }
+    }
 
+    private void executeKnowledgeExtract(String contentType, String url,
+            SliceConfig sliceConfig,
+            FileInfoV2 fileInfoV2,
+            ExtractKnowledgeTask extractKnowledgeTask) {
         final String source = fileInfoV2.getSource();
         KnowledgeResponse response;
 
@@ -703,6 +713,30 @@ public class KnowledgeService {
             FileInfoV2 fileInfoV2,
             ExtractKnowledgeTask extractKnowledgeTask,
             FileInfoV2Service fileInfoV2Service) {
+        boolean extractionSucceeded;
+        try {
+            extractionSucceeded = executeKnowledgeEmbeddingExtract(contentType, url, sliceConfig, fileInfoV2,
+                    extractKnowledgeTask);
+        } catch (Exception e) {
+            handleUnexpectedExtractionFailure(fileInfoV2, extractKnowledgeTask, e);
+            return;
+        }
+        if (!extractionSucceeded) {
+            return;
+        }
+
+        try {
+            fileInfoV2Service.saveTaskAndUpdateFileStatus(fileInfoV2.getId());
+            fileInfoV2Service.embeddingFile(fileInfoV2.getId(), fileInfoV2.getSpaceId());
+        } catch (Exception e) {
+            handleUnexpectedEmbeddingFailure(fileInfoV2, fileInfoV2Service, e);
+        }
+    }
+
+    private boolean executeKnowledgeEmbeddingExtract(String contentType, String url,
+            SliceConfig sliceConfig,
+            FileInfoV2 fileInfoV2,
+            ExtractKnowledgeTask extractKnowledgeTask) {
         final String source = fileInfoV2.getSource();
         KnowledgeResponse response;
 
@@ -710,7 +744,7 @@ public class KnowledgeService {
         if (ProjectContent.isCbgRagCompatible(source)) {
             response = doCbgUploadSplit(sliceConfig, fileInfoV2, extractKnowledgeTask);
             if (response == null) {
-                return; // already updated status on failure
+                return false; // already updated status on failure
             }
         } else {
             response = doUrlSplit(url, sliceConfig, fileInfoV2);
@@ -722,13 +756,13 @@ public class KnowledgeService {
             log.error("Document chunking failed : {}", errMsg);
             updateTaskAndFileStatus(fileInfoV2, extractKnowledgeTask,
                     "Document chunking failed, " + errMsg, false);
-            return;
+            return false;
         }
 
         // 3) Parse data -> List<ChunkInfo>
         final List<ChunkInfo> chunkInfos = parseChunkInfosOrFail(response, fileInfoV2, extractKnowledgeTask);
         if (chunkInfos == null) {
-            return; // status updated inside on failure
+            return false; // status updated inside on failure
         }
 
         // 4) Empty result guard with image-specific hint
@@ -737,7 +771,7 @@ public class KnowledgeService {
                     ? "Document cannot be chunked, please check if the image contains text"
                     : "Document cannot be chunked, please check if the file meets upload requirements";
             updateTaskAndFileStatus(fileInfoV2, extractKnowledgeTask, reason, false);
-            return;
+            return false;
         }
 
         // 5) Persist preview chunks
@@ -752,10 +786,73 @@ public class KnowledgeService {
         // 7) Update lastUuid rule (CBG uses chunk's docId)
         updateLastUuidBySource(fileInfoV2, chunkInfos);
 
-        // 8) Final success status + embedding-trigger
+        // 8) Final parsing success. The caller triggers embedding in a separate guarded stage so an
+        // embedding failure is not misclassified as a parsing failure.
         updateTaskAndFileStatus(fileInfoV2, extractKnowledgeTask, null, true);
-        fileInfoV2Service.saveTaskAndUpdateFileStatus(fileInfoV2.getId());
-        fileInfoV2Service.embeddingFile(fileInfoV2.getId(), fileInfoV2.getSpaceId());
+        return true;
+    }
+
+    private void handleUnexpectedExtractionFailure(
+            FileInfoV2 fileInfoV2,
+            ExtractKnowledgeTask extractKnowledgeTask,
+            Exception error) {
+        String detail = StringUtils.defaultIfBlank(
+                error.getMessage(), error.getClass().getSimpleName());
+        String reason = "Knowledge extraction failed unexpectedly: " + detail;
+        log.error(
+                "Unexpected knowledge extraction failure: fileId={}, taskId={}, source={}, reason={}",
+                fileInfoV2.getId(),
+                extractKnowledgeTask.getTaskId(),
+                fileInfoV2.getSource(),
+                detail,
+                error);
+        try {
+            updateTaskAndFileStatus(
+                    fileInfoV2, extractKnowledgeTask, reason, false);
+        } catch (Exception statusError) {
+            log.error(
+                    "Failed to persist terminal extraction status: fileId={}, taskId={}",
+                    fileInfoV2.getId(),
+                    extractKnowledgeTask.getTaskId(),
+                    statusError);
+        }
+    }
+
+    private void handleUnexpectedEmbeddingFailure(
+            FileInfoV2 fileInfoV2,
+            FileInfoV2Service fileInfoV2Service,
+            Exception error) {
+        String detail = StringUtils.defaultIfBlank(
+                error.getMessage(), error.getClass().getSimpleName());
+        String reason = "Knowledge embedding failed unexpectedly: " + detail;
+        log.error(
+                "Unexpected knowledge embedding failure: fileId={}, source={}, reason={}",
+                fileInfoV2.getId(),
+                fileInfoV2.getSource(),
+                detail,
+                error);
+        try {
+            FileInfoV2 latest = fileInfoV2Service.getById(fileInfoV2.getId());
+            if (latest == null) {
+                log.error("Failed to persist terminal embedding status: file not found, fileId={}",
+                        fileInfoV2.getId());
+                return;
+            }
+            // embeddingFile can report a later, already-persisted terminal status before throwing
+            // an ancillary exception. Do not regress a successful result.
+            if (Objects.equals(latest.getStatus(), ProjectContent.FILE_EMBEDDING_SUCCESSED)) {
+                return;
+            }
+            latest.setStatus(ProjectContent.FILE_EMBEDDING_FAILED);
+            latest.setReason(reason);
+            latest.setUpdateTime(new Timestamp(System.currentTimeMillis()));
+            fileInfoV2Service.updateById(latest);
+        } catch (Exception statusError) {
+            log.error(
+                    "Failed to persist terminal embedding status: fileId={}",
+                    fileInfoV2.getId(),
+                    statusError);
+        }
     }
 
     /**

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
@@ -2283,6 +2283,44 @@ class FileInfoV2ServiceTest {
         }
 
         /**
+         * A fast async worker may commit a terminal state before sliceFile returns. The
+         * dispatcher must never overwrite that state with FILE_PARSE_DOING.
+         */
+        @Test
+        @DisplayName("Slice file - fast async completion does not regress status")
+        void testSliceFile_FastAsyncCompletionDoesNotRegressStatus() {
+            Long fileId = 1L;
+            SliceConfig sliceConfig = new SliceConfig();
+            sliceConfig.setType(1);
+
+            mockFileInfo.setType("txt");
+            mockFileInfo.setAddress("s3://bucket/test.txt");
+            mockFileInfo.setSource("AIUI-RAG2");
+            mockFileInfo.setStatus(ProjectContent.FILE_PARSE_DOING);
+
+            ReflectionTestUtils.setField(fileInfoV2Service, "extractKnowledgeTaskService", extractKnowledgeTaskService);
+            ReflectionTestUtils.setField(fileInfoV2Service, "configInfoService", configInfoService);
+
+            when(fileInfoV2Mapper.selectById(fileId)).thenReturn(mockFileInfo);
+            when(configInfoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(null);
+            when(extractKnowledgeTaskService.save(any(ExtractKnowledgeTask.class))).thenReturn(true);
+            doAnswer(invocation -> {
+                FileInfoV2 asyncFile = invocation.getArgument(3);
+                asyncFile.setStatus(ProjectContent.FILE_PARSE_SUCCESSED);
+                return null;
+            }).when(knowledgeService).knowledgeExtractAsync(
+                    anyString(), anyString(), any(SliceConfig.class),
+                    any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
+            doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
+
+            DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, 0);
+
+            assertThat(result.isParseSuccess()).isTrue();
+            assertThat(mockFileInfo.getStatus()).isEqualTo(ProjectContent.FILE_PARSE_SUCCESSED);
+            verify(fileInfoV2Service, never()).updateById(any(FileInfoV2.class));
+        }
+
+        /**
          * Test sliceFile - file not found.
          */
         @Test
@@ -2304,6 +2342,67 @@ class FileInfoV2ServiceTest {
         }
 
         /**
+         * Missing storage metadata must close a previously scheduled file as a terminal
+         * failure instead of throwing before the async guard and leaving status 0.
+         */
+        @Test
+        @DisplayName("Slice file - missing address closes parse status")
+        void testSliceFile_MissingAddressClosesParseStatus() {
+            Long fileId = 1L;
+            SliceConfig sliceConfig = new SliceConfig();
+            sliceConfig.setType(1);
+
+            mockFileInfo.setType("docx");
+            mockFileInfo.setAddress(null);
+            mockFileInfo.setSource("CBG-RAG");
+            mockFileInfo.setStatus(ProjectContent.FILE_PARSE_DOING);
+
+            ReflectionTestUtils.setField(fileInfoV2Service, "configInfoService", configInfoService);
+
+            when(fileInfoV2Mapper.selectById(fileId)).thenReturn(mockFileInfo);
+            when(configInfoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(null);
+            doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
+
+            DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, 0);
+
+            assertThat(result.isParseSuccess()).isFalse();
+            assertThat(mockFileInfo.getStatus()).isEqualTo(ProjectContent.FILE_PARSE_FAILED);
+            assertThat(mockFileInfo.getReason()).contains("File address is empty");
+            verify(knowledgeService, never()).knowledgeExtractAsync(
+                    anyString(), anyString(), any(SliceConfig.class),
+                    any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
+            verify(fileInfoV2Service, times(1)).updateById(mockFileInfo);
+        }
+
+        @Test
+        @DisplayName("Slice file - missing type closes parse status")
+        void testSliceFile_MissingTypeClosesParseStatus() {
+            Long fileId = 1L;
+            SliceConfig sliceConfig = new SliceConfig();
+            sliceConfig.setType(1);
+
+            mockFileInfo.setType(null);
+            mockFileInfo.setSource("CBG-RAG");
+            mockFileInfo.setStatus(ProjectContent.FILE_PARSE_DOING);
+
+            ReflectionTestUtils.setField(fileInfoV2Service, "configInfoService", configInfoService);
+
+            when(fileInfoV2Mapper.selectById(fileId)).thenReturn(mockFileInfo);
+            when(configInfoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(null);
+            doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
+
+            DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, 0);
+
+            assertThat(result.isParseSuccess()).isFalse();
+            assertThat(mockFileInfo.getStatus()).isEqualTo(ProjectContent.FILE_PARSE_FAILED);
+            assertThat(mockFileInfo.getReason()).contains("File type is empty");
+            verify(knowledgeService, never()).knowledgeExtractAsync(
+                    anyString(), anyString(), any(SliceConfig.class),
+                    any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
+            verify(fileInfoV2Service, times(1)).updateById(mockFileInfo);
+        }
+
+        /**
          * Test sliceFile - CBG-RAG with unsupported file type.
          */
         @Test
@@ -2321,6 +2420,7 @@ class FileInfoV2ServiceTest {
 
             when(fileInfoV2Mapper.selectById(fileId)).thenReturn(mockFileInfo);
             when(configInfoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(null);
+            doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
 
             // When
             DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, backEmbedding);
@@ -2328,6 +2428,12 @@ class FileInfoV2ServiceTest {
             // Then
             assertThat(result).isNotNull();
             assertThat(result.isParseSuccess()).isFalse();
+            assertThat(mockFileInfo.getStatus()).isEqualTo(ProjectContent.FILE_PARSE_FAILED);
+            assertThat(mockFileInfo.getReason()).contains("Unsupported file type: xyz");
+            verify(knowledgeService, never()).knowledgeExtractAsync(
+                    anyString(), anyString(), any(SliceConfig.class),
+                    any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
+            verify(fileInfoV2Service, times(1)).updateById(mockFileInfo);
         }
 
         /**

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -2086,6 +2086,34 @@ class KnowledgeServiceTest {
         }
 
         /**
+         * Unexpected transport/runtime failures must close the async task with a terminal
+         * failure instead of leaving the file in FILE_PARSE_DOING forever.
+         */
+        @Test
+        @DisplayName("Extract knowledge closes status on unexpected exception")
+        void testKnowledgeExtractAsync_UnexpectedExceptionClosesStatus() {
+            String contentType = "text/plain";
+            String url = "http://example.com/document.txt";
+            mockFileInfo.setSource("AIUI-RAG2");
+            mockFileInfo.setStatus(ProjectContent.FILE_PARSE_DOING);
+
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any()))
+                    .thenThrow(new RuntimeException("connection reset"));
+            when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
+            when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
+
+            knowledgeService.knowledgeExtractAsync(
+                    contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask);
+
+            assertThat(mockFileInfo.getStatus()).isEqualTo(ProjectContent.FILE_PARSE_FAILED);
+            assertThat(mockFileInfo.getReason()).contains("connection reset");
+            assertThat(mockExtractTask.getStatus()).isEqualTo(2);
+            assertThat(mockExtractTask.getTaskStatus()).isEqualTo(1);
+            verify(fileInfoV2Service, times(1)).updateById(mockFileInfo);
+            verify(extractKnowledgeTaskService, times(1)).updateById(mockExtractTask);
+        }
+
+        /**
          * Test extraction with special error code 11111.
          */
         @Test
@@ -2315,6 +2343,44 @@ class KnowledgeServiceTest {
             // Then
             verify(mockFileService, never()).saveTaskAndUpdateFileStatus(anyLong());
             verify(mockFileService, never()).embeddingFile(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("Embedding trigger failure does not regress parse status")
+        void testKnowledgeEmbeddingExtractAsync_EmbeddingTriggerFailureUsesEmbeddingStatus() {
+            String contentType = "text/plain";
+            String url = "http://example.com/document.txt";
+            mockFileInfo.setSource("AIUI-RAG2");
+            mockFileInfo.setSpaceId(1L);
+
+            KnowledgeResponse response = new KnowledgeResponse();
+            response.setCode(0);
+            JSONArray dataArray = new JSONArray();
+            ChunkInfo chunk = new ChunkInfo();
+            chunk.setContent("Test chunk content");
+            chunk.setDocId("file-uuid-001");
+            dataArray.add(JSON.parseObject(JSON.toJSONString(chunk)));
+            response.setData(dataArray);
+
+            when(knowledgeV2ServiceCallHandler.documentSplit(any(), any())).thenReturn(response);
+            when(fileInfoV2Service.getById(anyLong())).thenReturn(mockFileInfo);
+            when(previewKnowledgeMapper.countByFileId(anyString())).thenReturn(0L);
+            when(previewKnowledgeMapper.insertBatch(anyList())).thenReturn(1);
+            when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
+            when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
+            doThrow(new RuntimeException("embedding queue unavailable"))
+                    .when(mockFileService).saveTaskAndUpdateFileStatus(mockFileInfo.getId());
+            when(mockFileService.getById(mockFileInfo.getId())).thenReturn(mockFileInfo);
+            when(mockFileService.updateById(any(FileInfoV2.class))).thenReturn(true);
+
+            knowledgeService.knowledgeEmbeddingExtractAsync(
+                    contentType, url, mockSliceConfig, mockFileInfo, mockExtractTask, mockFileService);
+
+            assertThat(mockExtractTask.getStatus()).isEqualTo(1);
+            assertThat(mockFileInfo.getStatus()).isEqualTo(ProjectContent.FILE_EMBEDDING_FAILED);
+            assertThat(mockFileInfo.getReason()).contains("embedding queue unavailable");
+            verify(mockFileService, never()).embeddingFile(anyLong(), anyLong());
+            verify(mockFileService, times(1)).updateById(mockFileInfo);
         }
 
         /**

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -924,107 +924,179 @@ async def add_chunk(
 # ==================== Helper Functions ====================
 
 
-async def _check_document_parsing_status(
-    dataset_id: str, doc_id: str
-) -> tuple[str, int, bool]:
-    """
-    Check document parsing status
-
-    Args:
-        dataset_id: Dataset ID
-        doc_id: Document ID
-
-    Returns:
-        (status, token_count, found)
-    """
-    response = await list_documents_in_dataset(dataset_id, doc_id, page=1, page_size=30)
-
-    if response.get("code") != 0:
-        return "UNKNOWN", 0, False
-
-    docs = response.get("data", {}).get("docs", [])
-    for doc in docs:
-        if doc.get("id") == doc_id:
-            run_status = doc.get("run", "UNSTART")
-            token_count = doc.get("token_count", 0)
-            return run_status, token_count, True
-
-    logger.warning(f"Document {doc_id} not found in list")
-    return "NOT_FOUND", 0, False
+_PARSING_FAILURE_STATES = frozenset({"FAIL", "CANCEL"})
 
 
-def _handle_parsing_status_result(
-    doc_id: str, run_status: str, token_count: int
-) -> Optional[str]:
-    """
-    Handle parsing status and determine if parsing is complete
+def _parsing_snapshot(doc_info: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the RAGFlow fields needed to decide and diagnose parsing state."""
+    progress_msg = str(doc_info.get("progress_msg") or "")
+    return {
+        "status": str(doc_info.get("run") or "UNSTART").upper(),
+        "progress": doc_info.get("progress", 0),
+        "chunk_count": doc_info.get("chunk_count", 0) or 0,
+        "token_count": doc_info.get("token_count", 0) or 0,
+        # Keep status logs bounded even when RAGFlow returns a long task trace.
+        "progress_msg": progress_msg.replace("\n", " | ")[:500],
+    }
 
-    Args:
-        doc_id: Document ID
-        run_status: Current parsing status
-        token_count: Token count
 
-    Returns:
-        Final status if complete, None if should continue waiting
-
-    Raises:
-        Exception: If parsing failed
-    """
-    if run_status == "DONE":
-        logger.info(f"Document {doc_id} parsing completed with {token_count} tokens")
-        return run_status
-    elif run_status == "FAIL":
-        raise Exception(f"Document {doc_id} parsing failed")
-    elif run_status == "RUNNING":
-        logger.info(f"Document {doc_id} is being parsed...")
-
-    return None
+def _format_parsing_snapshot(snapshot: Dict[str, Any]) -> str:
+    """Format a compact status description for logs and propagated errors."""
+    return (
+        f"status={snapshot['status']}, progress={snapshot['progress']}, "
+        f"chunks={snapshot['chunk_count']}, tokens={snapshot['token_count']}, "
+        f"message={snapshot['progress_msg'] or '-'}"
+    )
 
 
 async def wait_for_parsing(
-    dataset_id: str, doc_id: str, max_wait_time: int = 300
+    dataset_id: str,
+    doc_id: str,
+    max_wait_time: int = 300,
+    poll_interval: float = 3.0,
+    max_status_errors: int = 3,
 ) -> str:
     """
-    Wait for document parsing completion
+    Wait for RAGFlow to reach a terminal document parsing state.
+
+    RAGFlow exposes ``run`` as the authoritative state. ``chunk_count`` and
+    ``token_count`` are result statistics and may legitimately be zero, so
+    neither is used as an additional completion gate.
 
     Args:
         dataset_id: Dataset ID
         doc_id: Document ID
         max_wait_time: Maximum wait time (seconds)
+        poll_interval: Delay between status checks (seconds)
+        max_status_errors: Consecutive status-query failures allowed
 
     Returns:
-        Final parsing status
+        ``DONE`` when parsing completes.
 
     Raises:
-        Exception: Raised when parsing fails
+        ValueError: If wait parameters are invalid.
+        ThirdPartyException: If RAGFlow fails, cancels, or times out.
     """
-    start_time = time.time()
-    last_status = None
+    if max_wait_time <= 0:
+        raise ValueError("max_wait_time must be greater than 0")
+    if poll_interval <= 0:
+        raise ValueError("poll_interval must be greater than 0")
+    if max_status_errors <= 0:
+        raise ValueError("max_status_errors must be greater than 0")
 
-    while time.time() - start_time < max_wait_time:
+    started_at = time.monotonic()
+    last_snapshot: Optional[Dict[str, Any]] = None
+    document_missing_logged = False
+    consecutive_status_errors = 0
+    last_status_error: Optional[Exception] = None
+
+    while time.monotonic() - started_at < max_wait_time:
+        status_error: Optional[Exception] = None
         try:
-            run_status, token_count, found = await _check_document_parsing_status(
-                dataset_id, doc_id
+            doc_info = await get_document_info(dataset_id, doc_id)
+        except Exception as error:
+            doc_info = None
+            status_error = error
+
+        # A status request may begin before the deadline and finish after it.
+        # Record the returned snapshot for diagnostics, but never turn a late
+        # terminal response into success after the configured wait expired.
+        deadline_reached = time.monotonic() - started_at >= max_wait_time
+
+        if status_error is not None:
+            last_status_error = status_error
+            if deadline_reached:
+                break
+            consecutive_status_errors += 1
+            logger.warning(
+                "Failed to query RAGFlow parsing status: "
+                "dataset=%s doc=%s attempt=%d/%d error=%s",
+                dataset_id,
+                doc_id,
+                consecutive_status_errors,
+                max_status_errors,
+                status_error,
             )
+            if consecutive_status_errors >= max_status_errors:
+                raise ThirdPartyException(
+                    msg=(
+                        "Unable to query RAGFlow document parsing status after "
+                        f"{consecutive_status_errors} attempts: doc={doc_id}, "
+                        f"error={status_error}"
+                    ),
+                    e=CodeEnum.RAGFLOW_RAGError,
+                ) from status_error
+        else:
+            consecutive_status_errors = 0
+            last_status_error = None
 
-            if run_status != last_status:
-                logger.info(
-                    f"Document {doc_id} status: {run_status}, tokens: {token_count}"
+        if doc_info is None and status_error is None:
+            if not document_missing_logged:
+                logger.warning(
+                    "RAGFlow document not visible while waiting: dataset=%s doc=%s",
+                    dataset_id,
+                    doc_id,
                 )
-                last_status = run_status
+                document_missing_logged = True
+        elif doc_info is not None:
+            snapshot = _parsing_snapshot(doc_info)
+            if snapshot != last_snapshot:
+                logger.info(
+                    "RAGFlow parsing status: dataset=%s doc=%s %s",
+                    dataset_id,
+                    doc_id,
+                    _format_parsing_snapshot(snapshot),
+                )
+                last_snapshot = snapshot
 
-            if found:
-                result = _handle_parsing_status_result(doc_id, run_status, token_count)
-                if result:
-                    return result
+            if deadline_reached:
+                break
 
-            await asyncio.sleep(3)
+            run_status = snapshot["status"]
+            if run_status == "DONE":
+                if snapshot["chunk_count"] == 0:
+                    logger.warning(
+                        "RAGFlow parsing completed with zero chunks: "
+                        "dataset=%s doc=%s %s",
+                        dataset_id,
+                        doc_id,
+                        _format_parsing_snapshot(snapshot),
+                    )
+                return "DONE"
 
-        except Exception as e:
-            logger.warning(f"Error checking parsing status: {e}")
-            await asyncio.sleep(3)
+            if run_status in _PARSING_FAILURE_STATES:
+                raise ThirdPartyException(
+                    msg=(
+                        f"RAGFlow document parsing ended with {run_status}: "
+                        f"doc={doc_id}, {_format_parsing_snapshot(snapshot)}"
+                    ),
+                    e=CodeEnum.RAGFLOW_RAGError,
+                )
 
+        remaining = max_wait_time - (time.monotonic() - started_at)
+        if remaining <= 0:
+            break
+        await asyncio.sleep(min(poll_interval, remaining))
+
+    if last_snapshot is not None:
+        last_context = _format_parsing_snapshot(last_snapshot)
+        if last_status_error is not None:
+            last_context += f", last status error={str(last_status_error)[:500]}"
+    elif last_status_error is not None:
+        last_context = f"last status error={str(last_status_error)[:500]}"
+    else:
+        last_context = "document was not visible"
     logger.warning(
-        f"Document parsing timeout after {max_wait_time} seconds, last status: {last_status}"
+        "RAGFlow document parsing timed out after %s seconds: " "dataset=%s doc=%s %s",
+        max_wait_time,
+        dataset_id,
+        doc_id,
+        last_context,
     )
-    return last_status or "TIMEOUT"
+    raise ThirdPartyException(
+        msg=(
+            f"RAGFlow document parsing timed out after {max_wait_time} seconds: "
+            f"doc={doc_id}, {last_context}"
+        ),
+        e=CodeEnum.RAGFLOW_RAGError,
+    )

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -9,7 +9,6 @@ Provides helper methods for RAGFlow document processing, including file handling
 import asyncio
 import logging
 import os
-import time
 import urllib.parse
 from typing import Any, Dict, List, Optional, Union
 
@@ -19,10 +18,11 @@ from fastapi import UploadFile
 from knowledge.domain.platform_account_config import get_managed_config_value
 from knowledge.infra.ragflow.ragflow_client import (
     create_dataset,
+    fetch_all_document_chunks,
+    get_document_info,
     list_datasets,
-    list_document_chunks,
-    list_documents_in_dataset,
     update_dataset,
+    wait_for_parsing as wait_for_document_parsing,
 )
 
 logger = logging.getLogger(__name__)
@@ -300,70 +300,121 @@ class RagflowUtils:
         dataset_id: str, doc_id: str, max_retries: int = 15, retry_delay: float = 3.0
     ) -> List[Dict[str, Any]]:
         """
-        Get all chunk content of a document
+        Get all chunks after parsing, retrying incomplete search snapshots.
+
+        Each attempt delegates to the canonical fail-closed paginator. RAGFlow
+        API errors and incomplete pagination therefore propagate instead of
+        being misreported as a valid empty document.
 
         Args:
             dataset_id: Dataset ID
             doc_id: Document ID
-            max_retries: Maximum number of retry attempts to get chunks (default: 15)
+            max_retries: Maximum incomplete-snapshot retries (default: 15)
             retry_delay: Delay between retries in seconds (default: 3.0)
 
         Returns:
-            List of chunk data, returns empty list if retrieval fails
+            Complete chunk list, or an empty list after all empty retries.
         """
+        if max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+        if retry_delay < 0:
+            raise ValueError("retry_delay must be non-negative")
+
+        doc_info = await get_document_info(dataset_id, doc_id)
+        if doc_info is None:
+            raise RuntimeError(
+                f"RAGFlow document disappeared before chunk retrieval: doc={doc_id}"
+            )
+
+        raw_expected_count = doc_info.get("chunk_count")
         try:
-            all_chunks = []
-            page = 1
-            page_size = 100  # Get 100 chunks per page
-            retry_count = 0
+            expected_count = (
+                int(raw_expected_count) if raw_expected_count is not None else None
+            )
+        except (TypeError, ValueError):
+            expected_count = None
+        if expected_count is not None and expected_count < 0:
+            expected_count = None
 
-            while True:
-                # Use functional API to get chunks, supports pagination
-                chunks_response = await list_document_chunks(
-                    dataset_id, doc_id, page=page, page_size=page_size
+        last_visible_count = 0
+        last_chunk_ids: Optional[tuple[str, ...]] = None
+        stable_partial_reads = 0
+        for attempt in range(max_retries + 1):
+            chunks = await fetch_all_document_chunks(dataset_id, doc_id, page_size=100)
+            last_visible_count = len(chunks)
+            has_complete_snapshot = (
+                expected_count is not None and last_visible_count >= expected_count
+            )
+            if has_complete_snapshot:
+                logger.info(
+                    "Retrieved complete RAGFlow chunk snapshot: "
+                    "dataset=%s doc=%s visible=%d expected=%s",
+                    dataset_id,
+                    doc_id,
+                    last_visible_count,
+                    expected_count,
                 )
+                return chunks
 
-                if chunks_response.get("code") == 0:
-                    data = chunks_response.get("data", {})
-                    chunks = data.get("chunks", [])
-                    total = data.get("total", 0)
+            chunk_ids = tuple(sorted(str(chunk.get("id", "")) for chunk in chunks))
+            if chunks and chunk_ids == last_chunk_ids:
+                stable_partial_reads += 1
+            else:
+                stable_partial_reads = 0
+            last_chunk_ids = chunk_ids
 
-                    if chunks:
-                        all_chunks.extend(chunks)
-                        logger.info(
-                            f"Got page {page} chunks: {len(chunks)} items, total: {len(all_chunks)} items"
-                        )
+            # RAGFlow may over-count document chunks when identical content in
+            # separate tasks produces the same content-addressed chunk ID.
+            # Treat metadata count as a visibility target, but accept a
+            # non-empty ID set after two additional unchanged observations.
+            if chunks and stable_partial_reads >= 2:
+                logger.warning(
+                    "RAGFlow chunk snapshot stabilized below metadata count: "
+                    "dataset=%s doc=%s visible=%d expected=%s",
+                    dataset_id,
+                    doc_id,
+                    last_visible_count,
+                    expected_count,
+                )
+                return chunks
 
-                        # If all chunks are retrieved, exit loop
-                        if len(all_chunks) >= total:
-                            break
-
-                        page += 1
-                        retry_count = 0
-                    else:
-                        # No chunks found - might be because RAGFlow is still indexing
-                        if retry_count < max_retries and page == 1:
-                            retry_count += 1
-                            logger.info(
-                                f"No chunks found yet for document {doc_id}, retrying... (attempt {retry_count}/{max_retries})"
-                            )
-                            await asyncio.sleep(retry_delay)
-                            continue
-                        else:
-                            # No more chunks or max retries reached
-                            break
-                else:
-                    logger.warning(f"Failed to get chunks: {chunks_response}")
-                    break
+            if attempt == max_retries:
+                break
 
             logger.info(
-                f"Successfully retrieved all {len(all_chunks)} chunks of document {doc_id}"
+                "RAGFlow chunks are not fully visible yet: "
+                "dataset=%s doc=%s visible=%d expected=%s retry=%d/%d",
+                dataset_id,
+                doc_id,
+                last_visible_count,
+                expected_count,
+                attempt + 1,
+                max_retries,
             )
-            return all_chunks
+            await asyncio.sleep(retry_delay)
 
-        except Exception as e:
-            logger.error(f"Exception while getting document chunks: {e}")
-            return []
+        if expected_count is not None and expected_count > last_visible_count:
+            raise RuntimeError(
+                "RAGFlow chunk snapshot remained incomplete after retries: "
+                f"doc={doc_id}, visible={last_visible_count}, "
+                f"expected={expected_count}"
+            )
+
+        if last_visible_count > 0:
+            raise RuntimeError(
+                "RAGFlow chunk snapshot did not stabilize after retries: "
+                f"doc={doc_id}, visible={last_visible_count}, "
+                f"expected={expected_count}"
+            )
+
+        logger.warning(
+            "RAGFlow document returned zero chunks after retries: "
+            "dataset=%s doc=%s attempts=%d",
+            dataset_id,
+            doc_id,
+            max_retries + 1,
+        )
+        return []
 
     @staticmethod
     def convert_to_standard_format(
@@ -398,115 +449,15 @@ class RagflowUtils:
         return result
 
     @staticmethod
-    async def _check_document_status(dataset_id: str, doc_id: str) -> tuple[str, int]:
-        """
-        Check parsing status of a single document
-
-        Args:
-            dataset_id: Dataset ID
-            doc_id: Document ID
-
-        Returns:
-            (status, token count)
-        """
-        response = await list_documents_in_dataset(dataset_id, doc_id)
-
-        if response.get("code") != 0:
-            return "UNKNOWN", 0
-
-        docs = response.get("data", {}).get("docs", [])
-        for doc in docs:
-            if doc.get("id") == doc_id:
-                run_status = doc.get("run", "UNSTART")
-                token_count = doc.get("token_count", 0)
-                return run_status, token_count
-
-        logger.warning(f"Document {doc_id} not found in list")
-        return "NOT_FOUND", 0
-
-    @staticmethod
-    def _handle_parsing_status(
-        doc_id: str, run_status: str, token_count: int
-    ) -> Optional[str]:
-        """
-        Handle parsing status
-
-        Args:
-            doc_id: Document ID
-            run_status: Running status
-            token_count: Token count
-
-        Returns:
-            Processed status, returns None if need to continue waiting
-        """
-        if run_status == "DONE":
-            if token_count > 0:
-                logger.info(
-                    f"Document {doc_id} parsing completed with {token_count} tokens"
-                )
-                return run_status
-            else:
-                logger.warning(
-                    f"Document {doc_id} status is DONE but token_count is 0, will continue waiting..."
-                )
-                return None
-        elif run_status == "FAIL":
-            raise Exception(f"Document {doc_id} parsing failed")
-        elif run_status == "RUNNING":
-            logger.info(f"Document {doc_id} is being parsed...")
-
-        return None  # Continue waiting
-
-    @staticmethod
     async def wait_for_parsing(
         dataset_id: str, doc_id: str, max_wait_time: int = 300
     ) -> str:
-        """
-        Wait for document parsing completion
-
-        Args:
-            dataset_id: Dataset ID
-            doc_id: Document ID
-            max_wait_time: Maximum wait time (seconds)
-
-        Returns:
-            Final parsing status
-
-        Raises:
-            Exception: Raised when parsing fails
-        """
-        start_time = time.time()
-        last_status = None
-
-        while time.time() - start_time < max_wait_time:
-            try:
-                run_status, token_count = await RagflowUtils._check_document_status(
-                    dataset_id, doc_id
-                )
-
-                if run_status != last_status:
-                    logger.info(
-                        f"Document {doc_id} status: {run_status}, tokens: {token_count}"
-                    )
-                    last_status = run_status
-
-                # Handle status, if returns non-None value, parsing is complete or failed
-                result = RagflowUtils._handle_parsing_status(
-                    doc_id, run_status, token_count
-                )
-                if result:
-                    return result
-
-                await asyncio.sleep(1)
-
-            except Exception as e:
-                logger.warning(f"Error checking parsing status: {e}")
-                await asyncio.sleep(1)
-
-        logger.warning(
-            f"Document parsing timeout after {max_wait_time} seconds, last status: {last_status}"
+        """Backward-compatible wrapper around the canonical client poller."""
+        return await wait_for_document_parsing(
+            dataset_id=dataset_id,
+            doc_id=doc_id,
+            max_wait_time=max_wait_time,
         )
-        return last_status or "TIMEOUT"
 
     @staticmethod
     def build_parser_config(

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -248,29 +248,42 @@ class RagflowRAGStrategy(RAGStrategy):
 
     async def _handle_document_parsing(self, dataset_id: str, doc_id: str) -> None:
         """Handle document parsing and wait for completion."""
-        logger.info("Triggering document parsing...")
+        logger.info(
+            "Triggering RAGFlow document parsing: dataset=%s doc=%s",
+            dataset_id,
+            doc_id,
+        )
         parse_response = await ragflow_client.parse_documents(dataset_id, [doc_id])
 
-        if parse_response.get("code") == 0:
-            logger.info("Document parsing triggered successfully")
-            try:
-                final_status = await RagflowUtils.wait_for_parsing(
-                    dataset_id, doc_id, max_wait_time=300
-                )
-                logger.info(
-                    "Document parsing completed, final status: %s", final_status
-                )
-            except Exception as parse_error:
-                logger.warning("Parsing wait timeout or error: %s", parse_error)
-                final_status = "TIMEOUT"
+        if parse_response.get("code") != 0:
+            message = parse_response.get("message", "unknown RAGFlow error")
+            logger.warning(
+                "RAGFlow rejected document parsing: dataset=%s doc=%s code=%s "
+                "message=%s",
+                dataset_id,
+                doc_id,
+                parse_response.get("code"),
+                message,
+            )
+            raise ThirdPartyException(
+                msg=f"Failed to trigger RAGFlow document parsing: {message}",
+                e=CodeEnum.RAGFLOW_RAGError,
+            )
 
-            if final_status != "DONE":
-                raise ValueError(
-                    "File parsing timeout or error, please check in RAGFlow"
-                )
-        else:
-            logger.warning("File parsing failed: %s", parse_response)
-            raise ValueError("File parsing failed, please check in RAGFlow")
+        logger.info(
+            "RAGFlow document parsing triggered: dataset=%s doc=%s",
+            dataset_id,
+            doc_id,
+        )
+        final_status = await ragflow_client.wait_for_parsing(
+            dataset_id, doc_id, max_wait_time=300
+        )
+        logger.info(
+            "RAGFlow document parsing completed: dataset=%s doc=%s status=%s",
+            dataset_id,
+            doc_id,
+            final_status,
+        )
 
     async def split(
         self,
@@ -359,6 +372,17 @@ class RagflowRAGStrategy(RAGStrategy):
                 doc_id = await self._process_document_upload(file_input, dataset_id)
                 await self._handle_document_parsing(dataset_id, doc_id)
                 chunks_data = await RagflowUtils.get_document_chunks(dataset_id, doc_id)
+                if not chunks_data:
+                    logger.error(
+                        "RAGFlow parsing completed but returned zero chunks: "
+                        "dataset=%s doc=%s",
+                        dataset_id,
+                        doc_id,
+                    )
+                    raise CustomException(
+                        CodeEnum.ChunkQueryFailed,
+                        f"RAGFlow produced zero chunks for document {doc_id}",
+                    )
 
             # Step 7: Convert to standard format
             result = RagflowUtils.convert_to_standard_format(doc_id, chunks_data)
@@ -366,7 +390,7 @@ class RagflowRAGStrategy(RAGStrategy):
             logger.info("Split processing completed, returning %d chunks", len(result))
             return result
 
-        except CustomException:
+        except (CustomException, ThirdPartyException):
             raise
         except Exception as e:
             logger.error("Split operation failed: %s", e)
@@ -1121,10 +1145,9 @@ class RagflowRAGStrategy(RAGStrategy):
         """Atomic upsert: upload + parse + fetch chunks + delete old.
 
         Any failure at any step rolls back the pending new doc and preserves
-        old_doc_id. Chunks fetch is intentionally inside the transaction:
-        RagflowUtils.get_document_chunks silently returns [] on fetch
-        failure, so deleting the old doc before verifying non-empty chunks
-        would strand the file as un-retrievable.
+        old_doc_id. Chunks fetch is intentionally inside the transaction so
+        the old document is not deleted until a complete, non-empty chunk set
+        has been verified.
 
         Returns (new_doc_id, chunks_data) with chunks_data non-empty.
         """

--- a/core/knowledge/tests/infra/ragflow/ragflow_client_parsing_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_client_parsing_test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for RAGFlow document parsing status polling."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.exceptions.exception import ThirdPartyException
+from knowledge.infra.ragflow import ragflow_client
+
+_GET_DOCUMENT_INFO = "knowledge.infra.ragflow.ragflow_client.get_document_info"
+_SLEEP = "knowledge.infra.ragflow.ragflow_client.asyncio.sleep"
+_MONOTONIC = "knowledge.infra.ragflow.ragflow_client.time.monotonic"
+
+
+def _document(
+    run: str,
+    *,
+    chunk_count: int = 0,
+    token_count: int = 0,
+    progress: float = 0,
+    progress_msg: str = "",
+) -> dict:
+    return {
+        "id": "doc-1",
+        "run": run,
+        "chunk_count": chunk_count,
+        "token_count": token_count,
+        "progress": progress,
+        "progress_msg": progress_msg,
+    }
+
+
+@pytest.mark.asyncio
+async def test_done_with_zero_token_count_completes_immediately() -> None:
+    """DONE is terminal even when the token statistic is zero."""
+    doc = _document(
+        "DONE",
+        chunk_count=12,
+        token_count=0,
+        progress=1,
+        progress_msg="Task done",
+    )
+    with patch(_GET_DOCUMENT_INFO, new=AsyncMock(return_value=doc)) as mock_get, patch(
+        _SLEEP, new=AsyncMock()
+    ) as mock_sleep:
+        result = await ragflow_client.wait_for_parsing(
+            "ds-1", "doc-1", max_wait_time=10, poll_interval=0.1
+        )
+
+    assert result == "DONE"
+    mock_get.assert_awaited_once_with("ds-1", "doc-1")
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_done_with_zero_chunks_is_terminal_for_status_poller() -> None:
+    """Chunk validation is separate from the authoritative RAGFlow run state."""
+    doc = _document(
+        "DONE",
+        chunk_count=0,
+        token_count=0,
+        progress=1,
+        progress_msg="No chunk built from file.docx",
+    )
+    with patch(_GET_DOCUMENT_INFO, new=AsyncMock(return_value=doc)), patch(
+        _SLEEP, new=AsyncMock()
+    ) as mock_sleep:
+        result = await ragflow_client.wait_for_parsing(
+            "ds-1", "doc-1", max_wait_time=10, poll_interval=0.1
+        )
+
+    assert result == "DONE"
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_running_then_done_polls_until_terminal_state() -> None:
+    running = _document("RUNNING", progress=0.5, progress_msg="Embedding")
+    done = _document("DONE", chunk_count=3, token_count=42, progress=1)
+    with patch(
+        _GET_DOCUMENT_INFO,
+        new=AsyncMock(side_effect=[running, done]),
+    ) as mock_get, patch(_SLEEP, new=AsyncMock()) as mock_sleep:
+        result = await ragflow_client.wait_for_parsing(
+            "ds-1", "doc-1", max_wait_time=10, poll_interval=0.1
+        )
+
+    assert result == "DONE"
+    assert mock_get.await_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["FAIL", "CANCEL"])
+async def test_failure_states_raise_immediately(terminal_status: str) -> None:
+    doc = _document(
+        terminal_status,
+        progress=-1,
+        progress_msg="Embedding service unavailable",
+    )
+    with patch(_GET_DOCUMENT_INFO, new=AsyncMock(return_value=doc)), patch(
+        _SLEEP, new=AsyncMock()
+    ) as mock_sleep:
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await ragflow_client.wait_for_parsing(
+                "ds-1", "doc-1", max_wait_time=10, poll_interval=0.1
+            )
+
+    assert terminal_status in str(exc_info.value)
+    assert "Embedding service unavailable" in str(exc_info.value)
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_status_transport_error_is_retried() -> None:
+    done = _document("DONE", chunk_count=2, token_count=0, progress=1)
+    with patch(
+        _GET_DOCUMENT_INFO,
+        new=AsyncMock(side_effect=[RuntimeError("connection reset"), done]),
+    ) as mock_get, patch(_SLEEP, new=AsyncMock()) as mock_sleep:
+        result = await ragflow_client.wait_for_parsing(
+            "ds-1", "doc-1", max_wait_time=10, poll_interval=0.1
+        )
+
+    assert result == "DONE"
+    assert mock_get.await_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repeated_status_transport_errors_fail_after_limit() -> None:
+    with patch(
+        _GET_DOCUMENT_INFO,
+        new=AsyncMock(side_effect=RuntimeError("connection reset")),
+    ) as mock_get, patch(_SLEEP, new=AsyncMock()) as mock_sleep:
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await ragflow_client.wait_for_parsing(
+                "ds-1",
+                "doc-1",
+                max_wait_time=10,
+                poll_interval=0.1,
+                max_status_errors=2,
+            )
+
+    assert "after 2 attempts" in str(exc_info.value)
+    assert "connection reset" in str(exc_info.value)
+    assert mock_get.await_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_timeout_raises_instead_of_returning_last_status() -> None:
+    running = _document("RUNNING", progress=0.8, progress_msg="Indexing")
+    with patch(_GET_DOCUMENT_INFO, new=AsyncMock(return_value=running)), patch(
+        _SLEEP, new=AsyncMock()
+    ) as mock_sleep, patch(_MONOTONIC, side_effect=[0.0, 0.0, 2.0]):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await ragflow_client.wait_for_parsing(
+                "ds-1", "doc-1", max_wait_time=1, poll_interval=0.1
+            )
+
+    assert "timed out after 1 seconds" in str(exc_info.value)
+    assert "status=RUNNING" in str(exc_info.value)
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_done_response_arriving_after_deadline_is_timeout() -> None:
+    """A terminal response cannot turn an already-expired wait into success."""
+    done = _document("DONE", chunk_count=2, token_count=0, progress=1)
+    with patch(_GET_DOCUMENT_INFO, new=AsyncMock(return_value=done)), patch(
+        _SLEEP, new=AsyncMock()
+    ) as mock_sleep, patch(_MONOTONIC, side_effect=[0.0, 0.0, 2.0]):
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await ragflow_client.wait_for_parsing(
+                "ds-1", "doc-1", max_wait_time=1, poll_interval=0.1
+            )
+
+    assert "timed out after 1 seconds" in str(exc_info.value)
+    assert "status=DONE" in str(exc_info.value)
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_wait_time", "poll_interval", "max_status_errors", "expected"),
+    [
+        (0, 1.0, 3, "max_wait_time"),
+        (1, 0, 3, "poll_interval"),
+        (1, 1.0, 0, "max_status_errors"),
+    ],
+)
+async def test_invalid_wait_parameters_are_rejected(
+    max_wait_time: int,
+    poll_interval: float,
+    max_status_errors: int,
+    expected: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected):
+        await ragflow_client.wait_for_parsing(
+            "ds-1",
+            "doc-1",
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+            max_status_errors=max_status_errors,
+        )

--- a/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
@@ -41,6 +41,164 @@ class TestGetDefaultDatasetName:
         assert RagflowUtils.get_default_dataset_name() == DEFAULT_RAGFLOW_DATASET_NAME
 
 
+@pytest.mark.asyncio
+async def test_wait_for_parsing_delegates_to_canonical_client() -> None:
+    """Legacy utility entry point must not maintain a second polling policy."""
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.wait_for_document_parsing",
+        new=AsyncMock(return_value="DONE"),
+    ) as mock_wait:
+        result = await RagflowUtils.wait_for_parsing("ds-1", "doc-1", max_wait_time=12)
+
+    assert result == "DONE"
+    mock_wait.assert_awaited_once_with(
+        dataset_id="ds-1",
+        doc_id="doc-1",
+        max_wait_time=12,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_retries_empty_complete_results() -> None:
+    chunks = [{"id": "chunk-1", "content": "hello"}]
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1", "chunk_count": 1}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(side_effect=[[], chunks]),
+    ) as mock_fetch, patch(
+        "knowledge.infra.ragflow.ragflow_utils.asyncio.sleep",
+        new=AsyncMock(),
+    ) as mock_sleep:
+        result = await RagflowUtils.get_document_chunks(
+            "ds-1", "doc-1", max_retries=1, retry_delay=0
+        )
+
+    assert result == chunks
+    assert mock_fetch.await_count == 2
+    mock_sleep.assert_awaited_once_with(0)
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_zero_metadata_count_returns_without_retry() -> None:
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1", "chunk_count": 0}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(return_value=[]),
+    ) as mock_fetch, patch(
+        "knowledge.infra.ragflow.ragflow_utils.asyncio.sleep",
+        new=AsyncMock(),
+    ) as mock_sleep:
+        result = await RagflowUtils.get_document_chunks("ds-1", "doc-1")
+
+    assert result == []
+    mock_fetch.assert_awaited_once()
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_propagates_fetch_failure() -> None:
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1", "chunk_count": 1}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(side_effect=RuntimeError("incomplete page")),
+    ):
+        with pytest.raises(RuntimeError, match="incomplete page"):
+            await RagflowUtils.get_document_chunks(
+                "ds-1", "doc-1", max_retries=1, retry_delay=0
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_retries_non_empty_partial_snapshot() -> None:
+    partial = [{"id": "chunk-1"}]
+    complete = [
+        {"id": "chunk-1"},
+        {"id": "chunk-2"},
+        {"id": "chunk-3"},
+    ]
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1", "chunk_count": 3}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(side_effect=[partial, complete]),
+    ) as mock_fetch, patch(
+        "knowledge.infra.ragflow.ragflow_utils.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        result = await RagflowUtils.get_document_chunks(
+            "ds-1", "doc-1", max_retries=1, retry_delay=0
+        )
+
+    assert result == complete
+    assert mock_fetch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_accepts_stable_deduplicated_snapshot() -> None:
+    partial = [{"id": "chunk-1"}]
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1", "chunk_count": 3}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(return_value=partial),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        result = await RagflowUtils.get_document_chunks(
+            "ds-1", "doc-1", max_retries=2, retry_delay=0
+        )
+
+    assert result == partial
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_without_expected_count_waits_for_stability() -> None:
+    visible = [{"id": "chunk-1"}, {"id": "chunk-2"}]
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1"}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(return_value=visible),
+    ) as mock_fetch, patch(
+        "knowledge.infra.ragflow.ragflow_utils.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        result = await RagflowUtils.get_document_chunks(
+            "ds-1", "doc-1", max_retries=2, retry_delay=0
+        )
+
+    assert result == visible
+    assert mock_fetch.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_rejects_missing_expected_chunks() -> None:
+    with patch(
+        "knowledge.infra.ragflow.ragflow_utils.get_document_info",
+        new=AsyncMock(return_value={"id": "doc-1", "chunk_count": 3}),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.fetch_all_document_chunks",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "knowledge.infra.ragflow.ragflow_utils.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        with pytest.raises(RuntimeError, match="visible=0, expected=3"):
+            await RagflowUtils.get_document_chunks(
+                "ds-1", "doc-1", max_retries=1, retry_delay=0
+            )
+
+
 # ---------------------------------------------------------------------------
 # ensure_dataset description sync (lazy + best-effort)
 # ---------------------------------------------------------------------------

--- a/core/knowledge/tests/service/impl/ragflow_strategy_parsing_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_parsing_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for RAGFlow strategy parsing orchestration."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.consts.error_code import CodeEnum
+from knowledge.exceptions.exception import CustomException, ThirdPartyException
+from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
+
+
+@pytest.mark.asyncio
+async def test_handle_document_parsing_waits_with_canonical_client() -> None:
+    strategy = RagflowRAGStrategy()
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
+        new=AsyncMock(return_value={"code": 0}),
+    ) as mock_parse, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.wait_for_parsing",
+        new=AsyncMock(return_value="DONE"),
+    ) as mock_wait:
+        await strategy._handle_document_parsing("ds-1", "doc-1")
+
+    mock_parse.assert_awaited_once_with("ds-1", ["doc-1"])
+    mock_wait.assert_awaited_once_with("ds-1", "doc-1", max_wait_time=300)
+
+
+@pytest.mark.asyncio
+async def test_handle_document_parsing_surfaces_trigger_failure() -> None:
+    strategy = RagflowRAGStrategy()
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
+        new=AsyncMock(return_value={"code": 103, "message": "queue unavailable"}),
+    ), patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.wait_for_parsing",
+        new=AsyncMock(),
+    ) as mock_wait:
+        with pytest.raises(ThirdPartyException) as exc_info:
+            await strategy._handle_document_parsing("ds-1", "doc-1")
+
+    assert "queue unavailable" in str(exc_info.value)
+    mock_wait.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_document_parsing_propagates_wait_failure() -> None:
+    strategy = RagflowRAGStrategy()
+    wait_error = ThirdPartyException(
+        msg="RAGFlow document parsing timed out",
+        e=CodeEnum.RAGFLOW_RAGError,
+    )
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
+        new=AsyncMock(return_value={"code": 0}),
+    ), patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.wait_for_parsing",
+        new=AsyncMock(side_effect=wait_error),
+    ):
+        with pytest.raises(ThirdPartyException, match="timed out"):
+            await strategy._handle_document_parsing("ds-1", "doc-1")
+
+
+class _Upload:
+    filename = "large.docx"
+
+
+@pytest.mark.asyncio
+async def test_first_upload_zero_chunks_returns_explicit_failure() -> None:
+    strategy = RagflowRAGStrategy()
+    with patch.object(
+        strategy, "_resolve_dataset_id", new=AsyncMock(return_value="ds-1")
+    ), patch.object(
+        strategy,
+        "_process_document_upload",
+        new=AsyncMock(return_value="doc-1"),
+    ), patch.object(
+        strategy, "_handle_document_parsing", new=AsyncMock(return_value=None)
+    ), patch(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        new=AsyncMock(return_value=[]),
+    ):
+        with pytest.raises(CustomException) as exc_info:
+            await strategy.split(file=_Upload(), datasetId="ds-1")
+
+    assert exc_info.value.code == CodeEnum.ChunkQueryFailed.code
+    assert "zero chunks" in str(exc_info.value)

--- a/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
@@ -388,7 +388,7 @@ async def test_split_document_id_none_uses_legacy_create_only_path(
         return "ds-1"
 
     async def fake_get_document_chunks(dataset_id: str, doc_id: str) -> list[Any]:
-        return []
+        return [{"id": "chunk-1", "content": "parsed"}]
 
     monkeypatch.setattr(
         "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset",
@@ -445,7 +445,7 @@ async def test_split_document_id_set_uses_upsert_path(
         return "ds-1"
 
     async def fake_get_document_chunks(dataset_id: str, doc_id: str) -> list[Any]:
-        return []
+        return [{"id": "chunk-1", "content": "parsed"}]
 
     monkeypatch.setattr(
         "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset",
@@ -525,7 +525,7 @@ async def test_split_prefers_kwargs_group_over_default(
         return "ds-1"
 
     async def fake_get_document_chunks(dataset_id: str, doc_id: str) -> list[Any]:
-        return []
+        return [{"id": "chunk-1", "content": "parsed"}]
 
     monkeypatch.setattr(
         "knowledge.service.impl.ragflow_strategy.RagflowUtils.ensure_dataset",


### PR DESCRIPTION
## Summary
- honor RAGFlow terminal parse states without waiting on zero token statistics
- wait for complete or stable chunk snapshots for large documents
- persist terminal extraction and embedding failures in the console backend

## Testing
- 150 RAGFlow-related Python tests passed
- Black, Python compile checks, and git diff checks passed
- Java regression tests added; Maven tests were not run locally because JDK/Maven are unavailable