### PR TITLE
fix(console): pin validated DNS for redirect probes

### DIFF
--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -123,9 +123,9 @@ public class UrlCheckTool {
         // IP during the actual request.
         Dns pinnedDns = createPinnedDns(Dns.SYSTEM, ipWhiteList);
         OkHttpClient client = REDIRECT_PROBE_CLIENT.newBuilder().dns(pinnedDns).build();
+        // The direct client connects only to addresses returned by the validated, pinned DNS.
+        // codeql[java/ssrf]
         Request request = new Request.Builder()
-                // The direct client connects only to addresses returned by the validated, pinned DNS.
-                // codeql[java/ssrf]
                 .url(u)
                 .head()
                 .build();

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -7,6 +7,10 @@ import com.iflytek.astron.console.toolkit.mapper.ConfigInfoMapper;
 import com.iflytek.astron.console.toolkit.util.ssrf.SsrfValidators;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.Dns;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +19,7 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -67,6 +72,16 @@ public class UrlCheckTool {
             "bit.ly", "tinyurl.com", "t.co", "rebrandly.com", "is.gd", "t.ly",
             "monojson.com", "t.cn", "url.cn", "dwz.cn");
 
+    // Shared base client for redirect probing. Redirects are inspected one hop at a time, and direct
+    // connections ensure that the per-call pinned DNS controls the actual destination address.
+    private static final OkHttpClient REDIRECT_PROBE_CLIENT = new OkHttpClient.Builder()
+            .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .proxy(Proxy.NO_PROXY)
+            .build();
+
     /**
      * Gets the direct redirected URL without following it automatically.
      *
@@ -100,25 +115,20 @@ public class UrlCheckTool {
     }
 
     private RedirectLookupResult lookupRedirect(String url, List<String> ipWhiteList) throws IOException {
-        HttpURLConnection conn = null;
-        try {
-            URL u = toSafeHttpUrl(url);
-            ensurePublicAddresses(u.getHost(), ipWhiteList);
-            URLConnection urlConnection = u.openConnection();
-            if (!(urlConnection instanceof HttpURLConnection httpURLConnection)) {
-                throw new BusinessException(ResponseEnum.TOOLBOX_URL_HTTP_HTTPS_ONLY);
-            }
-            conn = httpURLConnection;
-            conn.setInstanceFollowRedirects(false);
-            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
-            conn.setReadTimeout(READ_TIMEOUT_MS);
-            conn.setRequestMethod("HEAD");
-            int code = conn.getResponseCode();
-            return new RedirectLookupResult(code, conn.getHeaderField("Location"));
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
+        URL u = toSafeHttpUrl(url);
+        // Pin DNS resolution to the validated public addresses so the address vetted here is exactly
+        // the one connected to. Resolving inside the client (instead of a separate pre-flight check
+        // followed by an independent resolution at connect time) removes the DNS-rebinding / TOCTOU
+        // window where a hostname could resolve to a public IP during validation and to an internal
+        // IP during the actual request.
+        Dns pinnedDns = createPinnedDns(Dns.SYSTEM, ipWhiteList);
+        OkHttpClient client = REDIRECT_PROBE_CLIENT.newBuilder().dns(pinnedDns).build();
+        Request request = new Request.Builder()
+                .url(u)
+                .head()
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            return new RedirectLookupResult(response.code(), response.header("Location"));
         }
     }
 
@@ -487,27 +497,6 @@ public class UrlCheckTool {
 
     private record RedirectLookupResult(int statusCode, String location) {}
 
-    private boolean isHostInDomainAllowList(String host, List<String> domainWhiteList) {
-        if (StringUtils.isBlank(host) || domainWhiteList == null || domainWhiteList.isEmpty()) {
-            return false;
-        }
-        String normalizedHost = StringUtils.lowerCase(StringUtils.trim(host), Locale.ROOT);
-        for (String allowed : domainWhiteList) {
-            String normalizedAllowed = StringUtils.lowerCase(StringUtils.trimToEmpty(allowed), Locale.ROOT);
-            // Remove leading dot if present (e.g., ".example.com" -> "example.com")
-            if (normalizedAllowed.startsWith(".")) {
-                normalizedAllowed = normalizedAllowed.substring(1);
-            }
-            if (normalizedAllowed.isEmpty()) {
-                continue;
-            }
-            if (normalizedHost.equals(normalizedAllowed) || normalizedHost.endsWith("." + normalizedAllowed)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private URL toSafeHttpUrl(String url) throws IOException {
         try {
             URI uri = new URI(url);
@@ -537,13 +526,56 @@ public class UrlCheckTool {
         }
     }
 
-    private void ensurePublicAddresses(String host, List<String> ipWhiteList) throws UnknownHostException {
+    /**
+     * Creates a DNS implementation that pins the first validated resolution for each hostname. The
+     * caller therefore connects to exactly the addresses accepted by the IP policy, including if the
+     * HTTP client retries the lookup.
+     *
+     * <p>
+     * A restricted (loopback/private/link-local/etc.) address is rejected unless the host is an IP
+     * literal explicitly allowed by the IP whitelist, mirroring {@code validateUrlAgainstBlacklist}. An
+     * IP whitelist entry can only exempt an IP-literal URL, so a hostname cannot switch to an internal
+     * address between validation and connection.
+     * </p>
+     *
+     * @param resolver DNS resolver used for the initial lookup
+     * @param ipWhiteList allowed exact IPs or CIDR ranges for IP-literal hosts
+     * @return DNS implementation that returns only pinned, validated addresses
+     */
+    static Dns createPinnedDns(Dns resolver, List<String> ipWhiteList) {
+        return new Dns() {
+            private final Map<String, List<InetAddress>> pinnedAddresses = new HashMap<>();
+
+            @Override
+            public synchronized List<InetAddress> lookup(String hostname) throws UnknownHostException {
+                List<InetAddress> addresses = pinnedAddresses.get(hostname);
+                if (addresses == null) {
+                    addresses = List.copyOf(resolvePublicAddresses(resolver, hostname, ipWhiteList));
+                    pinnedAddresses.put(hostname, addresses);
+                }
+                return addresses;
+            }
+        };
+    }
+
+    private static List<InetAddress> resolvePublicAddresses(
+            Dns resolver, String host, List<String> ipWhiteList) throws UnknownHostException {
         boolean ipLiteral = SsrfValidators.isIpLiteral(host);
-        for (InetAddress address : InetAddress.getAllByName(host)) {
-            if (!(ipLiteral && SsrfValidators.isAddressMatchedByIpRules(address, ipWhiteList))
-                    && SsrfValidators.isRestrictedAddress(address)) {
+        List<InetAddress> resolved = resolver.lookup(host);
+        List<InetAddress> allowed = new ArrayList<>(resolved.size());
+        for (InetAddress address : resolved) {
+            if (ipLiteral && SsrfValidators.isAddressMatchedByIpRules(address, ipWhiteList)) {
+                allowed.add(address);
+                continue;
+            }
+            if (SsrfValidators.isRestrictedAddress(address)) {
                 throw new BusinessException(ResponseEnum.TOOLBOX_URL_ILLEGAL);
             }
+            allowed.add(address);
         }
+        if (allowed.isEmpty()) {
+            throw new UnknownHostException(host);
+        }
+        return allowed;
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/UrlCheckTool.java
@@ -124,6 +124,8 @@ public class UrlCheckTool {
         Dns pinnedDns = createPinnedDns(Dns.SYSTEM, ipWhiteList);
         OkHttpClient client = REDIRECT_PROBE_CLIENT.newBuilder().dns(pinnedDns).build();
         Request request = new Request.Builder()
+                // The direct client connects only to addresses returned by the validated, pinned DNS.
+                // codeql[java/ssrf]
                 .url(u)
                 .head()
                 .build();

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/UrlCheckToolTest.java
@@ -4,14 +4,17 @@ import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.toolkit.entity.table.ConfigInfo;
 import com.iflytek.astron.console.toolkit.mapper.ConfigInfoMapper;
 import com.sun.net.httpserver.HttpServer;
+import okhttp3.Dns;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -152,6 +155,33 @@ class UrlCheckToolTest {
         URL safeUrl = (URL) method.invoke(tool, "https://example.com/a%20b?q=a%20b");
 
         assertEquals("https://example.com/a%20b?q=a%20b", safeUrl.toString());
+    }
+
+    @Test
+    void pinnedDnsReusesValidatedAddressesInsteadOfResolvingAgain() throws Exception {
+        InetAddress publicAddress = InetAddress.getByAddress(
+                "rebind.example", new byte[] {93, (byte) 184, (byte) 216, 34});
+        InetAddress privateAddress = InetAddress.getByAddress(
+                "rebind.example", new byte[] {(byte) 192, (byte) 168, 1, 10});
+        AtomicInteger lookups = new AtomicInteger();
+        Dns rebindingResolver = hostname -> lookups.getAndIncrement() == 0
+                ? List.of(publicAddress)
+                : List.of(privateAddress);
+        Dns pinnedDns = UrlCheckTool.createPinnedDns(rebindingResolver, List.of());
+
+        assertEquals(List.of(publicAddress), pinnedDns.lookup("rebind.example"));
+        assertEquals(List.of(publicAddress), pinnedDns.lookup("rebind.example"));
+        assertEquals(1, lookups.get());
+    }
+
+    @Test
+    void pinnedDnsDoesNotApplyIpWhitelistToHostname() throws Exception {
+        InetAddress privateAddress = InetAddress.getByAddress(
+                "rebind.example", new byte[] {(byte) 192, (byte) 168, 1, 10});
+        Dns resolver = hostname -> List.of(privateAddress);
+        Dns pinnedDns = UrlCheckTool.createPinnedDns(resolver, List.of("192.168.1.10"));
+
+        assertThrows(BusinessException.class, () -> pinnedDns.lookup("rebind.example"));
     }
 
     private static ConfigInfoMapper mockConfigMapper(String ipBlackList, String segmentBlackList) {


### PR DESCRIPTION
## Summary

- replace the redirect probe's validation-then-connect flow with an OkHttp client using validated, pinned DNS results
- disable proxying and automatic redirects so the validated addresses control the actual connection target
- preserve IP-literal whitelist semantics and remove the unused domain allow-list helper
- add regression coverage for DNS rebinding and hostname/IP-whitelist isolation

## Validation

- `mvn -pl toolkit -am '-Dtest=UrlCheckToolTest,SsrfValidatorsTest' '-Dsurefire.failIfNoSpecifiedTests=false' test` (19 tests passed)
- `mvn -pl toolkit spotless:check`
- targeted Checkstyle (0 violations)
- `mvn -pl toolkit -am -DskipTests package pmd:check`