### PR TITLE
fix(console): make artifact validator constructor injectable

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowArtifactFileValidator.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowArtifactFileValidator.java
@@ -33,6 +33,7 @@ import org.apache.poi.poifs.filesystem.DirectoryEntry;
 import org.apache.poi.poifs.filesystem.Entry;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.tika.Tika;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -107,6 +108,7 @@ public class WorkflowArtifactFileValidator {
     private final OoxmlResourceLimits ooxmlResourceLimits;
     private final Tika tika = new Tika();
 
+    @Autowired
     public WorkflowArtifactFileValidator(SkillSandboxArtifactProperties properties) {
         this(
                 properties,

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowArtifactFileValidatorTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowArtifactFileValidatorTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.util.unit.DataSize;
 
@@ -51,6 +52,20 @@ class WorkflowArtifactFileValidatorTest {
         properties = new SkillSandboxArtifactProperties();
         properties.setArtifactMaxFileSize(DataSize.ofMegabytes(2));
         validator = new WorkflowArtifactFileValidator(properties);
+    }
+
+    @Test
+    void springContextWiresProductionConstructor() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext()) {
+            context.registerBean(
+                    SkillSandboxArtifactProperties.class, () -> properties);
+            context.register(WorkflowArtifactFileValidator.class);
+
+            context.refresh();
+
+            assertThat(context.getBean(WorkflowArtifactFileValidator.class)).isNotNull();
+        }
     }
 
     @ParameterizedTest(name = "accepts real {0} artifact")


### PR DESCRIPTION
## Summary
- mark the production artifact-validator constructor for Spring injection
- add a regression test that refreshes a Spring context and resolves the validator bean

## Validation
- regression coverage included in WorkflowArtifactFileValidatorTest