### PR TITLE
[HER Hack-Astron # 2] Langfuse integration via OpenTelemetry bridge

### DIFF
--- a/core/workflow/extensions/otlp/trace/langfuse_exporter.py
+++ b/core/workflow/extensions/otlp/trace/langfuse_exporter.py
@@ -1,0 +1,97 @@
+"""
+Langfuse OpenTelemetry bridge for Astron Agent.
+
+Astron Agent already emits OpenTelemetry spans for every workflow run, node,
+and LLM call (see ``workflow.extensions.otlp.trace``). This module forwards
+those spans to Langfuse's OpenTelemetry ingestion endpoint so traces, latency,
+and (where the underlying instrumentation records them) token usage appear in
+Langfuse without re-instrumenting every provider.
+
+The bridge is strictly opt-in and off by default. Enable it with:
+
+    LANGFUSE_ENABLED=1
+    LANGFUSE_PUBLIC_KEY=pk-lf-...
+    LANGFUSE_SECRET_KEY=sk-lf-...
+    LANGFUSE_HOST=https://cloud.langfuse.com   # or http://localhost:3000 (self-hosted >= v3.22.0)
+
+Transport follows Langfuse's documented OTLP contract:
+- endpoint ``{LANGFUSE_HOST}/api/public/otel``
+- Basic auth header built from ``public_key:secret_key``
+- ``x-langfuse-ingestion-version: 4`` for real-time ingestion
+
+Langfuse accepts OTLP over HTTP (JSON or protobuf); gRPC is not supported, so
+this module intentionally uses the OTLP HTTP exporter rather than the gRPC
+exporter used for the main OTLP backend.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Optional
+
+from loguru import logger
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
+
+#: Header that makes directly-ingested OTel data appear in real time on the
+#: Langfuse v4 data model (without it, ingestion can be delayed up to 10 min).
+_LANGFUSE_INGESTION_VERSION = "4"
+
+_ENABLED_VALUES = {"1", "true", "yes", "on"}
+
+
+def langfuse_enabled() -> bool:
+    """Return True when ``LANGFUSE_ENABLED`` is a truthy value."""
+    return os.getenv("LANGFUSE_ENABLED", "0").strip().lower() in _ENABLED_VALUES
+
+
+def _auth_header(public_key: str, secret_key: str) -> str:
+    """Build the Basic auth value for Langfuse ingestion."""
+    token = base64.b64encode(f"{public_key}:{secret_key}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def _headers(public_key: str, secret_key: str) -> dict[str, str]:
+    headers = {"x-langfuse-ingestion-version": _LANGFUSE_INGESTION_VERSION}
+    if public_key and secret_key:
+        headers["Authorization"] = _auth_header(public_key, secret_key)
+    return headers
+
+
+def build_langfuse_exporter(
+    host: Optional[str] = None,
+    public_key: Optional[str] = None,
+    secret_key: Optional[str] = None,
+    timeout: int = 5000,
+) -> SpanExporter:
+    """Build an OTLP HTTP span exporter pointed at Langfuse.
+
+    Falls back to environment variables for any unset argument. Credentials
+    come from ``LANGFUSE_HOST`` / ``LANGFUSE_PUBLIC_KEY`` / ``LANGFUSE_SECRET_KEY``.
+    """
+    host = (host or os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")).rstrip("/")
+    public_key = public_key if public_key is not None else os.getenv("LANGFUSE_PUBLIC_KEY", "")
+    secret_key = secret_key if secret_key is not None else os.getenv("LANGFUSE_SECRET_KEY", "")
+    endpoint = f"{host}/api/public/otel"
+    return OTLPSpanExporter(
+        endpoint=endpoint,
+        headers=_headers(public_key, secret_key),
+        timeout=timeout,
+    )
+
+
+def init_langfuse_processor(exporter: Optional[SpanExporter] = None) -> Optional[BatchSpanProcessor]:
+    """Create a span processor forwarding spans to Langfuse.
+
+    Returns ``None`` when the integration is disabled, so callers can attach it
+    conditionally without importing optional dependencies eagerly.
+
+    :param exporter: Optional pre-built exporter (mainly for tests); defaults to
+        :func:`build_langfuse_exporter` using environment configuration.
+    """
+    if not langfuse_enabled():
+        return None
+    exporter = exporter or build_langfuse_exporter()
+    logger.info("Langfuse OpenTelemetry bridge enabled -> exporting spans to Langfuse")
+    return BatchSpanProcessor(exporter)

--- a/core/workflow/extensions/otlp/trace/trace.py
+++ b/core/workflow/extensions/otlp/trace/trace.py
@@ -138,6 +138,20 @@ def init_trace(
     file_processor = BatchSpanProcessor(file_exporter)
     provider.add_span_processor(file_processor)
 
+    # Optional Langfuse bridge: forwards the same workflow spans to Langfuse's
+    # OTel endpoint when LANGFUSE_ENABLED is set. Imported lazily so the
+    # integration is a no-op (and dependency-free) when disabled.
+    try:
+        from workflow.extensions.otlp.trace.langfuse_exporter import (
+            init_langfuse_processor,
+        )
+
+        langfuse_processor = init_langfuse_processor()
+        if langfuse_processor is not None:
+            provider.add_span_processor(langfuse_processor)
+    except Exception as exc:  # noqa: BLE001 - observability must never break tracing
+        logger.warning(f"Failed to initialize Langfuse bridge: {exc}")
+
     # Set global default tracer provider
     trace.set_tracer_provider(provider)
     logger.debug("✅ Trace initialized successfully")

--- a/core/workflow/tests/extensions/otlp/trace/test_langfuse_exporter.py
+++ b/core/workflow/tests/extensions/otlp/trace/test_langfuse_exporter.py
@@ -1,0 +1,111 @@
+"""Unit tests for the Langfuse OpenTelemetry bridge.
+
+The exporter module is intentionally dependency-light so these tests run
+without a live Langfuse instance: they verify env gating, the Basic auth
+header, the OTLP endpoint, and that a real OTel span is exported over HTTP to
+``{host}/api/public/otel`` with the required headers.
+"""
+
+import base64
+import os
+from typing import Optional
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from workflow.extensions.otlp.trace.langfuse_exporter import (
+    _auth_header,
+    _headers,
+    build_langfuse_exporter,
+    init_langfuse_processor,
+    langfuse_enabled,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "LANGFUSE_ENABLED",
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "LANGFUSE_HOST",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert langfuse_enabled() is False
+    assert init_langfuse_processor() is None
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_enabled_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("LANGFUSE_ENABLED", value)
+    assert langfuse_enabled() is True
+
+
+def test_auth_header_encodes_public_and_secret_key() -> None:
+    expected = "Basic " + base64.b64encode(b"pk-lf-1:sk-lf-2").decode("ascii")
+    assert _auth_header("pk-lf-1", "sk-lf-2") == expected
+
+
+def test_headers_include_auth_and_ingestion_version() -> None:
+    headers = _headers("pk-lf-1", "sk-lf-2")
+    assert headers["Authorization"].startswith("Basic ")
+    assert headers["x-langfuse-ingestion-version"] == "4"
+
+
+def test_headers_work_without_credentials() -> None:
+    headers = _headers("", "")
+    assert "Authorization" not in headers
+    assert headers["x-langfuse-ingestion-version"] == "4"
+
+
+def test_exporter_endpoint_uses_langfuse_otel_path() -> None:
+    exporter = build_langfuse_exporter(
+        host="http://localhost:3000", public_key="pk", secret_key="sk"
+    )
+    assert exporter._endpoint == "http://localhost:3000/api/public/otel"  # type: ignore[attr-defined]
+
+
+def test_init_returns_processor_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_ENABLED", "1")
+    processor = init_langfuse_processor()
+    assert processor is not None
+    processor.shutdown()
+
+
+def test_span_exported_to_langfuse_endpoint_with_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a real OTel span is POSTed to Langfuse's OTLP endpoint.
+
+    ``pytest-httpserver`` must be installed for this test; it is skipped when
+    unavailable so the rest of the suite still runs.
+    """
+    httpserver_module = pytest.importorskip("pytest_httpserver")
+    server = httpserver_module.HTTPServer(host="127.0.0.1", port=0)
+    server.expect_request("/api/public/otel").respond_with_data("{}")
+    server.start()
+
+    monkeypatch.setenv("LANGFUSE_ENABLED", "1")
+    exporter = build_langfuse_exporter(
+        host=f"http://127.0.0.1:{server.port}",
+        public_key="pk-lf-test",
+        secret_key="sk-lf-test",
+    )
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    with trace.get_tracer("test").start_as_current_span("workflow-run") as span:
+        span.set_attribute("gen_ai.request.model", "gpt-4o")
+
+    requests = list(server.log) if hasattr(server, "log") else []
+    assert len(requests) == 1
+    request = requests[0][0]
+    assert request.path == "/api/public/otel"
+    assert request.headers["Authorization"] == _auth_header("pk-lf-test", "sk-lf-test")
+    assert request.headers["x-langfuse-ingestion-version"] == "4"
+    server.stop()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -103,6 +103,33 @@ Configuration items in this document are marked as follows:
 | OTLP_TRACE_MAX_EXPORT_BATCH_SIZE | Required | int | OTLP trace batch export maximum size | 2048 |
 | OTLP_TRACE_EXPORT_TIMEOUT_MILLIS | Required | int | OTLP trace export timeout (milliseconds) | 3000 |
 
+### Langfuse (OpenTelemetry bridge)
+
+Optional. Forwards the workflow's existing OpenTelemetry spans to
+[Langfuse](https://langfuse.com) so agent traces, latency, and (where the
+underlying provider records them) token usage appear in Langfuse without
+re-instrumenting each LLM provider. Uses Langfuse's documented OTLP ingestion
+endpoint (`{LANGFUSE_HOST}/api/public/otel`, OTLP over HTTP). No additional
+Python dependency is required.
+
+| Variable Name | Configuration Type | Type | Description | Example Value |
+|---------------|-------------------|------|-------------|---------------|
+| LANGFUSE_ENABLED | Required | bool | Enable the Langfuse bridge (0/1, true/false) | 0 |
+| LANGFUSE_PUBLIC_KEY | Required when enabled | string | Langfuse project public key (`pk-lf-...`) | pk-lf-xxxx |
+| LANGFUSE_SECRET_KEY | Required when enabled | string | Langfuse project secret key (`sk-lf-...`) | sk-lf-xxxx |
+| LANGFUSE_HOST | Optional | string | Langfuse host. Cloud regions or self-hosted (`http://localhost:3000`, self-hosted >= v3.22.0) | https://cloud.langfuse.com |
+
+Example:
+
+```bash
+export LANGFUSE_ENABLED=1
+export LANGFUSE_PUBLIC_KEY=pk-lf-xxxx
+export LANGFUSE_SECRET_KEY=sk-lf-xxxx
+export LANGFUSE_HOST=https://cloud.langfuse.com
+```
+
+
+
 ---
 
 ## 3. Basic Service Port Configuration

--- a/examples/langfuse-observability/README.md
+++ b/examples/langfuse-observability/README.md
@@ -1,0 +1,46 @@
+# Langfuse observability for Astron Agent
+
+Forwards Astron Agent's existing OpenTelemetry workflow traces to
+[Langfuse](https://langfuse.com) so you can inspect every agent run, node, and
+LLM call in a nested trace view.
+
+## 1. Run Langfuse (self-hosted, free)
+
+```bash
+docker run -d --name langfuse -p 3000:3000 ghcr.io/langfuse/langfuse:latest
+# open http://localhost:3000, create an account and a project
+# copy the project's public key (pk-lf-...) and secret key (sk-lf-...)
+```
+
+> Langfuse is MIT-licensed and self-hostable. Cloud is available at
+> langfuse.com if you prefer a managed instance.
+
+## 2. Enable the bridge in Astron Agent
+
+```bash
+export LANGFUSE_ENABLED=1
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+export LANGFUSE_HOST=http://localhost:3000
+```
+
+That's it. The workflow service registers an extra OpenTelemetry span
+processor that exports the same spans it already emits to Langfuse's OTLP
+endpoint (`/api/public/otel`). Disable it anytime by unsetting
+`LANGFUSE_ENABLED` — the bridge is off by default and adds no dependency.
+
+## 3. Run a workflow
+
+Run any workflow through the console. In Langfuse, open **Traces** and you'll
+see each workflow run with its nested node/LLM spans, duration, and status.
+LLM provider spans that record model + token usage surface as generation
+observations.
+
+## How it works
+
+- `core/workflow/extensions/otlp/trace/langfuse_exporter.py` builds an OTLP
+  HTTP span exporter pointed at Langfuse's ingestion endpoint with Basic auth
+  and the `x-langfuse-ingestion-version: 4` header (real-time ingestion).
+- `init_trace()` in `trace.py` attaches it to the tracer provider only when
+  `LANGFUSE_ENABLED` is truthy.
+- Transport is OTLP over HTTP (JSON/protobuf), which Langfuse supports.


### PR DESCRIPTION
Closes #1575

## What

Adds opt-in **Langfuse observability** to Astron Agent's workflow service via an OpenTelemetry bridge (Option C from the issue).

Astron Agent already emits an OpenTelemetry span for every workflow run, node, and LLM call. This PR forwards those spans to Langfuse's OTLP ingestion endpoint so traces, latency, and (where providers record them) token usage appear in Langfuse — without re-instrumenting each LLM provider.

## How

- `core/workflow/extensions/otlp/trace/langfuse_exporter.py` — builds an OTLP HTTP span exporter pointed at `{LANGFUSE_HOST}/api/public/otel`, with Basic auth (`LANGFUSE_PUBLIC_KEY:LANGFUSE_SECRET_KEY`) and the `x-langfuse-ingestion-version: 4` header for real-time ingestion.
- `init_trace()` — attaches the Langfuse span processor to the tracer provider **only when** `LANGFUSE_ENABLED` is truthy (lazy import; zero impact when disabled; no new required dependency — OTLP HTTP is already a core dep).
- Tests — `tests/extensions/otlp/trace/test_langfuse_exporter.py` (12 tests, incl. an end-to-end export to a real OTLP endpoint with header assertions).
- Docs — `docs/CONFIGURATION.md` env reference + `examples/langfuse-observability/README.md` runnable example.

## Config

```bash
export LANGFUSE_ENABLED=1
export LANGFUSE_PUBLIC_KEY=pk-lf-...
export LANGFUSE_SECRET_KEY=sk-lf-...
export LANGFUSE_HOST=https://cloud.langfuse.com   # or http://localhost:3000 (self-hosted)
```

Works with Langfuse cloud or self-hosted (>= v3.22.0, which supports the OTLP `/api/public/otel` endpoint).

## Tests

```
12 passed
```