### PR TITLE
fix(console): preserve MinIO policy compatibility

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -106,6 +106,12 @@ jobs:
           mvn -f console/backend/pom.xml -pl hub
           -Dtest=SkillSandboxDeploymentConfigurationTest test
 
+      - name: Verify MinIO bucket policy compatibility
+        timeout-minutes: 10
+        run: >-
+          mvn -f console/backend/pom.xml -pl commons
+          -Dtest=S3ClientUtilMinioPolicyCompatibilityIT test
+
       - name: Verify rendered sandbox credential contract
         run: >-
           python3 docker/astronAgent/scripts/verify_security_contract.py

--- a/console/backend/commons/pom.xml
+++ b/console/backend/commons/pom.xml
@@ -103,6 +103,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/util/S3ClientUtil.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/util/S3ClientUtil.java
@@ -132,9 +132,10 @@ public class S3ClientUtil {
                 | InvalidResponseException | IOException | NoSuchAlgorithmException | ServerException
                 | XmlParserException e) {
             log.error(
-                    "Failed to check/create/configure S3 bucket '{}' (errorType={})",
+                    "Failed to check/create/configure S3 bucket '{}' (errorType={}, errorCode={})",
                     defaultBucket,
-                    exceptionType(e));
+                    exceptionType(e),
+                    safeS3ErrorCode(e));
             throw new BusinessException(ResponseEnum.INTERNAL_SERVER_ERROR);
         }
     }
@@ -213,7 +214,7 @@ public class S3ClientUtil {
                 new JSONObject().fluentPut(
                         "StringEquals",
                         new JSONObject().fluentPut(
-                                "aws:PrincipalType", "Anonymous")));
+                                "aws:principaltype", "Anonymous")));
         statement.put(
                 "Resource",
                 new JSONArray()
@@ -248,9 +249,10 @@ public class S3ClientUtil {
                 | ServerException
                 | XmlParserException exception) {
             log.error(
-                    "Failed to restore public read policy for S3 bucket '{}' (errorType={})",
+                    "Failed to restore public read policy for S3 bucket '{}' (errorType={}, errorCode={})",
                     defaultBucket,
-                    exceptionType(exception));
+                    exceptionType(exception),
+                    safeS3ErrorCode(exception));
             throw new BusinessException(ResponseEnum.INTERNAL_SERVER_ERROR);
         }
     }
@@ -337,9 +339,10 @@ public class S3ClientUtil {
                 | ServerException
                 | XmlParserException exception) {
             log.error(
-                    "Failed to initialize private S3 bucket '{}' (errorType={})",
+                    "Failed to initialize private S3 bucket '{}' (errorType={}, errorCode={})",
                     bucketName,
-                    exceptionType(exception));
+                    exceptionType(exception),
+                    safeS3ErrorCode(exception));
             throw new BusinessException(ResponseEnum.INTERNAL_SERVER_ERROR);
         }
     }
