### PR TITLE
fix(knowledge): satisfy remote quality checks

### DIFF
--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
@@ -2283,8 +2283,8 @@ class FileInfoV2ServiceTest {
         }
 
         /**
-         * A fast async worker may commit a terminal state before sliceFile returns. The
-         * dispatcher must never overwrite that state with FILE_PARSE_DOING.
+         * A fast async worker may commit a terminal state before sliceFile returns. The dispatcher must
+         * never overwrite that state with FILE_PARSE_DOING.
          */
         @Test
         @DisplayName("Slice file - fast async completion does not regress status")
@@ -2308,9 +2308,10 @@ class FileInfoV2ServiceTest {
                 FileInfoV2 asyncFile = invocation.getArgument(3);
                 asyncFile.setStatus(ProjectContent.FILE_PARSE_SUCCESSED);
                 return null;
-            }).when(knowledgeService).knowledgeExtractAsync(
-                    anyString(), anyString(), any(SliceConfig.class),
-                    any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
+            }).when(knowledgeService)
+                    .knowledgeExtractAsync(
+                            anyString(), anyString(), any(SliceConfig.class),
+                            any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
             doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
 
             DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, 0);
@@ -2342,8 +2343,8 @@ class FileInfoV2ServiceTest {
         }
 
         /**
-         * Missing storage metadata must close a previously scheduled file as a terminal
-         * failure instead of throwing before the async guard and leaving status 0.
+         * Missing storage metadata must close a previously scheduled file as a terminal failure instead of
+         * throwing before the async guard and leaving status 0.
          */
         @Test
         @DisplayName("Slice file - missing address closes parse status")

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/KnowledgeServiceTest.java
@@ -2086,8 +2086,8 @@ class KnowledgeServiceTest {
         }
 
         /**
-         * Unexpected transport/runtime failures must close the async task with a terminal
-         * failure instead of leaving the file in FILE_PARSE_DOING forever.
+         * Unexpected transport/runtime failures must close the async task with a terminal failure instead
+         * of leaving the file in FILE_PARSE_DOING forever.
          */
         @Test
         @DisplayName("Extract knowledge closes status on unexpected exception")
@@ -2369,7 +2369,8 @@ class KnowledgeServiceTest {
             when(fileInfoV2Service.updateById(any(FileInfoV2.class))).thenReturn(true);
             when(extractKnowledgeTaskService.updateById(any(ExtractKnowledgeTask.class))).thenReturn(true);
             doThrow(new RuntimeException("embedding queue unavailable"))
-                    .when(mockFileService).saveTaskAndUpdateFileStatus(mockFileInfo.getId());
+                    .when(mockFileService)
+                    .saveTaskAndUpdateFileStatus(mockFileInfo.getId());
             when(mockFileService.getById(mockFileInfo.getId())).thenReturn(mockFileInfo);
             when(mockFileService.updateById(any(FileInfoV2.class))).thenReturn(true);
 

--- a/core/knowledge/infra/ragflow/ragflow_client.py
+++ b/core/knowledge/infra/ragflow/ragflow_client.py
@@ -949,6 +949,131 @@ def _format_parsing_snapshot(snapshot: Dict[str, Any]) -> str:
     )
 
 
