### PR TITLE
docs: add code of conduct contact

### DIFF
--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [ifly_opensource@iflytek.com](mailto:ifly_opensource@iflytek.com). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
## Summary

- replace the unresolved Code of Conduct contact placeholder
- provide the iFLYTEK open-source contact address as a clickable email link

## Why

The enforcement section currently leaves contributors without an actionable reporting channel because it still contains the Contributor Covenant template placeholder.

## Validation

- `git diff --check`
- confirmed the placeholder is removed
- confirmed the commit is based directly on the latest upstream `main`
- confirmed the commit has a matching DCO sign-off