@@ -1071,5 +1074,26 @@ public class S3ClientUtil {
     private static String exceptionType(Throwable exception) {
         String simpleName = exception.getClass().getSimpleName();
         return simpleName.isEmpty() ? exception.getClass().getName() : simpleName;
+    }
+
+    private static String safeS3ErrorCode(Throwable exception) {
+        if (!(exception instanceof ErrorResponseException errorResponseException)
+                || errorResponseException.errorResponse() == null) {
+            return "unavailable";
+        }
+        String code = errorResponseException.errorResponse().code();
+        if (code == null || code.isEmpty() || code.length() > 64) {
+            return "unavailable";
+        }
+        for (int index = 0; index < code.length(); index++) {
+            char value = code.charAt(index);
+            if (!Character.isLetterOrDigit(value)
+                    && value != '.'
+                    && value != '_'
+                    && value != '-') {
+                return "unavailable";
+            }
+        }
+        return code;
     }
 }

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/S3ClientUtilMinioPolicyCompatibilityIT.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/S3ClientUtilMinioPolicyCompatibilityIT.java
@@ -1,0 +1,166 @@
+package com.iflytek.astron.console.commons.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.minio.GetObjectArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.SetBucketPolicyArgs;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class S3ClientUtilMinioPolicyCompatibilityIT {
+    private static final String MINIO_IMAGE =
+            "minio/minio:RELEASE.2025-07-23T15-54-02Z";
+    private static final String ACCESS_KEY = "codex-policy-root";
+    private static final String SECRET_KEY = "codex-policy-password-2026";
+    private static final String DEFAULT_BUCKET = "console-oss";
+    private static final String ARTIFACT_BUCKET = "workflow-artifacts";
+    private static final String PUBLIC_OBJECT = "public/asset.txt";
+    private static final String ARTIFACT_OBJECT =
+            "workflow/artifacts/42/secret.txt";
+    private static final byte[] PUBLIC_CONTENT =
+            "public asset".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] ARTIFACT_CONTENT =
+            "private artifact".getBytes(StandardCharsets.UTF_8);
+
+    @Container
+    private static final GenericContainer<?> MINIO =
+            new GenericContainer<>(DockerImageName.parse(MINIO_IMAGE))
+                    .withEnv("MINIO_ROOT_USER", ACCESS_KEY)
+                    .withEnv("MINIO_ROOT_PASSWORD", SECRET_KEY)
+                    .withCommand("server", "/data", "--address", ":9000")
+                    .withExposedPorts(9000)
+                    .waitingFor(Wait.forHttp("/minio/health/cluster").forStatusCode(200))
+                    .withStartupTimeout(Duration.ofMinutes(2));
+
+    @Test
+    void productionMinioAcceptsPolicyAndEnforcesArtifactPrivacy() throws Exception {
+        String endpoint = "http://" + MINIO.getHost() + ":" + MINIO.getMappedPort(9000);
+        MinioClient adminClient = MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(ACCESS_KEY, SECRET_KEY)
+                .build();
+        adminClient.makeBucket(
+                MakeBucketArgs.builder().bucket(DEFAULT_BUCKET).build());
+        adminClient.setBucketPolicy(SetBucketPolicyArgs.builder()
+                .bucket(DEFAULT_BUCKET)
+                .config(legacyPublicReadPolicy())
+                .build());
+
+        S3ClientUtil clientUtil = configuredClient(endpoint);
+        clientUtil.init();
+        clientUtil.ensurePrivateBucket(ARTIFACT_BUCKET);
+
+        String reconciledPolicy = adminClient.getBucketPolicy(
+                io.minio.GetBucketPolicyArgs.builder().bucket(DEFAULT_BUCKET).build());
+        assertThat(reconciledPolicy)
+                .contains(
+                        "AstronPublicReadExcludingWorkflowArtifacts",
+                        "AstronDenyWorkflowArtifactReads",
+                        "aws:principaltype")
+                .doesNotContain("LegacyPublicRead", "aws:PrincipalType");
+
+        putObject(adminClient, DEFAULT_BUCKET, PUBLIC_OBJECT, PUBLIC_CONTENT);
+        putObject(adminClient, DEFAULT_BUCKET, ARTIFACT_OBJECT, ARTIFACT_CONTENT);
+        putObject(adminClient, ARTIFACT_BUCKET, ARTIFACT_OBJECT, ARTIFACT_CONTENT);
+
+        assertThat(anonymousGet(endpoint, DEFAULT_BUCKET, PUBLIC_OBJECT).statusCode())
+                .isEqualTo(200);
+        assertThat(anonymousGet(endpoint, DEFAULT_BUCKET, ARTIFACT_OBJECT).statusCode())
+                .isEqualTo(403);
+        assertThat(anonymousGet(endpoint, ARTIFACT_BUCKET, ARTIFACT_OBJECT).statusCode())
+                .isEqualTo(403);
+
+        try (InputStream response = adminClient.getObject(GetObjectArgs.builder()
+                .bucket(DEFAULT_BUCKET)
+                .object(ARTIFACT_OBJECT)
+                .build())) {
+            assertThat(response.readAllBytes()).isEqualTo(ARTIFACT_CONTENT);
+        }
+
+        assertPresignedArtifactDownload(
+                clientUtil, DEFAULT_BUCKET, ARTIFACT_OBJECT, ARTIFACT_CONTENT);
+        assertPresignedArtifactDownload(
+                clientUtil, ARTIFACT_BUCKET, ARTIFACT_OBJECT, ARTIFACT_CONTENT);
+    }
+
+    private static S3ClientUtil configuredClient(String endpoint) {
+        S3ClientUtil clientUtil = new S3ClientUtil();
+        ReflectionTestUtils.setField(clientUtil, "endpoint", endpoint);
+        ReflectionTestUtils.setField(clientUtil, "remoteEndpoint", endpoint);
+        ReflectionTestUtils.setField(clientUtil, "accessKey", ACCESS_KEY);
+        ReflectionTestUtils.setField(clientUtil, "secretKey", SECRET_KEY);
+        ReflectionTestUtils.setField(clientUtil, "defaultBucket", DEFAULT_BUCKET);
+        ReflectionTestUtils.setField(clientUtil, "presignExpirySeconds", 600);
+        ReflectionTestUtils.setField(clientUtil, "enablePublicRead", true);
+        return clientUtil;
+    }
+
+    private static void putObject(
+            MinioClient client, String bucket, String object, byte[] content) throws Exception {
+        client.putObject(PutObjectArgs.builder()
+                .bucket(bucket)
+                .object(object)
+                .stream(new ByteArrayInputStream(content), content.length, -1)
+                .contentType("text/plain")
+                .build());
+    }
+
+    private static HttpResponse<byte[]> anonymousGet(
+            String endpoint, String bucket, String object) throws Exception {
+        return get(endpoint + "/" + bucket + "/" + object);
+    }
+
+    private static void assertPresignedArtifactDownload(
+            S3ClientUtil clientUtil,
+            String bucket,
+            String object,
+            byte[] expectedContent)
+            throws Exception {
+        String presignedUrl = clientUtil.generatePresignedDownloadUrl(
+                bucket, object, "artifact.txt", 300);
+        HttpResponse<byte[]> response = get(presignedUrl);
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo(expectedContent);
+    }
+
+    private static HttpResponse<byte[]> get(String url) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .GET()
+                .build();
+        return HttpClient.newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofByteArray());
+    }
+
+    private static String legacyPublicReadPolicy() {
+        return """
+                {
+                  "Version":"2012-10-17",
+                  "Statement":[{
+                    "Sid":"LegacyPublicRead",
+                    "Effect":"Allow",
+                    "Principal":{"AWS":["*"]},
+                    "Action":["s3:GetObject"],
+                    "Resource":["arn:aws:s3:::%s/*"]
+                  }]
+                }
+                """.formatted(DEFAULT_BUCKET);
+    }
+}

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/S3ClientUtilWorkflowArtifactTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/S3ClientUtilWorkflowArtifactTest.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import io.minio.CopyObjectArgs;
 import io.minio.GetPresignedObjectUrlArgs;
