### PR TITLE
test(console): remove obsolete parsing status stubs

### DIFF
--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
@@ -2269,7 +2269,6 @@ class FileInfoV2ServiceTest {
             when(configInfoService.getOnly(any(LambdaQueryWrapper.class))).thenReturn(null);
             when(extractKnowledgeTaskService.save(any(ExtractKnowledgeTask.class))).thenReturn(true);
             doNothing().when(knowledgeService).knowledgeExtractAsync(anyString(), anyString(), any(SliceConfig.class), any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
-            doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
 
             // When
             DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, backEmbedding);
@@ -2312,7 +2311,6 @@ class FileInfoV2ServiceTest {
                     .knowledgeExtractAsync(
                             anyString(), anyString(), any(SliceConfig.class),
                             any(FileInfoV2.class), any(ExtractKnowledgeTask.class));
-            doReturn(true).when(fileInfoV2Service).updateById(any(FileInfoV2.class));
 
             DealFileResult result = fileInfoV2Service.sliceFile(fileId, sliceConfig, 0);
 


### PR DESCRIPTION
## Summary
- remove two updateById stubs that are intentionally unused after terminal-state overwrite protection
- retain assertions that the normal dispatcher and fast async completion paths do not perform stale status updates

## Remote test evidence
- Console Backend reached 801 tests before Mockito reported exactly these two UnnecessaryStubbing errors
- all other test matrix targets passed, including core/knowledge with 399 passed
- full remote quality and test matrix will be rerun after merge