### PR TITLE
fix(docker): enforce secure deployment contract

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -81,13 +81,43 @@ jobs:
           echo "📤 Should push: $SHOULD_PUSH"
           echo "🏗️ Platforms: $PLATFORMS"
 
+  verify-compose-security-contract:
+    name: 🔐 Verify Compose Security Contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+          cache-dependency-path: console/backend/pom.xml
+
+      - name: Build Hub test dependencies
+        run: >-
+          mvn -f console/backend/pom.xml -pl hub -am
+          -DskipTests install
+
+      - name: Verify sandbox deployment configuration binding
+        run: >-
+          mvn -f console/backend/pom.xml -pl hub
+          -Dtest=SkillSandboxDeploymentConfigurationTest test
+
+      - name: Verify rendered sandbox credential contract
+        run: >-
+          python3 docker/astronAgent/scripts/verify_security_contract.py
+          --ci-placeholder-required-env
+
   # ============================================================================
   # Stage 2: Build astron Agent Docker Images (Parallel Jobs)
   # ============================================================================
   build-core-tenant:
     name: 🏢 Build Core Tenant
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -133,7 +163,7 @@ jobs:
   build-core-database:
     name: 🧠 Build Core Database
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -179,7 +209,7 @@ jobs:
   build-core-rpa:
     name: 🤖 Build Core RPA
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -225,7 +255,7 @@ jobs:
   build-core-link:
     name: 🔗 Build Core Link
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -271,7 +301,7 @@ jobs:
   build-core-aitools:
     name: 🛠️ Build Core AI Tools
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -317,7 +347,7 @@ jobs:
   build-core-agent:
     name: 🤖 Build Core Agent
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -363,7 +393,7 @@ jobs:
   build-core-knowledge:
     name: 📚 Build Core Knowledge
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -409,7 +439,7 @@ jobs:
   build-core-workflow:
     name: ⚡ Build Core Workflow
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -455,7 +485,7 @@ jobs:
   build-console-frontend:
     name: 🌐 Build Console Frontend
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -503,7 +533,7 @@ jobs:
   build-console-hub:
     name: 🎯 Build Console Hub
     runs-on: ubuntu-latest
-    needs: detect-and-prepare
+    needs: [detect-and-prepare, verify-compose-security-contract]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -556,6 +586,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - detect-and-prepare
+      - verify-compose-security-contract
       - build-core-tenant
       - build-core-database
       - build-core-rpa
@@ -573,6 +604,7 @@ jobs:
           echo "=== 🐳 astron Agent Multi-Service Docker Build Summary ==="
           echo ""
           echo "🔍 Project Detection: ${{ needs.detect-and-prepare.result }}"
+          echo "🔐 Compose Security Contract: ${{ needs.verify-compose-security-contract.result }}"
           echo "📊 Version: ${{ needs.detect-and-prepare.outputs.version }}"
           echo "📤 Push to Registry: ${{ needs.detect-and-prepare.outputs.should-push }}"
           echo "🏗️ Target Platforms: ${{ needs.detect-and-prepare.outputs.platforms }}"

