### PR TITLE
style(workflow): align import helper formatting

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowExportService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowExportService.java
@@ -1446,7 +1446,8 @@ public class WorkflowExportService {
 
     private List<Map<String, Object>> resolveDependencyManifest(
             Map<String, ManifestToolReference> references) {
-        Set<String> toolIds = references.values().stream()
+        Set<String> toolIds = references.values()
+                .stream()
                 .map(ManifestToolReference::toolId)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         List<ToolBox> versions = toolBoxService.list(new LambdaQueryWrapper<ToolBox>()


### PR DESCRIPTION
## Summary
- apply the exact Spotless line wrapping required for the workflow import helper

## Validation
- remote rerun: TypeScript, Go, and Python checks passed
- Java compiled successfully and reported only this Spotless violation
- full remote validation will restart after merge

Issue: #1603