### PR TITLE
fix(security): fail closed on unset database and Redis credentials

### DIFF
--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -13,17 +13,21 @@ ASTRON_AGENT_VERSION=latest
 # ============================================================================
 
 # PostgreSQL Configuration
+# Required: set a strong, unique password. The stack refuses to start while this
+# is empty. Example generator: openssl rand -hex 24
 POSTGRES_USER=spark
-POSTGRES_PASSWORD=spark123
+POSTGRES_PASSWORD=
 # PostgreSQL connection configuration. If deploying middleware independently, modify the following configuration; otherwise, use default
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 
 # MySQL Configuration
-MYSQL_ROOT_PASSWORD=root123
+# Required: set a strong, unique password. The stack refuses to start while this
+# is empty. Example generator: openssl rand -hex 24
+MYSQL_ROOT_PASSWORD=
 # MySQL connection configuration. If deploying middleware independently, modify the following configuration; otherwise, use default
 MYSQL_USER=root
-MYSQL_PASSWORD=${MYSQL_ROOT_PASSWORD:-root123}
+MYSQL_PASSWORD=${MYSQL_ROOT_PASSWORD}
 MYSQL_HOST=mysql
 MYSQL_PORT=3306
 MYSQL_URL=jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true
@@ -146,7 +150,7 @@ DATABASE_DB_TYPE=mysql
 # Database username
 DATABASE_USERNAME=${MYSQL_USER:-root}
 # Database password
-DATABASE_PASSWORD=${MYSQL_PASSWORD:-root123}
+DATABASE_PASSWORD=${MYSQL_PASSWORD}
 # Database (ip:port)/database name
 DATABASE_URL=(mysql:3306)/tenant
 # Database maximum connections

--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -33,7 +33,9 @@ MYSQL_PORT=3306
 MYSQL_URL=jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true
 
 # Redis Configuration
-REDIS_PASSWORD=123
+# Required: set a strong, unique password. The stack refuses to start while this
+# is empty. Example generator: openssl rand -hex 24
+REDIS_PASSWORD=
 REDIS_DATABASE=0
 REDIS_IS_CLUSTER=false
 REDIS_CLUSTER_ADDR=

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
     networks:
       - astron-agent-network
     restart: always
-    command: redis-server ${REDIS_PASSWORD:+--requirepass} ${REDIS_PASSWORD}
+    command: redis-server --requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ${REDIS_PASSWORD:+-a \"$REDIS_PASSWORD\"} ping | grep PONG"]
       interval: ${HEALTH_CHECK_INTERVAL:-30s}
@@ -276,7 +276,7 @@ services:
       OTLP_ENABLE: "${OTLP_ENABLE:-0}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -335,7 +335,7 @@ services:
       REDIS_IS_CLUSTER: "${REDIS_IS_CLUSTER:-false}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
       OTLP_ENDPOINT: "${OTLP_ENDPOINT:-127.0.0.1:4317}"
       OTLP_ENABLE: "${OTLP_ENABLE:-0}"
       KAFKA_ENABLE: "${KAFKA_ENABLE:-0}"
@@ -373,7 +373,7 @@ services:
       KAFKA_SERVERS: "${KAFKA_SERVERS:-kafka:29092}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
       REDIS_DATABASE: "${REDIS_DATABASE:-0}"
       REDIS_DATABASE_CONSOLE: "${REDIS_DATABASE_CONSOLE:-0}"
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
@@ -412,7 +412,7 @@ services:
       SERVICE_WS_PING_TIMEOUT: "${SERVICE_WS_PING_TIMEOUT:-false}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
       REDIS_EXPIRE: "${REDIS_EXPIRE:-3600}"
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
@@ -499,7 +499,7 @@ services:
       OTLP_ENABLE: "${OTLP_ENABLE:-0}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
       REDIS_DATABASE_CONSOLE: "${REDIS_DATABASE_CONSOLE:-0}"
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
@@ -544,7 +544,7 @@ services:
       CONSOLE_MYSQL_DB: "${CONSOLE_MYSQL_DB:-astron_console}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
       REDIS_DATABASE_CONSOLE: "${REDIS_DATABASE_CONSOLE:-0}"
       REDIS_EXPIRE: "${REDIS_EXPIRE:-3600}"
       OTLP_ENDPOINT: "${OTLP_ENDPOINT:-127.0.0.1:4317}"
