### PR TITLE
fix(workflow): support zero-parameter code entrypoints

### DIFF
--- a/core/workflow/engine/nodes/code/code_node.py
+++ b/core/workflow/engine/nodes/code/code_node.py
@@ -276,13 +276,13 @@ def _parser_code_parameter(python_code: str) -> list[str]:
     # Regex pattern to match function definitions with optional type hints
     re_pattern = r"def\s+(\w+)\s*\(([^)]*)\)\s*(?:->\s*[\w\[\],\s]*)?:"
     re_matches = re.findall(re_pattern, python_code, re.DOTALL)
-    re_parameter = ""
+    re_parameter: str | None = None
     # Find the main function specifically
     for re_match in re_matches:
         if re_match[0].strip() == "main":
             re_parameter = re_match[1].strip()
             break
-    if not re_parameter:
+    if re_parameter is None:
         raise CustomException(
             CodeEnum.CODE_BUILD_ERROR,
             err_msg="can not find main function",

--- a/core/workflow/tests/engine/nodes/test_code_node.py
+++ b/core/workflow/tests/engine/nodes/test_code_node.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from workflow.engine.nodes.code import code_node
+from workflow.engine.nodes.code.executor import base_executor
+from workflow.engine.nodes.entities import node_run_result as node_result
+from workflow.exception.e import CustomException
+from workflow.exception.errors.err_code import CodeEnum
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def main():\n    return {}",
+        "def main(   ):\n    return {}",
+    ],
+)
+def test_parser_accepts_zero_parameter_main(source: str) -> None:
+    assert code_node._parser_code_parameter(source) == []
+
+
+def test_parser_preserves_main_parameters() -> None:
+    source = "\n".join(
+        [
+            "def main(name: str, count: int):",
+            "    return {'name': name, 'count': count}",
+        ]
+    )
+
+    assert code_node._parser_code_parameter(source) == ["name", "count"]
+
+
+def test_parser_rejects_code_without_main() -> None:
+    with pytest.raises(CustomException) as exc_info:
+        code_node._parser_code_parameter("def helper():\n    return {}")
+
+    assert exc_info.value.code == CodeEnum.CODE_BUILD_ERROR.code
+
+
+@pytest.mark.asyncio
+async def test_code_node_executes_zero_parameter_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = AsyncMock()
+    executor.execute.return_value = '{"result":"ok"}'
+    monkeypatch.setattr(
+        base_executor.CodeExecutorFactory,
+        "create_executor",
+        lambda _executor_type: executor,
+    )
+    node = code_node.CodeNode(
+        codeLanguage="python",
+        input_identifier=[],
+        output_identifier=["result"],
+        code="def main():\n    return {'result': 'ok'}",
+        appId="app-1",
+        uid="user-1",
+        node_id="ifly-code::node-1",
+        sandbox={"enabled": True, "uid": "user-1"},
+    )
+    variable_pool = MagicMock()
+    variable_pool.get_output_schema.return_value = {"type": "string"}
+    span = MagicMock()
+    span.add_info_events_async = AsyncMock()
+    span.add_info_event_async = AsyncMock()
+
+    result = await node.async_execute(variable_pool, span)
+
+    assert result.status is node_result.WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.inputs == {}
+    assert result.outputs == {"result": "ok"}
+    variable_pool.get_variable.assert_not_called()
+    executor.execute.assert_awaited_once()


### PR DESCRIPTION
## Summary
- distinguish an empty `main()` parameter list from a missing `main` function
- add parser and execution regressions for zero-parameter code nodes

## Validation
- 62 workflow code-node and sandbox tests passed
- Black, isort, flake8, and mypy checks passed