### PR TITLE
[HER Hack-Astron #2] Langfuse OTLP workflow tracing

### DIFF
--- a/core/workflow/config.env
+++ b/core/workflow/config.env
@@ -69,6 +69,13 @@ OTLP_ENABLE=0
 # OTLP headers for authentication
 OTLP_HEADERS=
 
+# Langfuse accepts native OpenTelemetry traces over OTLP/HTTP. Set these values
+# to enable Langfuse without changing the default OTLP exporter.
+LANGFUSE_ENABLED=false
+LANGFUSE_HOST=https://cloud.langfuse.com
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+
 # Metrics Collection Configuration
 # SDK metric reporting interval, recommended < 30000ms, default: 1000ms
 OTLP_METRIC_EXPORT_INTERVAL_MILLIS=3000

--- a/core/workflow/extensions/otlp/trace/trace.py
+++ b/core/workflow/extensions/otlp/trace/trace.py
@@ -1,11 +1,15 @@
 import json
 import os
+from base64 import b64encode
 from enum import Enum
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 from loguru import logger
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter as HttpOTLPSpanExporter,
+)
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import ReadableSpan, SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -74,6 +78,28 @@ class FileSpanExporter(SpanExporter):
         return None
 
 
+def get_langfuse_export_config() -> tuple[str, Mapping[str, str]] | None:
+    """Return the OTLP/HTTP endpoint and authentication headers for Langfuse.
+
+    Langfuse natively accepts OpenTelemetry traces, so the workflow engine can
+    keep its existing tracing model and avoid a vendor-specific SDK dependency.
+    """
+    if os.getenv("LANGFUSE_ENABLED", "false").lower() != "true":
+        return None
+
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+    if not public_key or not secret_key:
+        raise ValueError(
+            "LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are required when "
+            "LANGFUSE_ENABLED=true"
+        )
+
+    host = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com").rstrip("/")
+    credentials = b64encode(f"{public_key}:{secret_key}".encode()).decode()
+    return f"{host}/api/public/otel/v1/traces", {"Authorization": f"Basic {credentials}"}
+
+
 def init_trace(
     endpoint: str,
     service_name: str,
@@ -118,7 +144,24 @@ def init_trace(
     provider = TracerProvider(resource=resource, span_limits=span_limits)
 
     # Create OTLP exporter for remote trace export
-    if os.getenv("OTLP_ENABLE", "0") == "1":
+    langfuse_config = get_langfuse_export_config()
+    if langfuse_config:
+        langfuse_endpoint, langfuse_headers = langfuse_config
+        exporter = HttpOTLPSpanExporter(
+            endpoint=langfuse_endpoint,
+            timeout=timeout,
+            headers=langfuse_headers,
+        )
+        processor = BatchSpanProcessor(
+            exporter,
+            max_queue_size=max_queue_size,
+            schedule_delay_millis=schedule_delay_millis,
+            max_export_batch_size=max_export_batch_size,
+            export_timeout_millis=export_timeout_millis,
+        )
+        provider.add_span_processor(processor)
+        logger.info("Langfuse OTLP trace exporter enabled")
+    elif os.getenv("OTLP_ENABLE", "0") == "1":
         if headers:
             headers = ",".join([f"{k}={v}" for k, v in json.loads(headers).items()])
         exporter = OTLPSpanExporter(

--- a/core/workflow/tests/extensions/otlp/trace/test_langfuse_config.py
+++ b/core/workflow/tests/extensions/otlp/trace/test_langfuse_config.py
@@ -1,0 +1,34 @@
+import base64
+
+import pytest
+
+from workflow.extensions.otlp.trace.trace import get_langfuse_export_config
+
+
+def test_langfuse_config_is_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGFUSE_ENABLED", raising=False)
+    assert get_langfuse_export_config() is None
+
+
+def test_langfuse_config_builds_otlp_http_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_ENABLED", "true")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example/")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+
+    endpoint, headers = get_langfuse_export_config() or (None, None)
+
+    assert endpoint == "https://langfuse.example/api/public/otel/v1/traces"
+    assert headers == {
+        "Authorization": "Basic "
+        + base64.b64encode(b"pk-test:sk-test").decode()
+    }
+
+
+def test_langfuse_config_requires_both_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_ENABLED", "true")
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="LANGFUSE_PUBLIC_KEY"):
+        get_langfuse_export_config()

--- a/docs/en/observability/langfuse.md
+++ b/docs/en/observability/langfuse.md
@@ -1,0 +1,38 @@
+# Langfuse tracing for workflows
+
+The workflow service already emits OpenTelemetry spans for HTTP requests, nodes,
+and workflow execution. Langfuse can ingest those spans directly through OTLP,
+so no Langfuse SDK is added to the execution path.
+
+## Configuration
+
+Set the following environment variables for the workflow service:
+
+```dotenv
+LANGFUSE_ENABLED=true
+LANGFUSE_HOST=https://cloud.langfuse.com
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+```
+
+For a self-hosted Langfuse deployment, set `LANGFUSE_HOST` to its public URL.
+Keep both keys in the deployment secret store; do not add them to `config.env`.
+
+When enabled, Astron sends traces to
+`$LANGFUSE_HOST/api/public/otel/v1/traces` with OTLP/HTTP Basic authentication.
+When disabled, the existing `OTLP_ENABLE` gRPC exporter remains unchanged.
+
+## Verify a trace
+
+1. Start the workflow service with `LANGFUSE_ENABLED=true` and the two keys.
+2. Run any workflow or call a workflow HTTP endpoint.
+3. Open the Langfuse project and inspect the new trace. It should include the
+   workflow request span and child spans produced by workflow nodes.
+
+The included unit tests verify endpoint construction, credential encoding, and
+the disabled default:
+
+```sh
+cd core/workflow
+uv run pytest tests/extensions/otlp/trace/test_langfuse_config.py
+```


### PR DESCRIPTION
Closes #1575

## What changed
- Adds an opt-in Langfuse exporter that uses standard OTLP/HTTP and leaves the existing OTLP/gRPC path unchanged.
- Configures authenticated Langfuse export from `LANGFUSE_*` environment variables.
- Adds a reproduction guide and unit coverage for the disabled default, endpoint construction, and credential validation.

## Validation
```sh
PYTHONPATH="<test-deps>;core;core/common" python -m pytest core/workflow/tests/extensions/otlp/trace/test_langfuse_config.py
```
Result: 3 passed.

## AI assistance disclosure
- Agent/model: OpenAI Codex (GPT-5).
- Prompt template: "Implement an opt-in, vendor-neutral OpenTelemetry/OTLP Langfuse integration in Astron's workflow service. Preserve existing OTLP behavior, add tests and reproducible documentation."
- Review and changes: inspected the existing workflow OTel exporter and service lifecycle; selected Langfuse's native OTLP/HTTP ingestion rather than adding a vendor SDK; added credential validation, default-off behavior, tests, and deployment documentation.
