### PR TITLE
feat(workflow): expose RAGFlow reranker in knowledge nodes

### DIFF
--- a/console/frontend/_tests_/knowledge-parameter.test.js
+++ b/console/frontend/_tests_/knowledge-parameter.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyRerankId,
+  clearRerankIdForNonRagflow,
+} from '../src/components/workflow/modal/knowledge-rerank.js';
+
+test('applyRerankId trims and stores a configured model ID', () => {
+  const nodeParam = {};
+
+  applyRerankId(nodeParam, 'Ragflow-RAG', '  bge-reranker-v2-m3  ');
+
+  assert.equal(nodeParam.rerankId, 'bge-reranker-v2-m3');
+});
+
+test('applyRerankId removes an empty model ID from the workflow DSL', () => {
+  const nodeParam = {
+    rerankId: 'old-reranker',
+  };
+
+  applyRerankId(nodeParam, 'Ragflow-RAG', '   ');
+
+  assert.equal('rerankId' in nodeParam, false);
+});
+
+test('applyRerankId removes stale configuration for another RAG strategy', () => {
+  const nodeParam = {
+    rerankId: 'old-reranker',
+  };
+
+  applyRerankId(nodeParam, 'CBG-RAG', 'old-reranker');
+
+  assert.equal('rerankId' in nodeParam, false);
+});
+
+test('RAGFlow knowledge changes preserve the configured rerank model', () => {
+  const nodeParam = {
+    rerankId: 'bge-reranker-v2-m3',
+  };
+
+  clearRerankIdForNonRagflow(nodeParam, 'Ragflow-RAG');
+
+  assert.equal(nodeParam.rerankId, 'bge-reranker-v2-m3');
+});

--- a/console/frontend/src/components/workflow/modal/add-knowledge/index.tsx
+++ b/console/frontend/src/components/workflow/modal/add-knowledge/index.tsx
@@ -18,6 +18,7 @@ import {
   useAddKnowledgeProps,
 } from '@/components/workflow/types';
 import { Icons } from '@/components/workflow/icons';
