### PR TITLE
fix(ci): satisfy remote quality checks

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowArtifactService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowArtifactService.java
@@ -88,7 +88,20 @@ public class WorkflowArtifactService
             fixedDelayString = "${skill.sandbox.artifact-legacy-reconcile-interval-ms:300000}",
             initialDelayString = "${skill.sandbox.artifact-legacy-reconcile-initial-delay-ms:300000}")
     public synchronized void migrateLegacyArtifactStorage() {
-        String sourceBucket = s3ClientUtil.getDefaultBucket();
+        LegacyReferenceMigrationResult migration = migrateLegacyArtifactReferences();
+        LegacyPublicCleanupResult cleanup = cleanupLegacyPublicArtifacts();
+        int failed = migration.failed() + cleanup.failed();
+        if (migration.migrated() > 0 || failed > 0 || cleanup.cleaned() > 0 || cleanup.retained() > 0) {
+            log.info(
+                    "Legacy workflow artifact storage reconciliation finished, migrated={}, cleaned={}, retained={}, failed={}",
+                    migration.migrated(),
+                    cleanup.cleaned(),
+                    cleanup.retained(),
+                    failed);
+        }
+    }
+
+    private LegacyReferenceMigrationResult migrateLegacyArtifactReferences() {
         String targetBucket = artifactProperties.getArtifactBucket();
         Long lastId = null;
         int migrated = 0;
@@ -155,8 +168,14 @@ public class WorkflowArtifactService
                 migrated++;
             }
         }
+        return new LegacyReferenceMigrationResult(migrated, failed);
+    }
+
+    private LegacyPublicCleanupResult cleanupLegacyPublicArtifacts() {
+        String sourceBucket = s3ClientUtil.getDefaultBucket();
         int cleaned = 0;
         int retained = 0;
+        int failed = 0;
         try {
             List<String> publicObjectKeys =
                     s3ClientUtil.listObjectKeys(
@@ -211,15 +230,12 @@ public class WorkflowArtifactService
                     "Unable to reconcile the legacy public workflow artifact prefix; its anonymous access remains blocked",
                     exception);
         }
-        if (migrated > 0 || failed > 0 || cleaned > 0 || retained > 0) {
-            log.info(
-                    "Legacy workflow artifact storage reconciliation finished, migrated={}, cleaned={}, retained={}, failed={}",
-                    migrated,
-                    cleaned,
-                    retained,
-                    failed);
-        }
+        return new LegacyPublicCleanupResult(cleaned, retained, failed);
     }
+
+    private record LegacyReferenceMigrationResult(int migrated, int failed) {}
+
+    private record LegacyPublicCleanupResult(int cleaned, int retained, int failed) {}
 
     public List<WorkflowArtifactDto> listArtifacts(Long workflowId) {
         assertWorkflowVisible(workflowId);

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -1471,6 +1471,12 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
      * @return Debug result
      */
     public ApiResult<Object> nodeDebug(String nodeId, WorkflowDebugDto debugDto) {
+        BizWorkflowNode node = prepareNodeDebug(debugDto);
+        injectScriptSandboxIntoCodeNodes(List.of(node), debugDto.getFlowId());
+        return executeNodeDebug(nodeId, debugDto);
+    }
+
+    private BizWorkflowNode prepareNodeDebug(WorkflowDebugDto debugDto) {
         // The submitted payload contains only the node being debugged and is fully client
         // controlled. Authorize the workflow and validate the complete persisted draft first so
         // callers cannot omit an unresolved imported node or strip its marker to reach core.
@@ -1531,8 +1537,11 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
                 throw new BusinessException(ResponseEnum.INTERNAL_SERVER_ERROR);
             }
         }
-        injectScriptSandboxIntoCodeNodes(List.of(node), debugDto.getFlowId());
+        return node;
+    }
 