@@ -227,13 +230,23 @@ class S3ClientUtilWorkflowArtifactTest {
         ArgumentCaptor<SetBucketPolicyArgs> arguments =
                 ArgumentCaptor.forClass(SetBucketPolicyArgs.class);
         verify(minioClient).setBucketPolicy(arguments.capture());
-        assertThat(arguments.getValue().config())
-                .contains("NotResource")
-                .contains("arn:aws:s3:::console-oss/workflow/artifacts")
-                .contains("AstronDenyWorkflowArtifactReads")
-                .contains("aws:PrincipalType")
-                .contains("Anonymous")
-                .doesNotContain("\"Resource\":\"arn:aws:s3:::console-oss/*\"");
+        JSONObject policy = JSON.parseObject(arguments.getValue().config());
+        JSONObject publicRead = statementBySid(
+                policy.getJSONArray("Statement"),
+                "AstronPublicReadExcludingWorkflowArtifacts");
+        assertThat(publicRead.containsKey("NotResource")).isTrue();
+        assertThat(publicRead.getJSONArray("NotResource"))
+                .contains(
+                        "arn:aws:s3:::console-oss/workflow/artifacts",
+                        "arn:aws:s3:::console-oss/workflow/artifacts/*");
+        assertThat(publicRead.containsKey("Resource")).isFalse();
+
+        JSONObject artifactDeny = statementBySid(
+                policy.getJSONArray("Statement"), "AstronDenyWorkflowArtifactReads");
+        assertThat(artifactDeny.getString("Effect")).isEqualTo("Deny");
+        assertThat(artifactDeny.getJSONObject("Condition").getJSONObject("StringEquals"))
+                .containsEntry("aws:principaltype", "Anonymous")
+                .doesNotContainKey("aws:PrincipalType");
     }
 
     @Test
@@ -379,5 +392,15 @@ class S3ClientUtilWorkflowArtifactTest {
         verify(minioClient).removeObject(remove.capture());
         assertThat(remove.getValue().bucket()).isEqualTo("console-oss");
         assertThat(remove.getValue().object()).isEqualTo("workflow/artifacts/1/file.txt");
+    }
+
+    private static JSONObject statementBySid(JSONArray statements, String sid) {
+        for (Object value : statements) {
+            if (value instanceof JSONObject statement
+                    && sid.equals(statement.getString("Sid"))) {
+                return statement;
+            }
+        }
+        throw new AssertionError("Missing bucket policy statement: " + sid);
     }
 }


### PR DESCRIPTION
## Summary
- normalize the anonymous-principal condition key for MinIO bucket policy compatibility
- log validated S3 error codes without exposing unsafe response content
- add unit and container-backed MinIO policy regression coverage
- run the compatibility integration test in the image-build security gate