### PR TITLE
feat: add initial RISC-V support for tenant and agent

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           context: .
           file: ./core/tenant/Dockerfile
-          platforms: ${{ needs.detect-and-prepare.outputs.platforms }}
+          platforms: linux/amd64,linux/arm64,linux/riscv64
           push: ${{ needs.detect-and-prepare.outputs.should-push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -575,7 +575,8 @@ jobs:
           echo "🔍 Project Detection: ${{ needs.detect-and-prepare.result }}"
           echo "📊 Version: ${{ needs.detect-and-prepare.outputs.version }}"
           echo "📤 Push to Registry: ${{ needs.detect-and-prepare.outputs.should-push }}"
-          echo "🏗️ Target Platforms: ${{ needs.detect-and-prepare.outputs.platforms }}"
+          echo "🏗️ Default Target Platforms: ${{ needs.detect-and-prepare.outputs.platforms }}"
+          echo "🏢 Core Tenant Platforms: linux/amd64,linux/arm64,linux/riscv64"
           echo ""
 
           echo "🐳 Docker Build Results:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,9 @@ jobs:
               go test -coverprofile=coverage.out -covermode=atomic ./...
               echo "📊 Generating coverage report..."
               go tool cover -func=coverage.out
+              echo "🏗️ Cross-compiling core-tenant for linux/riscv64..."
+              CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 go build -trimpath -o /tmp/core-tenant-linux-riscv64 .
+              file /tmp/core-tenant-linux-riscv64
               ;;
             python)
               echo "📦 Installing dependencies..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
         with:
           context: .
           file: ./${{ matrix.service.path }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.service.name == 'tenant' && 'linux/amd64,linux/arm64,linux/riscv64' || 'linux/amd64,linux/arm64' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/core/agent/Dockerfile.riscv64
+++ b/core/agent/Dockerfile.riscv64
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1
+
+ARG BIANBU_IMAGE=astron/bianbu-base:24.04.1-riscv64
+
+FROM ${BIANBU_IMAGE} AS native-wheel-builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG LIBRDKAFKA_VERSION=2.11.1
+ARG LIBRDKAFKA_SHA256=a2c87186b081e2705bb7d5338d5a01bc88d43273619b372ccb7bb0d264d0ca9f
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential ca-certificates curl libcurl4-openssl-dev libffi-dev \
+      liblz4-dev libsasl2-dev libssl-dev libzstd-dev pkg-config \
+      python3-dev python3-venv zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY docker/riscv64/.cache/core-agent/librdkafka-2.11.1.tar.gz /tmp/librdkafka.tar.gz
+RUN echo "${LIBRDKAFKA_SHA256}  /tmp/librdkafka.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/librdkafka.tar.gz -C /tmp \
+    && cd "/tmp/librdkafka-${LIBRDKAFKA_VERSION}" \
+    && ./configure --prefix="/opt/librdkafka-${LIBRDKAFKA_VERSION}" \
+    && make -C src -j"$(nproc)" \
+    && make -C src install
+
+ENV PKG_CONFIG_PATH=/opt/librdkafka-2.11.1/lib/pkgconfig \
+    CPPFLAGS=-I/opt/librdkafka-2.11.1/include \
+    CFLAGS=-I/opt/librdkafka-2.11.1/include \
+    LDFLAGS="-L/opt/librdkafka-2.11.1/lib -Wl,-rpath,/opt/librdkafka-2.11.1/lib" \
+    LD_LIBRARY_PATH=/opt/librdkafka-2.11.1/lib
+
+COPY docker/riscv64/.cache/core-agent/confluent_kafka-2.11.1.tar.gz /tmp/confluent_kafka-2.11.1.tar.gz
+RUN echo "a9366d9dc07a527ed0dcef9c24ba38238cf9dc63c3f53b79da15d45ce4459166  /tmp/confluent_kafka-2.11.1.tar.gz" | sha256sum -c - \
+    && python3 -m venv /tmp/wheel-venv \
+    && /tmp/wheel-venv/bin/pip wheel --no-deps \
+      --wheel-dir /tmp/wheelhouse /tmp/confluent_kafka-2.11.1.tar.gz
+
+FROM ${BIANBU_IMAGE} AS runtime
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG UV_VERSION=0.12.5
+ARG UV_SHA256=2a6fe4a685225082d82f8afba169d038d669f85bf6cff7f5f733079a7b7282d5
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl libcurl4 liblz4-1 libsasl2-2 libssl3t64 libzstd1 \
+      python3 python3-venv zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY docker/riscv64/.cache/core-agent/uv-0.12.5-riscv64.tar.gz /tmp/uv.tar.gz
+RUN echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && install -m 0755 /tmp/uv-riscv64gc-unknown-linux-gnu/uv /usr/local/bin/uv
+
+COPY --from=native-wheel-builder /opt/librdkafka-2.11.1 /opt/librdkafka-2.11.1
+COPY --from=native-wheel-builder /tmp/wheelhouse /tmp/wheels
+
+ENV LD_LIBRARY_PATH=/opt/librdkafka-2.11.1/lib \
+    UV_PROJECT_ENVIRONMENT=/opt/core/.venv \
+    PYTHONPATH=/opt/core
+
+WORKDIR /opt/core
+COPY core/agent/pyproject.toml core/agent/uv.lock ./
+
+COPY docker/riscv64/.cache/core-agent/aiohttp-3.11.14-cp312-cp312-linux_riscv64.whl /tmp/wheels/
+COPY docker/riscv64/.cache/core-agent/grpcio-1.75.1-cp312-cp312-linux_riscv64.whl /tmp/wheels/
+COPY docker/riscv64/.cache/core-agent/jiter-0.9.0-cp312-cp312-linux_riscv64.whl /tmp/wheels/
+COPY docker/riscv64/.cache/core-agent/pydantic_core-2.33.0-cp312-cp312-linux_riscv64.whl /tmp/wheels/
+RUN echo "e45d8935d09e6d760486c544c1fd55f4f316410c259aefafaadb872fb36e228a  /tmp/wheels/aiohttp-3.11.14-cp312-cp312-linux_riscv64.whl" | sha256sum -c - \
+    && echo "b8d38a13fb82911b0afc77b228d8ebbf36fee1fd1411065d7f5a8558093c9c12  /tmp/wheels/grpcio-1.75.1-cp312-cp312-linux_riscv64.whl" | sha256sum -c - \
+    && echo "f89e843d3bbfb41d97c95e6f0f78ee3e06120d1e0b2830488dca9359c954d37d  /tmp/wheels/jiter-0.9.0-cp312-cp312-linux_riscv64.whl" | sha256sum -c - \
+    && echo "a86e3495e492f6856e77aa01dd162c1a0402a7fea43279df5d66581424e9f12d  /tmp/wheels/pydantic_core-2.33.0-cp312-cp312-linux_riscv64.whl" | sha256sum -c -
+
+RUN uv sync --frozen --no-install-project \
+      --no-install-package aiohttp \
+      --no-install-package confluent-kafka \
+      --no-install-package grpcio \
+      --no-install-package jiter \
+      --no-install-package pydantic-core \
+      -i https://pypi.tuna.tsinghua.edu.cn/simple/ \
+    && uv pip install --no-deps --python /opt/core/.venv/bin/python /tmp/wheels/*.whl \
+    && uv pip install --no-deps --python /opt/core/.venv/bin/python /usr/share/python-wheels/setuptools-*.whl \
+    && uv pip check --python /opt/core/.venv/bin/python \
+    && rm -rf /root/.cache/uv /tmp/wheels
+
+COPY core/common ./common
+COPY core/agent ./agent
+
+STOPSIGNAL SIGTERM
+CMD ["/opt/core/.venv/bin/python", "agent/main.py"]

--- a/core/tenant/Dockerfile
+++ b/core/tenant/Dockerfile
@@ -1,12 +1,19 @@
-FROM golang:1.23 AS builder
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH
 WORKDIR /opt/tenant
 ENV GOPROXY=https://goproxy.cn,direct
 COPY ./core/tenant/go.mod ./core/tenant/go.sum ./
 RUN go mod download
 COPY ./core/tenant .
-RUN go build -o tenant .
-FROM debian:bookworm-slim
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w" -o tenant .
+
+FROM scratch
 WORKDIR /opt/tenant
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /opt/tenant/tenant .
-STOPSIGNAL 3
+STOPSIGNAL SIGTERM
 CMD ["./tenant"]

--- a/docker/riscv64/import-bianbu-base.sh
+++ b/docker/riscv64/import-bianbu-base.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+rootfs_url=https://archive.spacemit.com/bianbu-base/bianbu-base-24.04.1-base-riscv64.tar.gz
+rootfs_sha256=a3f8ca97d8c399c05f8284adad8cc26980e3b7fe63e85026396d29174a9a554c
+image=astron/bianbu-base:24.04.1-riscv64
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+rootfs="$workdir/bianbu-base.tar.gz"
+
+curl -4 -fL --retry 5 -o "$rootfs" "$rootfs_url"
+echo "$rootfs_sha256  $rootfs" | sha256sum -c -
+docker import --platform linux/riscv64 "$rootfs" "$image" >/dev/null
+
+test "$(docker run --rm "$image" /bin/uname -m)" = riscv64
+echo "Imported and verified $image"

--- a/docker/riscv64/prepare-core-agent-assets.sh
+++ b/docker/riscv64/prepare-core-agent-assets.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cache_dir="$script_dir/.cache/core-agent"
+mkdir -p "$cache_dir"
+
+download() {
+  local filename=$1
+  local sha256=$2
+  local url=$3
+  local destination="$cache_dir/$filename"
+  local temporary="$destination.part"
+
+  if [[ -f "$destination" ]] && echo "$sha256  $destination" | sha256sum -c - >/dev/null; then
+    echo "Verified cached $filename"
+    return
+  fi
+
+  curl -4 -fL --retry 5 --connect-timeout 20 --continue-at - \
+    -o "$temporary" "$url"
+  echo "$sha256  $temporary" | sha256sum -c -
+  mv "$temporary" "$destination"
+}
+
+download \
+  librdkafka-2.11.1.tar.gz \
+  a2c87186b081e2705bb7d5338d5a01bc88d43273619b372ccb7bb0d264d0ca9f \
+  https://codeload.github.com/confluentinc/librdkafka/tar.gz/refs/tags/v2.11.1
+
+download \
+  confluent_kafka-2.11.1.tar.gz \
+  a9366d9dc07a527ed0dcef9c24ba38238cf9dc63c3f53b79da15d45ce4459166 \
+  https://pypi.tuna.tsinghua.edu.cn/packages/e1/e4/cd2dc58cd583788a362c2d59d179a6537b81c3bf70c6a1907c508117ca77/confluent_kafka-2.11.1.tar.gz
+
+download \
+  uv-0.12.5-riscv64.tar.gz \
+  2a6fe4a685225082d82f8afba169d038d669f85bf6cff7f5f733079a7b7282d5 \
+  https://github.com/astral-sh/uv/releases/download/0.12.5/uv-riscv64gc-unknown-linux-gnu.tar.gz
+
+download \
+  aiohttp-3.11.14-cp312-cp312-linux_riscv64.whl \
+  e45d8935d09e6d760486c544c1fd55f4f316410c259aefafaadb872fb36e228a \
+  https://git.spacemit.com/api/v4/projects/33/packages/pypi/files/e45d8935d09e6d760486c544c1fd55f4f316410c259aefafaadb872fb36e228a/aiohttp-3.11.14-cp312-cp312-linux_riscv64.whl
+
+download \
+  grpcio-1.75.1-cp312-cp312-linux_riscv64.whl \
+  b8d38a13fb82911b0afc77b228d8ebbf36fee1fd1411065d7f5a8558093c9c12 \
+  https://git.spacemit.com/api/v4/projects/33/packages/pypi/files/b8d38a13fb82911b0afc77b228d8ebbf36fee1fd1411065d7f5a8558093c9c12/grpcio-1.75.1-cp312-cp312-linux_riscv64.whl
+
+download \
+  jiter-0.9.0-cp312-cp312-linux_riscv64.whl \
+  f89e843d3bbfb41d97c95e6f0f78ee3e06120d1e0b2830488dca9359c954d37d \
+  https://git.spacemit.com/api/v4/projects/33/packages/pypi/files/f89e843d3bbfb41d97c95e6f0f78ee3e06120d1e0b2830488dca9359c954d37d/jiter-0.9.0-cp312-cp312-linux_riscv64.whl
+
+download \
+  pydantic_core-2.33.0-cp312-cp312-linux_riscv64.whl \
+  a86e3495e492f6856e77aa01dd162c1a0402a7fea43279df5d66581424e9f12d \
+  https://git.spacemit.com/api/v4/projects/33/packages/pypi/files/a86e3495e492f6856e77aa01dd162c1a0402a7fea43279df5d66581424e9f12d/pydantic_core-2.33.0-cp312-cp312-linux_riscv64.whl
+
+echo "Prepared verified core-agent assets in $cache_dir"

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ After startup, you can access the services at the following addresses:
 
 - [🔌 Integration Guide](/guide/integration) — call published workflows from an existing project via HTTP/SSE
 - [🚀 Deployment Guide](/DEPLOYMENT_GUIDE)
+- [🧩 RISC-V support status](/RISCV64)
 - [🔧 Configuration](/CONFIGURATION)
 - [🏢 Case Studies](/cases/)
 - [🚀 Quick Start](https://www.xfyun.cn/doc/spark/Agent02-%E5%BF%AB%E9%80%9F%E5%BC%80%E5%A7%8B.html)

--- a/docs/RISCV64.md
+++ b/docs/RISCV64.md
@@ -1,0 +1,81 @@
+# RISC-V (`linux/riscv64`) support
+
+## Current scope
+
+RISC-V support is incremental. `core-tenant` and `core-agent` now have verified `linux/riscv64` build and runtime paths. The full Docker Compose stack is **not yet supported** on RISC-V.
+
+| Component | `linux/riscv64` status | Notes |
+| --- | --- | --- |
+| `core-tenant` | Verified | Static Go binary in a `scratch` image; CI and release manifests include `linux/riscv64`. |
+| `core-database` | Not yet verified | Python dependencies and the target runtime image need an architecture audit. |
+| `core-rpa` | Not yet verified | Optional component; Python and external RPA dependencies need an architecture audit. |
+| `core-link` | Not yet verified | Python dependencies need an architecture audit. |
+| `core-aitools` | Not yet verified | Python, object-storage, and database dependencies need an architecture audit. |
+| `core-agent` | Verified, native build | `Dockerfile.riscv64` builds on a real RISC-V host; 239 tests and both health endpoints pass. It is not yet added to the public image workflow. |
+| `core-knowledge` | Not yet verified | Python/RAG dependencies need an architecture audit. |
+| `core-workflow` | Not yet verified | Python native dependencies, including the architecture markers in `pyproject.toml`, need remediation. |
+| Console frontend and hub | Not yet verified | Node/Nginx and Java runtime images need an architecture audit. |
+| Optional RAGFlow/RPA stack | Unsupported | Keep disabled until its images, native libraries, and hard-coded x86 paths are replaced or verified. |
+
+Do not deploy `docker/astronAgent/docker-compose.yaml` unchanged on RISC-V. It still references components that do not publish or have not verified `linux/riscv64` artifacts.
+
+## Build design for `core-tenant`
+
+The builder runs on the Buildx build platform and cross-compiles a static target binary using `TARGETOS` and `TARGETARCH`. The runtime stage uses `scratch`, so a target-architecture Debian image is not required.
+
+Build a single RISC-V image on an AMD64 or ARM64 Buildx host:
+
+```bash
+docker buildx build \
+  --platform linux/riscv64 \
+  --file core/tenant/Dockerfile \
+  --tag astron-agent/core-tenant:riscv64 \
+  --load \
+  .
+```
+
+Publishing workflows build `core-tenant` for `linux/amd64`, `linux/arm64`, and `linux/riscv64`. Other services retain their current AMD64/ARM64 platform list.
+
+## Build `core-agent` on native RISC-V
+
+The Python service currently requires a native RISC-V build. Prepare the compatible Bianbu base image and hash-verified assets first:
+
+```bash
+./docker/riscv64/import-bianbu-base.sh
+./docker/riscv64/prepare-core-agent-assets.sh
+docker build --file core/agent/Dockerfile.riscv64 --tag astron-agent/core-agent:riscv64 .
+```
+
+The Git-ignored `docker/riscv64/.cache/` holds verified assets. Do not substitute `harbor.spacemit.com/bianbu/bianbu:latest` on SpacemiT X60: the inspected image required unavailable RISC-V vector extensions. The importer uses the compatible, SHA-256-pinned official Bianbu rootfs.
+
+## Native verification
+
+The initial native validation used the following environment:
+
+- Astron Agent base commit: `327eee28a8407d5450a1e5c5aa44705f6adbda85`
+- OS: Bianbu 2.3, Linux 6.6.63
+- CPU: 8-core SpacemiT X60
+- Architecture: `riscv64`
+- Go: 1.23.1 (`linux/riscv64`)
+- Python: 3.12.3 (`riscv64`)
+- Docker: 26.1.3 (`linux/riscv64`)
+- MySQL: 8.0.40 (`riscv64`)
+- uv: 0.12.5 (`riscv64gc-unknown-linux-gnu`)
+- librdkafka: 2.11.1, built from verified source
+
+Reproduce the native compile checks from `core/tenant`:
+
+```bash
+go test ./...
+CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 \
+  go build -trimpath -o core-tenant-linux-riscv64 .
+file core-tenant-linux-riscv64
+```
+
+The verified runtime sequence started the `scratch` image against a temporary MySQL database, received `{"message":"pong"}` from `GET /ping`, applied migration `20260326_0001`, created `schema_migrations`, `tb_app`, and `tb_auth`, and shut down cleanly on `SIGTERM` with exit code 0.
+
+The verified `core-agent` image reported `linux/riscv64`, imported all five native dependencies at their locked versions, passed all 239 tests, returned `UP` from both `GET /health/live` and `GET /health/ready`, and stopped with exit code 0.
+
+## CI guardrail
+
+The Go test job cross-compiles `core-tenant` with `CGO_ENABLED=0 GOOS=linux GOARCH=riscv64`. `core-agent` remains a native RISC-V build until an appropriate native runner or controlled wheelhouse artifacts are available. A true RISC-V smoke test remains required before expanding support to another component or claiming full-stack compatibility.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -125,6 +125,7 @@ docker compose -f docker-compose-with-auth.yaml up -d
 
 - [🔌 集成指南](guide/integration.md) — 通过 HTTP/SSE 在现有项目中调用已发布工作流
 - [🚀 部署指南](DEPLOYMENT_GUIDE.md)
+- [🧩 RISC-V 支持状态](RISCV64.md)
 - [🔧 配置说明](CONFIGURATION.md)
 - [🏗️ 模块说明](PROJECT_MODULES.md)
 - [🤝 贡献指南](CONTRIBUTING.md)

--- a/docs/zh/RISCV64.md
+++ b/docs/zh/RISCV64.md
@@ -1,0 +1,81 @@
+# RISC-V（`linux/riscv64`）支持状态
+
+## 当前范围
+
+RISC-V 支持按组件逐步推进。`core-tenant` 与 `core-agent` 已完成 `linux/riscv64` 构建和运行验证；Astron Agent 完整 Docker Compose 栈目前**尚未支持** RISC-V。
+
+| 组件 | `linux/riscv64` 状态 | 说明 |
+| --- | --- | --- |
+| `core-tenant` | 已验证 | Go 静态二进制 + `scratch` 镜像；CI 与发布清单包含 `linux/riscv64`。 |
+| `core-database` | 尚未验证 | 需要审计 Python 依赖和目标运行镜像。 |
+| `core-rpa` | 尚未验证 | 可选组件；需要审计 Python 与外部 RPA 依赖。 |
+| `core-link` | 尚未验证 | 需要审计 Python 依赖。 |
+| `core-aitools` | 尚未验证 | 需要审计 Python、对象存储和数据库依赖。 |
+| `core-agent` | 已验证，原生构建 | `Dockerfile.riscv64` 在真实 RISC-V 主机构建；239 项测试和两个健康端点均通过。尚未加入公开镜像工作流。 |
+| `core-knowledge` | 尚未验证 | 需要审计 Python/RAG 依赖。 |
+| `core-workflow` | 尚未验证 | 需要修复 `pyproject.toml` 架构条件并审计 Python 原生依赖。 |
+| 控制台前端与 Hub | 尚未验证 | 需要审计 Node/Nginx 与 Java 运行镜像。 |
+| 可选 RAGFlow/RPA 栈 | 不支持 | 在镜像、原生库和写死的 x86 路径完成替换或验证前保持禁用。 |
+
+不要在 RISC-V 上原样部署 `docker/astronAgent/docker-compose.yaml`，其中仍引用没有发布或没有验证 `linux/riscv64` 产物的组件。
+
+## `core-tenant` 构建设计
+
+构建阶段固定运行在 Buildx 的构建平台，通过 `TARGETOS` 和 `TARGETARCH` 交叉编译静态目标二进制；运行阶段使用 `scratch`，不依赖目标架构的 Debian 基础镜像。
+
+在 AMD64 或 ARM64 Buildx 主机上构建单架构 RISC-V 镜像：
+
+```bash
+docker buildx build \
+  --platform linux/riscv64 \
+  --file core/tenant/Dockerfile \
+  --tag astron-agent/core-tenant:riscv64 \
+  --load \
+  .
+```
+
+发布工作流只为 `core-tenant` 增加 `linux/riscv64`，其余服务继续保持现有 AMD64/ARM64 平台范围。
+
+## 在原生 RISC-V 上构建 `core-agent`
+
+Python 服务当前需要真实 RISC-V 主机。构建前先准备兼容的 Bianbu 基础镜像和经哈希校验的资产：
+
+```bash
+./docker/riscv64/import-bianbu-base.sh
+./docker/riscv64/prepare-core-agent-assets.sh
+docker build --file core/agent/Dockerfile.riscv64 --tag astron-agent/core-agent:riscv64 .
+```
+
+资产缓存位于已被 Git 忽略的 `docker/riscv64/.cache/`。不要在 SpacemiT X60 上替换为 `harbor.spacemit.com/bianbu/bianbu:latest`：验证时该镜像要求测试主机不具备的 RISC-V 向量扩展。导入脚本改用兼容且固定 SHA-256 的官方 Bianbu rootfs。
+
+## 真机验证
+
+首轮真机验证环境：
+
+- Astron Agent 基线提交：`327eee28a8407d5450a1e5c5aa44705f6adbda85`
+- 操作系统：Bianbu 2.3，Linux 6.6.63
+- CPU：8 核 SpacemiT X60
+- 架构：`riscv64`
+- Go：1.23.1（`linux/riscv64`）
+- Python：3.12.3（`riscv64`）
+- Docker：26.1.3（`linux/riscv64`）
+- MySQL：8.0.40（`riscv64`）
+- uv：0.12.5（`riscv64gc-unknown-linux-gnu`）
+- librdkafka：2.11.1，从已校验源码原生构建
+
+在 `core/tenant` 目录复现原生编译检查：
+
+```bash
+go test ./...
+CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 \
+  go build -trimpath -o core-tenant-linux-riscv64 .
+file core-tenant-linux-riscv64
+```
+
+已验证的运行闭环为：使用临时 MySQL 测试库启动 `scratch` 镜像；`GET /ping` 返回 `{"message":"pong"}`；成功应用迁移 `20260326_0001` 并创建 `schema_migrations`、`tb_app`、`tb_auth`；收到 `SIGTERM` 后优雅退出，退出码为 0。
+
+已验证的 `core-agent` 镜像报告 `linux/riscv64`，按锁定版本导入 5 个原生依赖，通过全部 239 项测试；`GET /health/live` 与 `GET /health/ready` 均返回 `UP`，停止后退出码为 0。
+
+## CI 防回归
+
+Go 测试任务会执行 `CGO_ENABLED=0 GOOS=linux GOARCH=riscv64` 交叉编译。`core-agent` 暂时保持原生 RISC-V 构建，直到具备合适的原生 runner 或受控 wheelhouse 产物。每扩展一个新组件，仍必须补充真实 RISC-V 环境 smoke test；在完成前不得声称整套平台兼容。


### PR DESCRIPTION
## 背景：为什么要做这个 PR

本 PR 为 Astron Agent 建立第一阶段、可复现、可审核的 `linux/riscv64` 支持，直接服务于 Astron Agent 社区参加 **开源之夏 2026** 的组织报名与项目准备。

开源之夏 2026 [组织指南](https://docs2026.summer.ospp.ac.cn/help/CommunityGuide) 明确：

- 2026 年活动以基础软件为技术中心、以 RISC-V 为生态重心；
- 组织发布项目首先应支持 RISC-V，尚未支持的组织应发布此类项目并完成结项；
- 项目详情需要说明背景、已有工作、不足、目标、量化产出，并使用组织现有成果仓库，而不是新建空仓库。

因此，这个 PR 的目的不是提前宣称“整套 Astron Agent 已适配完成”，而是在现有 `iflytek/astron-agent` 主仓库中落地一个真实、可验证的 RISC-V 基线：先打通两个关键服务，并把剩余服务的兼容状态、构建约束和后续工作写清楚。这样既能形成组织审核所需的真实适配凭证，也为后续开源之夏项目提供可复现的起点和诚实的任务边界。

## 这个 PR 做了什么

### 1. `core-tenant`：可发布的多架构镜像

- 将 Go 构建阶段固定在 Buildx 的 `$BUILDPLATFORM`；
- 根据 `TARGETOS/TARGETARCH` 静态交叉编译，支持 `GOARCH=riscv64`；
- 运行层由 `debian:bookworm-slim` 改为 `scratch`，避免依赖不存在的 riscv64 Debian 官方镜像；
- 保留 CA 证书，停止信号改为应用已监听的 `SIGTERM`；
- CI 增加 `linux/riscv64` 交叉编译守护；
- build-push 与 release 只为已验证的 tenant 增加 `linux/riscv64`，不影响其他服务现有 AMD64/ARM64 发布范围。

### 2. `core-agent`：真实 RISC-V 主机原生镜像

新增 `core/agent/Dockerfile.riscv64`，在真实 RISC-V 主机完成 Python 3.12 镜像构建：

- 使用 SHA-256 固定的 SpacemiT/Bianbu 官方 rootfs；
- 原生构建并安装 `librdkafka 2.11.1`；
- 严格使用现有 `uv.lock`；
- 对 PyPI 尚未提供 riscv64 wheel 的关键原生依赖，使用 SpacemiT 官方 wheel，并逐个校验 SHA-256；
- 原生构建唯一缺失的 `confluent-kafka 2.11.1` wheel；
- 显式处理 Python 3.12 + `redis 3.5.3` 对 `distutils` 的兼容需求；
- 执行 `uv pip check`，确保最终环境的 102 个包依赖一致。

同时新增：

- `docker/riscv64/import-bianbu-base.sh`：下载、校验并导入与 X60 指令集兼容的 Bianbu rootfs；
- `docker/riscv64/prepare-core-agent-assets.sh`：预取并校验 uv、librdkafka、sdist 和 RISC-V wheels；
- `docs/RISCV64.md` 与 `docs/zh/RISCV64.md`：中英文兼容矩阵、构建方法、实测环境、已知限制和后续范围。

## 为什么不直接使用现有官方镜像

适配过程中验证了以下实际阻塞：

- Docker Hub 的部分 Python/Debian 目标镜像没有 `linux/riscv64` manifest；
- `harbor.spacemit.com/bianbu/bianbu:latest` 虽标记为 riscv64，但其用户态二进制要求当前 X60 云机不具备的 RISC-V Vector 扩展，会以 `Illegal instruction` 退出；
- Bianbu 自带 `librdkafka 2.3.0`，而锁定的 `confluent-kafka 2.11.1` 要求 `librdkafka >= 2.11.1`；
- Python 3.12 移除了 `distutils`，而锁定的 `redis 3.5.3` 仍会导入它。

本 PR 分别通过静态 Go 运行层、兼容 rootfs、固定哈希 wheelhouse、原生 librdkafka 和本地 setuptools wheel 解决这些问题。

## 真机验证

验证环境：

- 8 核 SpacemiT X60；
- Bianbu 2.3 / Linux 6.6.63；
- `riscv64`；
- 15 GiB 内存；
- Docker 26.1.3 / Buildx 0.14.1 / Compose 2.27.1；
- Go 1.23.1、Python 3.12.3、MySQL 8.0.40。

### `core-tenant`

- 全部 Go 测试通过；
- 产物为静态 UCB RISC-V ELF；
- 镜像架构为 `linux/riscv64`；
- `GET /ping` 返回 `{"message":"pong"}`；
- MySQL 迁移 `20260326_0001` 成功，创建 `schema_migrations`、`tb_app`、`tb_auth`；
- `SIGTERM` 优雅退出，退出码 0。

### `core-agent`

- 最终镜像架构为 `linux/riscv64`；
- 镜像内完整测试：`239 passed`；
- `aiohttp 3.11.14`、`confluent-kafka 2.11.1`、`grpcio 1.75.1`、`jiter 0.9.0`、`pydantic-core 2.33.0` 均在 RISC-V 成功导入；
- 运行时 `librdkafka` 为 2.11.1；
- `GET /health/live` 与 `GET /health/ready` 均返回 `UP`，六个初始化服务全部 ready；
- 优雅停止退出码 0。

### GitHub 检查

- DCO：通过；
- CLA：通过；
- CodeQL：全部通过；
- CI lint/test/Summary：全部通过；
- 可选 `claude-review`：两次均因评审服务交换 OIDC token 时返回 `401 Invalid OIDC token` 失败，与 PR 代码无关，未产生评审意见。

## 明确不包含的范围

本 PR **不声称完整 Astron Agent Compose 栈已经支持 RISC-V**。以下仍待后续审计和适配：

- `core-database`、`core-link`、`core-aitools`、`core-knowledge`、`core-workflow`；
- console frontend / hub；
- 可选 RPA、RAGFlow、专有 SDK 和本地大模型推理能力。

`core-agent` 当前保持真实 RISC-V 主机原生构建，暂不加入公共镜像发布矩阵；需要项目方确认 native runner 或受控 wheelhouse 的发布策略。

## 希望 reviewers 重点确认

- `@dongjiang1989`：请重点确认 RISC-V 支持边界、Docker/CI 架构设计，以及是否符合主仓库长期维护方向；
- `@lyj715824`：请重点确认开源之夏组织报名/项目发布语境、社区对外说明、兼容矩阵与后续项目范围是否合适。

Related: [开源之夏 2026 组织指南](https://docs2026.summer.ospp.ac.cn/help/CommunityGuide)