--- a/console/backend/hub/Dockerfile
+++ b/console/backend/hub/Dockerfile
@@ -15,7 +15,7 @@ FROM eclipse-temurin:21-jre
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y locales tzdata && \
+    apt-get install -y --no-install-recommends curl locales tzdata && \
     locale-gen zh_CN.UTF-8 && \
     ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
     echo "Asia/Shanghai" > /etc/timezone && \

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/config/SkillSandboxDeploymentConfigurationTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/config/SkillSandboxDeploymentConfigurationTest.java
@@ -1,0 +1,128 @@
+package com.iflytek.astron.console.hub.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.iflytek.astron.console.toolkit.config.properties.SandboxRuntimeCredentialProperties;
+import com.iflytek.astron.console.toolkit.config.properties.SkillSandboxArtifactProperties;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.validation.BindValidationException;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+class SkillSandboxDeploymentConfigurationTest {
+
+    private static final String ARTIFACT_TOKEN_FILE_ENV =
+            "SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN_FILE";
+    private static final String RUNTIME_TOKEN_FILE_ENV =
+            "SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE";
+    private static final String ARTIFACT_TOKEN_FILE_PROPERTY =
+            "skill.sandbox.artifact-upload-token-file";
+    private static final String RUNTIME_TOKEN_FILE_PROPERTY =
+            "skill.sandbox.runtime-credential.token-file";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withInitializer(new ConfigDataApplicationContextInitializer())
+            .withUserConfiguration(SandboxDeploymentPropertiesConfiguration.class);
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void bindsIndependentTokenFilePathsFromApplicationYamlEnvironmentPlaceholders() {
+        Path artifactTokenFile = temporaryDirectory.resolve("artifact-upload-token.not-a-secret");
+        Path runtimeTokenFile = temporaryDirectory.resolve("runtime-credential-token.not-a-secret");
+
+        withEnvironment(Map.of(
+                ARTIFACT_TOKEN_FILE_ENV,
+                artifactTokenFile.toString(),
+                RUNTIME_TOKEN_FILE_ENV,
+                runtimeTokenFile.toString()))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertApplicationYamlDefinesPlaceholder(
+                            context.getEnvironment(),
+                            ARTIFACT_TOKEN_FILE_PROPERTY,
+                            "${" + ARTIFACT_TOKEN_FILE_ENV + ":}");
+                    assertApplicationYamlDefinesPlaceholder(
+                            context.getEnvironment(),
+                            RUNTIME_TOKEN_FILE_PROPERTY,
+                            "${" + RUNTIME_TOKEN_FILE_ENV + ":}");
+                    assertThat(context.getEnvironment().getProperty(ARTIFACT_TOKEN_FILE_PROPERTY))
+                            .isEqualTo(artifactTokenFile.toString());
+                    assertThat(context.getEnvironment().getProperty(RUNTIME_TOKEN_FILE_PROPERTY))
+                            .isEqualTo(runtimeTokenFile.toString());
+
+                    SkillSandboxArtifactProperties artifactProperties =
+                            context.getBean(SkillSandboxArtifactProperties.class);
+                    SandboxRuntimeCredentialProperties runtimeProperties =
+                            context.getBean(SandboxRuntimeCredentialProperties.class);
+
+                    assertThat(artifactProperties.getArtifactUploadTokenFile())
+                            .isEqualTo(artifactTokenFile.toString());
+                    assertThat(runtimeProperties.getTokenFile())
+                            .isEqualTo(runtimeTokenFile.toString())
+                            .isNotEqualTo(artifactProperties.getArtifactUploadTokenFile());
+                });
+    }
+
+    @Test
+    void failsValidationWhenArtifactTokenSourceIsMissing() {
+        Path runtimeTokenFile = temporaryDirectory.resolve("runtime-only-token.not-a-secret");
+
+        withEnvironment(Map.of(RUNTIME_TOKEN_FILE_ENV, runtimeTokenFile.toString()))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseInstanceOf(BindValidationException.class)
+                            .hasStackTraceContaining(
+                                    "skill.sandbox artifact upload token or token file must be configured");
+                });
+    }
+
+    @Test
+    void failsValidationWhenRuntimeCredentialSourceIsMissing() {
+        Path artifactTokenFile = temporaryDirectory.resolve("artifact-only-token.not-a-secret");
+
+        withEnvironment(Map.of(ARTIFACT_TOKEN_FILE_ENV, artifactTokenFile.toString()))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseInstanceOf(BindValidationException.class)
+                            .hasStackTraceContaining(
+                                    "skill.sandbox runtime credential token or token file must be configured");
+                });
+    }
+
+    private ApplicationContextRunner withEnvironment(Map<String, Object> environmentVariables) {
+        return contextRunner.withInitializer(context -> {
+            var propertySources = context.getEnvironment().getPropertySources();
+            propertySources.remove(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME);
+            propertySources.addLast(new SystemEnvironmentPropertySource(
+                    StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                    environmentVariables));
+        });
+    }
+
+    private void assertApplicationYamlDefinesPlaceholder(
+            ConfigurableEnvironment environment, String propertyName, String placeholder) {
+        assertThat(environment.getPropertySources())
+                .filteredOn(propertySource -> propertySource.getName().contains("application.yml"))
+                .anySatisfy(propertySource -> assertThat(propertySource.getProperty(propertyName)).hasToString(placeholder));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties({
+            SkillSandboxArtifactProperties.class,
+            SandboxRuntimeCredentialProperties.class
+    })
+    static class SandboxDeploymentPropertiesConfiguration {
+    }
+}

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -464,6 +464,8 @@ services:
       SKILL_RESOURCE_TRUSTED_ORIGIN: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT to the exact origin used by presigned URLs}"
       SKILL_RESOURCE_TRUSTED_BUCKET: "${OSS_BUCKET_CONSOLE:?Set OSS_BUCKET_CONSOLE explicitly}"
     depends_on:
