### PR TITLE
fix(security): suppress false-positive CodeQL sensitive-hashing alerts

### DIFF
--- a/core/common/utils/hmac_auth.py
+++ b/core/common/utils/hmac_auth.py
@@ -58,6 +58,8 @@ class HMACAuth:
         signature_origin = "host: {}\ndate: {}\n{} {} HTTP/1.1".format(
             url_result.hostname, date, method, url_result.path
         )
+        # SHA-256 is the digest algorithm for HMAC request authentication, not password hashing.
+        # codeql[py/weak-sensitive-data-hashing]
         signature_sha = hmac.new(
             api_secret.encode("utf-8"),
             signature_origin.encode("utf-8"),
@@ -103,6 +105,8 @@ class HMACAuth:
         signatureStr += method + " " + path + " " + "HTTP/1.1" + "\n"
         signatureStr += "digest: " + digest
 
+        # SHA-256 is the digest algorithm for HMAC request authentication, not password hashing.
+        # codeql[py/weak-sensitive-data-hashing]
         signature = hmac.new(
             bytes(api_secret, encoding="UTF-8"),
             bytes(signatureStr, encoding="UTF-8"),

--- a/core/knowledge/utils/spark_signature.py
+++ b/core/knowledge/utils/spark_signature.py
@@ -39,6 +39,9 @@ def md5(cipher_text: str) -> str:
     """
     try:
         data = cipher_text.encode("utf-8")
+        # The upstream Spark API mandates MD5(appid + timestamp) as the HMAC-SHA1 message.
+        # The application ID is public protocol metadata, not a password or stored secret.
+        # codeql[py/weak-sensitive-data-hashing]
         md = hashlib.md5()
         md.update(data)
         return md.hexdigest()


### PR DESCRIPTION
## What this does

Suppresses two false-positive CodeQL `py/weak-sensitive-data-hashing` alerts by annotating the call sites:

- `core/common/utils/hmac_auth.py` — HMAC-SHA256 is the digest algorithm for **request authentication signing**, not password hashing (×2 sites).
- `core/knowledge/utils/spark_signature.py` — the upstream Spark API **mandates** `MD5(appid + timestamp)` as the HMAC-SHA1 message; the application ID is public protocol metadata, not a stored secret.

Each is annotated with a `# codeql[py/weak-sensitive-data-hashing]` comment plus a one-line rationale, so the scanner stops flagging protocol-mandated crypto without weakening anything.

## Scope change (rebased 2026-09-02)

This PR originally also reworked `UrlCheckTool.java` to pin DNS on the redirect-following path. **That part has been dropped**: main's #1669 ("prevent SSRF in outbound plugin requests") removed `UrlCheckTool`'s redirect-following mechanism entirely — the component performing the HTTP request is now responsible for disabling redirects — so the redirect sink this PR hardened no longer exists. Re-adding the okhttp redirect client would reintroduce exactly the code #1669 deleted. The Java SSRF concern is therefore already covered upstream; this PR is now the remaining, independent Python-only suppression.

DCO + CLA signed; author = committer = sign-off.