+import { clearRerankIdForNonRagflow } from '../knowledge-rerank';
 
 const useAddKnowledge = (): useAddKnowledgeProps => {
   const { t } = useTranslation();
@@ -130,6 +131,7 @@ const useAddKnowledge = (): useAddKnowledgeProps => {
             old.data.nodeParam.repoList.splice(findKnowledgeIndex, 1);
           }
           old.data.nodeParam.ragType = knowledge?.tag;
+          clearRerankIdForNonRagflow(old.data.nodeParam, knowledge?.tag);
           old.data.outputs = generateKnowledgeOutput(knowledge?.tag);
           return {
             ...cloneDeep(old),

--- a/console/frontend/src/components/workflow/modal/knowledge-detail/index.tsx
+++ b/console/frontend/src/components/workflow/modal/knowledge-detail/index.tsx
@@ -51,6 +51,7 @@ import {
 import { Icons } from '@/components/workflow/icons';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { getFixedUrl, getAuthorization } from '@/components/workflow/utils';
+import { clearRerankIdForNonRagflow } from '../knowledge-rerank';
 
 function KnowledgePreviewModal(): React.ReactElement {
   const knowledgeDetailModalOpen = useFlowsManager(
@@ -185,6 +186,10 @@ const KnowledgeToolbar = ({
           old.data.nodeParam.repoList.splice(findKnowledgeIndex, 1);
         }
         old.data.nodeParam.ragType = knowledge?.tag;
+        clearRerankIdForNonRagflow(
+          old.data.nodeParam,
+          (knowledge as { tag?: string }).tag
+        );
         old.data.outputs = generateKnowledgeOutput(knowledge?.tag);
         return {
           ...cloneDeep(old),

--- a/console/frontend/src/components/workflow/modal/knowledge-parameter/index.tsx
+++ b/console/frontend/src/components/workflow/modal/knowledge-parameter/index.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Slider, InputNumber, Button } from 'antd';
+import type { Node } from 'reactflow';
+import { Slider, InputNumber, Input, Button } from 'antd';
 import { useTranslation } from 'react-i18next';
 import useFlowsManager from '@/components/workflow/store/use-flows-manager';
 import { useMemoizedFn } from 'ahooks';
 import { cloneDeep } from 'lodash';
 import { RepoConfig } from '@/components/workflow/types';
+import { applyRerankId, RAGFLOW_RAG_TYPE } from '../knowledge-rerank';
 
 const KnowledgeParameter = (): React.ReactElement => {
   const { t } = useTranslation();
@@ -31,12 +33,14 @@ const KnowledgeParameter = (): React.ReactElement => {
     setRepoConfig({
       topN: currentNode?.data.nodeParam.topN,
       score: currentNode?.data.nodeParam.score,
+      rerankId: currentNode?.data.nodeParam.rerankId,
     });
   }, [currentNode]);
 
-  const handleParameterChange = useMemoizedFn((fn: (old: unknown) => void) => {
+  const handleParameterChange = useMemoizedFn((fn: (old: Node) => void) => {
+    if (!currentNode) return;
     autoSaveCurrentFlow();
-    setNode(currentNode?.id, old => {
+    setNode(currentNode.id, old => {
       fn(old);
       return {
         ...cloneDeep(old),
@@ -49,12 +53,19 @@ const KnowledgeParameter = (): React.ReactElement => {
     handleParameterChange(old => {
       old.data.nodeParam.topN = repoConfig?.topN;
       old.data.nodeParam.score = repoConfig?.score || 0.2;
+      applyRerankId(
+        old.data.nodeParam,
+        currentNode.data.nodeParam.ragType,
+        repoConfig?.rerankId
+      );
     });
     setKnowledgeParameterModalInfo({
       open: false,
       nodeId: '',
     });
   });
+
+  const isRagflow = currentNode?.data.nodeParam.ragType === RAGFLOW_RAG_TYPE;
 
   return (
     <>
@@ -126,7 +137,7 @@ const KnowledgeParameter = (): React.ReactElement => {
                     onChange={(value: unknown) => {
                       setRepoConfig({
                         ...repoConfig,
-                        score: value,
+                        score: typeof value === 'number' ? value : undefined,
                       });
                     }}
                     precision={2}
@@ -135,6 +146,33 @@ const KnowledgeParameter = (): React.ReactElement => {
                     controls={false}
                   />
                 </div>
+                {isRagflow ? (
+                  <>
+                    <p className="text-second font-medium mt-2.5">
+                      {t('workflow.nodes.parameterModal.rerankModelId')}
+                    </p>
+                    <p className="text-desc mt-1.5">
+                      {t(
+                        'workflow.nodes.parameterModal.rerankModelIdDescription'
+                      )}
+                    </p>
+                    <Input
+                      className="global-input mt-3"
+                      value={repoConfig.rerankId}
+                      placeholder={t(
+                        'workflow.nodes.parameterModal.rerankModelIdPlaceholder'
+                      )}
+                      maxLength={512}
+                      allowClear
+                      onChange={event =>
+                        setRepoConfig({
+                          ...repoConfig,
+                          rerankId: event.target.value,
+                        })
+                      }
+                    />
+                  </>
+                ) : null}
                 <div className="flex flex-row-reverse gap-3 mt-7">
                   <Button
                     type="primary"

--- a/console/frontend/src/components/workflow/modal/knowledge-rerank.ts
+++ b/console/frontend/src/components/workflow/modal/knowledge-rerank.ts
@@ -1,0 +1,26 @@
+export const RAGFLOW_RAG_TYPE = 'Ragflow-RAG';
+
+export const clearRerankIdForNonRagflow = (
+  nodeParam: Record<string, unknown>,
+  ragType: unknown
+): void => {
+  if (ragType !== RAGFLOW_RAG_TYPE) {
+    delete nodeParam.rerankId;
+  }
+};
+
+export const applyRerankId = (
+  nodeParam: Record<string, unknown>,
+  ragType: unknown,
+  rerankId?: string
+): void => {
+  clearRerankIdForNonRagflow(nodeParam, ragType);
+  if (ragType !== RAGFLOW_RAG_TYPE) return;
+
+  const normalizedRerankId = rerankId?.trim();
+  if (normalizedRerankId) {
+    nodeParam.rerankId = normalizedRerankId;
+    return;
+  }
+  delete nodeParam.rerankId;
+};

--- a/console/frontend/src/components/workflow/types/modal/knowledge-parameter.ts
+++ b/console/frontend/src/components/workflow/types/modal/knowledge-parameter.ts
@@ -3,4 +3,5 @@
 export interface RepoConfig {
   topN?: number;
   score?: number;
+  rerankId?: string;
 }

--- a/console/frontend/src/locales/en-En/workflow.ts
+++ b/console/frontend/src/locales/en-En/workflow.ts
@@ -681,6 +681,10 @@ const translation = {
       scoreThreshold: 'Score Threshold',
       scoreThresholdDescription:
         'Used to set the similarity threshold for text fragment filtering.',
+      rerankModelId: 'Rerank model ID',
+      rerankModelIdDescription:
+        'Optional. Enter a rerank model ID configured in RAGFlow. Leave it empty to keep the current retrieval behavior.',
+      rerankModelIdPlaceholder: 'Enter a rerank model ID',
     },
     relatedKnowledgeModal: {
       title: 'Select Knowledge Base',

--- a/console/frontend/src/locales/zh-ZH/workflow.ts
+++ b/console/frontend/src/locales/zh-ZH/workflow.ts
@@ -654,6 +654,10 @@ const translation = {
         '用于筛选与 用户问题相似度最高的文本片段。系统同时会根据选用模型上下文窗口大小动态调整分段数量。',
       scoreThreshold: 'Score 阈值',
       scoreThresholdDescription: '用于设置文本片段筛选的相似度阈值。',
+      rerankModelId: 'Rerank 模型 ID',
+      rerankModelIdDescription:
+        '可选。填写 RAGFlow 中已配置的 Rerank 模型 ID；留空时保持当前检索行为。',
+      rerankModelIdPlaceholder: '请输入 Rerank 模型 ID',
     },
     relatedKnowledgeModal: {
       title: '选择知识库',

--- a/core/workflow/engine/nodes/knowledge/knowledge_client.py
+++ b/core/workflow/engine/nodes/knowledge/knowledge_client.py
@@ -31,6 +31,7 @@ class KnowledgeConfig:
         dataset_ids: list[str] = [],
         threshold: float = 0.1,
         history: list[HistoryItem] = [],
+        rerank_id: str = "",
     ):
         """
         Initialize knowledge configuration parameters.
@@ -43,6 +44,7 @@ class KnowledgeConfig:
         :param flow_id: Optional flow ID for context
         :param doc_ids: Optional list of specific document IDs to search
         :param threshold: Minimum similarity threshold for results (default: 0.1)
+        :param rerank_id: Optional RAGFlow rerank model identifier
         """
         self.top_n = top_n
         self.rag_type = rag_type
@@ -54,6 +56,7 @@ class KnowledgeConfig:
         self.dataset_ids = dataset_ids
         self.threshold = threshold
         self.history = history
+        self.rerank_id = rerank_id
 
 
 class KnowledgeClient:
@@ -151,18 +154,18 @@ class KnowledgeClient:
         if self.config.rag_type == "Ragflow-RAG" and self.config.dataset_ids:
             match["datasetId"] = self.config.dataset_ids
 
-        _payload = json.dumps(
-            {
-                "query": self.config.query,
-                "topN": self.config.top_n,
-                "ragType": self.config.rag_type,
-                "match": match,
-                "history": [item.dict() for item in self.config.history],
-            },
-            ensure_ascii=True,
-        )
+        payload = {
+            "query": self.config.query,
+            "topN": self.config.top_n,
+            "ragType": self.config.rag_type,
+            "match": match,
+            "history": [item.dict() for item in self.config.history],
+        }
+        rerank_id = self.config.rerank_id.strip()
+        if self.config.rag_type == "Ragflow-RAG" and rerank_id:
+            payload["ragflow_ext"] = {"rerank_id": rerank_id}
 
-        return _payload
+        return json.dumps(payload, ensure_ascii=True)
 
     def headers(self) -> dict[str, str]:
         return {

--- a/core/workflow/engine/nodes/knowledge/knowledge_node.py
+++ b/core/workflow/engine/nodes/knowledge/knowledge_node.py
@@ -84,6 +84,7 @@ class KnowledgeNode(BaseLLMNode):
         default_factory=list
     )  # Optional list of specific document IDs to search
     datasetIds: list[str] = Field(default_factory=list)
+    rerankId: str = Field(default="", max_length=512)
     score: float = Field(default=0.1)  # Minimum similarity threshold for results
     enableChatHistoryV2: EnableChatHistoryV2 = Field(
         default_factory=EnableChatHistoryV2
@@ -328,6 +329,7 @@ class KnowledgeNode(BaseLLMNode):
                 dataset_ids=repo_and_doc_ids.dataset_ids,
                 threshold=self.score,
                 history=history,
+                rerank_id=self.rerankId,
             )
             # Perform knowledge base search
             search_result = await KnowledgeClient(config=knowledge_config).top_k(

--- a/core/workflow/tests/engine/nodes/knowledge/test_knowledge_client.py
+++ b/core/workflow/tests/engine/nodes/knowledge/test_knowledge_client.py
@@ -22,6 +22,66 @@ def test_payload_includes_dataset_ids_for_ragflow() -> None:
     assert payload["match"]["datasetId"] == ["dataset-1"]
 
 
+def test_payload_includes_trimmed_rerank_id_for_ragflow() -> None:
+    config = KnowledgeConfig(
+        top_n="3",
+        rag_type="Ragflow-RAG",
+        repo_id=["repo-1"],
+        dataset_ids=["dataset-1"],
+        url="http://knowledge/knowledge/v1/chunk/query",
+        query="hello",
+        rerank_id="  bge-reranker-v2-m3  ",
+    )
+
+    payload = json.loads(KnowledgeClient(config=config).payload())
+
+    assert payload["ragflow_ext"] == {"rerank_id": "bge-reranker-v2-m3"}
+
+
+def test_payload_omits_ragflow_ext_when_rerank_id_is_blank() -> None:
+    config = KnowledgeConfig(
+        top_n="3",
+        rag_type="Ragflow-RAG",
+        repo_id=["repo-1"],
+        dataset_ids=["dataset-1"],
+        url="http://knowledge/knowledge/v1/chunk/query",
+        query="hello",
+        rerank_id="   ",
+    )
+
+    payload = json.loads(KnowledgeClient(config=config).payload())
+
+    assert payload == {
+        "query": "hello",
+        "topN": "3",
+        "ragType": "Ragflow-RAG",
+        "match": {
+            "repoId": ["repo-1"],
+            "docIds": [],
+            "flowId": "",
+            "threshold": 0.1,
+            "datasetId": ["dataset-1"],
+        },
+        "history": [],
+    }
+
+
+def test_payload_ignores_rerank_id_for_non_ragflow_strategy() -> None:
+    config = KnowledgeConfig(
+        top_n="3",
+        rag_type="AIUI-RAG2",
+        repo_id=["repo-1"],
+        url="http://knowledge/knowledge/v1/chunk/query",
+        query="hello",
+        rerank_id="bge-reranker-v2-m3",
+    )
+
+    payload = json.loads(KnowledgeClient(config=config).payload())
+
+    assert "ragflow_ext" not in payload
+    assert "datasetId" not in payload["match"]
+
+
 def test_headers_include_page_managed_ragflow_config() -> None:
     config = KnowledgeConfig(
         top_n="3",

--- a/core/workflow/tests/engine/nodes/knowledge/test_knowledge_node.py
+++ b/core/workflow/tests/engine/nodes/knowledge/test_knowledge_node.py
@@ -1,0 +1,110 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from workflow.engine.entities.variable_pool import ParamKey, VariablePool
+from workflow.engine.entities.workflow_dsl import WorkflowDSL
+from workflow.engine.node import NodeFactory
+from workflow.engine.nodes.entities.node_run_result import WorkflowNodeExecutionStatus
+from workflow.engine.nodes.knowledge.knowledge_node import KnowledgeNode
+from workflow.extensions.otlp.trace.span import Span
+
+KNOWLEDGE_NODE_ID = "knowledge-base::11111111-1111-1111-1111-111111111111"
+
+
+def build_workflow_dsl(*, rerank_id: str | None = None) -> WorkflowDSL:
+    node_param: dict[str, object] = {
+        "topN": "3",
+        "ragType": "Ragflow-RAG",
+        "repoId": ["repo-1"],
+        "datasetIds": ["dataset-1"],
+        "score": 0.2,
+    }
+    if rerank_id is not None:
+        node_param["rerankId"] = rerank_id
+
+    return WorkflowDSL.model_validate(
+        {
+            "nodes": [
+                {
+                    "id": KNOWLEDGE_NODE_ID,
+                    "data": {
+                        "inputs": [
+                            {
+                                "id": "query-input",
+                                "name": "query",
+                                "schema": {
+                                    "type": "string",
+                                    "value": {
+                                        "type": "literal",
+                                        "content": "hello",
+                                    },
+                                },
+                            }
+                        ],
+                        "nodeMeta": {
+                            "aliasName": "Knowledge",
+                            "nodeType": "knowledge-base",
+                        },
+                        "nodeParam": node_param,
+                        "outputs": [
+                            {
+                                "id": "result-output",
+                                "name": "result",
+                                "required": False,
+                                "schema": {"type": "array"},
+                            }
+                        ],
+                    },
+                }
+            ],
+            "edges": [],
+        }
+    )
+
+
+def test_workflow_dsl_passes_rerank_id_to_knowledge_client() -> None:
+    dsl = build_workflow_dsl(rerank_id="bge-reranker-v2-m3")
+    span = Span()
+    engine_node = NodeFactory.create(dsl.nodes[0], span)
+    variable_pool = VariablePool(dsl.nodes)
+    variable_pool.system_params.set(ParamKey.FlowId, "flow-1")
+
+    with (
+        patch.dict("os.environ", {"KNOWLEDGE_BASE_URL": "http://knowledge"}),
+        patch.object(KnowledgeNode, "_load_llm_config"),
+        patch(
+            "workflow.engine.nodes.knowledge.knowledge_node.KnowledgeClient"
+        ) as client_class,
+    ):
+        client_class.return_value.top_k = AsyncMock(
+            return_value=json.dumps({"results": []})
+        )
+        result = asyncio.run(
+            engine_node.node_instance.async_execute(variable_pool, span)
+        )
+
+    config = client_class.call_args.kwargs["config"]
+    assert config.rerank_id == "bge-reranker-v2-m3"
+    assert config.rag_type == "Ragflow-RAG"
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+
+
+def test_legacy_workflow_dsl_defaults_to_no_rerank_model() -> None:
+    dsl = build_workflow_dsl()
+
+    engine_node = NodeFactory.create(dsl.nodes[0], Span())
+
+    assert engine_node.node_instance.rerankId == ""
+
+
+def test_knowledge_node_rejects_overlong_rerank_id() -> None:
+    with pytest.raises(ValidationError):
+        KnowledgeNode(
+            input_identifier=["query"],
+            output_identifier=["result"],
+            rerankId="x" * 513,
+        )


### PR DESCRIPTION
## Summary

RAGFlow retrieval already accepts `ragflow_ext.rerank_id` in the Knowledge service, but workflow knowledge nodes had no way to configure or forward it. This PR completes that caller path for the standard `knowledge-base` workflow node.

Call chain: parameter modal → workflow DSL `nodeParam.rerankId` → `KnowledgeNode` → `KnowledgeClient` → `/knowledge/v1/chunk/query` as `ragflow_ext.rerank_id`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

Advances #650. Builds on the Knowledge service API added in #1231.

## Changes

- Show an optional rerank model ID only for `Ragflow-RAG` knowledge nodes, with Chinese and English guidance.
- Trim values before saving/sending, remove blank values, and cap the workflow field at 512 characters.
- Remove stale rerank configuration when a node switches to another RAG strategy.
- Forward `ragflow_ext.rerank_id` only when the runtime strategy is `Ragflow-RAG` and the value is non-empty.
- Keep legacy DSL and the default request payload unchanged when no reranker is configured.

No console backend or database change is needed because workflow `nodeParam` is stored and forwarded as JSON. This PR intentionally covers the workflow `knowledge-base` node only; the Agent knowledge tool has a separate call chain and is outside this PR.

## Testing

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing completed against a deployed RAGFlow instance

Executed locally:

- Workflow test suite: `298 passed`
- Knowledge workflow regression tests: `9 passed`
- Frontend unit suite on Node.js 20: `10 passed`
- Frontend production build: passed
- Changed frontend files: Prettier and ESLint passed
- Changed Python files: Black, isort, and flake8 passed
- Workflow payload validated against the existing Knowledge service `ChunkQueryReq` contract

The repository-wide `npm run type-check` is not currently green on upstream `main` because of pre-existing diagnostics outside this change. The new rerank helper and parameter path were checked separately, and the production build passes.

## Screenshots

Not included. The new field is conditional on selecting a RAGFlow knowledge base and is covered by the frontend persistence tests and production build.

## Checklist

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated where needed (UI copy and i18n)
- [x] No breaking changes

## AI assistance disclosure

I used OpenAI Codex (GPT-5) to help trace the call chain and expand the regression tests. I reviewed the implementation, compatibility boundaries, and test results line by line, and I take responsibility for this contribution.
