### PR TITLE
docs: add privacy and content safety policies

### DIFF
--- a/docs/CONTENT_SAFETY.md
+++ b/docs/CONTENT_SAFETY.md
@@ -108,6 +108,42 @@ days. The organization security policy has a separate 48-hour acknowledgment tar
 for vulnerability reports. Independent deployers must publish their own service
 level and emergency path.
 
+### Appeals for community harassment decisions
+
+For harassment or other Code of Conduct cases on Astron Agent's project-managed
+community surfaces, the reporter, the person accused, or another person materially
+affected by the outcome may request a review. Send the request to
+[ifly_opensource@iflytek.com](mailto:ifly_opensource@iflytek.com) with the subject
+`Astron Agent Code of Conduct appeal`. Include the original case reference, the
+outcome being challenged, and at least one reason for review, such as a material
+procedural error, a relevant conflict of interest, significant new evidence, or
+a remedy that appears clearly disproportionate.
+
+Appeals are handled as follows:
+
+1. Receipt should be acknowledged within a few business days. If more time is
+   needed, the appellant should receive periodic status updates where practical.
+2. A person who did not make the original decision and has no conflict of interest
+   will review the request. The reviewer may seek an additional impartial reviewer
+   or qualified external advice when the case requires it.
+3. Review is limited to the stated grounds and relevant evidence. It is not a new
+   investigation unless fairness or significant new information requires one.
+4. Temporary protective measures may remain in place during review when needed to
+   protect people or evidence. They may be modified if they become unnecessary or
+   disproportionate.
+5. The reviewer may uphold, modify, or reverse the original decision, or return
+   the matter for a new investigation. The appellant and other affected parties
+   will receive a written outcome and a concise explanation to the extent privacy,
+   safety, and law permit.
+
+Appeal information is shared only with people who need it to conduct the review,
+protect participants, or comply with law. Reviewers must protect reporter and
+witness identities, avoid unnecessary disclosure of personal data, and follow the
+confidentiality and conflict-of-interest rules in the linked incident resolution
+procedures. Retaliation for making or participating in a good-faith appeal is
+prohibited. This process does not restrict any rights or remedies available under
+applicable law.
+
 ## Review, action, notice, and appeal
 
 A deployer's documented moderation process should:

--- a/docs/CONTENT_SAFETY.md
+++ b/docs/CONTENT_SAFETY.md
@@ -55,9 +55,9 @@ Important limitations are public and intentional:
 
 The relevant settings are documented in the workflow configuration templates, and
 the implementation is available in the