@@ -679,7 +679,7 @@ services:
       MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       REDIS_HOST: "${REDIS_HOST:-redis}"
       REDIS_PORT: "${REDIS_PORT:-6379}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Set REDIS_PASSWORD to a strong, unique value}"
       REDIS_DATABASE_CONSOLE: "${REDIS_DATABASE_CONSOLE:-0}"
       OSS_ENDPOINT: "${OSS_ENDPOINT:-http://minio:${EXPOSE_MINIO_PORT:-18998}}"
       OSS_REMOTE_ENDPOINT: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT explicitly}"

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_DB: sparkdb_manager
       POSTGRES_USER: ${POSTGRES_USER:-spark}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-spark123}
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a strong, unique value}"
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -29,7 +29,7 @@ services:
     image: mysql:8.4.6
     container_name: astron-agent-mysql
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root123}
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD to a strong, unique value}"
       MYSQL_DATABASE: ${CONSOLE_MYSQL_DB:-astron_console}
     volumes:
       - mysql_data:/var/lib/mysql
@@ -232,7 +232,7 @@ services:
       SERVICE_LOCATION: "${SERVICE_LOCATION:-hf}"
       DATABASE_DB_TYPE: "${DATABASE_DB_TYPE:-mysql}"
       DATABASE_USERNAME: "${DATABASE_USERNAME:-root}"
-      DATABASE_PASSWORD: "${DATABASE_PASSWORD:-root123}"
+      DATABASE_PASSWORD: "${DATABASE_PASSWORD:?Set DATABASE_PASSWORD to a strong, unique value}"
       DATABASE_URL: "${DATABASE_URL:-(localhost:3306)/tenant}"
       DATABASE_MAX_OPEN_CONNS: "${DATABASE_MAX_OPEN_CONNS:-5}"
       DATABASE_MAX_IDLE_CONNS: "${DATABASE_MAX_IDLE_CONNS:-5}"
@@ -265,12 +265,12 @@ services:
       PGSQL_HOST: "${POSTGRES_HOST:-postgres}"
       PGSQL_PORT: "${POSTGRES_PORT:-5432}"
       PGSQL_USER: "${POSTGRES_USER:-spark}"
-      PGSQL_PASSWORD: "${POSTGRES_PASSWORD:-spark123}"
+      PGSQL_PASSWORD: "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a strong, unique value}"
       PGSQL_DATABASE: "${DATABASE_POSTGRES_DATABASE:-sparkdb_manager}"
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       MYSQL_DATABASE: "${DATABASE_MYSQL_DATABASE:-sparkdb_manager}"
       OTLP_ENDPOINT: "${OTLP_ENDPOINT:-127.0.0.1:4317}"
       OTLP_ENABLE: "${OTLP_ENABLE:-0}"
@@ -330,7 +330,7 @@ services:
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       MYSQL_DB: "${LINK_MYSQL_DB:-spark-link}"
       REDIS_IS_CLUSTER: "${REDIS_IS_CLUSTER:-false}"
       REDIS_ADDR: "${REDIS_ADDR:-redis:6379}"
@@ -379,7 +379,7 @@ services:
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       CONSOLE_MYSQL_DB: "${CONSOLE_MYSQL_DB:-astron_console}"
       MYSQL_URL: "${MYSQL_URL:-jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true}"
     depends_on:
@@ -417,7 +417,7 @@ services:
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       MYSQL_DB: "${AGENT_MYSQL_DB:-agent}"
       OTLP_ENDPOINT: "${OTLP_ENDPOINT:-127.0.0.1:4317}"
       LANGFUSE_ENABLED: "${LANGFUSE_ENABLED:-false}"
