### PR TITLE
docs: update NOTICE project name

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,8 @@
-OpenStellar
+Astron Agent
 Copyright 2025 iFlytek Co., Ltd.
 
 This product includes software developed at
-iFlytek Co., Ltd. (https://github.com/iflytek/openstellar).
+iFlytek Co., Ltd. (https://github.com/iflytek/astron-agent).
 
 This software contains code derived from other open source projects.
 See individual source files for more details.


### PR DESCRIPTION
## Summary

- rename the project from OpenStellar to Astron Agent in `NOTICE`
- update the repository URL to `https://github.com/iflytek/astron-agent`

## Why

The NOTICE file still referenced the project's former name and repository after the rename. This update keeps the distributed legal notice aligned with the current project identity.

## Impact

Documentation and attribution metadata only; there is no runtime behavior change.

## Validation

- `git diff --check`
- verified the PR range contains only `NOTICE`