### PR TITLE
fix(knowledge): apply RAGFlow parser config before parsing

### DIFF
--- a/console/backend/hub/src/main/resources/db/migration/V1.44__expand_knowledge_content_columns.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.44__expand_knowledge_content_columns.sql
@@ -1,0 +1,8 @@
+-- Preview and embedded rows contain serialized chunk JSON with both content
+-- and context. LONGTEXT covers the full supported upload size even when a
+-- delimiter-free document remains one chunk and multibyte text is duplicated.
+ALTER TABLE `preview_knowledge`
+    MODIFY COLUMN `content` LONGTEXT NULL;
+
+ALTER TABLE `knowledge`
+    MODIFY COLUMN `content` LONGTEXT NULL;

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/controller/knowledge/FileController.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/controller/knowledge/FileController.java
@@ -21,12 +21,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -92,9 +90,6 @@ public class FileController {
      */
     @PostMapping("/slice")
     public ApiResult<Boolean> sliceFiles(@RequestBody DealFileVO sliceFileVO) throws InterruptedException, ExecutionException {
-        if (StringUtils.isEmpty(sliceFileVO.getSliceConfig().getSeperator().get(0))) {
-            sliceFileVO.getSliceConfig().setSeperator(Collections.singletonList("\n"));
-        }
         Result<Boolean> result = fileInfoV2Service.sliceFiles(sliceFileVO);
         if (result.noError()) {
             return ApiResult.success(result.getData());

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/FileInfoV2Service.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/repo/FileInfoV2Service.java
@@ -495,9 +495,10 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
      * @throws BusinessException if files are currently being parsed or slice range is invalid
      */
     public Result<Boolean> sliceFiles(DealFileVO sliceFileVO) throws InterruptedException, ExecutionException {
+        SliceConfig sliceConfig = normalizeAndValidateSliceConfig(sliceFileVO);
         Long spaceId = SpaceInfoUtil.getSpaceId();
         if (ProjectContent.isSparkRagCompatible(sliceFileVO.getTag())) {
-            if (sliceFileVO.getSliceConfig().getType().equals(1)) {
+            if (Integer.valueOf(1).equals(sliceConfig.getType())) {
                 HashMap<String, String> header = new HashMap<>();
                 // Spark split interface
                 String url = sparkDocUrl + "/openapi/v1/file/split";
@@ -506,7 +507,7 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
                 params.put("isSplitDefault", false);
                 params.put("splitType", "wiki");
                 JSONObject wikiSplit = new JSONObject();
-                List<String> separator = sliceFileVO.getSliceConfig().getSeperator();
+                List<String> separator = sliceConfig.getSeperator();
                 List<String> separatorBase64 = new ArrayList<>();
                 if (!separator.isEmpty()) {
                     for (String string : separator) {
@@ -515,8 +516,8 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
                     }
                 }
                 wikiSplit.put("chunkSeparators", separatorBase64);
-                wikiSplit.put("chunkSize", sliceFileVO.getSliceConfig().getLengthRange().get(1));
-                wikiSplit.put("minChunkSize", sliceFileVO.getSliceConfig().getLengthRange().get(0));
+                wikiSplit.put("chunkSize", sliceConfig.getLengthRange().get(1));
+                wikiSplit.put("minChunkSize", sliceConfig.getLengthRange().get(0));
                 params.put("wikiSplitExtends", wikiSplit);
                 String post = OkHttpUtil.post(url, header, params.toJSONString());
                 JSONObject jsonObject = JSONObject.parseObject(post);
@@ -544,13 +545,7 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
                         throw new BusinessException(ResponseEnum.REPO_KNOWLEDGE_SPLITTING);
                     }
                     // Check slice default values and range
-                    if (sliceFileVO.getSliceConfig().getLengthRange() != null) {
-                        if (ProjectContent.isAiuiRagCompatible(fileInfoV2.getSource())) {
-                            if (sliceFileVO.getSliceConfig().getLengthRange().get(0) < 16 || sliceFileVO.getSliceConfig().getLengthRange().get(1) > 1024) {
-                                throw new BusinessException(ResponseEnum.REPO_FILE_SLICE_RANGE_16_1024);
-                            }
-                        }
-                    }
+                    validateSliceRangeForAiui(sliceConfig, fileInfoV2.getSource());
                     Long fileId = fileInfoV2.getId();
                     // Insert data into file_directory_tree table
                     FileDirectoryTree fileDirectoryTree = fileDirectoryTreeService.getOnly(Wrappers.lambdaQuery(FileDirectoryTree.class)
@@ -569,7 +564,6 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
                         fileDirectoryTreeMapper.insert(fileDirectoryTree);
                     }
                     // Update slice configuration
-                    SliceConfig sliceConfig = sliceFileVO.getSliceConfig();
                     fileInfoV2.setSliceConfig(JSON.toJSONString(sliceConfig));
                     fileInfoV2.setCurrentSliceConfig(JSON.toJSONString(sliceConfig));
                     fileInfoV2.setStatus(ProjectContent.FILE_PARSE_DOING);
@@ -1308,10 +1302,14 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
      * @throws BusinessException if files are currently being processed or configuration is invalid
      */
     public void retry(DealFileVO sliceFileVO, HttpServletRequest request) throws InterruptedException, ExecutionException {
+        if (sliceFileVO == null || sliceFileVO.getFileIds() == null) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
         Long spaceId = SpaceInfoUtil.getSpaceId();
 
         // 1) Spark: Retry with "custom splitting"
         if (ProjectContent.isSparkRagCompatible(sliceFileVO.getTag())) {
+            normalizeAndValidateSliceConfig(sliceFileVO);
             retrySparkSplitIfNeeded(sliceFileVO);
             return;
         }
@@ -1384,8 +1382,7 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
      * @throws BusinessException if file is currently being parsed or range is invalid
      */
     private void handleParseFailedRetry(FileInfoV2 file, DealFileVO vo, Long spaceId, ExecutorService pool) {
-        // Auto separator fallback
-        ensureSeparatorDefault(vo.getSliceConfig());
+        SliceConfig sc = normalizeAndValidateSliceConfig(vo);
 
         // Permission validation (consistent with original logic: validate only when spaceId is null)
         if (spaceId == null)
@@ -1397,13 +1394,12 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
         }
 
         // AIUI slice range validation
-        validateSliceRangeForAiui(vo.getSliceConfig(), file.getSource());
+        validateSliceRangeForAiui(sc, file.getSource());
 
         // Ensure directory tree existence
         ensureFileDirectoryTree(file);
 
         // Update slice configuration & set status to parsing
-        SliceConfig sc = vo.getSliceConfig();
         file.setSliceConfig(JSON.toJSONString(sc));
         file.setCurrentSliceConfig(JSON.toJSONString(sc));
         file.setStatus(ProjectContent.FILE_PARSE_DOING);
@@ -1463,12 +1459,50 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
      * @param sc slice configuration to check and update
      */
     private void ensureSeparatorDefault(SliceConfig sc) {
-        if (sc == null)
-            return;
         List<String> sep = sc.getSeperator();
-        if (sep == null || sep.isEmpty() || StringUtils.isEmpty(sep.get(0))) {
+        if (sep == null || sep.isEmpty()) {
             sc.setSeperator(Collections.singletonList("\n"));
+            return;
         }
+        List<String> normalized = sep.stream()
+                .filter(value -> !StringUtils.isEmpty(value))
+                .collect(Collectors.toList());
+        sc.setSeperator(normalized.isEmpty()
+                ? Collections.singletonList("\n")
+                : normalized);
+    }
+
+    /**
+     * Normalize a slicing request and reject malformed ranges before any file status or directory state
+     * is changed.
+     *
+     * @param vo slicing request
+     * @return normalized slice configuration
+     * @throws BusinessException when required configuration is missing or malformed
+     */
+    private SliceConfig normalizeAndValidateSliceConfig(DealFileVO vo) {
+        if (vo == null || CollectionUtils.isEmpty(vo.getFileIds()) || vo.getSliceConfig() == null) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+
+        SliceConfig sc = vo.getSliceConfig();
+        Integer type = sc.getType();
+        if (!Integer.valueOf(0).equals(type) && !Integer.valueOf(1).equals(type)) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+
+        List<Integer> range = sc.getLengthRange();
+        if ((range == null || range.isEmpty()) && Integer.valueOf(1).equals(type)) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+        if (range != null && !range.isEmpty()
+                && (range.size() != 2 || range.get(0) == null || range.get(1) == null
+                        || range.get(0) <= 0 || range.get(1) <= 0 || range.get(0) > range.get(1))) {
+            throw new BusinessException(ResponseEnum.PARAMETER_ERROR);
+        }
+
+        ensureSeparatorDefault(sc);
+        return sc;
     }
 
     /**
@@ -1479,14 +1513,13 @@ public class FileInfoV2Service extends ServiceImpl<FileInfoV2Mapper, FileInfoV2>
      * @throws BusinessException if range is invalid for AIUI source
      */
     private void validateSliceRangeForAiui(SliceConfig sc, String source) {
-        if (sc == null || !ProjectContent.isAiuiRagCompatible(source))
+        if (!ProjectContent.isAiuiRagCompatible(source)
+                || CollectionUtils.isEmpty(sc.getLengthRange()))
             return;
-        if (sc.getLengthRange() != null) {
-            Integer min = sc.getLengthRange().get(0);
-            Integer max = sc.getLengthRange().get(1);
-            if (min < 16 || max > 1024) {
-                throw new BusinessException(ResponseEnum.REPO_FILE_SLICE_RANGE_16_1024);
-            }
+        Integer min = sc.getLengthRange().get(0);
+        Integer max = sc.getLengthRange().get(1);
+        if (min < 16 || max > 1024) {
+            throw new BusinessException(ResponseEnum.REPO_FILE_SLICE_RANGE_16_1024);
         }
     }
 

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/controller/knowledge/FileControllerTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/controller/knowledge/FileControllerTest.java
@@ -245,8 +245,8 @@ class FileControllerTest {
          * @throws ExecutionException if the operation fails during execution
          */
         @Test
-        @DisplayName("Slice files successfully - Empty separator defaults to newline")
-        void sliceFiles_Success_EmptySeparatorDefaultsToNewline() throws InterruptedException, ExecutionException {
+        @DisplayName("Slice files successfully - Empty separator delegates to service")
+        void sliceFiles_Success_EmptySeparatorDelegatesToService() throws InterruptedException, ExecutionException {
             // Given
             dealFileVO.getSliceConfig().setSeperator(Collections.singletonList(""));
             @SuppressWarnings("unchecked")
@@ -262,7 +262,7 @@ class FileControllerTest {
             assertThat(result).isNotNull();
             assertThat(result.code()).isEqualTo(0);
             assertThat(result.data()).isTrue();
-            assertThat(dealFileVO.getSliceConfig().getSeperator()).containsExactly("\n");
+            assertThat(dealFileVO.getSliceConfig().getSeperator()).containsExactly("");
             verify(fileInfoV2Service, times(1)).sliceFiles(dealFileVO);
         }
 
@@ -274,8 +274,8 @@ class FileControllerTest {
          * @throws ExecutionException if the operation fails during execution
          */
         @Test
-        @DisplayName("Slice files successfully - Null separator defaults to newline")
-        void sliceFiles_Success_NullSeparatorDefaultsToNewline() throws InterruptedException, ExecutionException {
+        @DisplayName("Slice files successfully - Null separator delegates to service")
+        void sliceFiles_Success_NullSeparatorDelegatesToService() throws InterruptedException, ExecutionException {
             // Given
             dealFileVO.getSliceConfig().setSeperator(Collections.singletonList(null));
             @SuppressWarnings("unchecked")
@@ -290,7 +290,7 @@ class FileControllerTest {
             // Then
             assertThat(result).isNotNull();
             assertThat(result.code()).isEqualTo(0);
-            assertThat(dealFileVO.getSliceConfig().getSeperator()).containsExactly("\n");
+            assertThat(dealFileVO.getSliceConfig().getSeperator()).containsExactly((String) null);
             verify(fileInfoV2Service, times(1)).sliceFiles(dealFileVO);
         }
 
@@ -978,8 +978,8 @@ class FileControllerTest {
     class EdgeCaseTests {
 
         /**
-         * Test sliceFiles with empty separator list Verifies that empty separator list causes
-         * IndexOutOfBoundsException
+         * Test sliceFiles with empty separator list Verifies that the controller does not index into
+         * request configuration and delegates normalization to the service.
          *
          * @throws InterruptedException if the operation is interrupted
          * @throws ExecutionException if the operation fails during execution
@@ -989,10 +989,18 @@ class FileControllerTest {
         void sliceFiles_EmptySeparatorList() throws InterruptedException, ExecutionException {
             // Given
             dealFileVO.getSliceConfig().setSeperator(Collections.emptyList());
+            @SuppressWarnings("unchecked")
+            Result<Boolean> successResult = mock(Result.class);
+            when(successResult.noError()).thenReturn(true);
+            when(successResult.getData()).thenReturn(true);
+            when(fileInfoV2Service.sliceFiles(dealFileVO)).thenReturn(successResult);
 
-            // When & Then - Verify edge condition
-            assertThatThrownBy(() -> fileController.sliceFiles(dealFileVO))
-                    .isInstanceOf(IndexOutOfBoundsException.class);
+            // When
+            ApiResult<Boolean> result = fileController.sliceFiles(dealFileVO);
+
+            // Then
+            assertThat(result.data()).isTrue();
+            verify(fileInfoV2Service).sliceFiles(dealFileVO);
         }
 
         /**

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/knowledge/FileInfoV2ServiceTest.java
@@ -2794,7 +2794,7 @@ class FileInfoV2ServiceTest {
             SliceConfig sliceConfig = new SliceConfig();
             sliceConfig.setType(1);
             sliceConfig.setLengthRange(Arrays.asList(100, 500));
-            sliceConfig.setSeperator(Arrays.asList("。", "！", "？"));
+            sliceConfig.setSeperator(Collections.emptyList());
             dealFileVO.setSliceConfig(sliceConfig);
 
             mockFileInfo.setStatus(ProjectContent.FILE_PARSE_SUCCESSED);
@@ -2827,7 +2827,57 @@ class FileInfoV2ServiceTest {
             // Then
             assertThat(result).isNotNull();
             assertThat(result.getData()).isTrue();
+            assertThat(sliceConfig.getSeperator()).containsExactly("\n");
             verify(fileInfoV2Mapper, atLeastOnce()).listByIds(anyList());
+        }
+
+        @Test
+        @DisplayName("Slice files - null slice config returns parameter error")
+        void testSliceFiles_NullSliceConfig() {
+            DealFileVO dealFileVO = new DealFileVO();
+            dealFileVO.setFileIds(Collections.singletonList("1"));
+            dealFileVO.setTag("Ragflow-RAG");
+
+            assertThatThrownBy(() -> fileInfoV2Service.sliceFiles(dealFileVO))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("responseEnum")
+                    .isEqualTo(ResponseEnum.PARAMETER_ERROR);
+            verify(fileInfoV2Mapper, never()).listByIds(anyList());
+        }
+
+        @Test
+        @DisplayName("Slice files - incomplete length range returns parameter error")
+        void testSliceFiles_IncompleteLengthRange() {
+            DealFileVO dealFileVO = new DealFileVO();
+            dealFileVO.setFileIds(Collections.singletonList("1"));
+            dealFileVO.setTag("Ragflow-RAG");
+            SliceConfig sliceConfig = new SliceConfig();
+            sliceConfig.setType(1);
+            sliceConfig.setLengthRange(Collections.singletonList(256));
+            dealFileVO.setSliceConfig(sliceConfig);
+
+            assertThatThrownBy(() -> fileInfoV2Service.sliceFiles(dealFileVO))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("responseEnum")
+                    .isEqualTo(ResponseEnum.PARAMETER_ERROR);
+            verify(fileInfoV2Mapper, never()).listByIds(anyList());
+        }
+
+        @Test
+        @DisplayName("Slice files - default Spark slicing accepts omitted range")
+        void testSliceFiles_DefaultSparkSliceWithoutRange() throws Exception {
+            DealFileVO dealFileVO = new DealFileVO();
+            dealFileVO.setFileIds(Collections.singletonList("1"));
+            dealFileVO.setTag(ProjectContent.FILE_SOURCE_SPARK_RAG_STR);
+            SliceConfig sliceConfig = new SliceConfig();
+            sliceConfig.setType(0);
+            dealFileVO.setSliceConfig(sliceConfig);
+
+            Result<Boolean> result = fileInfoV2Service.sliceFiles(dealFileVO);
+
+            assertThat(result.getData()).isTrue();
+            assertThat(sliceConfig.getSeperator()).containsExactly("\n");
+            verify(fileInfoV2Mapper, never()).listByIds(anyList());
         }
 
         /**

--- a/core/knowledge/infra/ragflow/ragflow_utils.py
+++ b/core/knowledge/infra/ragflow/ragflow_utils.py
@@ -486,7 +486,10 @@ class RagflowUtils:
 
     @staticmethod
     def build_parser_config(
-        lengthRange: List[int], overlap: int, separator: List[str], titleSplit: bool
+        lengthRange: Optional[List[int]],
+        overlap: int,
+        separator: Optional[List[str]],
+        titleSplit: bool,
     ) -> Dict[str, Any]:
         """
         Build parser configuration
@@ -500,31 +503,49 @@ class RagflowUtils:
         Returns:
             Parser configuration dictionary
         """
-        # Build RAGFlow parser configuration based on abstract interface parameters
-        chunk_token_count = (
-            lengthRange[1]
-            if len(lengthRange) > 1
-            else lengthRange[0] if lengthRange else 256
-        )
+        # RAGFlow's parser uses the configured maximum as its target chunk
+        # size. ``overlap`` and ``titleSplit`` are intentionally not forwarded:
+        # v0.20.5 has no overlap field, and title splitting is not equivalent
+        # to changing PDF layout recognition/OCR mode.
+        _ = overlap, titleSplit
+        if lengthRange is None:
+            chunk_token_num = 256
+        else:
+            if len(lengthRange) not in (1, 2) or any(
+                isinstance(value, bool) or not isinstance(value, int)
+                for value in lengthRange
+            ):
+                raise ValueError("lengthRange must contain one or two integers")
+            if any(value <= 0 for value in lengthRange):
+                raise ValueError("lengthRange values must be greater than zero")
+            if len(lengthRange) == 2 and lengthRange[0] > lengthRange[1]:
+                raise ValueError("lengthRange minimum cannot exceed maximum")
+            chunk_token_num = lengthRange[-1]
 
-        # Separator handling: convert abstract interface separator to RAGFlow delimiter format
-        delimiter = "\\n"
-        if separator:
-            delimiter = "".join(separator) + "\\n"
+        # The Astron UI can send either a literal ``\\n`` or an actual newline.
+        # In RAGFlow v0.20.5, unquoted delimiter characters are independent;
+        # a multi-character delimiter must be wrapped in backticks.
+        normalized_separators = []
+        for value in separator or []:
+            normalized = value.replace("\\n", "\n")
+            if not normalized:
+                continue
+            normalized_separators.append(
+                normalized if len(normalized) == 1 else f"`{normalized}`"
+            )
+        if not any("\n" in value for value in normalized_separators):
+            normalized_separators.append("\n")
+        delimiter = "".join(normalized_separators)
 
         parser_config = {
-            "chunk_token_count": min(
-                chunk_token_count, 2048
-            ),  # RAGFlow limits maximum 2048
+            "chunk_token_num": min(chunk_token_num, 2048),
             "delimiter": delimiter,
-            "layout_recognize": titleSplit,  # Use titleSplit to control layout recognition
-            "html4excel": False,
-            "task_page_size": 12,  # PDF specific, default value
-            "raptor": {"use_raptor": False},
         }
 
         logger.info(
-            f"Built parser config: chunk_size={chunk_token_count}, delimiter='{delimiter}', layout_recognize={titleSplit}"
+            "Built RAGFlow parser config: chunk_token_num=%d, delimiter=%r",
+            parser_config["chunk_token_num"],
+            delimiter,
         )
         return parser_config
 

--- a/core/knowledge/service/impl/ragflow_strategy.py
+++ b/core/knowledge/service/impl/ragflow_strategy.py
@@ -246,8 +246,43 @@ class RagflowRAGStrategy(RAGStrategy):
         else:
             raise ValueError("File upload failed: no document returned")
 
-    async def _handle_document_parsing(self, dataset_id: str, doc_id: str) -> None:
-        """Handle document parsing and wait for completion."""
+    async def _handle_document_parsing(
+        self, dataset_id: str, doc_id: str, parser_config: Dict[str, Any]
+    ) -> None:
+        """Configure a document, trigger parsing, and wait for completion.
+
+        Only parser parameters are updated here. RAGFlow selects specialized
+        parsers for formats such as images, presentations, and email during
+        upload; forcing every document back to ``naive`` would either discard
+        that selection or make the update fail for visual documents.
+        """
+        logger.info(
+            "Configuring RAGFlow document parser: dataset=%s doc=%s "
+            "chunk_token_num=%s",
+            dataset_id,
+            doc_id,
+            parser_config.get("chunk_token_num"),
+        )
+        update_response = await ragflow_client.update_document(
+            dataset_id,
+            doc_id,
+            parser_config=parser_config,
+        )
+        if update_response.get("code") != 0:
+            message = update_response.get("message", "unknown RAGFlow error")
+            logger.warning(
+                "RAGFlow rejected document parser configuration: "
+                "dataset=%s doc=%s code=%s message=%s",
+                dataset_id,
+                doc_id,
+                update_response.get("code"),
+                message,
+            )
+            raise ThirdPartyException(
+                msg=f"Failed to configure RAGFlow document parser: {message}",
+                e=CodeEnum.RAGFLOW_RAGError,
+            )
+
         logger.info(
             "Triggering RAGFlow document parsing: dataset=%s doc=%s",
             dataset_id,
@@ -284,6 +319,25 @@ class RagflowRAGStrategy(RAGStrategy):
             doc_id,
             final_status,
         )
+
+    def _validate_document_chunks(
+        self,
+        doc_id: str,
+        chunks_data: List[Dict[str, Any]],
+    ) -> None:
+        """Reject empty RAGFlow output.
+
+        A large single chunk is valid when the source contains no configured
+        delimiter: RAGFlow v0.20.5's naive merger does not forcibly split one
+        oversized segment. Console therefore stores such chunks in LONGTEXT
+        instead of treating their size as proof that configuration was ignored.
+        """
+        if not chunks_data:
+            logger.error("RAGFlow produced zero chunks: doc=%s", doc_id)
+            raise CustomException(
+                CodeEnum.ChunkQueryFailed,
+                f"RAGFlow produced zero chunks for document {doc_id}",
+            )
 
     async def split(
         self,
@@ -340,6 +394,12 @@ class RagflowRAGStrategy(RAGStrategy):
         lengthRange, separator, cutOff = self._parse_form_data_parameters(
             lengthRange, separator, cutOff
         )
+        parser_config = RagflowUtils.build_parser_config(
+            lengthRange=lengthRange,
+            overlap=overlap,
+            separator=separator or cutOff,
+            titleSplit=titleSplit,
+        )
 
         # Determine which input method is being used
         file_input = file if file else fileUrl
@@ -366,23 +426,25 @@ class RagflowRAGStrategy(RAGStrategy):
             if document_id:
                 logger.info("re-slice upsert old_doc_id=%s", document_id)
                 doc_id, chunks_data = await self._upsert_document(
-                    file_input, dataset_id, document_id
+                    file_input, dataset_id, document_id, parser_config
                 )
             else:
                 doc_id = await self._process_document_upload(file_input, dataset_id)
-                await self._handle_document_parsing(dataset_id, doc_id)
-                chunks_data = await RagflowUtils.get_document_chunks(dataset_id, doc_id)
-                if not chunks_data:
-                    logger.error(
-                        "RAGFlow parsing completed but returned zero chunks: "
-                        "dataset=%s doc=%s",
-                        dataset_id,
+                try:
+                    await self._handle_document_parsing(
+                        dataset_id, doc_id, parser_config
+                    )
+                    chunks_data = await RagflowUtils.get_document_chunks(
+                        dataset_id, doc_id
+                    )
+                    self._validate_document_chunks(doc_id, chunks_data)
+                except Exception:
+                    logger.exception(
+                        "RAGFlow first-upload ingestion failed, rolling back %s",
                         doc_id,
                     )
-                    raise CustomException(
-                        CodeEnum.ChunkQueryFailed,
-                        f"RAGFlow produced zero chunks for document {doc_id}",
-                    )
+                    await self._safe_delete_document(dataset_id, doc_id, log_only=True)
+                    raise
 
             # Step 7: Convert to standard format
             result = RagflowUtils.convert_to_standard_format(doc_id, chunks_data)
@@ -1141,6 +1203,7 @@ class RagflowRAGStrategy(RAGStrategy):
         file_input: Any,
         dataset_id: str,
         old_doc_id: str,
+        parser_config: Dict[str, Any],
     ) -> tuple[str, List[Dict[str, Any]]]:
         """Atomic upsert: upload + parse + fetch chunks + delete old.
 
@@ -1157,7 +1220,9 @@ class RagflowRAGStrategy(RAGStrategy):
         )
 
         try:
-            await self._handle_document_parsing(dataset_id, pending_doc_id)
+            await self._handle_document_parsing(
+                dataset_id, pending_doc_id, parser_config
+            )
         except Exception:
             logger.exception("upsert parse failed, rolling back %s", pending_doc_id)
             await self._safe_delete_document(dataset_id, pending_doc_id, log_only=True)
@@ -1167,21 +1232,11 @@ class RagflowRAGStrategy(RAGStrategy):
             chunks_data = await RagflowUtils.get_document_chunks(
                 dataset_id, pending_doc_id
             )
+            self._validate_document_chunks(pending_doc_id, chunks_data)
         except Exception:
             logger.exception("upsert fetch failed, rolling back %s", pending_doc_id)
             await self._safe_delete_document(dataset_id, pending_doc_id, log_only=True)
             raise
-
-        if not chunks_data:
-            logger.error(
-                "upsert new doc %s returned zero chunks, rolling back",
-                pending_doc_id,
-            )
-            await self._safe_delete_document(dataset_id, pending_doc_id, log_only=True)
-            raise CustomException(
-                CodeEnum.ChunkQueryFailed,
-                f"Upsert produced zero chunks for pending doc {pending_doc_id}",
-            )
 
         await self._safe_delete_document(dataset_id, old_doc_id)
         return pending_doc_id, chunks_data

--- a/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
+++ b/core/knowledge/tests/infra/ragflow/ragflow_utils_test.py
@@ -41,6 +41,47 @@ class TestGetDefaultDatasetName:
         assert RagflowUtils.get_default_dataset_name() == DEFAULT_RAGFLOW_DATASET_NAME
 
 
+class TestBuildParserConfig:
+    """Tests for the RAGFlow v0.20.5 naive parser payload."""
+
+    def test_uses_official_chunk_token_field_and_normalizes_newline(self) -> None:
+        config = RagflowUtils.build_parser_config(
+            [1, 256], overlap=16, separator=["\\n", "。"], titleSplit=False
+        )
+
+        assert config["chunk_token_num"] == 256
+        assert "chunk_token_count" not in config
+        assert config["delimiter"] == "\n。"
+        assert "layout_recognize" not in config
+
+    def test_defaults_and_caps_chunk_token_num(self) -> None:
+        default_config = RagflowUtils.build_parser_config(
+            None, overlap=16, separator=None, titleSplit=True
+        )
+        capped_config = RagflowUtils.build_parser_config(
+            [1, 4096], overlap=16, separator=["。"], titleSplit=False
+        )
+
+        assert default_config["chunk_token_num"] == 256
+        assert default_config["delimiter"] == "\n"
+        assert "layout_recognize" not in default_config
+        assert capped_config["chunk_token_num"] == 2048
+
+    def test_wraps_multi_character_delimiter_for_ragflow(self) -> None:
+        config = RagflowUtils.build_parser_config(
+            [1, 256], overlap=16, separator=["EOF", "。"], titleSplit=False
+        )
+
+        assert config["delimiter"] == "`EOF`。\n"
+
+    @pytest.mark.parametrize("length_range", [[], [0, 256], [256, 1], [1, 2, 3]])
+    def test_rejects_invalid_length_range(self, length_range: list[int]) -> None:
+        with pytest.raises(ValueError):
+            RagflowUtils.build_parser_config(
+                length_range, overlap=16, separator=None, titleSplit=False
+            )
+
+
 @pytest.mark.asyncio
 async def test_wait_for_parsing_delegates_to_canonical_client() -> None:
     """Legacy utility entry point must not maintain a second polling policy."""

--- a/core/knowledge/tests/service/impl/ragflow_strategy_parsing_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_parsing_test.py
@@ -10,27 +10,74 @@ from knowledge.consts.error_code import CodeEnum
 from knowledge.exceptions.exception import CustomException, ThirdPartyException
 from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 
+_PARSER_CONFIG = {
+    "chunk_token_num": 256,
+    "delimiter": "\n",
+}
+
 
 @pytest.mark.asyncio
 async def test_handle_document_parsing_waits_with_canonical_client() -> None:
     strategy = RagflowRAGStrategy()
+    calls: list[str] = []
+
+    async def update_document(*args: object, **kwargs: object) -> dict[str, int]:
+        calls.append("update")
+        return {"code": 0}
+
+    async def parse_documents(*args: object, **kwargs: object) -> dict[str, int]:
+        calls.append("parse")
+        return {"code": 0}
+
     with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_document",
+        new=AsyncMock(side_effect=update_document),
+    ) as mock_update, patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
-        new=AsyncMock(return_value={"code": 0}),
+        new=AsyncMock(side_effect=parse_documents),
     ) as mock_parse, patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.wait_for_parsing",
         new=AsyncMock(return_value="DONE"),
     ) as mock_wait:
-        await strategy._handle_document_parsing("ds-1", "doc-1")
+        await strategy._handle_document_parsing("ds-1", "doc-1", _PARSER_CONFIG)
 
+    mock_update.assert_awaited_once_with(
+        "ds-1",
+        "doc-1",
+        parser_config=_PARSER_CONFIG,
+    )
     mock_parse.assert_awaited_once_with("ds-1", ["doc-1"])
     mock_wait.assert_awaited_once_with("ds-1", "doc-1", max_wait_time=300)
+    assert calls == ["update", "parse"]
+
+
+@pytest.mark.asyncio
+async def test_handle_document_parsing_stops_when_configuration_fails() -> None:
+    strategy = RagflowRAGStrategy()
+    with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_document",
+        new=AsyncMock(return_value={"code": 102, "message": "invalid parser config"}),
+    ), patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
+        new=AsyncMock(),
+    ) as mock_parse, patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.wait_for_parsing",
+        new=AsyncMock(),
+    ) as mock_wait:
+        with pytest.raises(ThirdPartyException, match="invalid parser config"):
+            await strategy._handle_document_parsing("ds-1", "doc-1", _PARSER_CONFIG)
+
+    mock_parse.assert_not_awaited()
+    mock_wait.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_handle_document_parsing_surfaces_trigger_failure() -> None:
     strategy = RagflowRAGStrategy()
     with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_document",
+        new=AsyncMock(return_value={"code": 0}),
+    ), patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
         new=AsyncMock(return_value={"code": 103, "message": "queue unavailable"}),
     ), patch(
@@ -38,7 +85,7 @@ async def test_handle_document_parsing_surfaces_trigger_failure() -> None:
         new=AsyncMock(),
     ) as mock_wait:
         with pytest.raises(ThirdPartyException) as exc_info:
-            await strategy._handle_document_parsing("ds-1", "doc-1")
+            await strategy._handle_document_parsing("ds-1", "doc-1", _PARSER_CONFIG)
 
     assert "queue unavailable" in str(exc_info.value)
     mock_wait.assert_not_awaited()
@@ -52,6 +99,9 @@ async def test_handle_document_parsing_propagates_wait_failure() -> None:
         e=CodeEnum.RAGFLOW_RAGError,
     )
     with patch(
+        "knowledge.service.impl.ragflow_strategy.ragflow_client.update_document",
+        new=AsyncMock(return_value={"code": 0}),
+    ), patch(
         "knowledge.service.impl.ragflow_strategy.ragflow_client.parse_documents",
         new=AsyncMock(return_value={"code": 0}),
     ), patch(
@@ -59,7 +109,7 @@ async def test_handle_document_parsing_propagates_wait_failure() -> None:
         new=AsyncMock(side_effect=wait_error),
     ):
         with pytest.raises(ThirdPartyException, match="timed out"):
-            await strategy._handle_document_parsing("ds-1", "doc-1")
+            await strategy._handle_document_parsing("ds-1", "doc-1", _PARSER_CONFIG)
 
 
 class _Upload:
@@ -80,9 +130,38 @@ async def test_first_upload_zero_chunks_returns_explicit_failure() -> None:
     ), patch(
         "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
         new=AsyncMock(return_value=[]),
+    ), patch.object(
+        strategy, "_safe_delete_document", new=AsyncMock(return_value=None)
     ):
         with pytest.raises(CustomException) as exc_info:
             await strategy.split(file=_Upload(), datasetId="ds-1")
 
     assert exc_info.value.code == CodeEnum.ChunkQueryFailed.code
     assert "zero chunks" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_first_upload_accepts_large_single_chunk_without_delimiters() -> None:
+    strategy = RagflowRAGStrategy()
+    oversized = [{"id": "chunk-1", "content": "中" * 33_000}]
+    with patch.object(
+        strategy, "_resolve_dataset_id", new=AsyncMock(return_value="ds-1")
+    ), patch.object(
+        strategy,
+        "_process_document_upload",
+        new=AsyncMock(return_value="doc-1"),
+    ), patch.object(
+        strategy, "_handle_document_parsing", new=AsyncMock(return_value=None)
+    ), patch(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        new=AsyncMock(return_value=oversized),
+    ), patch.object(
+        strategy, "_safe_delete_document", new=AsyncMock(return_value=None)
+    ) as mock_delete:
+        result = await strategy.split(
+            file=_Upload(), datasetId="ds-1", lengthRange=[256, 1024]
+        )
+
+    assert len(result) == 1
+    assert result[0]["content"] == oversized[0]["content"]
+    mock_delete.assert_not_awaited()

--- a/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
+++ b/core/knowledge/tests/service/impl/ragflow_strategy_upsert_test.py
@@ -19,6 +19,11 @@ from knowledge.consts.error_code import CodeEnum
 from knowledge.exceptions.exception import CustomException
 from knowledge.service.impl.ragflow_strategy import RagflowRAGStrategy
 
+_PARSER_CONFIG = {
+    "chunk_token_num": 256,
+    "delimiter": "\n",
+}
+
 # ----------------------------------------------------------------------
 # Section A: _safe_delete_document
 # ----------------------------------------------------------------------
@@ -116,13 +121,14 @@ async def test_upsert_document_happy_path_deletes_old_returns_new(
             file_input=file_input,
             dataset_id="ds-1",
             old_doc_id="old-doc-xyz",
+            parser_config=_PARSER_CONFIG,
         )
 
     # Return is now a tuple of (doc_id, chunks_data) since the fetch+validate
     # is absorbed into the atomic transaction.
     assert result == (new_doc_id, fake_chunks)
     mock_upload.assert_awaited_once_with(file_input, "ds-1")
-    mock_parse.assert_awaited_once_with("ds-1", new_doc_id)
+    mock_parse.assert_awaited_once_with("ds-1", new_doc_id, _PARSER_CONFIG)
     # Only the OLD doc is deleted on success; pending is kept (it's now live)
     mock_delete.assert_awaited_once_with("ds-1", "old-doc-xyz")
 
@@ -155,6 +161,7 @@ async def test_upsert_document_upload_fails_no_delete_called() -> None:
                 file_input=object(),
                 dataset_id="ds-1",
                 old_doc_id="old-doc-xyz",
+                parser_config=_PARSER_CONFIG,
             )
 
     mock_parse.assert_not_awaited()
@@ -198,6 +205,7 @@ async def test_upsert_document_parse_fails_deletes_pending_not_old() -> None:
                 file_input=object(),
                 dataset_id="ds-1",
                 old_doc_id="old-doc-xyz",
+                parser_config=_PARSER_CONFIG,
             )
 
     # Exactly one delete call, targeting the PENDING doc (rollback), not the old one
@@ -254,6 +262,7 @@ async def test_upsert_document_delete_old_failure_raises_and_preserves_db_state(
                 file_input=object(),
                 dataset_id="ds-1",
                 old_doc_id="old-doc-xyz",
+                parser_config=_PARSER_CONFIG,
             )
 
     assert exc_info.value.code == CodeEnum.ChunkDeleteFailed.code
@@ -306,6 +315,7 @@ async def test_upsert_document_get_chunks_raises_rolls_back_pending(
                 file_input=object(),
                 dataset_id="ds-1",
                 old_doc_id="old-doc-xyz",
+                parser_config=_PARSER_CONFIG,
             )
 
     # Exactly ONE delete call: the PENDING doc (rollback). Old doc must NOT be touched.
@@ -363,12 +373,51 @@ async def test_upsert_document_get_chunks_empty_rolls_back_pending(
                 file_input=object(),
                 dataset_id="ds-1",
                 old_doc_id="old-doc-preserved",
+                parser_config=_PARSER_CONFIG,
             )
 
     assert exc_info.value.code == CodeEnum.ChunkQueryFailed.code
     assert "zero chunks" in str(exc_info.value)
     # Only the pending doc is deleted; old doc is preserved.
     assert delete_calls == [("ds-1", pending_doc_id, True)]
+
+
+@pytest.mark.asyncio
+async def test_upsert_document_accepts_large_single_chunk_without_delimiters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A legitimate delimiter-free large chunk can replace the previous doc."""
+    strategy = RagflowRAGStrategy()
+    pending_doc_id = "pending-doc-oversized"
+    oversized = [{"id": "chunk-1", "content": "中" * 33_000}]
+
+    monkeypatch.setattr(
+        "knowledge.service.impl.ragflow_strategy.RagflowUtils.get_document_chunks",
+        AsyncMock(return_value=oversized),
+    )
+
+    with (
+        patch.object(
+            strategy,
+            "_process_document_upload",
+            new=AsyncMock(return_value=pending_doc_id),
+        ),
+        patch.object(
+            strategy, "_handle_document_parsing", new=AsyncMock(return_value=None)
+        ),
+        patch.object(
+            strategy, "_safe_delete_document", new=AsyncMock(return_value=None)
+        ) as mock_delete,
+    ):
+        result = await strategy._upsert_document(
+            file_input=object(),
+            dataset_id="ds-1",
+            old_doc_id="old-doc-preserved",
+            parser_config=_PARSER_CONFIG,
+        )
+
+    assert result == (pending_doc_id, oversized)
+    mock_delete.assert_awaited_once_with("ds-1", "old-doc-preserved")
 
 
 # ----------------------------------------------------------------------
@@ -424,7 +473,7 @@ async def test_split_document_id_none_uses_legacy_create_only_path(
 
     mock_upsert.assert_not_awaited()
     mock_upload.assert_awaited_once_with(file_input, "ds-1")
-    mock_parse.assert_awaited_once_with("ds-1", "legacy-doc-id")
+    mock_parse.assert_awaited_once_with("ds-1", "legacy-doc-id", _PARSER_CONFIG)
 
 
 @pytest.mark.asyncio
@@ -479,7 +528,7 @@ async def test_split_document_id_set_uses_upsert_path(
     ):
         await strategy.split(file=file_input, document_id="doc-old")
 
-    mock_upsert.assert_awaited_once_with(file_input, "ds-1", "doc-old")
+    mock_upsert.assert_awaited_once_with(file_input, "ds-1", "doc-old", _PARSER_CONFIG)
     mock_upload.assert_not_awaited()
     mock_parse.assert_not_awaited()
 


### PR DESCRIPTION
## Summary

- apply the RAGFlow v0.20.5 parser configuration before triggering document parsing
- validate and normalize slicing requests, with rollback on failed RAGFlow ingestion
- expand stored knowledge content columns and add regression coverage for large documents

## Testing

- RAGFlow knowledge-service unit tests
- Console toolkit targeted tests and formatting checks