+    private ApiResult<Object> executeNodeDebug(String nodeId, WorkflowDebugDto debugDto) {
+        BizWorkflowData bizWorkflowData = debugDto.getData();
         // Build core protocol
         FlowProtocol protocol = new FlowProtocol();
         org.springframework.beans.BeanUtils.copyProperties(debugDto, protocol);

--- a/core/agent/service/plugin/skill_resource_security.py
+++ b/core/agent/service/plugin/skill_resource_security.py
@@ -52,74 +52,95 @@ def _decoded_path(raw_path: str) -> str:
     return path
 
 
+def _validate_resource_inputs(
+    candidate_value: str, origin_value: str, bucket: str
+) -> None:
+    if (
+        not candidate_value
+        or len(candidate_value) > 8192
+        or any(character in candidate_value for character in ("\r", "\n", "\t"))
+        or not origin_value
+        or len(origin_value) > 2048
+        or any(character in origin_value for character in ("\r", "\n", "\t"))
+        or not re.fullmatch(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]", bucket)
+    ):
+        raise ValueError
+
+
+def _validate_resource_origin(candidate: Any, origin: Any) -> None:
+    if (
+        origin.scheme.lower() not in {"http", "https"}
+        or not origin.hostname
+        or origin.username is not None
+        or origin.password is not None
+        or bool(origin.query)
+        or bool(origin.fragment)
+        or candidate.scheme.lower() != origin.scheme.lower()
+        or not candidate.hostname
+        or candidate.hostname.lower() != origin.hostname.lower()
+        or _effective_port(candidate) != _effective_port(origin)
+        or candidate.username is not None
+        or candidate.password is not None
+        or bool(candidate.fragment)
+    ):
+        raise ValueError
+
+
+def _validate_resource_path(candidate: Any, origin: Any, bucket: str) -> None:
+    origin_path = _decoded_path(origin.path or "/").rstrip("/")
+    candidate_path = _decoded_path(candidate.path)
+    if _INVALID_PERCENT_ESCAPE.search(candidate.query):
+        raise ValueError
+    required_prefix = f"{origin_path}/{bucket}/{SKILL_OBJECT_PREFIX}"
+    if not candidate_path.startswith(required_prefix) or len(candidate_path) <= len(
+        required_prefix
+    ):
+        raise ValueError
+
+
+def _parse_sigv4_parameters(query: str) -> dict[str, str]:
+    pairs = parse_qsl(
+        query,
+        keep_blank_values=True,
+        strict_parsing=True,
+        encoding="utf-8",
+        errors="strict",
+    )
+    parameters: dict[str, str] = {}
+    for raw_key, value in pairs:
+        key = raw_key.lower()
+        if not key or not value or key in parameters:
+            raise ValueError
+        parameters[key] = value
+    return parameters
+
+
+def _validate_sigv4_parameters(parameters: dict[str, str]) -> None:
+    if not _SIGV4_REQUIRED_PARAMETERS.issubset(parameters):
+        raise ValueError
+    if (
+        parameters["x-amz-algorithm"] != "AWS4-HMAC-SHA256"
+        or re.fullmatch(r"\d{8}T\d{6}Z", parameters["x-amz-date"]) is None
+        or re.fullmatch(r"[0-9a-fA-F]{64}", parameters["x-amz-signature"]) is None
+    ):
+        raise ValueError
+    expiry = int(parameters["x-amz-expires"])
+    if not 1 <= expiry <= 604800:
+        raise ValueError
+
+
 def validate_skill_resource_url(url: str) -> str:
     """Require the configured origin, console bucket, Skill prefix, and SigV4 shape."""
     candidate_value = str(url or "").strip()
     origin_value = (os.getenv(SKILL_RESOURCE_TRUSTED_ORIGIN_ENV) or "").strip()
     bucket = (os.getenv(SKILL_RESOURCE_TRUSTED_BUCKET_ENV) or "").strip()
     try:
-        if (
-            not candidate_value
-            or len(candidate_value) > 8192
-            or any(character in candidate_value for character in ("\r", "\n", "\t"))
-            or not origin_value
-            or len(origin_value) > 2048
-            or any(character in origin_value for character in ("\r", "\n", "\t"))
-            or not re.fullmatch(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]", bucket)
-        ):
-            raise ValueError
+        _validate_resource_inputs(candidate_value, origin_value, bucket)
         candidate = urlsplit(candidate_value)
         origin = urlsplit(origin_value)
-        if (
-            origin.scheme.lower() not in {"http", "https"}
-            or not origin.hostname
-            or origin.username is not None
-            or origin.password is not None
-            or bool(origin.query)
-            or bool(origin.fragment)
-            or candidate.scheme.lower() != origin.scheme.lower()
-            or not candidate.hostname
-            or candidate.hostname.lower() != origin.hostname.lower()
-            or _effective_port(candidate) != _effective_port(origin)
-            or candidate.username is not None
-            or candidate.password is not None
-            or bool(candidate.fragment)
-        ):
-            raise ValueError
-        origin_path = _decoded_path(origin.path or "/").rstrip("/")
-        candidate_path = _decoded_path(candidate.path)
-        if _INVALID_PERCENT_ESCAPE.search(candidate.query):
-            raise ValueError
-        required_prefix = f"{origin_path}/{bucket}/{SKILL_OBJECT_PREFIX}"
-        if not candidate_path.startswith(required_prefix) or len(candidate_path) <= len(
-            required_prefix
-        ):
-            raise ValueError
-
-        pairs = parse_qsl(
-            candidate.query,
-            keep_blank_values=True,
-            strict_parsing=True,
-            encoding="utf-8",
-            errors="strict",
-        )
-        parameters: dict[str, str] = {}
-        for raw_key, value in pairs:
-            key = raw_key.lower()
-            if not key or not value or key in parameters:
-                raise ValueError
-            parameters[key] = value
-        if not _SIGV4_REQUIRED_PARAMETERS.issubset(parameters):
-            raise ValueError
-        if (
-            parameters["x-amz-algorithm"] != "AWS4-HMAC-SHA256"
-            or re.fullmatch(r"\d{8}T\d{6}Z", parameters["x-amz-date"]) is None
-            or re.fullmatch(r"[0-9a-fA-F]{64}", parameters["x-amz-signature"]) is None
-        ):
-            raise ValueError
-        expiry = int(parameters["x-amz-expires"])
-        if not 1 <= expiry <= 604800:
-            raise ValueError
+        _validate_resource_origin(candidate, origin)
+        _validate_resource_path(candidate, origin, bucket)
+        _validate_sigv4_parameters(_parse_sigv4_parameters(candidate.query))
     except (TypeError, ValueError):
         raise RuntimeError(SKILL_RESOURCE_ERROR) from None
     return candidate_value

--- a/core/workflow/tests/alembic/test_flow_protocol_secret_sanitization.py
+++ b/core/workflow/tests/alembic/test_flow_protocol_secret_sanitization.py
@@ -66,7 +66,7 @@ def test_upgrade_updates_only_changed_valid_json_without_leaking_values(
     )
     unchanged = '{ "apiKey": "valid-model-key", "data": {"nodes": []} }'
     invalid = '{"sandbox":'
-    update_statements: list[tuple[str, object]] = []
+    update_statements: list[tuple[str, tuple[object, ...]]] = []
 
     @sa.event.listens_for(engine, "before_cursor_execute")
     def capture_updates(
@@ -78,6 +78,7 @@ def test_upgrade_updates_only_changed_valid_json_without_leaking_values(
         _executemany: bool,
     ) -> None:
         if statement.lstrip().upper().startswith("UPDATE"):
+            assert isinstance(parameters, tuple)
             update_statements.append((statement, parameters))
 
     with engine.begin() as connection:

--- a/core/workflow/tests/engine/nodes/test_code_node_sandbox.py
+++ b/core/workflow/tests/engine/nodes/test_code_node_sandbox.py
@@ -1210,6 +1210,9 @@ async def test_code_artifact_uploader_rejects_untrusted_response_shape(
     reflected_payload = json.loads(json.dumps(payload).replace("SENSITIVE", sentinel))
 
     class FakeResponse:
+        def __init__(self) -> None:
+            self.status = status
+
         async def __aenter__(self) -> "FakeResponse":
             return self
 
@@ -1233,9 +1236,7 @@ async def test_code_artifact_uploader_rejects_untrusted_response_shape(
             return None
 
         def post(self, *args: Any, **kwargs: Any) -> FakeResponse:
-            response = FakeResponse()
-            response.status = status
-            return response
+            return FakeResponse()
 
     monkeypatch.setattr(
         "workflow.engine.nodes.code.executor.e2b.e2b_executor.aiohttp.FormData",

--- a/core/workflow/tests/test_protocol_sanitization.py
+++ b/core/workflow/tests/test_protocol_sanitization.py
@@ -1,6 +1,7 @@
 """Tests for workflow protocol persistence and runtime sanitization."""
 
 import json
+from typing import Any
 
 from workflow.utils.protocol_sanitization import (
     sanitize_protocol,
@@ -9,7 +10,7 @@ from workflow.utils.protocol_sanitization import (
 
 
 def test_sanitizer_rebuilds_nested_sandboxes_and_removes_legacy_fields() -> None:
-    protocol = {
+    protocol: dict[str, Any] = {
         "apiKey": "valid-model-key",
         "api_key": "valid-provider-key",
         "artifact_upload_token": "global-legacy-token",


### PR DESCRIPTION
## Summary
- split long and complex Java workflow methods without changing behavior
- split Skill resource URL validation into focused helpers
- tighten workflow test doubles and annotations for mypy

## Validation
- fixes derived from remote Linux check-java and check-python failures
- full remote quality and test matrices will be rerun after merge