### PR TITLE
fix(workflow): safely remap plugins during cross-environment import

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/vo/WorkflowImportReport.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/vo/WorkflowImportReport.java
@@ -1,0 +1,36 @@
+package com.iflytek.astron.console.toolkit.entity.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Result details for resource bindings resolved while importing a workflow.
+ */
+@Data
+public class WorkflowImportReport {
+    private int mappedPluginCount;
+    private List<UnresolvedPlugin> unresolvedPlugins = new ArrayList<>();
+
+    public void pluginMapped() {
+        mappedPluginCount++;
+    }
+
+    public void pluginUnresolved(String nodeId, String nodeLabel, String pluginName, String reason) {
+        unresolvedPlugins.add(new UnresolvedPlugin(nodeId, nodeLabel, pluginName, reason));
+    }
+
+    /**
+     * Plugin node that could not be safely rebound in the target environment.
+     */
+    @Data
+    @AllArgsConstructor
+    public static class UnresolvedPlugin {
+        private String nodeId;
+        private String nodeLabel;
+        private String pluginName;
+        private String reason;
+    }
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/vo/WorkflowImportVo.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/entity/vo/WorkflowImportVo.java
@@ -1,0 +1,14 @@
+package com.iflytek.astron.console.toolkit.entity.vo;
+
+import com.iflytek.astron.console.commons.entity.workflow.Workflow;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Imported workflow response with non-breaking resource-resolution details.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WorkflowImportVo extends Workflow {
+    private WorkflowImportReport importReport;
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowExportService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowExportService.java
@@ -10,12 +10,16 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.esotericsoftware.minlog.Log;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.entity.workflow.Workflow;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.service.space.EnterpriseSpaceService;
 import com.iflytek.astron.console.commons.util.BotUtil;
 import com.iflytek.astron.console.commons.util.space.SpaceInfoUtil;
 import com.iflytek.astron.console.toolkit.config.properties.BizConfig;
@@ -25,9 +29,12 @@ import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowData;
 import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowNode;
 import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizNodeData;
 import com.iflytek.astron.console.toolkit.entity.dto.WorkflowReq;
+import com.iflytek.astron.console.toolkit.entity.enumVo.ToolboxStatusEnum;
 import com.iflytek.astron.console.toolkit.entity.table.database.DbInfo;
 import com.iflytek.astron.console.toolkit.entity.table.tool.ToolBox;
 import com.iflytek.astron.console.toolkit.entity.vo.LLMInfoVo;
+import com.iflytek.astron.console.toolkit.entity.vo.WorkflowImportReport;
+import com.iflytek.astron.console.toolkit.entity.vo.WorkflowImportVo;
 import com.iflytek.astron.console.toolkit.handler.UserInfoManagerHandler;
 import com.iflytek.astron.console.toolkit.mapper.database.DbInfoMapper;
 import com.iflytek.astron.console.toolkit.service.model.ModelService;
@@ -39,6 +46,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -50,6 +58,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -64,6 +74,19 @@ import java.util.stream.Collectors;
  */
 @Service
 public class WorkflowExportService {
+    private static final String DEFAULT_PLUGIN_VERSION = "V1.0";
+    private static final String PORTABLE_PLUGIN_KEY = "portablePlugin";
+    private static final String PORTABLE_PLUGIN_NAME_KEY = "name";
+    private static final String PORTABLE_PLUGIN_FINGERPRINT_KEY = "schemaFingerprint";
+    private static final String PORTABLE_PLUGIN_FINGERPRINT_VERSION_KEY = "schemaFingerprintVersion";
+    private static final int PORTABLE_PLUGIN_FINGERPRINT_VERSION = 1;
+    private static final String REASON_MISSING_METADATA = "MISSING_METADATA";
+    private static final String REASON_NOT_FOUND = "NOT_FOUND";
+    private static final String REASON_AMBIGUOUS = "AMBIGUOUS";
+    private static final String REASON_INCOMPATIBLE = "INCOMPATIBLE";
+    private static final int MAX_PLUGIN_NAME_LENGTH = 64;
+    private static final List<String> PORTABLE_SCHEMA_FIELDS = List.of(
+            "name", "type", "location", "required", "from", "open", "fatherType", "children");
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     static {
@@ -89,6 +112,8 @@ public class WorkflowExportService {
     DbInfoMapper dbInfoMapper;
     @Autowired
     CommonConfig commonConfig;
+    @Resource
+    EnterpriseSpaceService enterpriseSpaceService;
 
     /**
      * Export workflow data as YAML format.
@@ -103,23 +128,7 @@ public class WorkflowExportService {
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         try {
             BizWorkflowData bizWorkflowData = JSON.parseObject(workflow.getData(), BizWorkflowData.class);
-            // Only process nodes: remove private fields from each node.data.nodeParam
-            if (bizWorkflowData != null) {
-                List<BizWorkflowNode> nodes = bizWorkflowData.getNodes();
-                for (BizWorkflowNode node : nodes) {
-                    BizNodeData data = node.getData();
-                    if (data != null) {
-                        JSONObject param = data.getNodeParam();
-                        // if (param != null) {
-                        // param.keySet().removeIf(key ->
-                        // key.equals("uid") || key.equals("appId") || key.equals("repoList")
-                        // || key.equals("repoId") || key.equals("modelId")
-                        // || key.equals("llmId") || key.equals("serviceId")
-                        // );
-                        // }
-                    }
-                }
-            }
+            addPortablePluginMetadata(bizWorkflowData);
             Map<String, Object> meta = objectMapper.convertValue(workflow, Map.class);
 
             // Keep only whitelist fields
@@ -165,6 +174,12 @@ public class WorkflowExportService {
      */
     @SneakyThrows
     public ApiResult importWorkflowFromYaml(InputStream inputStream, HttpServletRequest request) {
+        String uid = UserInfoManagerHandler.getUserId();
+        Long targetSpaceId = SpaceInfoUtil.getSpaceId();
+        if (targetSpaceId != null && enterpriseSpaceService.checkUserBelongSpace(targetSpaceId, uid) == null) {
+            throw new BusinessException(ResponseEnum.PERMISSION_NOT_BELONG_SPACE);
+        }
+
         LoaderOptions loaderOptions = new LoaderOptions();
         Yaml yaml = new Yaml(new SafeConstructor(loaderOptions));
         Map<String, Object> rootMap = yaml.load(inputStream);
@@ -173,8 +188,6 @@ public class WorkflowExportService {
         if (root == null || !root.containsKey("flowMeta") || !root.containsKey("flowData")) {
             throw new BusinessException(ResponseEnum.WORKFLOW_DLS_UPLOAD_FAILED);
         }
-        String uid = UserInfoManagerHandler.getUserId();
-
         Map<String, Object> meta = (Map<String, Object>) root.get("flowMeta");
         Map<String, Object> flow = (Map<String, Object>) root.get("flowData");
 
@@ -193,7 +206,7 @@ public class WorkflowExportService {
         wf.setAdvancedConfig((String) meta.get("advancedConfig"));
         BizWorkflowData bizWorkflowData = objectMapper.convertValue(flow, BizWorkflowData.class);
         // Clear node private information
-        cleanNodesForImport(bizWorkflowData, uid, request);
+        WorkflowImportReport importReport = cleanNodesForImport(bizWorkflowData, uid, request);
         String data = objectMapper.writeValueAsString(bizWorkflowData);
         wf.setData(data);
         // Call core system to get flowId
@@ -218,17 +231,19 @@ public class WorkflowExportService {
             wf.setAvatarIcon("icon/common/emojiitem_00_10@2x.png");
         }
         // Save
-        Long spaceId = SpaceInfoUtil.getSpaceId();
-        wf.setSpaceId(spaceId);
+        wf.setSpaceId(targetSpaceId);
         workflowService.save(wf);
         // Sync to Spark database
-        Integer botId = botUtil.syncToSparkDatabase(wf, UserInfoManagerHandler.getUserId(), spaceId);
+        Integer botId = botUtil.syncToSparkDatabase(wf, UserInfoManagerHandler.getUserId(), targetSpaceId);
         JSONObject jsonData = new JSONObject();
         jsonData.put("botId", botId);
         // Update botId
         wf.setExt(jsonData.toJSONString());
         workflowService.updateById(wf);
-        return ApiResult.success(wf);
+        WorkflowImportVo response = new WorkflowImportVo();
+        BeanUtils.copyProperties(wf, response);
+        response.setImportReport(importReport);
+        return ApiResult.success(response);
     }
 
     /**
@@ -258,8 +273,12 @@ public class WorkflowExportService {
      * @param uid User ID
      * @param request HTTP request context
      */
-    public void cleanNodesForImport(BizWorkflowData bizWorkflowData, String uid, HttpServletRequest request) {
-        List<BizWorkflowNode> nodes = bizWorkflowData.getNodes();
+    public WorkflowImportReport cleanNodesForImport(BizWorkflowData bizWorkflowData, String uid,
+            HttpServletRequest request) {
+        WorkflowImportReport importReport = new WorkflowImportReport();
+        List<BizWorkflowNode> nodes = Optional.ofNullable(bizWorkflowData)
+                .map(BizWorkflowData::getNodes)
+                .orElseGet(Collections::emptyList);
         ModelDto modelDto = new ModelDto();
         modelDto.setPage(1);
         modelDto.setPageSize(999);
@@ -284,7 +303,7 @@ public class WorkflowExportService {
                     cleanLlmNode(param, allowedLlmSet, uid);
                     break;
                 case "plugin":
-                    cleanPluginNode(param, uid, data);
+                    cleanPluginNode(node, uid, importReport);
                     break;
                 case "flow":
                     cleanFlowNode(param, uid, data);
@@ -304,6 +323,11 @@ public class WorkflowExportService {
                     break;
             }
         }
+        if (importReport.getMappedPluginCount() > 0 || !importReport.getUnresolvedPlugins().isEmpty()) {
+            Log.info(String.format("Workflow import plugin resolution: mapped=%d, unresolved=%d",
+                    importReport.getMappedPluginCount(), importReport.getUnresolvedPlugins().size()));
+        }
+        return importReport;
     }
 
     /**
@@ -353,26 +377,365 @@ public class WorkflowExportService {
         }
     }
 
+    private void addPortablePluginMetadata(BizWorkflowData workflowData) {
+        if (workflowData == null || CollUtil.isEmpty(workflowData.getNodes())) {
+            return;
+        }
+        for (BizWorkflowNode node : workflowData.getNodes()) {
+            if (node == null || StringUtils.isBlank(node.getId()) || !node.getId().startsWith("plugin::")) {
+                continue;
+            }
+            BizNodeData data = node.getData();
+            if (data == null || data.getNodeParam() == null) {
+                continue;
+            }
+            ToolBox sourceTool = findDirectPlugin(data.getNodeParam(), null);
+            if (sourceTool == null) {
+                continue;
+            }
+            String fingerprint = pluginSchemaFingerprint(sourceTool);
+            if (StringUtils.isBlank(sourceTool.getName()) || fingerprint == null) {
+                continue;
+            }
+            JSONObject portablePlugin = new JSONObject();
+            portablePlugin.put(PORTABLE_PLUGIN_NAME_KEY, sourceTool.getName());
+            portablePlugin.put(PORTABLE_PLUGIN_FINGERPRINT_KEY, fingerprint);
+            portablePlugin.put(PORTABLE_PLUGIN_FINGERPRINT_VERSION_KEY, PORTABLE_PLUGIN_FINGERPRINT_VERSION);
+            data.setPluginName(sourceTool.getName());
+            data.getNodeParam().put(PORTABLE_PLUGIN_KEY, portablePlugin);
+        }
+    }
+
+    private PluginResolution resolvePlugin(JSONObject param, JSONObject portablePlugin, String uid) {
+        Object rawFingerprint = portablePlugin == null
+                ? null
+                : portablePlugin.get(PORTABLE_PLUGIN_FINGERPRINT_KEY);
+        String expectedFingerprint = rawFingerprint instanceof String fingerprint ? fingerprint : null;
+        ToolBox directTool = findDirectPlugin(param, expectedFingerprint);
+        if (directTool != null) {
+            return new PluginResolution(directTool, false, null);
+        }
+
+        if (portablePlugin == null) {
+            return new PluginResolution(null, false, REASON_MISSING_METADATA);
+        }
+        Object rawPluginName = portablePlugin.get(PORTABLE_PLUGIN_NAME_KEY);
+        String pluginName = rawPluginName instanceof String name ? name : null;
+        Object rawFingerprintVersion = portablePlugin.get(PORTABLE_PLUGIN_FINGERPRINT_VERSION_KEY);
+        if (StringUtils.isBlank(pluginName)
+                || pluginName.length() > MAX_PLUGIN_NAME_LENGTH
+                || !(rawFingerprintVersion instanceof Number fingerprintVersion)
+                || fingerprintVersion.intValue() != PORTABLE_PLUGIN_FINGERPRINT_VERSION
+                || !isValidFingerprint(expectedFingerprint)) {
+            return new PluginResolution(null, false, REASON_MISSING_METADATA);
+        }
+
+        Long spaceId = SpaceInfoUtil.getSpaceId();
+        LambdaQueryWrapper<ToolBox> namedToolQuery = pluginLookupQuery()
+                .eq(ToolBox::getName, pluginName)
+                .eq(ToolBox::getDeleted, false)
+                .eq(ToolBox::getStatus, ToolboxStatusEnum.FORMAL.getCode());
+        if (spaceId == null) {
+            namedToolQuery.isNull(ToolBox::getSpaceId).eq(ToolBox::getUserId, uid);
+        } else {
+            namedToolQuery.eq(ToolBox::getSpaceId, spaceId);
+        }
+        List<ToolBox> namedTools = safeToolList(namedToolQuery);
+        List<ToolBox> scopedTools = namedTools.stream()
+                .filter(this::isUsableFallbackTool)
+                .filter(tool -> pluginName.equals(tool.getName()))
+                .filter(tool -> isInCurrentImportScope(tool, uid))
+                .filter(this::isToolVisible)
+                .toList();
+        if (scopedTools.isEmpty()) {
+            return new PluginResolution(null, false, REASON_NOT_FOUND);
+        }
+
+        String sourceVersion = effectivePluginVersion(param.getString("version"));
+        List<ToolBox> versionMatches = scopedTools.stream()
+                .filter(tool -> sourceVersion.equals(effectivePluginVersion(tool.getVersion())))
+                .toList();
+        if (versionMatches.isEmpty()) {
+            return new PluginResolution(null, false, REASON_INCOMPATIBLE);
+        }
+
+        List<ToolBox> compatibleTools = versionMatches.stream()
+                .filter(tool -> expectedFingerprint.equals(pluginSchemaFingerprint(tool)))
+                .toList();
+        if (compatibleTools.isEmpty()) {
+            return new PluginResolution(null, false, REASON_INCOMPATIBLE);
+        }
+
+        Map<String, List<ToolBox>> toolsById = compatibleTools.stream()
+                .collect(Collectors.groupingBy(ToolBox::getToolId, LinkedHashMap::new, Collectors.toList()));
+        if (toolsById.size() != 1) {
+            return new PluginResolution(null, false, REASON_AMBIGUOUS);
+        }
+        ToolBox targetTool = selectUniqueRuntimeTool(toolsById.values().iterator().next(), null);
+        if (targetTool == null) {
+            return new PluginResolution(null, false, REASON_AMBIGUOUS);
+        }
+        return new PluginResolution(targetTool, true, null);
+    }
+
+    private ToolBox findDirectPlugin(JSONObject param, String expectedFingerprint) {
+        String pluginId = param.getString("pluginId");
+        if (StringUtils.isBlank(pluginId)) {
+            return null;
+        }
+        String version = effectivePluginVersion(param.getString("version"));
+        List<ToolBox> candidates = safeToolList(pluginLookupQuery()
+                .eq(ToolBox::getToolId, pluginId)
+                .eq(ToolBox::getDeleted, false)).stream()
+                .filter(this::hasRuntimeIdentity)
+                .filter(tool -> version.equals(effectivePluginVersion(tool.getVersion())))
+                .filter(this::isToolVisible)
+                .filter(tool -> expectedFingerprint == null
+                        || expectedFingerprint.equals(pluginSchemaFingerprint(tool)))
+                .toList();
+        return selectUniqueRuntimeTool(candidates, param.getString("operationId"));
+    }
+
+    private List<ToolBox> safeToolList(LambdaQueryWrapper<ToolBox> query) {
+        List<ToolBox> tools = toolBoxService.list(query);
+        return tools == null ? Collections.emptyList() : tools;
+    }
+
+    private LambdaQueryWrapper<ToolBox> pluginLookupQuery() {
+        return new LambdaQueryWrapper<ToolBox>().select(
+                ToolBox::getId,
+                ToolBox::getToolId,
+                ToolBox::getName,
+                ToolBox::getDescription,
+                ToolBox::getUserId,
+                ToolBox::getSpaceId,
+                ToolBox::getAppId,
+                ToolBox::getMethod,
+                ToolBox::getWebSchema,
+                ToolBox::getDeleted,
+                ToolBox::getIsPublic,
+                ToolBox::getOperationId,
+                ToolBox::getStatus,
+                ToolBox::getVersion);
+    }
+
+    private ToolBox selectUniqueRuntimeTool(List<ToolBox> candidates, String operationId) {
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        if (StringUtils.isNotBlank(operationId)) {
+            List<ToolBox> operationMatches = candidates.stream()
+                    .filter(tool -> operationId.equals(tool.getOperationId()))
+                    .toList();
+            if (operationMatches.size() == 1) {
+                return operationMatches.get(0);
+            }
+        }
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+        long runtimeIdentities = candidates.stream()
+                .map(tool -> String.join("\u0000",
+                        StringUtils.defaultString(tool.getToolId()),
+                        StringUtils.defaultString(tool.getOperationId()),
+                        StringUtils.defaultString(tool.getAppId()),
+                        effectivePluginVersion(tool.getVersion())))
+                .distinct()
+                .count();
+        return runtimeIdentities == 1 ? candidates.get(0) : null;
+    }
+
+    private boolean isUsableFallbackTool(ToolBox tool) {
+        return tool != null
+                && !Boolean.TRUE.equals(tool.getDeleted())
+                && ToolboxStatusEnum.FORMAL.getCode().equals(tool.getStatus())
+                && hasRuntimeIdentity(tool);
+    }
+
+    private boolean hasRuntimeIdentity(ToolBox tool) {
+        return tool != null
+                && StringUtils.isNoneBlank(tool.getToolId(), tool.getOperationId(), tool.getAppId());
+    }
+
+    private boolean isToolVisible(ToolBox tool) {
+        try {
+            ToolBox permissionView = new ToolBox();
+            permissionView.setId(tool.getId());
+            permissionView.setToolId(tool.getToolId());
+            permissionView.setUserId(tool.getUserId());
+            permissionView.setSpaceId(tool.getSpaceId());
+            permissionView.setIsPublic(tool.getIsPublic());
+            dataPermissionCheckTool.checkToolVisible(permissionView);
+            return true;
+        } catch (BusinessException e) {
+            return false;
+        }
+    }
+
+    private boolean isInCurrentImportScope(ToolBox tool, String uid) {
+        Long spaceId = SpaceInfoUtil.getSpaceId();
+        if (spaceId == null) {
+            return tool.getSpaceId() == null && Objects.equals(tool.getUserId(), uid);
+        }
+        return Objects.equals(tool.getSpaceId(), spaceId);
+    }
+
+    private void applyPluginBinding(JSONObject param, BizNodeData data, ToolBox targetTool, String uid) {
+        param.put("pluginId", targetTool.getToolId());
+        param.put("operationId", targetTool.getOperationId());
+        param.put("version", effectivePluginVersion(targetTool.getVersion()));
+        param.put("appId", targetTool.getAppId());
+        param.put("uid", uid);
+        param.put("toolDescription", targetTool.getDescription());
+        extractBusinessInputs(targetTool.getWebSchema()).ifPresent(inputs -> param.put("businessInput", inputs));
+        data.setPluginName(targetTool.getName());
+    }
+
+    private void clearPluginBinding(JSONObject param, BizNodeData data) {
+        List.of("pluginId", "operationId", "version", "appId", "uid", "toolDescription", "businessInput")
+                .forEach(param::remove);
+        data.setInputs(Collections.emptyList());
+        data.setOutputs(Collections.emptyList());
+    }
+
+    private Optional<List<String>> extractBusinessInputs(String webSchema) {
+        if (StringUtils.isBlank(webSchema)) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode inputs = objectMapper.readTree(webSchema).path("toolRequestInput");
+            List<String> businessInputs = new ArrayList<>();
+            collectBusinessInputs(inputs, businessInputs);
+            return Optional.of(businessInputs);
+        } catch (Exception e) {
+            Log.warn("Unable to rebuild imported plugin business inputs", e);
+            return Optional.empty();
+        }
+    }
+
+    private void collectBusinessInputs(JsonNode node, List<String> businessInputs) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return;
+        }
+        if (node.isArray()) {
+            node.forEach(child -> collectBusinessInputs(child, businessInputs));
+            return;
+        }
+        if (!node.isObject()) {
+            return;
+        }
+        if (node.path("from").asInt(-1) == 1
+                && !"array".equals(node.path("fatherType").asText())
+                && StringUtils.isNotBlank(node.path("name").asText())) {
+            businessInputs.add(node.path("name").asText());
+        }
+        collectBusinessInputs(node.path("children"), businessInputs);
+    }
+
+    private String pluginSchemaFingerprint(ToolBox tool) {
+        if (tool == null || StringUtils.isAnyBlank(tool.getMethod(), tool.getWebSchema())) {
+            return null;
+        }
+        try {
+            JsonNode webSchema = objectMapper.readTree(tool.getWebSchema());
+            JsonNode requestInput = webSchema.path("toolRequestInput");
+            JsonNode requestOutput = webSchema.path("toolRequestOutput");
+            if (!requestInput.isArray() || !requestOutput.isArray()) {
+                return null;
+            }
+            ObjectNode portableSchema = objectMapper.createObjectNode();
+            portableSchema.put("method", StringUtils.lowerCase(StringUtils.trimToEmpty(tool.getMethod()), Locale.ROOT));
+            portableSchema.set("toolRequestInput", canonicalizeSchema(requestInput));
+            portableSchema.set("toolRequestOutput", canonicalizeSchema(requestOutput));
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(objectMapper.writeValueAsBytes(portableSchema));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        } catch (Exception e) {
+            Log.warn("Unable to fingerprint plugin schema for workflow migration", e);
+            return null;
+        }
+    }
+
+    private JsonNode canonicalizeSchema(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return objectMapper.nullNode();
+        }
+        if (node.isArray()) {
+            List<JsonNode> children = new ArrayList<>();
+            node.forEach(child -> children.add(canonicalizeSchema(child)));
+            children.sort(Comparator.comparing(JsonNode::toString));
+            ArrayNode canonical = objectMapper.createArrayNode();
+            children.forEach(canonical::add);
+            return canonical;
+        }
+        if (node.isObject()) {
+            ObjectNode canonical = objectMapper.createObjectNode();
+            for (String field : PORTABLE_SCHEMA_FIELDS) {
+                if (node.has(field)) {
+                    canonical.set(field, canonicalizeSchema(node.get(field)));
+                }
+            }
+            return canonical;
+        }
+        return node.deepCopy();
+    }
+
+    private String effectivePluginVersion(String version) {
+        return StringUtils.defaultIfBlank(version, DEFAULT_PLUGIN_VERSION);
+    }
+
+    private boolean isValidFingerprint(String fingerprint) {
+        return fingerprint != null && fingerprint.matches("[0-9a-f]{64}");
+    }
+
+    private record PluginResolution(ToolBox toolBox, boolean remapped, String reason) {}
+
     /**
      * Process plugin/tool node during import.
      *
-     * @param param Node parameters
+     * @param node Plugin workflow node
      * @param uid User ID
-     * @param data Node data
+     * @param importReport Import resource-resolution report
      */
-    private void cleanPluginNode(JSONObject param, String uid,
-            BizNodeData data) {
-        String pluginId = param.getString("pluginId");
-        ToolBox toolBox = toolBoxService.getOnly(new LambdaQueryWrapper<ToolBox>()
-                .eq(ToolBox::getToolId, pluginId));
-        if (toolBox == null || (!Boolean.TRUE.equals(toolBox.getIsPublic())
-                && !Objects.equals(toolBox.getUserId(), String.valueOf(bizConfig.getAdminUid()))
-                && !Objects.equals(toolBox.getUserId(), uid))) {
-            param.remove("pluginId");
-            param.remove("uid");
-            data.setInputs(Collections.emptyList());
-            data.setOutputs(Collections.emptyList());
+    private void cleanPluginNode(BizWorkflowNode node, String uid, WorkflowImportReport importReport) {
+        BizNodeData data = node.getData();
+        JSONObject param = data.getNodeParam();
+        JSONObject portablePlugin = readPortablePluginMetadata(param);
+        PluginResolution resolution = resolvePlugin(param, portablePlugin, uid);
+        param.remove(PORTABLE_PLUGIN_KEY);
+
+        if (resolution.toolBox() != null) {
+            applyPluginBinding(param, data, resolution.toolBox(), uid);
+            if (resolution.remapped()) {
+                importReport.pluginMapped();
+            }
+            return;
         }
+
+        String pluginName = portablePlugin == null
+                ? data.getPluginName()
+                : portablePlugin.getString(PORTABLE_PLUGIN_NAME_KEY);
+        clearPluginBinding(param, data);
+        importReport.pluginUnresolved(node.getId(), data.getLabel(), pluginName, resolution.reason());
+    }
+
+    private JSONObject readPortablePluginMetadata(JSONObject param) {
+        Object rawMetadata = param.get(PORTABLE_PLUGIN_KEY);
+        if (rawMetadata instanceof JSONObject metadata) {
+            return metadata;
+        }
+        if (rawMetadata instanceof Map<?, ?> map) {
+            JSONObject metadata = new JSONObject();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() instanceof String key) {
+                    metadata.put(key, entry.getValue());
+                }
+            }
+            return metadata;
+        }
+        return null;
     }
 
     /**

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowExportServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowExportServiceTest.java
@@ -1,0 +1,627 @@
+package com.iflytek.astron.console.toolkit.service.workflow;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iflytek.astron.console.commons.config.JwtClaimsFilter;
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.entity.workflow.Workflow;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.service.space.EnterpriseSpaceService;
+import com.iflytek.astron.console.commons.util.BotUtil;
+import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
+import com.iflytek.astron.console.toolkit.entity.biz.modelconfig.ModelDto;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowData;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowNode;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizInputOutput;
+import com.iflytek.astron.console.toolkit.entity.biz.workflow.node.BizNodeData;
+import com.iflytek.astron.console.toolkit.entity.table.tool.ToolBox;
+import com.iflytek.astron.console.toolkit.entity.vo.LLMInfoVo;
+import com.iflytek.astron.console.toolkit.entity.vo.WorkflowImportReport;
+import com.iflytek.astron.console.toolkit.entity.vo.WorkflowImportVo;
+import com.iflytek.astron.console.toolkit.service.model.ModelService;
+import com.iflytek.astron.console.toolkit.service.tool.ToolBoxService;
+import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowExportServiceTest {
+    private static final String UID = "user-1";
+    private static final String PLUGIN_NAME = "demo-cross-env-plugin";
+
+    @Mock
+    private WorkflowService workflowService;
+    @Mock
+    private ModelService modelService;
+    @Mock
+    private BotUtil botUtil;
+    @Mock
+    private ToolBoxService toolBoxService;
+    @Mock
+    private DataPermissionCheckTool dataPermissionCheckTool;
+    @Mock
+    private CommonConfig commonConfig;
+    @Mock
+    private EnterpriseSpaceService enterpriseSpaceService;
+
+    private WorkflowExportService service;
+    private MockHttpServletRequest request;
+
+    @BeforeAll
+    static void initializeMybatisMetadata() {
+        TableInfoHelper.initTableInfo(
+                new MapperBuilderAssistant(new MybatisConfiguration(), "workflow-import-test"), ToolBox.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkflowExportService();
+        ReflectionTestUtils.setField(service, "workflowService", workflowService);
+        ReflectionTestUtils.setField(service, "modelService", modelService);
+        ReflectionTestUtils.setField(service, "botUtil", botUtil);
+        ReflectionTestUtils.setField(service, "toolBoxService", toolBoxService);
+        ReflectionTestUtils.setField(service, "dataPermissionCheckTool", dataPermissionCheckTool);
+        ReflectionTestUtils.setField(service, "commonConfig", commonConfig);
+        ReflectionTestUtils.setField(service, "enterpriseSpaceService", enterpriseSpaceService);
+
+        request = new MockHttpServletRequest();
+        request.setAttribute(JwtClaimsFilter.USER_ID_ATTRIBUTE, UID);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void exportAddsPortablePluginIdentityFromToolMetadata() {
+        BizWorkflowData flowData = workflowData(pluginNode("source-tool", "source-operation", "source-app"));
+        flowData.getNodes().get(0).getData().setLabel("renamed node label");
+        Workflow workflow = workflow(flowData);
+        ToolBox sourceTool = tool("source-tool", "source-operation", "source-app", UID, null,
+                schema("input-a", "source description", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(List.of(sourceTool));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        service.exportWorkflowDataAsYaml(workflow, output);
+
+        BizWorkflowData exported = readFlowData(output.toByteArray());
+        BizNodeData exportedData = exported.getNodes().get(0).getData();
+        JSONObject portable = exportedData.getNodeParam().getJSONObject("portablePlugin");
+        assertThat(exportedData.getPluginName()).isEqualTo(PLUGIN_NAME);
+        assertThat(portable.getString("name")).isEqualTo(PLUGIN_NAME);
+        assertThat(portable.getString("schemaFingerprint")).matches("[0-9a-f]{64}");
+        assertThat(portable.getIntValue("schemaFingerprintVersion")).isEqualTo(1);
+        assertThat(portable.toJSONString()).doesNotContain("source description", "input-a", "endpoint");
+        verify(dataPermissionCheckTool).checkWorkflowVisible(workflow, null);
+        ArgumentCaptor<ToolBox> permissionView = ArgumentCaptor.forClass(ToolBox.class);
+        verify(dataPermissionCheckTool).checkToolVisible(permissionView.capture());
+        assertThat(permissionView.getValue().getToolId()).isEqualTo("source-tool");
+        assertThat(permissionView.getValue().getWebSchema()).isNull();
+        assertThat(permissionView.getValue().getAuthInfo()).isNull();
+    }
+
+    @Test
+    void uniqueCompatiblePluginRemapsRuntimeIdentityAndPreservesNodeSchema() {
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        BizInputOutput input = node.getData().getInputs().get(0);
+        BizInputOutput output = node.getData().getOutputs().get(0);
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        JSONObject param = node.getData().getNodeParam();
+        assertThat(param.getString("pluginId")).isEqualTo("target-tool");
+        assertThat(param.getString("operationId")).isEqualTo("target-operation");
+        assertThat(param.getString("appId")).isEqualTo("target-app");
+        assertThat(param.getString("version")).isEqualTo("V1.0");
+        assertThat(param.getString("uid")).isEqualTo(UID);
+        assertThat(param.getString("toolDescription")).isEqualTo("target description");
+        assertThat(param.getList("businessInput", String.class)).containsExactly("query");
+        assertThat(param).doesNotContainKey("portablePlugin");
+        assertThat(node.getData().getInputs()).containsExactly(input);
+        assertThat(node.getData().getOutputs()).containsExactly(output);
+        assertThat(node.getData().getPluginName()).isEqualTo(PLUGIN_NAME);
+        assertThat(report.getMappedPluginCount()).isEqualTo(1);
+        assertThat(report.getUnresolvedPlugins()).isEmpty();
+    }
+
+    @Test
+    void existingVisiblePluginIdKeepsBackwardCompatibilityWithoutNameFallback() {
+        BizWorkflowNode node = pluginNode("target-tool", "target-operation", "target-app");
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertThat(node.getData().getNodeParam().getString("pluginId")).isEqualTo("target-tool");
+        assertThat(node.getData().getInputs()).hasSize(1);
+        assertThat(node.getData().getOutputs()).hasSize(1);
+        assertThat(report.getMappedPluginCount()).isZero();
+        assertThat(report.getUnresolvedPlugins()).isEmpty();
+        verify(toolBoxService, times(1)).list(any(LambdaQueryWrapper.class));
+    }
+
+    @Test
+    void existingDraftPluginIdKeepsBackwardCompatibility() {
+        BizWorkflowNode node = pluginNode("target-tool", "target-operation", "target-app");
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target", false));
+        target.setStatus(0);
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertThat(node.getData().getNodeParam().getString("pluginId")).isEqualTo("target-tool");
+        assertThat(node.getData().getInputs()).hasSize(1);
+        assertThat(node.getData().getOutputs()).hasSize(1);
+        assertThat(report.getMappedPluginCount()).isZero();
+        assertThat(report.getUnresolvedPlugins()).isEmpty();
+    }
+
+    @Test
+    void inaccessibleDirectPluginIdFailsClosed() {
+        BizWorkflowNode node = pluginNode("target-tool", "target-operation", "target-app");
+        ToolBox target = tool("target-tool", "target-operation", "target-app", "other-user", null,
+                schema("target-id", "target", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(List.of(target));
+        doThrow(new BusinessException(ResponseEnum.DATA_NOT_FOUND))
+                .when(dataPermissionCheckTool)
+                .checkToolVisible(any(ToolBox.class));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("MISSING_METADATA");
+    }
+
+    @Test
+    void duplicateCompatiblePluginNamesFailClosed() {
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        String fingerprint = fingerprintFor(schema("source-id", "source", false));
+        addPortableIdentity(node, PLUGIN_NAME, fingerprint);
+        ToolBox first = tool("target-a", "operation-a", "app-a", UID, null,
+                schema("target-a", "target a", false));
+        ToolBox second = tool("target-b", "operation-b", "app-b", UID, null,
+                schema("target-b", "target b", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(first, second));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getMappedPluginCount()).isZero();
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("AMBIGUOUS");
+    }
+
+    @Test
+    void multipleVersionsOfOnePluginAreNotTreatedAsNameAmbiguity() {
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        ToolBox versionOne = tool("target-tool", "operation-v1", "target-app", UID, null,
+                schema("target-v1", "target v1", false));
+        ToolBox versionTwo = tool("target-tool", "operation-v2", "target-app", UID, null,
+                schema("target-v2", "target v2", false));
+        versionTwo.setVersion("V2.0");
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(versionOne, versionTwo));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertThat(node.getData().getNodeParam().getString("pluginId")).isEqualTo("target-tool");
+        assertThat(node.getData().getNodeParam().getString("operationId")).isEqualTo("operation-v1");
+        assertThat(node.getData().getNodeParam().getString("version")).isEqualTo("V1.0");
+        assertThat(report.getMappedPluginCount()).isEqualTo(1);
+    }
+
+    @Test
+    void incompatibleSchemaFailsClosed() {
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target", true));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("INCOMPATIBLE");
+    }
+
+    @Test
+    void draftPluginIsNotConsideredForNameFallback() {
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target", false));
+        target.setStatus(0);
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void sameSpacePluginCanBeMatchedForCurrentSpace() {
+        request.addHeader("space-id", "100");
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        ToolBox target = tool("target-tool", "target-operation", "target-app", "other-member", 100L,
+                schema("target-id", "target", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertThat(node.getData().getNodeParam().getString("pluginId")).isEqualTo("target-tool");
+        assertThat(report.getMappedPluginCount()).isEqualTo(1);
+        verify(dataPermissionCheckTool).checkToolVisible(any(ToolBox.class));
+    }
+
+    @Test
+    void crossSpacePluginIsNotConsideredForFallback() {
+        request.addHeader("space-id", "100");
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        ToolBox target = tool("target-tool", "target-operation", "target-app", "other-user", 200L,
+                schema("target-id", "target", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void publicPluginOwnedByAnotherUserIsNotGuessedByName() {
+        BizWorkflowNode node = pluginNode("source-tool", "source-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, fingerprintFor(schema("source-id", "source", false)));
+        ToolBox target = tool("target-tool", "target-operation", "target-app", "other-user", null,
+                schema("target-id", "target", false));
+        target.setIsPublic(true);
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void oldYamlWithoutPortableMetadataStillFailsClosedWhenIdIsMissing() {
+        BizWorkflowNode node = pluginNode("missing-tool", "missing-operation", "source-app");
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(Collections.emptyList());
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("MISSING_METADATA");
+    }
+
+    @Test
+    void malformedPortableMetadataFailsClosedWithoutAbortingImport() {
+        BizWorkflowNode node = pluginNode("missing-tool", "missing-operation", "source-app");
+        node.getData().getNodeParam().put("portablePlugin", "not-an-object");
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(Collections.emptyList());
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("MISSING_METADATA");
+    }
+
+    @Test
+    void unsupportedFingerprintVersionFailsClosed() {
+        BizWorkflowNode node = pluginNode("missing-tool", "missing-operation", "source-app");
+        addPortableIdentity(node, PLUGIN_NAME, "0".repeat(64));
+        node.getData()
+                .getNodeParam()
+                .getJSONObject("portablePlugin")
+                .put("schemaFingerprintVersion", 2);
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(Collections.emptyList());
+        stubModelList();
+
+        WorkflowImportReport report = service.cleanNodesForImport(workflowData(node), UID, request);
+
+        assertPluginBindingCleared(node);
+        assertThat(report.getUnresolvedPlugins()).singleElement()
+                .extracting(WorkflowImportReport.UnresolvedPlugin::getReason)
+                .isEqualTo("MISSING_METADATA");
+    }
+
+    @Test
+    void exportImportRoundTripMatchesEquivalentSchemaWithDifferentPresentationFields() {
+        BizWorkflowNode sourceNode = pluginNode("source-tool", "source-operation", "source-app");
+        Workflow workflow = workflow(workflowData(sourceNode));
+        ToolBox source = tool("source-tool", "source-operation", "source-app", UID, null,
+                schema("source-id", "source description", false));
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target description", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class)))
+                .thenReturn(List.of(source))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(target));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        service.exportWorkflowDataAsYaml(workflow, output);
+        BizWorkflowData imported = readFlowData(output.toByteArray());
+        stubModelList();
+        WorkflowImportReport report = service.cleanNodesForImport(imported, UID, request);
+
+        BizWorkflowNode importedNode = imported.getNodes().get(0);
+        assertThat(importedNode.getData().getNodeParam().getString("pluginId")).isEqualTo("target-tool");
+        assertThat(importedNode.getData().getNodeParam().getString("operationId")).isEqualTo("target-operation");
+        assertThat(importedNode.getData().getInputs()).hasSize(1);
+        assertThat(importedNode.getData().getOutputs()).hasSize(1);
+        assertThat(report.getMappedPluginCount()).isEqualTo(1);
+    }
+
+    @Test
+    void importResponseKeepsWorkflowFieldsAtTopLevelAndIncludesReport() throws Exception {
+        BizWorkflowNode node = pluginNode("target-tool", "target-operation", "target-app");
+        ToolBox target = tool("target-tool", "target-operation", "target-app", UID, null,
+                schema("target-id", "target", false));
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(List.of(target));
+        stubModelList();
+        when(commonConfig.getAppId()).thenReturn("workflow-app");
+        when(workflowService.callProtocolAdd(any())).thenReturn(ApiResult.success("flow-new"));
+        doAnswer(invocation -> {
+            Workflow saved = invocation.getArgument(0);
+            saved.setId(42L);
+            return true;
+        }).when(workflowService).save(any(Workflow.class));
+        when(botUtil.syncToSparkDatabase(any(Workflow.class), eq(UID), eq(null))).thenReturn(7);
+        when(workflowService.updateById(any(Workflow.class))).thenReturn(true);
+        byte[] yaml = yamlFor(workflowData(node));
+
+        ApiResult<?> result = service.importWorkflowFromYaml(new ByteArrayInputStream(yaml), request);
+
+        assertThat(result.code()).isZero();
+        assertThat(result.data()).isInstanceOf(Workflow.class).isInstanceOf(WorkflowImportVo.class);
+        WorkflowImportVo imported = (WorkflowImportVo) result.data();
+        assertThat(imported.getFlowId()).isEqualTo("flow-new");
+        assertThat(imported.getId()).isEqualTo(42L);
+        assertThat(imported.getImportReport()).isNotNull();
+        assertThat(imported.getImportReport().getUnresolvedPlugins()).isEmpty();
+        JSONObject serialized = JSON.parseObject(new ObjectMapper().writeValueAsString(imported));
+        assertThat(serialized.getString("flowId")).isEqualTo("flow-new");
+        assertThat(serialized.getJSONObject("importReport")).isNotNull();
+        assertThat(serialized).doesNotContainKey("workflow");
+    }
+
+    @Test
+    void importRejectsSpaceHeaderWhenUserIsNotAMember() {
+        request.addHeader("space-id", "100");
+        byte[] yaml = yamlFor(workflowData(pluginNode("target-tool", "target-operation", "target-app")));
+
+        assertThatThrownBy(() -> service.importWorkflowFromYaml(new ByteArrayInputStream(yaml), request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getResponseEnum())
+                        .isEqualTo(ResponseEnum.PERMISSION_NOT_BELONG_SPACE));
+        verify(enterpriseSpaceService).checkUserBelongSpace(100L, UID);
+        verifyNoInteractions(workflowService, modelService, botUtil, toolBoxService);
+    }
+
+    private void stubModelList() {
+        Page<LLMInfoVo> page = new Page<>();
+        page.setRecords(Collections.emptyList());
+        when(modelService.getConditionList(any(ModelDto.class), same(request))).thenReturn(ApiResult.success(page));
+    }
+
+    private Workflow workflow(BizWorkflowData flowData) {
+        Workflow workflow = new Workflow();
+        workflow.setId(1L);
+        workflow.setName("portable workflow");
+        workflow.setUid(UID);
+        workflow.setData(JSON.toJSONString(flowData));
+        return workflow;
+    }
+
+    private BizWorkflowData workflowData(BizWorkflowNode node) {
+        BizWorkflowData flowData = new BizWorkflowData();
+        flowData.setNodes(List.of(node));
+        flowData.setEdges(Collections.emptyList());
+        return flowData;
+    }
+
+    private BizWorkflowNode pluginNode(String pluginId, String operationId, String appId) {
+        JSONObject param = new JSONObject();
+        param.put("pluginId", pluginId);
+        param.put("operationId", operationId);
+        param.put("appId", appId);
+        param.put("uid", "source-user");
+        param.put("version", "V1.0");
+        param.put("toolDescription", "source description");
+        param.put("businessInput", List.of("old-business-input"));
+
+        BizInputOutput input = new BizInputOutput();
+        input.setId("input-ref-id");
+        input.setName("query");
+        BizInputOutput output = new BizInputOutput();
+        output.setId("output-ref-id");
+        output.setName("answer");
+
+        BizNodeData data = new BizNodeData();
+        data.setLabel("Plugin node");
+        data.setNodeParam(param);
+        data.setInputs(List.of(input));
+        data.setOutputs(List.of(output));
+
+        BizWorkflowNode node = new BizWorkflowNode();
+        node.setId("plugin::node-1");
+        node.setData(data);
+        return node;
+    }
+
+    private ToolBox tool(String toolId, String operationId, String appId, String userId, Long spaceId,
+            String webSchema) {
+        ToolBox tool = new ToolBox();
+        tool.setToolId(toolId);
+        tool.setName(PLUGIN_NAME);
+        tool.setOperationId(operationId);
+        tool.setAppId(appId);
+        tool.setUserId(userId);
+        tool.setSpaceId(spaceId);
+        tool.setVersion("V1.0");
+        tool.setMethod("POST");
+        tool.setWebSchema(webSchema);
+        tool.setDescription("target description");
+        tool.setDeleted(false);
+        tool.setStatus(1);
+        tool.setIsPublic(false);
+        return tool;
+    }
+
+    private void addPortableIdentity(BizWorkflowNode node, String name, String fingerprint) {
+        JSONObject portable = new JSONObject();
+        portable.put("name", name);
+        portable.put("schemaFingerprint", fingerprint);
+        portable.put("schemaFingerprintVersion", 1);
+        node.getData().setPluginName(name);
+        node.getData().getNodeParam().put("portablePlugin", portable);
+    }
+
+    private String fingerprintFor(String webSchema) {
+        BizWorkflowNode node = pluginNode("fingerprint-tool", "fingerprint-operation", "fingerprint-app");
+        Workflow workflow = workflow(workflowData(node));
+        ToolBox tool = tool("fingerprint-tool", "fingerprint-operation", "fingerprint-app", UID, null, webSchema);
+        when(toolBoxService.list(any(LambdaQueryWrapper.class))).thenReturn(List.of(tool));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        service.exportWorkflowDataAsYaml(workflow, output);
+        String fingerprint = readFlowData(output.toByteArray()).getNodes()
+                .get(0)
+                .getData()
+                .getNodeParam()
+                .getJSONObject("portablePlugin")
+                .getString("schemaFingerprint");
+        clearInvocations(dataPermissionCheckTool);
+        return fingerprint;
+    }
+
+    private String schema(String idPrefix, String description, boolean incompatible) {
+        String inputType = incompatible ? "integer" : "string";
+        return "{\"toolRequestInput\":["
+                + "{\"id\":\"" + idPrefix + "-2\",\"name\":\"limit\",\"description\":\"" + description
+                + "\",\"type\":\"integer\",\"location\":\"body\",\"required\":false,\"default\":10,"
+                + "\"open\":true,\"from\":2},"
+                + "{\"id\":\"" + idPrefix + "-1\",\"name\":\"query\",\"description\":\"" + description
+                + "\",\"type\":\"" + inputType
+                + "\",\"location\":\"body\",\"required\":true,\"default\":\"\",\"open\":true,\"from\":1}],"
+                + "\"toolRequestOutput\":[{\"id\":\"" + idPrefix
+                + "-3\",\"name\":\"answer\",\"description\":\"" + description
+                + "\",\"type\":\"string\",\"open\":true}]}";
+    }
+
+    private void assertPluginBindingCleared(BizWorkflowNode node) {
+        JSONObject param = node.getData().getNodeParam();
+        assertThat(param).doesNotContainKeys(
+                "pluginId", "operationId", "version", "appId", "uid", "toolDescription", "businessInput",
+                "portablePlugin");
+        assertThat(node.getData().getInputs()).isEmpty();
+        assertThat(node.getData().getOutputs()).isEmpty();
+    }
+
+    private BizWorkflowData readFlowData(byte[] yamlBytes) {
+        LoaderOptions options = new LoaderOptions();
+        Map<String, Object> root = new Yaml(new SafeConstructor(options))
+                .load(new ByteArrayInputStream(yamlBytes));
+        return JSON.parseObject(JSON.toJSONString(root.get("flowData")), BizWorkflowData.class);
+    }
+
+    private byte[] yamlFor(BizWorkflowData flowData) {
+        Map<String, Object> root = Map.of(
+                "flowMeta", Map.of("name", "imported workflow"),
+                "flowData", JSON.parseObject(JSON.toJSONString(flowData)));
+        return new Yaml().dump(root).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/console/frontend/src/components/make-creation/components/WorkflowImportModal.tsx
+++ b/console/frontend/src/components/make-creation/components/WorkflowImportModal.tsx
@@ -23,6 +23,15 @@ interface FileUploadEvent {
 // 定义workflowImport响应类型
 interface WorkflowImportResponse {
   flowId: string;
+  importReport?: {
+    mappedPluginCount: number;
+    unresolvedPlugins: Array<{
+      nodeId: string;
+      nodeLabel?: string;
+      pluginName?: string;
+      reason: string;
+    }>;
+  };
 }
 
 // 定义自定义上传文件类型，扩展UploadFile
@@ -112,6 +121,33 @@ function WorkflowImportModal({
     })
       .then((value: unknown) => {
         const res = value as WorkflowImportResponse;
+        const unresolvedPlugins = res.importReport?.unresolvedPlugins || [];
+        if (unresolvedPlugins.length > 0) {
+          const nodeNames = unresolvedPlugins
+            .slice(0, 5)
+            .map(item => item.nodeLabel || item.pluginName || item.nodeId)
+            .join(', ');
+          const remainingNodes = Math.max(unresolvedPlugins.length - 5, 0);
+          message.warning({
+            content: i18next.t(
+              'workflow.promptDebugger.importPluginMappingWarning',
+              {
+                count: unresolvedPlugins.length,
+                nodes: nodeNames,
+                remaining:
+                  remainingNodes > 0
+                    ? i18next.t(
+                        'workflow.promptDebugger.importPluginMappingMore',
+                        {
+                          count: remainingNodes,
+                        }
+                      )
+                    : '',
+              }
+            ),
+            duration: 8,
+          });
+        }
         setWorkflowImportModalVisible(false);
         navigate(`/work_flow/${res.flowId}/arrange`);
       })

--- a/console/frontend/src/locales/en-En/workflow.ts
+++ b/console/frontend/src/locales/en-En/workflow.ts
@@ -916,6 +916,9 @@ const translation = {
     pleaseUploadYmlYamlFormat: 'Please upload yml, yaml format files!',
     fileFormatYmlYaml:
       'File format is yml, yaml, file size does not exceed 20M',
+    importPluginMappingWarning:
+      'Workflow imported, but {{count}} plugin node(s) could not be matched safely. Please select them manually: {{nodes}}{{remaining}}',
+    importPluginMappingMore: ' and {{count}} more',
     // AddTool component translations
     updateConfig: 'Update Config',
     // FlowOperatorPanel component translations

--- a/console/frontend/src/locales/zh-ZH/workflow.ts
+++ b/console/frontend/src/locales/zh-ZH/workflow.ts
@@ -878,6 +878,9 @@ const translation = {
     uploadFileSizeExceeded: '上传文件大小不能超出20M！',
     pleaseUploadYmlYamlFormat: '请上传yml、yaml格式文件！',
     fileFormatYmlYaml: '文件格式为yml、yaml，文件大小不超过20M',
+    importPluginMappingWarning:
+      '工作流已导入，但有 {{count}} 个插件节点未能安全匹配，请手动选择：{{nodes}}{{remaining}}',
+    importPluginMappingMore: ' 等另外 {{count}} 个节点',
     // AddTool component translations
     updateConfig: '更新配置',
     // FlowOperatorPanel component translations


### PR DESCRIPTION
## Summary

This fixes the cross-environment workflow import problem described in #1603. A plugin's `toolId` is local to one deployment, so importing the YAML into another environment used to drop the binding even when an equivalent plugin was already available there.

The importer still prefers the original ID. If that ID is unavailable, it now remaps only when there is exactly one compatible plugin in the current personal or space scope. Ambiguous or incompatible matches stay unbound and are reported to the user instead of being guessed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

Closes #1603

## Changes

- add a versioned, portable plugin descriptor to exported workflow YAML (name plus a canonical schema fingerprint; no endpoint, credentials, or raw schema)
- preserve direct-ID compatibility, including existing draft plugins
- fall back only to a unique, formal, visible, same-version and schema-compatible plugin in the current personal/space scope
- replace the complete runtime identity together (`pluginId`, `operationId`, `appId`, version and derived inputs), or fail closed without leaving a partial binding
- return an import report while keeping the existing top-level `Workflow` response shape
- show unresolved plugin nodes after import so they can be selected manually
- validate space membership before importing into a requested space

## Testing

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing completed

Ran locally with Java 21 and Node.js 20:

- full console backend test suite: `mvn test`
- targeted workflow import suite: 18 tests, 0 failures
- backend CI gates: compile, Spotless, Checkstyle, SpotBugs and PMD
- frontend Prettier and ESLint checks
- frontend production build

The repository's full TypeScript check still reports pre-existing errors across unrelated files; the CI workflow treats that step as non-blocking, and none of the errors point to the files changed here.

## Screenshots (if applicable)

Not included. The UI change is an import warning that only appears when plugin remapping cannot be done safely.

## Checklist

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (not needed for this bug fix)
- [x] Breaking changes documented (none)

实现过程中使用了 OpenAI Codex（GPT-5）辅助分析调用链和补充测试。我逐项审阅了代码、权限边界和测试结果，并对这次提交负责。