-[workflow audit system](../core/workflow/infra/audit_system/). Operators may add
-compatible layers at the model gateway, workflow, plugin, or application boundary,
-but should test their behavior before relying on them.
+[workflow audit system](https://github.com/iflytek/astron-agent/tree/main/core/workflow/infra/audit_system).
+Operators may add compatible layers at the model gateway, workflow, plugin, or
+application boundary, but should test their behavior before relying on them.
 
 ## Deployment safeguards
 
@@ -87,14 +87,14 @@ Turning on the optional audit service is one control, not a complete safety prog
 Reports about content in an independently operated Astron Agent application must
 go to that application's operator. The operator should publish a contact method
 near the user experience and ask reporters for the content or workflow identifier,
-time, reason for concern, and enough context to investigate. Reporters should not
-resend
-sensitive content unless it is necessary and the channel is protected.
+time, reason for concern, and enough context to investigate. Reporters should avoid
+resending sensitive content unless it is necessary and the channel is protected.
 
 For content on Astron Agent's project-managed community surfaces, report abusive
 or harassing conduct to
 [ifly_opensource@iflytek.com](mailto:ifly_opensource@iflytek.com) under the
-[Code of Conduct](../.github/code_of_conduct.md). Report security vulnerabilities
+[Code of Conduct](https://github.com/iflytek/astron-agent/blob/main/.github/code_of_conduct.md).
+Report security vulnerabilities
 privately to [security@iflytek.com](mailto:security@iflytek.com) under the public
 [iFLYTEK organization security policy](https://github.com/iflytek/.github/blob/main/SECURITY.md)
 and its detailed [community security policy](https://github.com/iflytek/community/blob/master/SECURITY.md).
@@ -138,8 +138,9 @@ contact and high-risk tools, provide child-accessible notices and reporting, and
 route serious concerns to trained personnel and the appropriate authorities.
 
 If those protections cannot be provided, the workflow should not be offered to
-children. The project [Code of Conduct](../.github/code_of_conduct.md) separately
-protects community participation from harassment regardless of age.
+children. The project
+[Code of Conduct](https://github.com/iflytek/astron-agent/blob/main/.github/code_of_conduct.md)
+separately protects community participation from harassment regardless of age.
 
 ## Privacy, transparency, and review
 

--- a/docs/CONTENT_SAFETY.md
+++ b/docs/CONTENT_SAFETY.md
@@ -101,10 +101,12 @@ and its detailed [community security policy](https://github.com/iflytek/communit
 Do not disclose vulnerabilities or personal data in a public issue.
 
 The project does not yet have enough comparable content reports to publish a
-meaningful historical average response time. Its target is to acknowledge reports
-about project-managed surfaces within three business days. The organization security
-policy has a separate 48-hour acknowledgment target for vulnerability reports.
-Independent deployers must publish their own service level and emergency path.
+meaningful historical average response time. The iFLYTEK community's
+[incident resolution procedures](https://github.com/iflytek/community/blob/master/code-of-conduct/coc-incident-resolution-procedures.md)
+state that Code of Conduct reports are usually acknowledged within a few business
+days. The organization security policy has a separate 48-hour acknowledgment target
+for vulnerability reports. Independent deployers must publish their own service
+level and emergency path.
 
 ## Review, action, notice, and appeal
 

--- a/docs/CONTENT_SAFETY.md
+++ b/docs/CONTENT_SAFETY.md
@@ -1,0 +1,151 @@
+# Content Safety Policy
+
+Last updated: August 13, 2026
+
+## Purpose and scope
+
+Astron Agent can accept user input, retrieve third-party material, invoke models
+and tools, and return generated content. Such content can be inaccurate, misleading,
+inappropriate, harmful, or illegal. This document describes the project's safety
+expectations, the optional controls in the software, and the responsibilities of
+people who deploy workflows.
+
+The Astron Agent maintainers do not operate or moderate every independently hosted
+deployment. Each deployer must assess its users, jurisdiction, domain, models, data,
+and tools; define enforceable rules; provide an end-user reporting channel; and
+staff its own review and appeal process. High-impact uses require safeguards beyond
+the general controls described here.
+
+## Baseline rules
+
+Deployments should not knowingly enable or distribute content or actions that:
+
+- violate applicable law or another person's rights;
+- sexually exploit or endanger children;
+- credibly threaten, harass, or promote violence or hateful abuse against people;
+- expose personal, confidential, or authentication data without authorization;
+- facilitate fraud, impersonation, malware, unauthorized access, or evasion of
+  security controls;
+- present fabricated or unverified claims as established fact where people could
+  suffer material harm; or
+- bypass the deployer's stated safety rules through a model, plugin, tool, or
+  retrieved document.
+
+Context matters. Legitimate security research, education, documentation, and
+reporting may discuss risky subjects without promoting harm. Human reviewers should
+consider purpose, audience, likely impact, and applicable law rather than relying
+on keywords alone.
+
+## Available technical controls
+
+Astron Agent contains an optional text-audit pipeline for workflow input and output.
+When configured, it can submit text to an iFLYTEK audit service and stop processing
+when that service returns a non-allow action. The implementation supports auditing
+user input and streamed text output.
+
+Important limitations are public and intentional:
+
+- content auditing is disabled by default (`AUDIT_ENABLE=0`);
+- enabling it requires the operator to configure the audit service and credentials;
+- text sent for auditing is disclosed to the configured audit service and must be
+  covered by the deployment's privacy notice and data-flow review;
+- media input and output audit methods are not currently implemented; and
+- no automated classifier can guarantee that all harmful content is detected or
+  that all flagged content is harmful.
+
+The relevant settings are documented in the workflow configuration templates, and
+the implementation is available in the
+[workflow audit system](../core/workflow/infra/audit_system/). Operators may add
+compatible layers at the model gateway, workflow, plugin, or application boundary,
+but should test their behavior before relying on them.
+
+## Deployment safeguards
+
+Before making a workflow available, its operator should:
+
+- document intended and prohibited uses, expected users, foreseeable misuse, and
+  escalation owners;
+- evaluate models, system prompts, tools, plugins, and knowledge sources for the
+  deployment's risk level;
+- apply least-privilege credentials and require human approval before consequential
+  external actions;
+- separate untrusted content from instructions and test prompt-injection and data
+  exfiltration scenarios;
+- disclose that output is AI-generated and may be wrong, and provide sources where
+  practical;
+- add domain-specific validation and qualified human review for decisions affecting
+  health, safety, rights, employment, education, finance, or access to essential
+  services;
+- monitor representative failures and abuse patterns without collecting unnecessary
+  personal data; and
+- provide a visible way to report content and challenge consequential outcomes.
+
+Turning on the optional audit service is one control, not a complete safety program.
+
+## Reporting and moderation process
+
+Reports about content in an independently operated Astron Agent application must
+go to that application's operator. The operator should publish a contact method
+near the user experience and ask reporters for the content or workflow identifier,
+time, reason for concern, and enough context to investigate. Reporters should not
+resend
+sensitive content unless it is necessary and the channel is protected.
+
+For content on Astron Agent's project-managed community surfaces, report abusive
+or harassing conduct to
+[ifly_opensource@iflytek.com](mailto:ifly_opensource@iflytek.com) under the
+[Code of Conduct](../.github/code_of_conduct.md). Report security vulnerabilities
+privately to [security@iflytek.com](mailto:security@iflytek.com) under the public
+[iFLYTEK organization security policy](https://github.com/iflytek/.github/blob/main/SECURITY.md)
+and its detailed [community security policy](https://github.com/iflytek/community/blob/master/SECURITY.md).
+Do not disclose vulnerabilities or personal data in a public issue.
+
+The project does not yet have enough comparable content reports to publish a
+meaningful historical average response time. Its target is to acknowledge reports
+about project-managed surfaces within three business days. The organization security
+policy has a separate 48-hour acknowledgment target for vulnerability reports.
+Independent deployers must publish their own service level and emergency path.
+
+## Review, action, notice, and appeal
+
+A deployer's documented moderation process should:
+
+1. triage imminent danger, child-safety concerns, and credible security incidents
+   for urgent specialist handling;
+2. preserve only the evidence needed for a proportionate review;
+3. assess the content, context, applicable rule, law, and possible user impact;
+4. take a proportionate action, such as warning the user, withholding content,
+   disabling a workflow or integration, restricting an account, or escalating to
+   an authorized specialist;
+5. record the rule and rationale, notify affected users when lawful and safe, and
+   provide an appeal route; and
+6. remove temporary evidence according to the deployment's retention schedule and
+   use confirmed incidents to improve safeguards.
+
+Automated decisions should be reversible where practical. Appeals should be reviewed
+by a person who was not solely responsible for the initial decision, especially
+when the outcome materially affects an individual.
+
+## Children and young people
+
+Astron Agent is a general-purpose development platform, not a child-directed service.
+A deployer that permits use by children or processes their data must perform an
+age-appropriate risk assessment, use any legally required parental or guardian
+consent, minimize collection and profiling, avoid manipulative design, restrict
+contact and high-risk tools, provide child-accessible notices and reporting, and
+route serious concerns to trained personnel and the appropriate authorities.
+
+If those protections cannot be provided, the workflow should not be offered to
+children. The project [Code of Conduct](../.github/code_of_conduct.md) separately
+protects community participation from harassment regardless of age.
+
+## Privacy, transparency, and review
+
+Content review itself can expose sensitive information. Reports, audit-service
+requests, logs, reviewer access, and retained evidence must follow the
+[Privacy and Data Governance](PRIVACY_AND_DATA_GOVERNANCE.md) document and the
+deployment's own privacy notice.
+
+Operators should disclose which safeguards are active, their important limitations,
+and any material external recipients. Material changes to this document are made
+through the repository's public review process, and the file history records them.

--- a/docs/PRIVACY_AND_DATA_GOVERNANCE.md
+++ b/docs/PRIVACY_AND_DATA_GOVERNANCE.md
@@ -1,0 +1,159 @@
+# Privacy and Data Governance Policy
+
+Last updated: August 13, 2026
+
+## Purpose and scope
+
+Astron Agent is open-source software for building and operating agentic workflows.
+This document explains the project's privacy and data-governance expectations and
+the controls available to people who deploy Astron Agent.
+
+The Astron Agent maintainers publish source code and project infrastructure; they
+do not operate every deployment made from that source code. The organization that
+deploys Astron Agent determines why and how personal data is processed in that
+deployment and is responsible for publishing a deployment-specific privacy notice,
+selecting lawful processing grounds, handling data-subject requests, and complying
+with the laws that apply to it. This document is not a substitute for that notice
+and does not claim that every deployment is automatically compliant with any law.
+
+## Applicable law
+
+Privacy and data-protection requirements depend on where a deployment operates,
+where its users and infrastructure are located, the people it serves, and the data
+and decisions in its workflows. Before processing personal data, each deployer must
+identify and document the domestic and international laws that apply to it, complete
+any required impact or transfer assessments, and reflect those obligations in its
+privacy notice, contracts, operating procedures, and technical configuration.
+
+If legal obligations conflict with a proposed workflow, the deployer should not
+run that workflow until it has a lawful design. Project documentation and
+configurable controls provide implementation support, not legal advice or a
+compliance certification.
+
+## Data the software can process
+
+The exact data depends on the workflows, models, plugins, authentication provider,
+and storage services selected by the deployer. A deployment can process:
+
+- account and authentication data supplied through the configured identity provider;
+- tenant, organization, space, role, and resource-membership identifiers;
+- prompts, model responses, conversation history, workflow state, and memory;
+- documents, metadata, extracted text, embeddings, and retrieval results used by
+  knowledge bases;
+- workflow definitions, agent configuration, plugin and tool inputs and outputs;
+- credentials and connection details for models, plugins, tools, and infrastructure;
+- operational records such as request identifiers, timestamps, errors, traces,
+  metrics, and logs; and
+- content sent to configured external model, tool, knowledge, or content-audit
+  services.
+
+Prompts, uploaded documents, and tool results may contain personal or sensitive
+data even when the platform does not require it. Deployers should classify these
+fields according to their actual use rather than relying only on field names.
+
+## Purposes and data minimization
+
+Data should be collected only when needed to authenticate users, isolate tenant
+resources, execute and improve the requested workflows, provide configured memory
+or knowledge retrieval, secure and troubleshoot the deployment, and meet applicable
+legal obligations.
+
+Deployers and workflow authors should:
+
+- use stable, pseudonymous identifiers where possible;
+- not place secrets or sensitive personal data in `uid`, `chat_id`, names, or other
+  fields that do not require it;
+- request only the input required for a workflow's stated purpose;
+- redact or tokenize personal data before sending it to a model or plugin when the
+  full value is unnecessary;
+- avoid collecting special-category or highly sensitive data unless the use case,
+  legal basis, safeguards, and deletion process have been reviewed; and
+- document the source, purpose, recipients, retention period, and lawful basis for
+  each material category of personal data.
+
+The [integration guide](guide/integration.md#production-checklist) also warns against
+putting secrets or sensitive personal data in identifiers.
+
+## Storage, access, and tenant boundaries
+
+Astron Agent supports authenticated deployments, application credentials, tenants,
+spaces, and permission checks. Its deployment architecture can use databases,
+object storage, caches, queues, search services, and observability systems. See
+the [deployment guide with authentication](DEPLOYMENT_GUIDE_WITH_AUTH.md) and the
+[configuration guide](CONFIGURATION.md).
+
+These capabilities do not replace secure deployment. Operators are responsible for:
+
+- enabling authentication and applying least-privilege roles to users and services;
+- changing example and default credentials before exposing a deployment;
+- keeping tenant resources and service accounts separated;
+- using HTTPS for external traffic and protected networks for internal services;
+- encrypting sensitive data and backups according to their threat model and legal
+  requirements;
+- storing secrets in an appropriate secrets manager instead of source code, logs,
+  workflow definitions, or client-side configuration;
+- limiting and reviewing access to databases, object storage, logs, traces, and
+  backups; and
+- testing authorization and tenant isolation for their configuration and extensions.
+
+## External services and international transfers
+
+Models, plugins, tools, knowledge services, identity providers, observability
+services, and optional content-audit services can receive data from a workflow.
+Before enabling one, the deployer should review its privacy terms, security
+practices, retention, training-data rules, hosting locations, subprocessors, and
+cross-border transfer mechanism. Workflow authors should make these recipients
+visible to the deployer and, where required, to end users.
+
+Astron Agent does not make an external service private merely by integrating it.
+Deployers should disable unused integrations and avoid sending a provider more data
+than it needs.
+
+## Retention, deletion, and portability
+
+The open-source project does not impose one retention period on independently
+operated deployments. Each deployer must define periods that are no longer than
+necessary for its stated purposes and legal duties.
+
+A deletion process should cover primary databases, conversation and memory stores,
+uploaded files, indexes and embeddings, caches, queues, logs, traces, exports, and
+backups. Where immediate backup deletion is impractical, deleted data should be
+isolated from normal use and expire under a documented backup schedule. Operators
+should also account for copies already sent to external services.
+
+Deployers should provide authenticated channels for access, correction, deletion,
+restriction, objection, and portability requests where applicable. Requests should
+be verified, recorded, completed within the legally required time, and denied only
+on a documented legal basis.
+
+## Security and incident handling
+
+Astron Agent follows the public [iFLYTEK organization security policy](https://github.com/iflytek/.github/blob/main/SECURITY.md),
+which points to the detailed [iFLYTEK community security policy](https://github.com/iflytek/community/blob/master/SECURITY.md).
+Security vulnerabilities must be reported privately to
+[security@iflytek.com](mailto:security@iflytek.com), not in a public issue. The
+organization policy describes the information to include, a 48-hour acknowledgment
+target, coordinated remediation and disclosure, and the supported-version policy.
+
+Operators remain responsible for monitoring their own deployments, maintaining an
+incident-response plan, preserving appropriate evidence, notifying affected parties
+and authorities when required, and applying security updates. Only the latest Astron
+Agent release should be expected to receive upstream security fixes.
+
+## Project and deployment privacy contacts
+
+- Report a vulnerability privately to
+  [security@iflytek.com](mailto:security@iflytek.com).
+- Send questions about this project document to
+  [ifly_opensource@iflytek.com](mailto:ifly_opensource@iflytek.com). Do not include
+  personal data or confidential incident details in a public GitHub issue.
+- Contact the operator named in a deployment's own privacy notice for data-subject
+  requests or incidents involving that deployment. Astron Agent maintainers cannot
+  access or delete data held by an independently operated instance.
+
+## Governance and changes
+
+Privacy-impacting changes should be reviewed for data minimization, permission and
+tenant boundaries, external disclosures, retention, logging, and deletion behavior.
+Material changes to this document are made through the repository's public review
+process. The file history records those changes.


### PR DESCRIPTION
## Summary

- add a public privacy and data governance policy for self-hosted Astron Agent deployments
- add a content safety policy covering optional audit controls, reporting, moderation, appeals, and child safety
- link the iFLYTEK organization and community security policies and the Astron Agent Code of Conduct

## Why

Astron Agent did not have project-level public documentation that described privacy responsibilities, data handling expectations, or content governance. These documents make the boundary between the open-source maintainers and independent deployers explicit and provide reviewable evidence for governance assessments.

## Important implementation boundaries

- content auditing is optional and disabled by default
- the current audit implementation covers text; media audit methods are not implemented
- deployment operators remain responsible for their own legal basis, privacy notice, retention, reporting channel, and moderation operations

## Validation

- `npx --yes markdownlint-cli2 docs/PRIVACY_AND_DATA_GOVERNANCE.md docs/CONTENT_SAFETY.md`
- `git diff --check upstream/main...HEAD`
- verified all repository-relative links in the two new documents resolve locally
- attempted `npm run docs:build`; VitePress reached repository content parsing but the existing `docs/ja/README.md` references missing `./imgs/WeCom_Group.png`, unrelated to this change