@@ -504,7 +504,7 @@ services:
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       CONSOLE_MYSQL_DB: "${CONSOLE_MYSQL_DB:-astron_console}"
       MYSQL_URL: "${MYSQL_URL:-jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true}"
     depends_on:
@@ -539,7 +539,7 @@ services:
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       MYSQL_DB: "${WORKFLOW_MYSQL_DB:-workflow}"
       CONSOLE_MYSQL_DB: "${CONSOLE_MYSQL_DB:-astron_console}"
       REDIS_CLUSTER_ADDR: "${REDIS_CLUSTER_ADDR}"
@@ -676,7 +676,7 @@ services:
       CONSOLE_DOMAIN: "${CONSOLE_DOMAIN:-https://your.deployment.domain}"
       MYSQL_URL: "${MYSQL_URL:-jdbc:mysql://mysql:3306/astron_console?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8&createDatabaseIfNotExist=true}"
       MYSQL_USER: "${MYSQL_USER:-root}"
-      MYSQL_PASSWORD: "${MYSQL_PASSWORD:-root123}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD:?Set MYSQL_PASSWORD to a strong, unique value}"
       REDIS_HOST: "${REDIS_HOST:-redis}"
       REDIS_PORT: "${REDIS_PORT:-6379}"
       REDIS_PASSWORD: "${REDIS_PASSWORD}"


### PR DESCRIPTION
## What

The bundled compose stack shipped well-known default credentials that the documented `cp .env.example .env` deployment path used verbatim:

- PostgreSQL superuser `spark123` and MySQL superuser `root123`, via `${VAR:-default}` fallbacks in compose plus the same values set in `.env.example`.
- Redis enabled `--requirepass` only when `REDIS_PASSWORD` was non-empty, and `.env.example` shipped the weak value `123` — so the default deployment ran Redis with a known password (or none, if the operator cleared it).

This aligns those credentials with the fail-fast preflight already used for MinIO/OSS.

## Changes

**`docker/astronAgent/docker-compose.yaml`**
- Database credentials (`POSTGRES_PASSWORD`, `MYSQL_ROOT_PASSWORD`, `MYSQL_PASSWORD`, `DATABASE_PASSWORD`): `${VAR:-weak-default}` → `${VAR:?message}`.
- Redis: server command now `redis-server --requirepass ${REDIS_PASSWORD:?…}` (password mandatory, no longer conditional), and every consumer's `REDIS_PASSWORD` reference is fail-fast.

**`docker/astronAgent/.env.example`**
- Blank `POSTGRES_PASSWORD` / `MYSQL_ROOT_PASSWORD` / `REDIS_PASSWORD` (with a short comment, same style as the MinIO block), and drop the `:-root123` fallbacks from the chained `MYSQL_PASSWORD` / `DATABASE_PASSWORD`.

## Why change both files

The compose `${VAR:-default}` fallback only triggers when the variable is unset. Because `.env.example` set the weak values explicitly, changing compose alone would have no effect on the default deployment — both files must change together.

## Validation

- `docker-compose.yaml` remains valid YAML (16 services parse).
- Compose variable semantics verified: an unset/empty credential aborts `docker compose up` with the guidance message; a set value resolves normally.

## Out of scope (follow-up, needs coordination)

Service-to-service auth secrets (`APP_AUTH_API_KEY`/`APP_AUTH_SECRET`, `COMMON_API_SECRET`, `TENANT_KEY`/`TENANT_SECRET`) still carry placeholder defaults. These are validated by the `core-tenant` service against provisioned key data, so making the client side fail-fast requires updating the tenant-side provisioning in lockstep; converting them here would break the default deployment. Left for a coordinated follow-up. `WORKFLOW_INTERNAL_API_KEY` intentionally keeps its placeholder default — the auth layer treats the placeholder as "not configured" and returns 503, so it is already fail-closed.