+def _validate_parsing_wait_parameters(
+    max_wait_time: int, poll_interval: float, max_status_errors: int
+) -> None:
+    """Reject polling configurations that cannot make forward progress."""
+    if max_wait_time <= 0:
+        raise ValueError("max_wait_time must be greater than 0")
+    if poll_interval <= 0:
+        raise ValueError("poll_interval must be greater than 0")
+    if max_status_errors <= 0:
+        raise ValueError("max_status_errors must be greater than 0")
+
+
+async def _query_document_parsing_status(
+    dataset_id: str, doc_id: str
+) -> tuple[Optional[Dict[str, Any]], Optional[Exception]]:
+    """Return a document snapshot or the recoverable query error."""
+    try:
+        return await get_document_info(dataset_id, doc_id), None
+    except Exception as error:
+        return None, error
+
+
+def _handle_parsing_status_error(
+    dataset_id: str,
+    doc_id: str,
+    error: Exception,
+    consecutive_errors: int,
+    max_status_errors: int,
+) -> int:
+    """Record a status-query failure and enforce its retry limit."""
+    consecutive_errors += 1
+    logger.warning(
+        "Failed to query RAGFlow parsing status: "
+        "dataset=%s doc=%s attempt=%d/%d error=%s",
+        dataset_id,
+        doc_id,
+        consecutive_errors,
+        max_status_errors,
+        error,
+    )
+    if consecutive_errors >= max_status_errors:
+        raise ThirdPartyException(
+            msg=(
+                "Unable to query RAGFlow document parsing status after "
+                f"{consecutive_errors} attempts: doc={doc_id}, error={error}"
+            ),
+            e=CodeEnum.RAGFLOW_RAGError,
+        ) from error
+    return consecutive_errors
+
+
+def _observe_parsing_status(
+    dataset_id: str,
+    doc_id: str,
+    doc_info: Optional[Dict[str, Any]],
+    last_snapshot: Optional[Dict[str, Any]],
+    document_missing_logged: bool,
+) -> tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]], bool]:
+    """Log a changed parsing snapshot or a missing document once."""
+    if doc_info is None:
+        if not document_missing_logged:
+            logger.warning(
+                "RAGFlow document not visible while waiting: dataset=%s doc=%s",
+                dataset_id,
+                doc_id,
+            )
+        return None, last_snapshot, True
+
+    snapshot = _parsing_snapshot(doc_info)
+    if snapshot != last_snapshot:
+        logger.info(
+            "RAGFlow parsing status: dataset=%s doc=%s %s",
+            dataset_id,
+            doc_id,
+            _format_parsing_snapshot(snapshot),
+        )
+    return snapshot, snapshot, document_missing_logged
+
+
+def _parsing_terminal_result(
+    dataset_id: str,
+    doc_id: str,
+    snapshot: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Return DONE or raise when a snapshot represents a terminal state."""
+    if snapshot is None:
+        return None
+
+    run_status = snapshot["status"]
+    if run_status == "DONE":
+        if snapshot["chunk_count"] == 0:
+            logger.warning(
+                "RAGFlow parsing completed with zero chunks: " "dataset=%s doc=%s %s",
+                dataset_id,
+                doc_id,
+                _format_parsing_snapshot(snapshot),
+            )
+        return "DONE"
+
+    if run_status in _PARSING_FAILURE_STATES:
+        raise ThirdPartyException(
+            msg=(
+                f"RAGFlow document parsing ended with {run_status}: "
+                f"doc={doc_id}, {_format_parsing_snapshot(snapshot)}"
+            ),
+            e=CodeEnum.RAGFLOW_RAGError,
+        )
+    return None
+
+
+def _parsing_timeout_context(
+    last_snapshot: Optional[Dict[str, Any]],
+    last_status_error: Optional[Exception],
+) -> str:
+    """Describe the last observable state for a timeout error."""
+    if last_snapshot is not None:
+        context = _format_parsing_snapshot(last_snapshot)
+        if last_status_error is not None:
+            context += f", last status error={str(last_status_error)[:500]}"
+        return context
+    if last_status_error is not None:
+        return f"last status error={str(last_status_error)[:500]}"
+    return "document was not visible"
+
+
 async def wait_for_parsing(
     dataset_id: str,
     doc_id: str,
@@ -977,12 +1102,7 @@ async def wait_for_parsing(
         ValueError: If wait parameters are invalid.
         ThirdPartyException: If RAGFlow fails, cancels, or times out.
     """
-    if max_wait_time <= 0:
-        raise ValueError("max_wait_time must be greater than 0")
-    if poll_interval <= 0:
-        raise ValueError("poll_interval must be greater than 0")
-    if max_status_errors <= 0:
-        raise ValueError("max_status_errors must be greater than 0")
+    _validate_parsing_wait_parameters(max_wait_time, poll_interval, max_status_errors)
 
     started_at = time.monotonic()
     last_snapshot: Optional[Dict[str, Any]] = None
@@ -991,12 +1111,9 @@ async def wait_for_parsing(
     last_status_error: Optional[Exception] = None
 
     while time.monotonic() - started_at < max_wait_time:
-        status_error: Optional[Exception] = None
-        try:
-            doc_info = await get_document_info(dataset_id, doc_id)
-        except Exception as error:
-            doc_info = None
-            status_error = error
+        doc_info, status_error = await _query_document_parsing_status(
+            dataset_id, doc_id
+        )
 
         # A status request may begin before the deadline and finish after it.
         # Record the returned snapshot for diagnostics, but never turn a late
@@ -1007,85 +1124,35 @@ async def wait_for_parsing(
             last_status_error = status_error
             if deadline_reached:
                 break
-            consecutive_status_errors += 1
-            logger.warning(
-                "Failed to query RAGFlow parsing status: "
-                "dataset=%s doc=%s attempt=%d/%d error=%s",
+            consecutive_status_errors = _handle_parsing_status_error(
                 dataset_id,
                 doc_id,
+                status_error,
                 consecutive_status_errors,
                 max_status_errors,
-                status_error,
             )
-            if consecutive_status_errors >= max_status_errors:
-                raise ThirdPartyException(
-                    msg=(
-                        "Unable to query RAGFlow document parsing status after "
-                        f"{consecutive_status_errors} attempts: doc={doc_id}, "
-                        f"error={status_error}"
-                    ),
-                    e=CodeEnum.RAGFLOW_RAGError,
-                ) from status_error
         else:
             consecutive_status_errors = 0
             last_status_error = None
-
-        if doc_info is None and status_error is None:
-            if not document_missing_logged:
-                logger.warning(
-                    "RAGFlow document not visible while waiting: dataset=%s doc=%s",
-                    dataset_id,
-                    doc_id,
-                )
-                document_missing_logged = True
-        elif doc_info is not None:
-            snapshot = _parsing_snapshot(doc_info)
-            if snapshot != last_snapshot:
-                logger.info(
-                    "RAGFlow parsing status: dataset=%s doc=%s %s",
-                    dataset_id,
-                    doc_id,
-                    _format_parsing_snapshot(snapshot),
-                )
-                last_snapshot = snapshot
-
+            snapshot, last_snapshot, document_missing_logged = _observe_parsing_status(
+                dataset_id,
+                doc_id,
+                doc_info,
+                last_snapshot,
+                document_missing_logged,
+            )
             if deadline_reached:
                 break
-
-            run_status = snapshot["status"]
-            if run_status == "DONE":
-                if snapshot["chunk_count"] == 0:
-                    logger.warning(
-                        "RAGFlow parsing completed with zero chunks: "
-                        "dataset=%s doc=%s %s",
-                        dataset_id,
-                        doc_id,
-                        _format_parsing_snapshot(snapshot),
-                    )
-                return "DONE"
-
-            if run_status in _PARSING_FAILURE_STATES:
-                raise ThirdPartyException(
-                    msg=(
-                        f"RAGFlow document parsing ended with {run_status}: "
-                        f"doc={doc_id}, {_format_parsing_snapshot(snapshot)}"
-                    ),
-                    e=CodeEnum.RAGFLOW_RAGError,
-                )
+            terminal_result = _parsing_terminal_result(dataset_id, doc_id, snapshot)
+            if terminal_result is not None:
+                return terminal_result
 
         remaining = max_wait_time - (time.monotonic() - started_at)
         if remaining <= 0:
             break
         await asyncio.sleep(min(poll_interval, remaining))
 
-    if last_snapshot is not None:
-        last_context = _format_parsing_snapshot(last_snapshot)
-        if last_status_error is not None:
-            last_context += f", last status error={str(last_status_error)[:500]}"
-    elif last_status_error is not None:
-        last_context = f"last status error={str(last_status_error)[:500]}"
-    else:
-        last_context = "document was not visible"
+    last_context = _parsing_timeout_context(last_snapshot, last_status_error)
     logger.warning(
         "RAGFlow document parsing timed out after %s seconds: " "dataset=%s doc=%s %s",
         max_wait_time,

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -296,6 +296,50 @@ class RagflowUtils:
             return file_content, filename
 
     @staticmethod
+    def _normalize_expected_chunk_count(raw_count: Any) -> Optional[int]:
+        """Return a usable non-negative metadata count when one is available."""
+        try:
+            expected_count = int(raw_count) if raw_count is not None else None
+        except (TypeError, ValueError):
+            return None
+        if expected_count is not None and expected_count < 0:
+            return None
+        return expected_count
+
+    @staticmethod
+    def _finalize_chunk_retrieval(
+        dataset_id: str,
+        doc_id: str,
+        *,
+        expected_count: Optional[int],
+        last_visible_count: int,
+        max_retries: int,
+    ) -> List[Dict[str, Any]]:
+        """Return an empty snapshot or raise the final incomplete-state error."""
+        if expected_count is not None and expected_count > last_visible_count:
+            raise RuntimeError(
+                "RAGFlow chunk snapshot remained incomplete after retries: "
+                f"doc={doc_id}, visible={last_visible_count}, "
+                f"expected={expected_count}"
+            )
+
+        if last_visible_count > 0:
+            raise RuntimeError(
+                "RAGFlow chunk snapshot did not stabilize after retries: "
+                f"doc={doc_id}, visible={last_visible_count}, "
+                f"expected={expected_count}"
+            )
+
+        logger.warning(
+            "RAGFlow document returned zero chunks after retries: "
+            "dataset=%s doc=%s attempts=%d",
+            dataset_id,
+            doc_id,
+            max_retries + 1,
+        )
+        return []
+
+    @staticmethod
     async def get_document_chunks(
         dataset_id: str, doc_id: str, max_retries: int = 15, retry_delay: float = 3.0
     ) -> List[Dict[str, Any]]:
@@ -326,15 +370,9 @@ class RagflowUtils:
                 f"RAGFlow document disappeared before chunk retrieval: doc={doc_id}"
             )
 
-        raw_expected_count = doc_info.get("chunk_count")
-        try:
-            expected_count = (
-                int(raw_expected_count) if raw_expected_count is not None else None
-            )
-        except (TypeError, ValueError):
-            expected_count = None
-        if expected_count is not None and expected_count < 0:
-            expected_count = None
+        expected_count = RagflowUtils._normalize_expected_chunk_count(
+            doc_info.get("chunk_count")
+        )
 
         last_visible_count = 0
         last_chunk_ids: Optional[tuple[str, ...]] = None
@@ -393,28 +431,13 @@ class RagflowUtils:
             )
             await asyncio.sleep(retry_delay)
 
-        if expected_count is not None and expected_count > last_visible_count:
-            raise RuntimeError(
-                "RAGFlow chunk snapshot remained incomplete after retries: "
-                f"doc={doc_id}, visible={last_visible_count}, "
-                f"expected={expected_count}"
-            )
-
-        if last_visible_count > 0:
-            raise RuntimeError(
-                "RAGFlow chunk snapshot did not stabilize after retries: "
-                f"doc={doc_id}, visible={last_visible_count}, "
-                f"expected={expected_count}"
-            )
-
-        logger.warning(
-            "RAGFlow document returned zero chunks after retries: "
-            "dataset=%s doc=%s attempts=%d",
+        return RagflowUtils._finalize_chunk_retrieval(
             dataset_id,
             doc_id,
-            max_retries + 1,
+            expected_count=expected_count,
+            last_visible_count=last_visible_count,
+            max_retries=max_retries,
         )
-        return []
 
     @staticmethod
     def convert_to_standard_format(


### PR DESCRIPTION
## Summary
- apply the configured Eclipse formatting to the new console regression tests
- split RAGFlow parsing polling and chunk snapshot decisions into focused helpers
- preserve terminal-state, timeout, retry, and stable-snapshot behavior while reducing flake8 complexity

## Validation
- git diff --check
- final validation will run through the required Linux remote CI matrix