+      console-hub:
+        condition: service_healthy
       postgres:
         condition: service_healthy
       mysql:
@@ -589,6 +591,8 @@ services:
       SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE: "/app/secrets/runtime/sandbox-runtime-credential-token"
       SKILL_SANDBOX_RUNTIME_CONFIG_URL: "http://console-hub:8080/skill-sandbox/internal-runtime-config"
     depends_on:
+      console-hub:
+        condition: service_healthy
       postgres:
         condition: service_healthy
       mysql:
@@ -753,6 +757,11 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent --show-error http://localhost:8080/health >/dev/null"]
+      interval: ${HEALTH_CHECK_INTERVAL:-30s}
+      timeout: ${HEALTH_CHECK_TIMEOUT:-10s}
+      retries: ${HEALTH_CHECK_RETRIES:-60}
     networks:
       - astron-agent-network
     restart: always

--- a/docker/astronAgent/scripts/verify_security_contract.py
+++ b/docker/astronAgent/scripts/verify_security_contract.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Verify the rendered Compose contract for sandbox credential handoff."""
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import (
+    Any,
+    Callable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+
+SERVICES = ("console-hub", "core-agent", "core-workflow")
+CONSUMERS = ("core-agent", "core-workflow")
+
+CREDENTIALS = (
+    {
+        "volume": "artifact_upload_secrets",
+        "target": "/app/secrets/artifact",
+        "file_env": "SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN_FILE",
+        "file_path": "/app/secrets/artifact/artifact-upload-token",
+    },
+    {
+        "volume": "sandbox_runtime_credential_secrets",
+        "target": "/app/secrets/runtime",
+        "file_env": "SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE",
+        "file_path": "/app/secrets/runtime/sandbox-runtime-credential-token",
+    },
+)
+
+INTERNAL_URLS = {
+    "SKILL_SANDBOX_ARTIFACT_UPLOAD_URL": (
+        "http://console-hub:8080/workflow/artifacts/internal-upload"
+    ),
+    "SKILL_SANDBOX_RUNTIME_CONFIG_URL": (
+        "http://console-hub:8080/skill-sandbox/internal-runtime-config"
+    ),
+}
+
+HUB_HEALTHCHECK_TEST = [
+    "CMD-SHELL",
+    "curl --fail --silent --show-error http://localhost:8080/health >/dev/null",
+]
+
+# CI has no deployment .env. These deliberately non-secret values satisfy only
+# Compose's required-variable interpolation so the rendered topology can be
+# checked. Deployment preflight must omit --ci-placeholder-required-env.
+CI_PLACEHOLDER_ENV = {
+    "MINIO_ROOT_USER": "ci-contract-user",
+    "MINIO_ROOT_PASSWORD": "ci-contract-password-2026",
+    "OSS_REMOTE_ENDPOINT": "http://minio.localhost:18998",
+    "OSS_ACCESS_KEY_ID": "ci-contract-access-key",
+    "OSS_ACCESS_KEY_SECRET": "ci-contract-credential-value",
+    "OSS_BUCKET_CONSOLE": "ci-contract-bucket",
+}
+
+
+class GateError(RuntimeError):
+    """A safe-to-print gate error which never contains rendered values."""
+
+
+def _render_compose(
+    compose_file: Path, *, ci_placeholder_required_env: bool
+) -> Mapping[str, Any]:
+    environment = os.environ.copy()
+    if ci_placeholder_required_env:
+        for name, value in CI_PLACEHOLDER_ENV.items():
+            environment.setdefault(name, value)
+
+    command = [
+        "docker",
+        "compose",
+        "-f",
+        compose_file.name,
+        "config",
+        "--format",
+        "json",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(compose_file.parent),
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise GateError("Docker CLI is unavailable") from exc
+
+    if completed.returncode != 0:
+        # Compose stderr can contain interpolated deployment data. Do not echo it.
+        raise GateError(
+            "docker compose config failed; Docker Compose v2 with "
+            "'config --format json' and all required deployment variables is required"
+        )
+
+    try:
+        rendered = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise GateError("docker compose config did not return valid JSON") from exc
+    if not isinstance(rendered, dict):
+        raise GateError("docker compose config returned an unexpected JSON root")
+    return rendered
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _mounts(service: Mapping[str, Any], target: str) -> List[Mapping[str, Any]]:
+    volumes = service.get("volumes", [])
+    if not isinstance(volumes, list):
+        return []
+    return [
+        volume
+        for volume in volumes
+        if isinstance(volume, dict) and volume.get("target") == target
+    ]
+
+
+def validate_contract(config: Mapping[str, Any]) -> List[str]:
+    """Return field-only contract errors without including configured values."""
+
+    errors: List[str] = []
+    services = _mapping(config.get("services"))
+    volumes = _mapping(config.get("volumes"))
+
+    for service_name in SERVICES:
+        if not isinstance(services.get(service_name), dict):
+            errors.append(f"services.{service_name}: missing")
+
+    for credential in CREDENTIALS:
+        volume_name = credential["volume"]
+        if not isinstance(volumes.get(volume_name), dict):
+            errors.append(f"volumes.{volume_name}: missing named volume")
+
+    resolved_volume_names: List[str] = []
+    for credential in CREDENTIALS:
+        volume_name = credential["volume"]
+        definition = volumes.get(volume_name)
+        if isinstance(definition, dict):
+            resolved_name = definition.get("name", volume_name)
+            if isinstance(resolved_name, str) and resolved_name:
+                resolved_volume_names.append(resolved_name)
+    if (
+        len(resolved_volume_names) == len(CREDENTIALS)
+        and len(set(resolved_volume_names)) != len(CREDENTIALS)
+    ):
+        errors.append("volumes.*.name: credential volumes must be independent")
+
+    for service_name in SERVICES:
+        service = _mapping(services.get(service_name))
+        environment = _mapping(service.get("environment"))
+
+        for credential in CREDENTIALS:
+            env_name = credential["file_env"]
+            if environment.get(env_name) != credential["file_path"]:
+                errors.append(
+                    f"services.{service_name}.environment.{env_name}: "
+                    "missing or unexpected"
+                )
+
+            target = credential["target"]
+            matching_mounts = _mounts(service, target)
+            mount_field = f"services.{service_name}.volumes[{target}]"
+            if len(matching_mounts) != 1:
+                errors.append(f"{mount_field}: missing or duplicated")
+                continue
+
+            mount = matching_mounts[0]
+            if (
+                mount.get("type") != "volume"
+                or mount.get("source") != credential["volume"]
+            ):
+                errors.append(f"{mount_field}.source/type: unexpected named volume")
+
+            expected_read_only = service_name in CONSUMERS
+            actual_read_only = mount.get("read_only", False) is True
+            if actual_read_only != expected_read_only:
+                expected_mode = "ro" if expected_read_only else "rw"
+                errors.append(f"{mount_field}.mode: expected {expected_mode}")
+
+    for service_name in CONSUMERS:
+        service = _mapping(services.get(service_name))
+        environment = _mapping(service.get("environment"))
+        for env_name, expected_url in INTERNAL_URLS.items():
+            if environment.get(env_name) != expected_url:
+                errors.append(
+                    f"services.{service_name}.environment.{env_name}: "
+                    "missing or unexpected"
+                )
+
+        hub_dependency = _mapping(_mapping(service.get("depends_on")).get("console-hub"))
+        if hub_dependency.get("condition") != "service_healthy":
+            errors.append(
+                f"services.{service_name}.depends_on.console-hub: "
+                "expected service_healthy"
+            )
+        if hub_dependency.get("required") is False:
+            errors.append(
+                f"services.{service_name}.depends_on.console-hub.required: "
+                "must not be false"
+            )
+
+    hub = _mapping(services.get("console-hub"))
+    healthcheck = hub.get("healthcheck")
+    healthcheck_field = "services.console-hub.healthcheck"
+    if not isinstance(healthcheck, dict):
+        errors.append(f"{healthcheck_field}: missing")
+    else:
+        test = healthcheck.get("test")
+        test_is_disabled = (
+            isinstance(test, str) and test.strip().upper() == "NONE"
+        ) or (
+            isinstance(test, list)
+            and bool(test)
+            and str(test[0]).strip().upper() == "NONE"
+        )
+        if healthcheck.get("disable") is True or test_is_disabled:
+            errors.append(f"{healthcheck_field}: disabled")
+        elif test != HUB_HEALTHCHECK_TEST:
+            errors.append(f"{healthcheck_field}.test: unexpected command or endpoint")
+
+    return errors
+
+
+def _set_mount_mode(
+    config: MutableMapping[str, Any], service_name: str, target: str, read_only: bool
+) -> None:
+    service = config["services"][service_name]
+    for mount in service["volumes"]:
+        if isinstance(mount, dict) and mount.get("target") == target:
+            mount["read_only"] = read_only
+            return
+    raise GateError("negative self-test fixture is incomplete")
+
+
+def _negative_cases() -> Sequence[
+    Tuple[str, Callable[[MutableMapping[str, Any], str], None], str]
+]:
+    def wrong_token_path(config: MutableMapping[str, Any], marker: str) -> None:
+        config["services"]["core-agent"]["environment"][
+            "SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN_FILE"
+        ] = marker
+
+    def missing_token_file(config: MutableMapping[str, Any], _marker: str) -> None:
+        config["services"]["core-workflow"]["environment"].pop(
+            "SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE", None
+        )
+
+    def writable_consumer(config: MutableMapping[str, Any], _marker: str) -> None:
+        _set_mount_mode(config, "core-workflow", "/app/secrets/artifact", False)
+
+    def readonly_producer(config: MutableMapping[str, Any], _marker: str) -> None:
+        _set_mount_mode(config, "console-hub", "/app/secrets/runtime", True)
+
+    def wrong_internal_url(config: MutableMapping[str, Any], marker: str) -> None:
+        config["services"]["core-agent"]["environment"][
+            "SKILL_SANDBOX_RUNTIME_CONFIG_URL"
+        ] = marker
+
+    def merged_volumes(config: MutableMapping[str, Any], _marker: str) -> None:
+        artifact_name = config["volumes"]["artifact_upload_secrets"].get(
+            "name", "artifact_upload_secrets"
+        )
+        config["volumes"]["sandbox_runtime_credential_secrets"][
+            "name"
+        ] = artifact_name
+
+    def disabled_healthcheck(config: MutableMapping[str, Any], _marker: str) -> None:
+        config["services"]["console-hub"]["healthcheck"] = {"disable": True}
+
+    def missing_hub_dependency(config: MutableMapping[str, Any], _marker: str) -> None:
+        config["services"]["core-workflow"]["depends_on"].pop("console-hub", None)
+
+    def optional_hub_dependency(config: MutableMapping[str, Any], _marker: str) -> None:
+        config["services"]["core-agent"]["depends_on"]["console-hub"][
+            "required"
+        ] = False
+
+    def wrong_hub_healthcheck_endpoint(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        config["services"]["console-hub"]["healthcheck"]["test"] = [
+            "CMD-SHELL",
+            "curl --fail --silent --show-error http://localhost:8080/not-health >/dev/null",
+        ]
+
+    def noop_hub_healthcheck(config: MutableMapping[str, Any], _marker: str) -> None:
+        config["services"]["console-hub"]["healthcheck"]["test"] = [
+            "CMD",
+            "true",
+        ]
+
+    return (
+        (
+            "wrong-token-file-path",
+            wrong_token_path,
+            "services.core-agent.environment.SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN_FILE",
+        ),
+        (
+            "missing-token-file",
+            missing_token_file,
+            "services.core-workflow.environment.SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE",
+        ),
+        (
+            "writable-consumer-volume",
+            writable_consumer,
+            "services.core-workflow.volumes[/app/secrets/artifact].mode",
+        ),
+        (
+            "readonly-producer-volume",
+            readonly_producer,
+            "services.console-hub.volumes[/app/secrets/runtime].mode",
+        ),
+        (
+            "wrong-internal-url",
+            wrong_internal_url,
+            "services.core-agent.environment.SKILL_SANDBOX_RUNTIME_CONFIG_URL",
+        ),
+        ("merged-named-volumes", merged_volumes, "volumes.*.name"),
+        (
+            "disabled-hub-healthcheck",
+            disabled_healthcheck,
+            "services.console-hub.healthcheck",
+        ),
+        (
+            "missing-healthy-hub-dependency",
+            missing_hub_dependency,
+            "services.core-workflow.depends_on.console-hub",
+        ),
+        (
+            "optional-healthy-hub-dependency",
+            optional_hub_dependency,
+            "services.core-agent.depends_on.console-hub.required",
+        ),
+        (
+            "wrong-hub-healthcheck-endpoint",
+            wrong_hub_healthcheck_endpoint,
+            "services.console-hub.healthcheck.test",
+        ),
+        (
+            "noop-hub-healthcheck",
+            noop_hub_healthcheck,
+            "services.console-hub.healthcheck.test",
+        ),
+    )
+
+
+def run_negative_self_tests(config: Mapping[str, Any]) -> None:
+    marker = "negative-self-test-sensitive-marker"
+    for case_name, mutate, expected_field in _negative_cases():
+        candidate = copy.deepcopy(config)
+        if not isinstance(candidate, dict):
+            raise GateError("negative self-test fixture is incomplete")
+
+        # A marker models unrelated sensitive environment data. Validation
+        # diagnostics must never serialize it, even when the candidate fails.
+        candidate["services"]["console-hub"]["environment"][
+            "SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN"
+        ] = marker
+        mutate(candidate, marker)
+        errors = validate_contract(candidate)
+        if not any(error.startswith(expected_field) for error in errors):
+            raise GateError(f"negative self-test did not fail: {case_name}")
+        if marker in "\n".join(errors):
+            raise GateError(f"negative self-test diagnostics were unsafe: {case_name}")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    default_compose_file = (
+        Path(__file__).resolve().parent.parent / "docker-compose-with-auth.yaml"
+    )
+    parser = argparse.ArgumentParser(
+        description="Verify sandbox credential and health contracts in rendered Compose JSON."
+    )
+    parser.add_argument(
+        "--compose-file",
+        type=Path,
+        default=default_compose_file,
+        help="Compose entrypoint (default: docker-compose-with-auth.yaml next to scripts/)",
+    )
+    parser.add_argument(
+        "--ci-placeholder-required-env",
+        action="store_true",
+        help="Use non-secret placeholders for required deployment variables in CI only",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    compose_file = args.compose_file.expanduser().resolve()
+    if not compose_file.is_file():
+        print("security contract gate: FAIL: compose file is missing", file=sys.stderr)
+        return 1
+
+    try:
+        config = _render_compose(
+            compose_file,
+            ci_placeholder_required_env=args.ci_placeholder_required_env,
+        )
+        errors = validate_contract(config)
+        if errors:
+            for error in errors:
+                print(f"security contract gate: FAIL: {error}", file=sys.stderr)
+            return 1
+        run_negative_self_tests(config)
+    except GateError as exc:
+        print(f"security contract gate: FAIL: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        # Never serialize an unexpected object which could include rendered env.
+        print("security contract gate: FAIL: internal validation error", file=sys.stderr)
+        return 1
+
+    print(
+        "security contract gate: PASS "
+        f"(3 services, 2 independent credential volumes, {len(_negative_cases())} negative cases)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/DEPLOYMENT_GUIDE_WITH_AUTH.md
+++ b/docs/DEPLOYMENT_GUIDE_WITH_AUTH.md
@@ -67,8 +67,8 @@ Before starting AstronAgent services, you need to configure the relevant connect
 # Navigate to astronAgent directory
 cd docker/astronAgent
 
-# Copy environment variable configuration
-cp .env.example .env
+# Create a deployment-only environment file with owner-only permissions
+install -m 600 .env.example .env
 ```
 
 The `.env` file is only used for startup, access addresses, authentication, database, Redis, object storage, and other infrastructure settings. Business capability accounts such as RAGFlow, iFLYTEK Open Platform, AI Ability Chat, Virtual Man, and Spark Knowledge Base are no longer configured in `.env`. Configure them in **Platform Account Management** after AstronAgent starts.
@@ -174,12 +174,16 @@ To start AstronAgent services, run our [docker-compose-with-auth.yaml](/docker/a
 # Navigate to astronAgent directory
 cd docker/astronAgent
 
-# Start all services (including Casdoor)
-docker compose -f docker-compose-with-auth.yaml up -d
+# Validate the fully rendered credential-sharing and health contract before changing the stack
+python3 scripts/verify_security_contract.py --compose-file docker-compose-with-auth.yaml
+
+# Start all services and wait for configured health checks to converge
+docker compose -f docker-compose-with-auth.yaml up -d --wait --wait-timeout 900
 ```
 
 **Note:**
 - Default Casdoor login credentials: username: `admin`, password: `123`
+- When upgrading, update the checked-out Compose files together with the application images. `docker compose pull` updates images only; it does not update `docker-compose.yaml`. Run the repository's deployment-contract preflight before stopping the current stack, preserve `.env` and named volumes, and never use `down -v` during a routine upgrade.
 
 ### Step 4: Configure Platform Account Management (Optional, configure business capabilities as needed)
 

--- a/docs/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
+++ b/docs/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
@@ -68,8 +68,8 @@ Before starting AstronAgent services, you need to configure the relevant connect
 # Navigate to astronAgent directory
 cd docker/astronAgent
 
-# Copy environment variable configuration
-cp .env.example .env
+# Create a deployment-only environment file with owner-only permissions
+install -m 600 .env.example .env
 ```
 
 The `.env` file is only used for startup, access addresses, authentication, database, Redis, object storage, and other infrastructure settings. Business capability accounts such as RAGFlow, iFLYTEK Open Platform, AI Ability Chat, Virtual Man, and Spark Knowledge Base are no longer configured in `.env`. Configure them in **Platform Account Management** after AstronAgent starts.
@@ -175,12 +175,16 @@ To start the AstronAgent service, run our [docker-compose-with-auth-rpa.yaml](/d
 # Navigate to the astronAgent directory
 cd docker/astronAgent
 
-# Start all services (includes Casdoor, RPA)
+# Validate the fully rendered credential-sharing and health contract before changing the stack
+python3 scripts/verify_security_contract.py --compose-file docker-compose-with-auth-rpa.yaml
+
+# Start all services (includes Casdoor and the one-shot RPA atlas task)
 docker compose -f docker-compose-with-auth-rpa.yaml up -d
 ```
 
 **Notes:**
 - Casdoor default login username: `admin`, password: `123`
+- When upgrading, update the checked-out Compose files together with the application images. `docker compose pull` updates images only; it does not update `docker-compose.yaml`. Run the repository's deployment-contract preflight before stopping the current stack, preserve `.env` and named volumes, and never use `down -v` during a routine upgrade.
 
 ### Step 4: Configure Platform Account Management (Optional, configure business capabilities as needed)
 

--- a/docs/zh/DEPLOYMENT_GUIDE_WITH_AUTH.md
+++ b/docs/zh/DEPLOYMENT_GUIDE_WITH_AUTH.md
@@ -67,8 +67,8 @@ docker compose logs -f ragflow
 # 进入 astronAgent 目录
 cd docker/astronAgent
 
-# 复制环境变量配置
-cp .env.example .env
+# 创建仅部署用户可读写的环境变量文件
+install -m 600 .env.example .env
 ```
 
 `.env` 文件只用于配置服务启动、访问地址、认证、数据库、Redis、对象存储等基础设施参数。RAGFlow、讯飞开放平台、AI Ability Chat、虚拟人能力、星火知识库等业务能力账号不再写入 `.env`，请在 AstronAgent 启动后登录控制台，通过 **平台账号管理** 页面配置。
@@ -174,12 +174,16 @@ curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
 # 进入 astronAgent 目录
 cd docker/astronAgent
 
-# 启动所有服务（包含 Casdoor）
-docker compose -f docker-compose-with-auth.yaml up -d
+# 变更服务前，先校验完整渲染后的凭据共享与健康检查契约
+python3 scripts/verify_security_contract.py --compose-file docker-compose-with-auth.yaml
+
+# 启动所有服务，并等待已配置的健康检查收敛
+docker compose -f docker-compose-with-auth.yaml up -d --wait --wait-timeout 900
 ```
 
 **说明：**
 - Casdoor默认的登录账户名：`admin`，密码：`123`
+- 升级时必须让检出的 Compose 清单与应用镜像同步更新。`docker compose pull` 只更新镜像，不会更新 `docker-compose.yaml`；停止现有服务前应运行仓库提供的部署契约预检，并保留 `.env` 与命名卷。常规升级禁止使用 `down -v`。
 
 ### 第四步：配置平台账号管理（可选，按需配置业务能力）
 

--- a/docs/zh/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
+++ b/docs/zh/DEPLOYMENT_GUIDE_WITH_AUTH_RPA.md
@@ -68,8 +68,8 @@ docker compose logs -f ragflow
 # 进入 astronAgent 目录
 cd docker/astronAgent
 
-# 复制环境变量配置
-cp .env.example .env
+# 创建仅部署用户可读写的环境变量文件
+install -m 600 .env.example .env
 ```
 
 `.env` 文件只用于配置服务启动、访问地址、认证、数据库、Redis、对象存储等基础设施参数。RAGFlow、讯飞开放平台、AI Ability Chat、虚拟人能力、星火知识库等业务能力账号不再写入 `.env`，请在 AstronAgent 启动后登录控制台，通过 **平台账号管理** 页面配置。
@@ -175,12 +175,16 @@ curl -X PUT 'https://chatdoc.xfyun.cn/openapi/v1/dataset/create' \
 # 进入 astronAgent 目录
 cd docker/astronAgent
 
-# 启动所有服务（包含 Casdoor, RPA）
+# 变更服务前，先校验完整渲染后的凭据共享与健康检查契约
+python3 scripts/verify_security_contract.py --compose-file docker-compose-with-auth-rpa.yaml
+
+# 启动所有服务（包含 Casdoor 和一次性 RPA atlas 任务）
 docker compose -f docker-compose-with-auth-rpa.yaml up -d
 ```
 
 **说明：**
 - Casdoor默认的登录账户名：`admin`，密码：`123`
+- 升级时必须让检出的 Compose 清单与应用镜像同步更新。`docker compose pull` 只更新镜像，不会更新 `docker-compose.yaml`；停止现有服务前应运行仓库提供的部署契约预检，并保留 `.env` 与命名卷。常规升级禁止使用 `down -v`。
 
 ### 第四步：配置平台账号管理（可选，按需配置业务能力）
 


### PR DESCRIPTION
## Summary
- add a CI security contract gate for authenticated Compose deployments
- make console-hub health a startup dependency for agent and workflow services
- cover required sandbox deployment credentials with focused backend tests
- document secure preflight and upgrade procedures

## Validation
- targeted Hub configuration tests
- Maven Spotless check
- Python 3.6 syntax compatibility
- authenticated and RPA Compose contract checks on the target Docker Compose runtime
- workflow YAML parsing and git diff checks