### PR TITLE
fix(ci): address layered quality failures

### DIFF
--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillRuntimeToolService.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/chat/springai/SkillRuntimeToolService.java
@@ -169,20 +169,38 @@ public class SkillRuntimeToolService {
         } catch (URISyntaxException exception) {
             throw new IOException("Skill resource URL is not allowed");
         }
-        String candidateScheme = normalizeScheme(candidate.getScheme());
+        validateConfiguredOrigin(configuredOrigin);
+        validateCandidateOrigin(candidate, configuredOrigin);
+        validateResourcePath(candidate, configuredOrigin);
+        validateSigV4Query(candidate.getRawQuery());
+    }
+
+    private void validateConfiguredOrigin(URI configuredOrigin) throws IOException {
         String configuredScheme = normalizeScheme(configuredOrigin.getScheme());
         if (!("http".equals(configuredScheme) || "https".equals(configuredScheme))
                 || StringUtils.isBlank(configuredOrigin.getHost())
                 || configuredOrigin.getRawUserInfo() != null
                 || configuredOrigin.getRawQuery() != null
-                || configuredOrigin.getRawFragment() != null
-                || !("http".equals(candidateScheme) || "https".equals(candidateScheme))
+                || configuredOrigin.getRawFragment() != null) {
+            throw new IOException("Skill resource URL is not allowed");
+        }
+    }
+
+    private void validateCandidateOrigin(URI candidate, URI configuredOrigin) throws IOException {
+        String candidateScheme = normalizeScheme(candidate.getScheme());
+        String configuredScheme = normalizeScheme(configuredOrigin.getScheme());
+        if (!("http".equals(candidateScheme) || "https".equals(candidateScheme))
                 || !candidateScheme.equals(configuredScheme)
                 || !StringUtils.equalsIgnoreCase(candidate.getHost(), configuredOrigin.getHost())
                 || effectivePort(candidate) != effectivePort(configuredOrigin)
                 || candidate.getRawUserInfo() != null
-                || candidate.getRawFragment() != null
-                || StringUtils.isBlank(candidate.getRawPath())
+                || candidate.getRawFragment() != null) {
+            throw new IOException("Skill resource URL is not allowed");
+        }
+    }
+
+    private void validateResourcePath(URI candidate, URI configuredOrigin) throws IOException {
+        if (StringUtils.isBlank(candidate.getRawPath())
                 || candidate.getRawPath().contains("\\")
                 || hasUnsafePathSegment(candidate.getPath())) {
             throw new IOException("Skill resource URL is not allowed");
@@ -197,7 +215,6 @@ public class SkillRuntimeToolService {
                 || candidatePath.length() <= requiredPrefix.length()) {
             throw new IOException("Skill resource URL is not allowed");
         }
-        validateSigV4Query(candidate.getRawQuery());
     }
 
     private String normalizeScheme(String scheme) {

--- a/core/agent/tests/test_skill_plugin.py
+++ b/core/agent/tests/test_skill_plugin.py
@@ -1229,6 +1229,9 @@ class TestSkillPluginFactory:
         )
 
         class FakeResponse:
+            def __init__(self) -> None:
+                self.status = status
+
             async def __aenter__(self) -> "FakeResponse":
                 return self
 
@@ -1252,9 +1255,7 @@ class TestSkillPluginFactory:
                 return None
 
             def post(self, *args: Any, **kwargs: Any) -> FakeResponse:
-                response = FakeResponse()
-                response.status = status
-                return response
+                return FakeResponse()
 
         monkeypatch.setattr(
             "agent.service.plugin.skill_sandbox.aiohttp.FormData", MagicMock

--- a/core/agent/tests/test_skill_sandbox_api.py
+++ b/core/agent/tests/test_skill_sandbox_api.py
@@ -140,7 +140,7 @@ def test_direct_sandbox_execution_requires_fresh_body_hmac(
     raw_body = b'{"skill_id":"skill-1"}'
     timestamp = now if case != "stale" else now - 301
     timestamp_value = str(timestamp)
-    signature = hmac.new(
+    signature: str | None = hmac.new(
         token.encode(),
         timestamp_value.encode() + b"\n" + raw_body,
         hashlib.sha256,


### PR DESCRIPTION
## Summary
- split Skill resource URL validation to satisfy Java complexity limits
- annotate nullable HMAC test input
- declare fake upload response status for mypy

## Validation
- derived from the second remote Linux quality-check pass
- full remote quality and test matrices will be rerun after merge