### PR TITLE
fix(console): remove vacuous exception check

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -1525,16 +1525,14 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             }
             checkAndEditData(bizNodeData, prefix);
             fixOnRepoNode(type, bizNodeData, prefix);
-        } catch (Exception exception) {
+        } catch (RuntimeException exception) {
             if (!node.getId().startsWith(WorkflowConst.NodeType.FLOW)
                     && CommonConst.FIXED_APPID_ENV.contains(env)) {
                 buidKeyInfo(bizNodeData);
                 checkAndEditData(bizNodeData, prefix);
                 fixOnRepoNode(type, bizNodeData, prefix);
-            } else if (exception instanceof RuntimeException runtimeException) {
-                throw runtimeException;
             } else {
-                throw new BusinessException(ResponseEnum.INTERNAL_SERVER_ERROR);
+                throw exception;
             }
         }
         return node;


### PR DESCRIPTION
## Summary
- preserve the node-debug runtime exception fallback behavior
- remove a vacuous RuntimeException type check reported by SpotBugs

## Validation
- derived from the third remote Linux check-java pass
- full remote quality and test matrices will be rerun after merge