### PR TITLE
docs: fix broken star history charts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ We welcome contributions of all kinds! Please see our [Contributing Guide](CONTR
 ## 🌟 Star History
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
+  <img src="https://star-history.dera.page/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
 </div>
 
 ## 📞 Support

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,7 +123,7 @@ We welcome contributions of all kinds! Please see our [Contributing Guide](/CONT
 ## 🌟 Star History
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
+  <img src="https://star-history.dera.page/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
 </div>
 
 ## 📞 Support

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -123,7 +123,7 @@ docker compose -f docker-compose-with-auth.yaml up -d
 ## 🌟 スター履歴
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
+  <img src="https://star-history.dera.page/svg?repos=iflytek/astron-agent&type=Date" alt="Star History Chart" width="600">
 </div>
 
 ## 📞 サポート

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -180,7 +180,7 @@ npm run docs:build
 ## 🌟 Star 历史
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-agent&type=Date" alt="Star 历史图表" width="600">
+  <img src="https://star-history.dera.page/svg?repos=iflytek/astron-agent&type=Date" alt="Star 历史图表" width="600">
 </div>
 
 ## 📞 支持


### PR DESCRIPTION
The star history charts embedded in the README and the localized docs are currently broken and show no data. This change restores them to a working service so that the project's star growth is visible again. The fix has been applied to the English, Chinese, and Japanese READMEs.