### PR TITLE
fix(security): harden internal service boundaries

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -113,9 +113,10 @@ jobs:
           -Dtest=S3ClientUtilMinioPolicyCompatibilityIT test
 
       - name: Verify rendered sandbox credential contract
-        run: >-
-          python3 docker/astronAgent/scripts/verify_security_contract.py
-          --ci-placeholder-required-env
+        run: python3 docker/astronAgent/scripts/verify_security_contract.py
+
+      - name: Verify Helm internal credential contract
+        run: python3 helm/astron-agent/tests/verify_tenant_bootstrap.py
 
   # ============================================================================
   # Stage 2: Build astron Agent Docker Images (Parallel Jobs)

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/security/TenantInternalApiKey.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/security/TenantInternalApiKey.java
@@ -1,0 +1,31 @@
+package com.iflytek.astron.console.commons.security;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
+
+/** Shared validation and header naming for trusted calls to the core tenant service. */
+public final class TenantInternalApiKey {
+
+    public static final String HEADER = "X-Tenant-Internal-Key";
+
+    private static final int MIN_LENGTH = 32;
+    private static final int MAX_LENGTH = 50;
+    private static final String LEGACY_PUBLIC_SECRET = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy";
+    private static final Pattern SAFE_VALUE = Pattern.compile("[A-Za-z0-9._~-]+");
+
+    private TenantInternalApiKey() {}
+
+    /** Return a normalized credential or fail closed before issuing an internal request. */
+    public static String requireConfigured(String configuredValue) {
+        String apiKey = StringUtils.trimToEmpty(configuredValue);
+        if (apiKey.length() < MIN_LENGTH
+                || apiKey.length() > MAX_LENGTH
+                || !SAFE_VALUE.matcher(apiKey).matches()
+                || LEGACY_PUBLIC_SECRET.equals(apiKey)) {
+            throw new IllegalStateException(
+                    "TENANT_SECRET must contain 32-50 safe characters and must not use the published legacy value");
+        }
+        return apiKey;
+    }
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/security/WorkflowGatewayIdentity.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/security/WorkflowGatewayIdentity.java
@@ -1,0 +1,70 @@
+package com.iflytek.astron.console.commons.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.HexFormat;
+import java.util.Set;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.lang3.StringUtils;
+
+/** Creates short-lived signed workflow identities without disclosing the shared internal key. */
+public final class WorkflowGatewayIdentity {
+
+    public static final String TIMESTAMP_HEADER = "X-Workflow-Gateway-Timestamp";
+    public static final String SIGNATURE_HEADER = "X-Workflow-Gateway-Signature";
+
+    private static final String POST = "POST";
+    private static final String HMAC_SHA_256 = "HmacSHA256";
+    private static final Set<String> PUBLIC_WORKFLOW_PATHS = Set.of(
+            "/workflow/v1/chat/completions", "/workflow/v1/resume");
+
+    private WorkflowGatewayIdentity() {}
+
+    /**
+     * Validate the original public request metadata and return the exact path bound into the signature.
+     * Query parameters are deliberately excluded; no decoding or path normalization is performed, so
+     * encoded or alternate paths fail closed.
+     */
+    public static String requireAuthorizedPath(String originalMethod, String originalUri) {
+        if (!POST.equals(originalMethod) || StringUtils.isEmpty(originalUri)) {
+            throw new IllegalArgumentException("unsupported workflow gateway request");
+        }
+        int queryStart = originalUri.indexOf('?');
+        String path = queryStart < 0 ? originalUri : originalUri.substring(0, queryStart);
+        if (!PUBLIC_WORKFLOW_PATHS.contains(path) || originalUri.indexOf('#') >= 0) {
+            throw new IllegalArgumentException("unsupported workflow gateway request");
+        }
+        return path;
+    }
+
+    /** Sign {@code method + newline + path + newline + appId + newline + epochSeconds}. */
+    public static String sign(
+            String configuredKey,
+            String method,
+            String path,
+            String appId,
+            long epochSeconds) {
+        String internalKey = WorkflowInternalApiKey.requireConfigured(configuredKey);
+        if (!POST.equals(method)
+                || !PUBLIC_WORKFLOW_PATHS.contains(path)
+                || StringUtils.isBlank(appId)
+                || appId.indexOf('\r') >= 0
+                || appId.indexOf('\n') >= 0
+                || epochSeconds < 0) {
+            throw new IllegalArgumentException("invalid workflow gateway identity");
+        }
+        String payload = method + '\n' + path + '\n' + appId + '\n' + epochSeconds;
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA_256);
+            mac.init(new SecretKeySpec(
+                    internalKey.getBytes(StandardCharsets.UTF_8), HMAC_SHA_256));
+            return HexFormat.of()
+                    .formatHex(
+                            mac.doFinal(payload.getBytes(StandardCharsets.UTF_8)));
+        } catch (GeneralSecurityException exception) {
+            throw new IllegalStateException(
+                    "Unable to sign workflow gateway identity", exception);
+        }
+    }
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/security/WorkflowInternalApiKey.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/security/WorkflowInternalApiKey.java
@@ -1,0 +1,27 @@
+package com.iflytek.astron.console.commons.security;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** Shared validation and header naming for trusted calls to the core workflow service. */
+public final class WorkflowInternalApiKey {
+
+    public static final String HEADER = "X-Workflow-Internal-Key";
+
+    private static final String PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY";
+    private static final int MIN_LENGTH = 32;
+
+    private WorkflowInternalApiKey() {}
+
+    /** Return a normalized credential or fail closed before issuing an internal request. */
+    public static String requireConfigured(String configuredValue) {
+        String apiKey = StringUtils.trimToEmpty(configuredValue);
+        if (apiKey.length() < MIN_LENGTH
+                || PLACEHOLDER.equals(apiKey)
+                || apiKey.indexOf('\r') >= 0
+                || apiKey.indexOf('\n') >= 0) {
+            throw new IllegalStateException(
+                    "WORKFLOW_INTERNAL_API_KEY must contain a non-default value of at least 32 characters");
+        }
+        return apiKey;
+    }
+}

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImpl.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImpl.java
@@ -90,6 +90,9 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
     @Value("${common.apiSecret}")
     private String appSecret;
 
+    @Value("${workflow.internal-api-key:}")
+    private String workflowInternalApiKey;
+
     /**
      * Handle chatbot workflow requests
      *
@@ -187,7 +190,8 @@ public class WorkflowBotChatServiceImpl implements WorkflowBotChatService {
             body = RequestBody.create(JSON.toJSONString(build), MediaType.parse("application/json; charset=utf-8"));
             apiUsedUrl = resumeUrl;
         }
-        WorkflowClient client = new WorkflowClient(apiUsedUrl, appId, appKey, appSecret, body);
+        WorkflowClient client = new WorkflowClient(
+                apiUsedUrl, appId, appKey, appSecret, body, workflowInternalApiKey);
         WorkflowListener listener = new WorkflowListener(client, chatReqRecords, sseId, wssListenerService, isDebug, sseEmitter);
         client.createWebSocketConnect(listener);
     }

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/util/MaasUtil.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/util/MaasUtil.java
@@ -16,6 +16,7 @@ import com.iflytek.astron.console.commons.entity.bot.UserLangChainInfo;
 import com.iflytek.astron.console.commons.enums.bot.BotUploadEnum;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import com.iflytek.astron.console.commons.service.bot.ChatBotTagService;
 import com.iflytek.astron.console.commons.service.data.UserLangChainDataService;
 import com.iflytek.astron.console.commons.service.workflow.impl.WorkflowBotParamServiceImpl;
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -77,6 +79,9 @@ public class MaasUtil {
 
     @Value("${maas.authApi}")
     private String authApi;
+
+    @Value("${workflow.internal-api-key:}")
+    private String workflowInternalApiKey;
 
     @Value("${maas.mcpHost}")
     private String mcpHost;
@@ -204,11 +209,15 @@ public class MaasUtil {
             // If it's newly created, then it's empty, use POST request
             httpMethod = "POST";
         }
-        log.info("----- maas synchronization request body: {}", JSONObject.toJSONString(param));
+        String requestJson = JSONObject.toJSONString(param);
+        log.info(
+                "MaaS workflow synchronization request prepared, method={}, bodyBytes={}",
+                httpMethod,
+                requestJson.getBytes(StandardCharsets.UTF_8).length);
 
         // Build request body
         RequestBody requestBody = RequestBody.create(
-                JSONObject.toJSONString(param),
+                requestJson,
                 MediaType.parse("application/json; charset=utf-8"));
 
         // Build request
@@ -242,7 +251,9 @@ public class MaasUtil {
 
         JSONObject res = JSONObject.parseObject(response);
         if (res.getInteger("code") != 0) {
-            log.error("------ Synchronize maas workflow failed, reason: {}", res);
+            log.error(
+                    "MaaS workflow synchronization was rejected, code={}",
+                    res.getInteger("code"));
             return new JSONObject();
         }
         return res;
@@ -434,18 +445,25 @@ public class MaasUtil {
      * @return String representation of response content
      */
     private String executeRequest(String url, MaasApi bodyData) {
+        String serializedBody = JSONObject.toJSONString(bodyData);
         RequestBody requestBody = RequestBody.create(
-                JSONObject.toJSONString(bodyData),
+                serializedBody,
                 MediaType.parse("application/json; charset=utf-8"));
         Request request = new Request.Builder()
                 .url(url)
                 .post(requestBody)
                 .addHeader("X-Consumer-Username", consumerId)
+                .addHeader(
+                        WorkflowInternalApiKey.HEADER,
+                        WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey))
                 .addHeader("Lang-Code", I18nUtil.getLanguage())
                 .addHeader("Authorization", "Bearer %s:%s".formatted(consumerKey, consumerSecret))
                 .addHeader(X_AUTH_SOURCE_HEADER, X_AUTH_SOURCE_VALUE)
                 .build();
-        log.info("MaasUtil executeRequest url: {} request: {}, header: {}, body: {}", request.url(), request, request.headers(), bodyData);
+        log.info(
+                "MaaS workflow API request, url={}, bodyBytes={}",
+                request.url(),
+                serializedBody.getBytes(StandardCharsets.UTF_8).length);
         try (Response httpResponse = HTTP_CLIENT.newCall(request).execute()) {
             ResponseBody responseBody = httpResponse.body();
             if (responseBody != null) {

--- a/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/workflow/WorkflowClient.java
+++ b/console/backend/commons/src/main/java/com/iflytek/astron/console/commons/workflow/WorkflowClient.java
@@ -1,5 +1,6 @@
 package com.iflytek.astron.console.commons.workflow;
 
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
@@ -25,6 +26,8 @@ public class WorkflowClient {
 
     private String appSecret;
 
+    private String workflowInternalApiKey;
+
     private Request request;
 
     private RequestBody requestBody;
@@ -39,12 +42,20 @@ public class WorkflowClient {
             .connectionPool(new ConnectionPool(1000, 10, TimeUnit.MINUTES))
             .build();
 
-    public WorkflowClient(String chatUrl, String appId, String appKey, String appSecret, RequestBody requestBody) {
+    public WorkflowClient(
+            String chatUrl,
+            String appId,
+            String appKey,
+            String appSecret,
+            RequestBody requestBody,
+            String workflowInternalApiKey) {
         this.chatUrl = chatUrl;
         this.appId = appId;
         this.appKey = appKey;
         this.appSecret = appSecret;
         this.requestBody = requestBody;
+        this.workflowInternalApiKey =
+                WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey);
     }
 
     /**
@@ -57,6 +68,7 @@ public class WorkflowClient {
         String wsURL = chatUrl;
         this.request = new Request.Builder()
                 .header("X-Consumer-Username", appId)
+                .header(WorkflowInternalApiKey.HEADER, workflowInternalApiKey)
                 .header("Authorization", genAuthorization())
                 .url(wsURL)
                 .post(requestBody)

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/security/TenantInternalApiKeyTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/security/TenantInternalApiKeyTest.java
@@ -1,0 +1,39 @@
+package com.iflytek.astron.console.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TenantInternalApiKeyTest {
+
+    @Test
+    void requireConfiguredAcceptsAndTrimsStrongCredential() {
+        String credential = "0123456789abcdef._~-0123456789abcdef";
+
+        assertThat(TenantInternalApiKey.requireConfigured("  " + credential + "  "))
+                .isEqualTo(credential);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            "",
+            "short-tenant-secret",
+            "0123456789abcdef\r0123456789abcdef",
+            "0123456789abcdef\n0123456789abcdef",
+            "0123456789abcdef!0123456789abcdef",
+            "0123456789abcdef中文0123456789abcdef",
+            "012345678901234567890123456789012345678901234567890",
+            "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+    })
+    void requireConfiguredRejectsValuesOutsideTenantBootstrapContract(String credential) {
+        assertThatThrownBy(() -> TenantInternalApiKey.requireConfigured(credential))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "TENANT_SECRET must contain 32-50 safe characters and must not use the published legacy value");
+    }
+}

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/security/WorkflowGatewayIdentityTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/security/WorkflowGatewayIdentityTest.java
@@ -1,0 +1,42 @@
+package com.iflytek.astron.console.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class WorkflowGatewayIdentityTest {
+
+    @Test
+    void signatureMatchesCrossLanguageFixedVector() {
+        assertThat(WorkflowGatewayIdentity.sign(
+                "g".repeat(32),
+                "POST",
+                "/workflow/v1/chat/completions",
+                "gateway-app",
+                1_700_000_000L))
+                .isEqualTo(
+                        "6261d5595286ac9407951e6c4c690bd1c50c2fbfe4f29addc50e3f437ef6a871");
+    }
+
+    @Test
+    void authorizedPathExcludesQueryWithoutDecodingThePath() {
+        assertThat(WorkflowGatewayIdentity.requireAuthorizedPath(
+                "POST", "/workflow/v1/resume?trace_id=123"))
+                .isEqualTo("/workflow/v1/resume");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "GET,/workflow/v1/chat/completions",
+            "POST,/workflow/v1/run",
+            "POST,/workflow/v1/chat%2Fcompletions",
+            "POST,/workflow/v1/chat/completions#fragment"
+    })
+    void unsupportedMethodOrAlternatePathFailsClosed(String method, String uri) {
+        assertThatThrownBy(() -> WorkflowGatewayIdentity.requireAuthorizedPath(method, uri))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/security/WorkflowInternalApiKeyTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/security/WorkflowInternalApiKeyTest.java
@@ -1,0 +1,36 @@
+package com.iflytek.astron.console.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class WorkflowInternalApiKeyTest {
+
+    @Test
+    void requireConfiguredAcceptsAndTrimsStrongCredential() {
+        String credential = "0123456789abcdef0123456789abcdef";
+
+        assertThat(WorkflowInternalApiKey.requireConfigured("  " + credential + "  "))
+                .isEqualTo(credential);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            "",
+            "short-internal-key",
+            "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY",
+            "0123456789abcdef\r0123456789abcdef",
+            "0123456789abcdef\n0123456789abcdef"
+    })
+    void requireConfiguredRejectsMissingDefaultOrHeaderInjectionValues(String credential) {
+        assertThatThrownBy(() -> WorkflowInternalApiKey.requireConfigured(credential))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "WORKFLOW_INTERNAL_API_KEY must contain a non-default value of at least 32 characters");
+    }
+}

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImplTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/service/workflow/impl/WorkflowBotChatServiceImplTest.java
@@ -100,6 +100,10 @@ class WorkflowBotChatServiceImplTest {
         ReflectionTestUtils.setField(workflowBotChatService, "appId", "testAppId");
         ReflectionTestUtils.setField(workflowBotChatService, "appKey", "testAppKey");
         ReflectionTestUtils.setField(workflowBotChatService, "appSecret", "testAppSecret");
+        ReflectionTestUtils.setField(
+                workflowBotChatService,
+                "workflowInternalApiKey",
+                "0123456789abcdef0123456789abcdef");
 
         // Set up test data
         sseId = "test-sse-id";

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/MaasUtilTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/MaasUtilTest.java
@@ -82,6 +82,10 @@ class MaasUtilTest {
         ReflectionTestUtils.setField(maasUtil, "consumerKey", "test-key");
         ReflectionTestUtils.setField(maasUtil, "publishApi", "http://test.com/publish");
         ReflectionTestUtils.setField(maasUtil, "authApi", "http://test.com/auth");
+        ReflectionTestUtils.setField(
+                maasUtil,
+                "workflowInternalApiKey",
+                "0123456789abcdef0123456789abcdef");
         ReflectionTestUtils.setField(maasUtil, "mcpHost", "http://test.com/mcp");
         ReflectionTestUtils.setField(maasUtil, "mcpReleaseUrl", "http://test.com/mcp/release");
     }

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/MaasUtilWorkflowInternalAuthTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/util/MaasUtilWorkflowInternalAuthTest.java
@@ -1,0 +1,150 @@
+package com.iflytek.astron.console.commons.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.iflytek.astron.console.commons.dto.bot.BotCreateForm;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MaasUtilWorkflowInternalAuthTest {
+
+    private static final String INTERNAL_KEY =
+            "internal-key-0123456789abcdef0123456789abcdef";
+    private static final String CONSUMER_KEY = "consumer-key-must-not-be-logged";
+    private static final String CONSUMER_SECRET = "consumer-secret-must-not-be-logged";
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void createApiSendsInternalKeyWithoutLoggingCredentials() throws IOException {
+        List<String> internalKeys = new CopyOnWriteArrayList<>();
+        List<String> authorizations = new CopyOnWriteArrayList<>();
+        List<String> consumers = new CopyOnWriteArrayList<>();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            internalKeys.add(exchange.getRequestHeaders()
+                    .getFirst("X-Workflow-Internal-Key"));
+            authorizations.add(exchange.getRequestHeaders().getFirst("Authorization"));
+            consumers.add(exchange.getRequestHeaders().getFirst("X-Consumer-Username"));
+            exchange.getRequestBody().readAllBytes();
+            byte[] response = "{\"code\":0}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(response);
+            }
+        });
+        server.start();
+
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        MaasUtil maasUtil = new MaasUtil();
+        ReflectionTestUtils.setField(maasUtil, "publishApi", baseUrl + "/publish");
+        ReflectionTestUtils.setField(maasUtil, "authApi", baseUrl + "/auth");
+        ReflectionTestUtils.setField(maasUtil, "consumerId", "consumer-app");
+        ReflectionTestUtils.setField(maasUtil, "consumerKey", CONSUMER_KEY);
+        ReflectionTestUtils.setField(maasUtil, "consumerSecret", CONSUMER_SECRET);
+        ReflectionTestUtils.setField(
+                maasUtil, "workflowInternalApiKey", INTERNAL_KEY);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(MaasUtil.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            maasUtil.createApi("flow-1", "target-app");
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(internalKeys).containsExactly(INTERNAL_KEY, INTERNAL_KEY);
+        assertThat(authorizations)
+                .containsExactly(
+                        "Bearer " + CONSUMER_KEY + ":" + CONSUMER_SECRET,
+                        "Bearer " + CONSUMER_KEY + ":" + CONSUMER_SECRET);
+        assertThat(consumers).containsExactly("consumer-app", "consumer-app");
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message)
+                        .contains("MaaS workflow API request")
+                        .contains("bodyBytes="))
+                .noneSatisfy(message -> assertThat(message)
+                        .containsAnyOf(INTERNAL_KEY, CONSUMER_KEY, CONSUMER_SECRET));
+    }
+
+    @Test
+    void synchronizeWorkflowLogsOnlySafeRequestAndResponseSummaries() throws IOException {
+        String authorization = "Bearer synchronization-credential-must-not-be-logged";
+        String requestSecret = "synchronization-request-secret";
+        String responseSecret = "synchronization-response-secret";
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/synchronize", exchange -> {
+            exchange.getRequestBody().readAllBytes();
+            byte[] response = ("{\"code\":401,\"api_secret\":\"" + responseSecret + "\"}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(response);
+            }
+        });
+        server.start();
+
+        MaasUtil maasUtil = new MaasUtil();
+        ReflectionTestUtils.setField(
+                maasUtil,
+                "synchronizeUrl",
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/synchronize");
+        ReflectionTestUtils.setField(maasUtil, "maasAppId", "maas-app");
+        BotCreateForm bot = new BotCreateForm();
+        bot.setBotId(1);
+        bot.setName(requestSecret);
+        bot.setBotDesc(requestSecret);
+        bot.setPrologue(requestSecret);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Authorization")).thenReturn(authorization);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(MaasUtil.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            assertThat(maasUtil.synchronizeWorkFlow(null, bot, request, 7L, 3, null)).isEmpty();
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message)
+                        .contains("MaaS workflow synchronization request prepared")
+                        .contains("method=POST")
+                        .contains("bodyBytes="))
+                .anySatisfy(message -> assertThat(message)
+                        .contains("MaaS workflow synchronization was rejected")
+                        .contains("code=401"))
+                .noneSatisfy(message -> assertThat(message)
+                        .containsAnyOf(authorization, requestSecret, responseSecret));
+    }
+}

--- a/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/workflow/WorkflowClientInternalAuthTest.java
+++ b/console/backend/commons/src/test/java/com/iflytek/astron/console/commons/workflow/WorkflowClientInternalAuthTest.java
@@ -1,0 +1,44 @@
+package com.iflytek.astron.console.commons.workflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class WorkflowClientInternalAuthTest {
+
+    private static final RequestBody EMPTY_JSON = RequestBody.create(
+            "{}", MediaType.parse("application/json"));
+
+    @Test
+    void constructorNormalizesInternalKeyBeforeTheAsynchronousRequest() {
+        String internalKey = "0123456789abcdef0123456789abcdef";
+
+        WorkflowClient client = new WorkflowClient(
+                "http://127.0.0.1/workflow/v1/chat/completions",
+                "app-id",
+                "app-key",
+                "app-secret",
+                EMPTY_JSON,
+                "  " + internalKey + "  ");
+
+        assertThat(ReflectionTestUtils.getField(client, "workflowInternalApiKey"))
+                .isEqualTo(internalKey);
+    }
+
+    @Test
+    void constructorRejectsPublishedPlaceholderBeforeTheAsynchronousRequest() {
+        assertThatThrownBy(() -> new WorkflowClient(
+                "http://127.0.0.1/workflow/v1/chat/completions",
+                "app-id",
+                "app-key",
+                "app-secret",
+                EMPTY_JSON,
+                "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageNotContaining("CHANGE_ME_WORKFLOW_INTERNAL_API_KEY");
+    }
+}

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/gateway/GatewayAuthController.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/controller/gateway/GatewayAuthController.java
@@ -1,7 +1,9 @@
 package com.iflytek.astron.console.hub.controller.gateway;
 
+import com.iflytek.astron.console.commons.security.WorkflowGatewayIdentity;
 import com.iflytek.astron.console.hub.service.gateway.GatewayAuthException;
 import com.iflytek.astron.console.hub.service.gateway.GatewayAuthService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -16,24 +18,49 @@ import org.springframework.web.bind.annotation.RestController;
 public class GatewayAuthController {
 
     private static final String CONSUMER_USERNAME_HEADER = "X-Consumer-Username";
+    private static final String ORIGINAL_URI_HEADER = "X-Original-URI";
+    private static final String ORIGINAL_METHOD_HEADER = "X-Original-Method";
 
     private final GatewayAuthService gatewayAuthService;
+    private final String workflowInternalApiKey;
 
-    public GatewayAuthController(GatewayAuthService gatewayAuthService) {
+    public GatewayAuthController(
+            GatewayAuthService gatewayAuthService,
+            @Value("${workflow.internal-api-key:}") String workflowInternalApiKey) {
         this.gatewayAuthService = gatewayAuthService;
+        this.workflowInternalApiKey = workflowInternalApiKey;
     }
 
     @GetMapping("/workflow")
     public ResponseEntity<Void> authWorkflow(
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader) {
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader,
+            @RequestHeader(value = ORIGINAL_URI_HEADER, required = false) String originalUri,
+            @RequestHeader(value = ORIGINAL_METHOD_HEADER, required = false) String originalMethod) {
         try {
+            String authorizedPath =
+                    WorkflowGatewayIdentity.requireAuthorizedPath(originalMethod, originalUri);
             String appId = gatewayAuthService.authenticateWorkflow(authorizationHeader);
+            long timestamp = System.currentTimeMillis() / 1000L;
+            String signature = WorkflowGatewayIdentity.sign(
+                    workflowInternalApiKey,
+                    originalMethod,
+                    authorizedPath,
+                    appId,
+                    timestamp);
             return ResponseEntity.noContent()
                     .cacheControl(CacheControl.noStore())
                     .header(CONSUMER_USERNAME_HEADER, appId)
+                    .header(
+                            WorkflowGatewayIdentity.TIMESTAMP_HEADER,
+                            Long.toString(timestamp))
+                    .header(WorkflowGatewayIdentity.SIGNATURE_HEADER, signature)
                     .build();
-        } catch (GatewayAuthException ex) {
+        } catch (GatewayAuthException | IllegalArgumentException ex) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .cacheControl(CacheControl.noStore())
+                    .build();
+        } catch (IllegalStateException ex) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                     .cacheControl(CacheControl.noStore())
                     .build();
         }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/gateway/impl/HttpTenantGatewayAuthClient.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/gateway/impl/HttpTenantGatewayAuthClient.java
@@ -2,6 +2,7 @@ package com.iflytek.astron.console.hub.service.gateway.impl;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.security.TenantInternalApiKey;
 import com.iflytek.astron.console.hub.service.gateway.TenantGatewayAuthClient;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.MediaType;
@@ -26,21 +27,36 @@ public class HttpTenantGatewayAuthClient implements TenantGatewayAuthClient {
 
     private final OkHttpClient httpClient;
     private final String verifyAppAuthUrl;
+    private final String tenantInternalKey;
 
     @Autowired
-    public HttpTenantGatewayAuthClient(@Value("${tenant.verify-app-auth}") String verifyAppAuthUrl) {
-        this(new OkHttpClient(), verifyAppAuthUrl);
+    public HttpTenantGatewayAuthClient(
+            @Value("${tenant.verify-app-auth}") String verifyAppAuthUrl,
+            @Value("${api.url.apiSecret:}") String tenantInternalKey) {
+        this(new OkHttpClient(), verifyAppAuthUrl, tenantInternalKey);
     }
 
-    HttpTenantGatewayAuthClient(OkHttpClient httpClient, String verifyAppAuthUrl) {
+    HttpTenantGatewayAuthClient(
+            OkHttpClient httpClient, String verifyAppAuthUrl, String tenantInternalKey) {
         this.httpClient = httpClient;
         this.verifyAppAuthUrl = verifyAppAuthUrl;
+        this.tenantInternalKey = tenantInternalKey;
     }
 
     @Override
     public Optional<String> verify(String apiKey, String apiSecret) {
-        if (!StringUtils.hasText(verifyAppAuthUrl)) {
-            log.warn("tenant verify app auth url is empty");
+        if (!StringUtils.hasText(verifyAppAuthUrl)
+                || !StringUtils.hasText(apiKey)
+                || !StringUtils.hasText(apiSecret)) {
+            log.warn("Tenant application credential verification is not configured or incomplete");
+            return Optional.empty();
+        }
+        String configuredInternalKey;
+        try {
+            configuredInternalKey =
+                    TenantInternalApiKey.requireConfigured(tenantInternalKey);
+        } catch (IllegalStateException exception) {
+            log.warn("Tenant internal authentication is not configured; verification was not sent");
             return Optional.empty();
         }
 
@@ -50,6 +66,7 @@ public class HttpTenantGatewayAuthClient implements TenantGatewayAuthClient {
 
         Request request = new Request.Builder()
                 .url(verifyAppAuthUrl)
+                .header(TenantInternalApiKey.HEADER, configuredInternalKey)
                 .post(RequestBody.create(requestBody.toJSONString(), JSON_MEDIA_TYPE))
                 .build();
 
@@ -60,7 +77,9 @@ public class HttpTenantGatewayAuthClient implements TenantGatewayAuthClient {
             }
             return parseAppId(response.body());
         } catch (IOException | RuntimeException ex) {
-            log.warn("tenant verify app auth request error", ex);
+            log.warn(
+                    "Tenant application credential verification request failed: {}",
+                    ex.getClass().getSimpleName());
             return Optional.empty();
         }
     }

--- a/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/TenantServiceImpl.java
+++ b/console/backend/hub/src/main/java/com/iflytek/astron/console/hub/service/publish/impl/TenantServiceImpl.java
@@ -2,6 +2,7 @@ package com.iflytek.astron.console.hub.service.publish.impl;
 
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.security.TenantInternalApiKey;
 import com.iflytek.astron.console.hub.dto.user.TenantAuth;
 import com.iflytek.astron.console.hub.service.publish.TenantService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,9 @@ public class TenantServiceImpl implements TenantService {
     @Value("${tenant.get-app-detail}")
     private String getAppDetail;
 
+    @Value("${api.url.tenantSecret:}")
+    private String tenantInternalKey;
+
     private static final OkHttpClient HTTP_CLIENT = new OkHttpClient().newBuilder()
             .connectionPool(new ConnectionPool(100, 5, TimeUnit.MINUTES))
             .connectTimeout(60, TimeUnit.SECONDS)
@@ -36,6 +40,10 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public String createApp(String uid, String appName, String appDesc) {
+        String configuredInternalKey = configuredTenantInternalKey();
+        if (configuredInternalKey == null) {
+            return null;
+        }
         JSONObject requestBody = new JSONObject();
         requestBody.put("request_id", uid + UUID.randomUUID());
         requestBody.put("app_name", appName);
@@ -46,34 +54,44 @@ public class TenantServiceImpl implements TenantService {
         RequestBody requestBodyForPost = RequestBody.create(MediaType.parse("application/json"), requestBody.toJSONString());
         Request request = new Request.Builder()
                 .url(createApp)
+                .header(TenantInternalApiKey.HEADER, configuredInternalKey)
                 .method("POST", requestBodyForPost)
                 .build();
 
-        JSONObject reqJson = new JSONObject();
         try (Response response = HTTP_CLIENT.newCall(request).execute()) {
             ResponseBody body = response.body();
             if ((!response.isSuccessful()) || (body == null)) {
-                log.error("tenant-service-create-app error request:  {}, response: {}", requestBody, reqJson);
+                log.error(
+                        "Tenant app creation request failed, status={}, hasResponseBody={}",
+                        response.code(),
+                        body != null);
                 return null;
             }
             String responseBody = body.string();
-            reqJson = JSONObject.parseObject(responseBody);
-            if (reqJson.getInteger("code") == 0 && reqJson.containsKey("data") && reqJson.getJSONObject("data").containsKey("app_id")) {
-                return reqJson.getJSONObject("data").getString("app_id");
+            JSONObject responseJson = JSONObject.parseObject(responseBody);
+            if (responseJson.getInteger("code") == 0 && responseJson.containsKey("data") && responseJson.getJSONObject("data").containsKey("app_id")) {
+                return responseJson.getJSONObject("data").getString("app_id");
             } else {
-                log.error("tenant-service-create-app is not successful request : {}, response: {}", requestBody, reqJson);
+                log.error(
+                        "Tenant app creation was rejected, code={}",
+                        responseJson.getInteger("code"));
             }
         } catch (Exception e) {
-            log.error("tenant-service-create-app throw exception request : {}", requestBody, e);
+            log.error("Tenant app creation request failed: {}", e.getClass().getSimpleName());
         }
         return null;
     }
 
     @Override
     public TenantAuth getAppDetail(String appId) {
+        String configuredInternalKey = configuredTenantInternalKey();
+        if (configuredInternalKey == null) {
+            return null;
+        }
         String requestUrl = String.format("%s?app_ids=%s", getAppDetail, appId);
         Request request = new Request.Builder()
                 .url(requestUrl)
+                .header(TenantInternalApiKey.HEADER, configuredInternalKey)
                 .method("GET", null)
                 .build();
 
@@ -81,7 +99,10 @@ public class TenantServiceImpl implements TenantService {
         try (Response response = HTTP_CLIENT.newCall(request).execute()) {
             ResponseBody body = response.body();
             if ((!response.isSuccessful()) || (body == null)) {
-                log.error("tenant-service-get-app-detail  error requestUrl: {}, response: {}", requestUrl, reqJson);
+                log.error(
+                        "Tenant app detail request failed, status={}, hasResponseBody={}",
+                        response.code(),
+                        body != null);
                 return null;
             }
             String responseBody = body.string();
@@ -90,12 +111,23 @@ public class TenantServiceImpl implements TenantService {
                     && reqJson.getJSONArray("data").getJSONObject(0).containsKey("auth_list")) {
                 return JSONArray.parseArray(reqJson.getJSONArray("data").getJSONObject(0).getString("auth_list"), TenantAuth.class).get(0);
             } else {
-                log.error("tenant-service-get-app-detail Lack of return requestUrl: {}, response: {}", requestUrl, reqJson);
+                log.error(
+                        "Tenant app detail response was rejected or incomplete, code={}",
+                        reqJson.getInteger("code"));
             }
         } catch (Exception e) {
-            log.error("tenant-service-get-app-detail throw exception requestUrl: {}", requestUrl, e);
+            log.error("Tenant app detail request failed: {}", e.getClass().getSimpleName());
         }
         return null;
+    }
+
+    private String configuredTenantInternalKey() {
+        try {
+            return TenantInternalApiKey.requireConfigured(tenantInternalKey);
+        } catch (IllegalStateException exception) {
+            log.warn("Tenant internal authentication is not configured; request was not sent");
+            return null;
+        }
     }
 
 }

--- a/console/backend/hub/src/main/resources/application.yml
+++ b/console/backend/hub/src/main/resources/application.yml
@@ -5,7 +5,13 @@ server:
 
 spring:
   config:
-    import: optional:classpath:application-toolkit.yml
+    import:
+      - optional:classpath:application-toolkit.yml
+      # Compose generates these files once in persistent named volumes. They are
+      # optional for source development and Helm, which injects the same values
+      # through Kubernetes Secrets.
+      - optional:file:/app/secrets/workflow/workflow-internal.properties
+      - optional:file:/app/secrets/tenant/tenant-bootstrap.properties
   profiles:
     active: dev
   application:

--- a/console/backend/hub/src/main/resources/db/migration/V1.48__remove_legacy_tenant_credentials_from_workflows.sql
+++ b/console/backend/hub/src/main/resources/db/migration/V1.48__remove_legacy_tenant_credentials_from_workflows.sql
@@ -1,0 +1,86 @@
+-- Remove the tenant credentials that were published in earlier example data.
+-- The replacement is intentionally limited to the exact disclosed values so
+-- user-provided credentials are never modified.
+SET @legacy_tenant_key = '7b709739e8da44536127a333c7603a83';
+SET @legacy_tenant_secret = 'NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy';
+
+UPDATE workflow
+SET published_data = REPLACE(
+        REPLACE(published_data, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE published_data LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR published_data LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE workflow
+SET `data` = REPLACE(
+        REPLACE(`data`, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE `data` LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR `data` LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE workflow
+SET bak = REPLACE(
+        REPLACE(bak, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE bak LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR bak LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE workflow_version
+SET `data` = REPLACE(
+        REPLACE(`data`, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE `data` LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR `data` LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE workflow_version
+SET sys_data = REPLACE(
+        REPLACE(sys_data, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE sys_data LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR sys_data LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE workflow_comparison
+SET `data` = REPLACE(
+        REPLACE(`data`, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE `data` LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR `data` LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE flow_protocol_temp
+SET biz_protocol = REPLACE(
+        REPLACE(biz_protocol, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE biz_protocol LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR biz_protocol LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE flow_protocol_temp
+SET sys_protocol = REPLACE(
+        REPLACE(sys_protocol, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE sys_protocol LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR sys_protocol LIKE CONCAT('%', @legacy_tenant_secret, '%');
+
+UPDATE exported_workflow_template
+SET snapshot_yaml = REPLACE(
+        REPLACE(snapshot_yaml, @legacy_tenant_key, ''),
+        @legacy_tenant_secret,
+        ''
+    )
+WHERE snapshot_yaml LIKE CONCAT('%', @legacy_tenant_key, '%')
+   OR snapshot_yaml LIKE CONCAT('%', @legacy_tenant_secret, '%');

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/config/GatewayAuthSecurityConfigTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/config/GatewayAuthSecurityConfigTest.java
@@ -30,7 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = GatewayAuthController.class,
         properties = {
                 "skill.sandbox.artifact-upload-token=0123456789abcdef0123456789abcdef",
-                "skill.sandbox.runtime-credential.token=abcdef0123456789abcdef0123456789"
+                "skill.sandbox.runtime-credential.token=abcdef0123456789abcdef0123456789",
+                "workflow.internal-api-key=0123456789abcdef0123456789abcdef"
         })
 @Import({
         SecurityConfig.class,
@@ -64,9 +65,20 @@ class GatewayAuthSecurityConfigTest {
         when(gatewayAuthService.authenticateWorkflow("Bearer key:secret")).thenReturn("app-123");
 
         mockMvc.perform(get("/internal/gateway/auth/workflow")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer key:secret"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer key:secret")
+                        .header("X-Original-URI", "/workflow/v1/chat/completions?trace_id=123")
+                        .header("X-Original-Method", "POST")
+                        .header("X-Consumer-Username", "attacker")
+                        .header("X-Workflow-Internal-Key", "attacker")
+                        .header("X-Workflow-Gateway-Timestamp", "1")
+                        .header("X-Workflow-Gateway-Signature", "attacker"))
                 .andExpect(status().isNoContent())
-                .andExpect(header().string("X-Consumer-Username", "app-123"));
+                .andExpect(header().string("X-Consumer-Username", "app-123"))
+                .andExpect(header().exists("X-Workflow-Gateway-Timestamp"))
+                .andExpect(header().string(
+                        "X-Workflow-Gateway-Signature",
+                        org.hamcrest.Matchers.matchesPattern("^[0-9a-f]{64}$")))
+                .andExpect(header().doesNotExist("X-Workflow-Internal-Key"));
 
         verify(gatewayAuthService).authenticateWorkflow("Bearer key:secret");
         verify(jwtDecoder, never()).decode(anyString());

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/controller/gateway/GatewayAuthControllerTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/controller/gateway/GatewayAuthControllerTest.java
@@ -1,5 +1,7 @@
 package com.iflytek.astron.console.hub.controller.gateway;
 
+import com.iflytek.astron.console.commons.security.WorkflowGatewayIdentity;
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import com.iflytek.astron.console.hub.service.gateway.GatewayAuthException;
 import com.iflytek.astron.console.hub.service.gateway.GatewayAuthService;
 import org.junit.jupiter.api.Test;
@@ -9,21 +11,40 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class GatewayAuthControllerTest {
 
+    private static final String INTERNAL_KEY = "0123456789abcdef0123456789abcdef";
+
     private final GatewayAuthService gatewayAuthService = mock(GatewayAuthService.class);
-    private final GatewayAuthController controller = new GatewayAuthController(gatewayAuthService);
+    private final GatewayAuthController controller =
+            new GatewayAuthController(gatewayAuthService, INTERNAL_KEY);
 
     @Test
     void authWorkflowReturnsNoContentAndTrustedConsumerHeader() {
         when(gatewayAuthService.authenticateWorkflow("Bearer key:secret")).thenReturn("app-123");
 
-        ResponseEntity<Void> response = controller.authWorkflow("Bearer key:secret");
+        ResponseEntity<Void> response = controller.authWorkflow(
+                "Bearer key:secret",
+                "/workflow/v1/chat/completions?trace_id=123",
+                "POST");
 
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
         assertEquals("app-123", response.getHeaders().getFirst("X-Consumer-Username"));
+        String timestamp = response.getHeaders().getFirst(
+                WorkflowGatewayIdentity.TIMESTAMP_HEADER);
+        assertEquals(
+                WorkflowGatewayIdentity.sign(
+                        INTERNAL_KEY,
+                        "POST",
+                        "/workflow/v1/chat/completions",
+                        "app-123",
+                        Long.parseLong(timestamp)),
+                response.getHeaders().getFirst(
+                        WorkflowGatewayIdentity.SIGNATURE_HEADER));
+        assertNull(response.getHeaders().getFirst(WorkflowInternalApiKey.HEADER));
         assertEquals("no-store", response.getHeaders().getCacheControl());
     }
 
@@ -31,10 +52,44 @@ class GatewayAuthControllerTest {
     void authWorkflowReturnsUnauthorizedWhenCredentialInvalid() {
         when(gatewayAuthService.authenticateWorkflow(null)).thenThrow(new GatewayAuthException("invalid credential"));
 
-        ResponseEntity<Void> response = controller.authWorkflow(null);
+        ResponseEntity<Void> response = controller.authWorkflow(
+                null, "/workflow/v1/resume", "POST");
 
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
         assertNull(response.getHeaders().getFirst("X-Consumer-Username"));
+        assertNull(response.getHeaders().getFirst(WorkflowInternalApiKey.HEADER));
+        assertNull(response.getHeaders().getFirst(
+                WorkflowGatewayIdentity.SIGNATURE_HEADER));
         assertEquals("no-store", response.getHeaders().getCacheControl());
+    }
+
+    @Test
+    void authWorkflowFailsClosedWithoutExposingIdentityWhenInternalKeyIsInvalid() {
+        when(gatewayAuthService.authenticateWorkflow("Bearer key:secret"))
+                .thenReturn("app-123");
+        GatewayAuthController invalidController =
+                new GatewayAuthController(gatewayAuthService, "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY");
+
+        ResponseEntity<Void> response =
+                invalidController.authWorkflow(
+                        "Bearer key:secret", "/workflow/v1/resume", "POST");
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertNull(response.getHeaders().getFirst("X-Consumer-Username"));
+        assertNull(response.getHeaders().getFirst(WorkflowInternalApiKey.HEADER));
+        assertEquals("no-store", response.getHeaders().getCacheControl());
+    }
+
+    @Test
+    void authWorkflowRejectsNonPublicOriginalRequestBeforeCredentialLookup() {
+        ResponseEntity<Void> response = controller.authWorkflow(
+                "Bearer key:secret", "/workflow/v1/run", "POST");
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertNull(response.getHeaders().getFirst("X-Consumer-Username"));
+        assertNull(response.getHeaders()
+                .getFirst(
+                        WorkflowGatewayIdentity.SIGNATURE_HEADER));
+        verifyNoInteractions(gatewayAuthService);
     }
 }

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/gateway/impl/HttpTenantGatewayAuthClientContextTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/gateway/impl/HttpTenantGatewayAuthClientContextTest.java
@@ -10,7 +10,9 @@ class HttpTenantGatewayAuthClientContextTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withBean(HttpTenantGatewayAuthClient.class)
-            .withPropertyValues("tenant.verify-app-auth=http://core-tenant:5052/v2/app/key/verify");
+            .withPropertyValues(
+                    "tenant.verify-app-auth=http://core-tenant:5052/v2/app/key/verify",
+                    "api.url.apiSecret=0123456789abcdef0123456789abcdef");
 
     @Test
     void createsTenantGatewayAuthClientFromSpringContext() {

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/gateway/impl/HttpTenantGatewayAuthClientTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/gateway/impl/HttpTenantGatewayAuthClientTest.java
@@ -1,0 +1,106 @@
+package com.iflytek.astron.console.hub.service.gateway.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.io.IOException;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+class HttpTenantGatewayAuthClientTest {
+
+    private static final String VERIFY_URL =
+            "http://core-tenant:5052/v2/app/key/verify";
+    private static final String INTERNAL_KEY =
+            "0123456789abcdef0123456789abcdef";
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json");
+
+    @Mock
+    private OkHttpClient httpClient;
+
+    @Mock
+    private Call call;
+
+    @Mock
+    private Response response;
+
+    private HttpTenantGatewayAuthClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new HttpTenantGatewayAuthClient(httpClient, VERIFY_URL, INTERNAL_KEY);
+    }
+
+    @Test
+    void sendsInternalKeyAndReturnsVerifiedAppId() throws Exception {
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(ResponseBody.create(
+                "{\"code\":0,\"data\":{\"appid\":\"app-123\"}}", JSON_MEDIA_TYPE));
+
+        assertThat(client.verify("api-key", "api-secret")).contains("app-123");
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient).newCall(requestCaptor.capture());
+        Request request = requestCaptor.getValue();
+        assertThat(request.method()).isEqualTo("POST");
+        assertThat(request.url().toString()).isEqualTo(VERIFY_URL);
+        assertThat(request.headers("X-Tenant-Internal-Key"))
+                .containsExactly(INTERNAL_KEY);
+    }
+
+    @Test
+    void missingInternalKeyFailsClosedWithoutCallingTenant() {
+        HttpTenantGatewayAuthClient unconfigured =
+                new HttpTenantGatewayAuthClient(httpClient, VERIFY_URL, "");
+
+        assertThat(unconfigured.verify("api-key", "api-secret")).isEmpty();
+
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void transportFailureDoesNotLogCredentials() throws Exception {
+        String apiKey = "api-key-must-not-be-logged";
+        String apiSecret = "api-secret-must-not-be-logged";
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenThrow(new IOException(
+                "upstream failure " + INTERNAL_KEY + " " + apiKey + " " + apiSecret));
+
+        Logger logger =
+                (Logger) LoggerFactory.getLogger(HttpTenantGatewayAuthClient.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            assertThat(client.verify(apiKey, apiSecret)).isEmpty();
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .noneSatisfy(message -> assertThat(message)
+                        .containsAnyOf(INTERNAL_KEY, apiKey, apiSecret));
+    }
+}

--- a/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/TenantServiceImplSecurityTest.java
+++ b/console/backend/hub/src/test/java/com/iflytek/astron/console/hub/service/publish/impl/TenantServiceImplSecurityTest.java
@@ -1,0 +1,169 @@
+package com.iflytek.astron.console.hub.service.publish.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TenantServiceImplSecurityTest {
+
+    private static final String INTERNAL_KEY =
+            "0123456789abcdef0123456789abcdef";
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void createAppDoesNotLogRequestOrCredentialBearingResponse() throws IOException {
+        String uid = "tenant-uid-must-not-be-logged";
+        String appName = "tenant-app-name-must-not-be-logged";
+        String appDescription = "tenant-app-description-must-not-be-logged";
+        String apiKey = "created-api-key-must-not-be-logged";
+        String apiSecret = "created-api-secret-must-not-be-logged";
+        AtomicReference<String> capturedInternalKey = new AtomicReference<>();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v2/app", exchange -> {
+            capturedInternalKey.set(
+                    exchange.getRequestHeaders().getFirst("X-Tenant-Internal-Key"));
+            exchange.getRequestBody().readAllBytes();
+            byte[] response = ("{\"code\":403,\"data\":{\"api_key\":\""
+                    + apiKey
+                    + "\",\"api_secret\":\""
+                    + apiSecret
+                    + "\"}}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(response);
+            }
+        });
+        server.start();
+
+        TenantServiceImpl service = new TenantServiceImpl();
+        ReflectionTestUtils.setField(
+                service,
+                "createApp",
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/v2/app");
+        ReflectionTestUtils.setField(service, "tenantInternalKey", INTERNAL_KEY);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(TenantServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            assertThat(service.createApp(uid, appName, appDescription)).isNull();
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message)
+                        .contains("Tenant app creation was rejected")
+                        .contains("code=403"))
+                .noneSatisfy(message -> assertThat(message)
+                        .containsAnyOf(
+                                uid,
+                                appName,
+                                appDescription,
+                                apiKey,
+                                apiSecret,
+                                INTERNAL_KEY));
+        assertThat(capturedInternalKey).hasValue(INTERNAL_KEY);
+    }
+
+    @Test
+    void getAppDetailDoesNotLogAppIdOrCredentialBearingResponse() throws IOException {
+        String appId = "tenant-app-id-must-not-be-logged";
+        String apiKey = "detail-api-key-must-not-be-logged";
+        String apiSecret = "detail-api-secret-must-not-be-logged";
+        AtomicReference<String> capturedInternalKey = new AtomicReference<>();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v2/app/details", exchange -> {
+            capturedInternalKey.set(
+                    exchange.getRequestHeaders().getFirst("X-Tenant-Internal-Key"));
+            byte[] response = ("{\"code\":403,\"data\":[{\"auth_list\":[{\"api_key\":\""
+                    + apiKey
+                    + "\",\"api_secret\":\""
+                    + apiSecret
+                    + "\"}]}]}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(response);
+            }
+        });
+        server.start();
+
+        TenantServiceImpl service = new TenantServiceImpl();
+        ReflectionTestUtils.setField(
+                service,
+                "getAppDetail",
+                "http://127.0.0.1:"
+                        + server.getAddress().getPort()
+                        + "/v2/app/details");
+        ReflectionTestUtils.setField(service, "tenantInternalKey", INTERNAL_KEY);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(TenantServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            assertThat(service.getAppDetail(appId)).isNull();
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message)
+                        .contains("Tenant app detail response was rejected or incomplete")
+                        .contains("code=403"))
+                .noneSatisfy(message -> assertThat(message)
+                        .containsAnyOf(appId, apiKey, apiSecret, INTERNAL_KEY));
+        assertThat(capturedInternalKey).hasValue(INTERNAL_KEY);
+    }
+
+    @Test
+    void missingInternalKeyFailsClosedBeforeAnyTenantRequest() throws IOException {
+        AtomicInteger requestCount = new AtomicInteger();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+        });
+        server.start();
+
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        TenantServiceImpl service = new TenantServiceImpl();
+        ReflectionTestUtils.setField(service, "createApp", baseUrl + "/v2/app");
+        ReflectionTestUtils.setField(
+                service, "getAppDetail", baseUrl + "/v2/app/details");
+        ReflectionTestUtils.setField(service, "tenantInternalKey", "short");
+
+        assertThat(service.createApp("uid", "name", "description")).isNull();
+        assertThat(service.getAppDetail("app-id")).isNull();
+        assertThat(requestCount).hasValue(0);
+    }
+}

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/external/ExternalApiService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/external/ExternalApiService.java
@@ -1,11 +1,23 @@
 package com.iflytek.astron.console.toolkit.service.external;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.security.TenantInternalApiKey;
 import com.iflytek.astron.console.toolkit.entity.dto.external.AppInfoResponse;
-import com.iflytek.astron.console.toolkit.util.OkHttpUtil;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Service for calling external third-party APIs
@@ -13,65 +25,84 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class ExternalApiService {
-    @Value("${api.url.appIdQryUrl}")
-    private String appIdQryUrl;
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
 
+    private final OkHttpClient httpClient;
+    private final String appAuthVerifyUrl;
+    private final String tenantInternalKey;
 
-    /**
-     * Query app info by API key
-     *
-     * @param apiKey API key
-     * @return AppInfoResponse
-     */
-    public AppInfoResponse getAppInfoByApiKey(String apiKey) {
-        String url = appIdQryUrl + "/v2/app/key/api_key/" + apiKey;
-        log.debug("Calling external API: {}", url);
+    @Autowired
+    public ExternalApiService(
+            @Value("${api.url.appAuthVerifyUrl}") String appAuthVerifyUrl,
+            @Value("${api.url.apiSecret:}") String tenantInternalKey) {
+        this(new OkHttpClient(), appAuthVerifyUrl, tenantInternalKey);
+    }
 
-        try {
-            String response = OkHttpUtil.get(url);
-            log.debug("External API response: {}", response);
-
-            // Check if response is valid JSON format
-            if (response == null || response.trim().isEmpty()) {
-                log.error("Empty response from external API for apiKey: {}", apiKey);
-                return createMockResponse(apiKey);
-            }
-
-            // Check for common error responses
-            if (response.contains("404") || response.contains("not found") ||
-                    response.contains("error") || !response.trim().startsWith("{")) {
-                log.warn("External API not available (response: {}), using mock data for apiKey: {}",
-                        response.trim(), apiKey);
-                return createMockResponse(apiKey);
-            }
-
-            return JSON.parseObject(response, AppInfoResponse.class);
-        } catch (Exception e) {
-            log.warn("Failed to query external API ({}), using mock data for apiKey: {}",
-                    e.getMessage(), apiKey);
-            return createMockResponse(apiKey);
-        }
+    ExternalApiService(
+            OkHttpClient httpClient, String appAuthVerifyUrl, String tenantInternalKey) {
+        this.httpClient = httpClient;
+        this.appAuthVerifyUrl = appAuthVerifyUrl;
+        this.tenantInternalKey = tenantInternalKey;
     }
 
     /**
-     * Create mock response when external API is not available TODO: Remove this when external API is
-     * fixed
+     * Verify the complete application credential pair with Tenant.
+     *
+     * @param apiKey API key
+     * @param apiSecret API secret
+     * @return verified application ID, or empty when verification cannot be completed
      */
-    private AppInfoResponse createMockResponse(String apiKey) {
-        AppInfoResponse response = new AppInfoResponse();
-        response.setCode(0);
-        response.setMessage("Success (Mock Data)");
+    public Optional<String> verifyAppCredentials(String apiKey, String apiSecret) {
+        if (!StringUtils.hasText(appAuthVerifyUrl)
+                || !StringUtils.hasText(apiKey)
+                || !StringUtils.hasText(apiSecret)) {
+            log.warn("Tenant application credential verification is not configured or incomplete");
+            return Optional.empty();
+        }
+        String configuredInternalKey;
+        try {
+            configuredInternalKey =
+                    TenantInternalApiKey.requireConfigured(tenantInternalKey);
+        } catch (IllegalStateException exception) {
+            log.warn("Tenant internal authentication is not configured; verification was not sent");
+            return Optional.empty();
+        }
 
-        AppInfoResponse.AppInfoData data = new AppInfoResponse.AppInfoData();
-        // Use a deterministic appId based on apiKey for consistency
-        data.setAppid("mock-app-" + apiKey.substring(0, Math.min(8, apiKey.length())));
-        data.setName("Mock Application");
-        data.setSource("mock");
-        data.setDesc("Mock application for testing");
+        JSONObject requestJson = new JSONObject();
+        requestJson.put("api_key", apiKey);
+        requestJson.put("api_secret", apiSecret);
+        Request request = new Request.Builder()
+                .url(appAuthVerifyUrl)
+                .header(TenantInternalApiKey.HEADER, configuredInternalKey)
+                .post(RequestBody.create(requestJson.toJSONString(), JSON_MEDIA_TYPE))
+                .build();
 
-        response.setData(data);
-
-        log.info("Generated mock response for apiKey: {}, appId: {}", apiKey, data.getAppid());
-        return response;
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                log.warn(
+                        "Tenant application credential verification failed, status={}",
+                        response.code());
+                return Optional.empty();
+            }
+            ResponseBody body = response.body();
+            if (body == null) {
+                log.warn("Tenant application credential verification returned an empty response");
+                return Optional.empty();
+            }
+            AppInfoResponse parsed = JSON.parseObject(body.string(), AppInfoResponse.class);
+            if (parsed == null || parsed.getCode() == null || parsed.getCode() != 0) {
+                return Optional.empty();
+            }
+            AppInfoResponse.AppInfoData data = parsed.getData();
+            return data != null && StringUtils.hasText(data.getAppid())
+                    ? Optional.of(data.getAppid())
+                    : Optional.empty();
+        } catch (IOException | RuntimeException exception) {
+            // Never include the request body, API key, API secret, or remote response in logs.
+            log.warn(
+                    "Tenant application credential verification request failed: {}",
+                    exception.getClass().getSimpleName());
+            return Optional.empty();
+        }
     }
 }

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/extra/AppService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/extra/AppService.java
@@ -66,21 +66,12 @@ public class AppService {
         String appUrl = apiUrl.getAppUrl() + "/key/" + appId;
         String resp;
         try {
-            resp = HeaderAuthHttpTool.get(appUrl, apiUrl.getApiKey(), apiUrl.getApiSecret());
-            log.info("getAkSk, resp = {}", resp);
+            resp = HeaderAuthHttpTool.tenantGet(
+                    appUrl, apiUrl.getApiKey(), apiUrl.getApiSecret());
         } catch (NoSuchAlgorithmException | InvalidKeyException | IOException e) {
             throw new RuntimeException(e);
         }
-        Object data = CommonTool.checkSystemCallResponse(resp);
-        String errMsg = "Failed to query APPID credentials. Please check if APPID belongs to you or if APPID has been deleted, APPID=" + appId;
-        if (data == null) {
-            throw new BusinessException(ResponseEnum.RESPONSE_FAILED, errMsg);
-        }
-        JSONArray array = JSON.parseArray(data.toString());
-        if (CollectionUtils.isEmpty(array)) {
-            throw new BusinessException(ResponseEnum.RESPONSE_FAILED, errMsg);
-        }
-        return array.getObject(0, AkSk.class);
+        return parseRemoteCredential(resp, appId, "cached");
     }
 
     /**
@@ -99,12 +90,16 @@ public class AppService {
         String appUrl = apiUrl.getAppUrl() + "/key/" + appId;
         String resp;
         try {
-            resp = HeaderAuthHttpTool.get(appUrl, apiUrl.getApiKey(), apiUrl.getApiSecret());
-            log.info("remoteCallAkSk, resp = {}", resp);
+            resp = HeaderAuthHttpTool.tenantGet(
+                    appUrl, apiUrl.getApiKey(), apiUrl.getApiSecret());
         } catch (NoSuchAlgorithmException | InvalidKeyException | IOException e) {
             throw new RuntimeException(e);
         }
-        Object data = CommonTool.checkSystemCallResponse(resp);
+        return parseRemoteCredential(resp, appId, "uncached");
+    }
+
+    private AkSk parseRemoteCredential(String response, String appId, String lookupMode) {
+        Object data = CommonTool.checkSystemCallResponse(response);
         String errMsg = "Failed to query APPID credentials. Please check if APPID belongs to you or if APPID has been deleted, APPID=" + appId;
         if (data == null) {
             throw new BusinessException(ResponseEnum.RESPONSE_FAILED, errMsg);
@@ -113,7 +108,13 @@ public class AppService {
         if (CollectionUtils.isEmpty(array)) {
             throw new BusinessException(ResponseEnum.RESPONSE_FAILED, errMsg);
         }
-        return array.getObject(0, AkSk.class);
+        AkSk credential = array.getObject(0, AkSk.class);
+        log.info(
+                "APP credential query succeeded, appId={}, mode={}, responseChars={}",
+                appId,
+                lookupMode,
+                response == null ? 0 : response.length());
+        return credential;
     }
 
     /**

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/extra/CoreSystemService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/extra/CoreSystemService.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.*;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import com.iflytek.astron.console.toolkit.common.constant.CommonConst;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
 import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
@@ -64,6 +65,9 @@ public class CoreSystemService {
     @Value("${spring.profiles.active}")
     String env;
 
+    @Value("${workflow.internal-api-key:}")
+    String workflowInternalApiKey;
+
     @Autowired
     AppService appService;
     @Autowired
@@ -95,6 +99,7 @@ public class CoreSystemService {
             requestHeader = assembleRequestHeader(url, apiUrl.getTenantKey(), apiUrl.getTenantSecret(), "POST", body.getBytes(StandardCharsets.UTF_8));
         }
         requestHeader.put(X_CONSUMER_USERNAME, apiUrl.getTenantId());
+        addWorkflowInternalApiKey(requestHeader);
         log.info(
                 "workflow protocol publish, url = {}, flowId = {}, bodyBytes = {}",
                 url,
@@ -143,6 +148,7 @@ public class CoreSystemService {
         }
         String authBody = authJson.toString();
         requestHeader.put(X_CONSUMER_USERNAME, apiUrl.getTenantId());
+        addWorkflowInternalApiKey(requestHeader);
         log.info(
                 "workflow protocol auth, url = {}, flowId = {}, bodyBytes = {}",
                 authUrl,
@@ -181,6 +187,7 @@ public class CoreSystemService {
         try {
             requestHeader = assembleRequestHeader(uploadUrl, apiKey, apiSecret, "POST", convertMapToBytes(param));
             requestHeader.put(X_CONSUMER_USERNAME, apiUrl.getTenantId());
+            addWorkflowInternalApiKey(requestHeader);
             requestHeader.put("Content-Type", "multipart/form-data");
             log.info(
                     "workflow protocol upload file, url = {}, fileBytes = {}",
@@ -226,6 +233,7 @@ public class CoreSystemService {
         try {
             requestHeader = assembleRequestHeader(authUrl, apiKey, apiSecret, "POST", convertMapToBytes(param));
             requestHeader.put(X_CONSUMER_USERNAME, apiUrl.getTenantId());
+            addWorkflowInternalApiKey(requestHeader);
             requestHeader.put("Content-Type", "multipart/form-data");
             log.info(
                     "workflow protocol upload files, url = {}, fileCount = {}",
@@ -375,7 +383,7 @@ public class CoreSystemService {
                 flowId,
                 version,
                 body.getBytes(StandardCharsets.UTF_8).length);
-        String response = OkHttpUtil.post(url, body);
+        String response = OkHttpUtil.post(url, workflowInternalHeaders(), body);
         ApiResult<?> result = parseApiResult(response, "workflow add comparisons", url);
         log.info(
                 "workflow add comparisons response, url = {}, flowId = {}, statusCode = {}",
@@ -401,7 +409,7 @@ public class CoreSystemService {
                 .fluentPut("flow_id", flowId)
                 .fluentPut("version", version)
                 .toString();
-        String response = OkHttpUtil.post(url, body);
+        String response = OkHttpUtil.post(url, workflowInternalHeaders(), body);
         JSONObject result = parseJsonObject(response, "workflow get comparison", url);
         log.info(
                 "workflow get comparison response, url = {}, flowId = {}, statusCode = {}",
@@ -438,7 +446,7 @@ public class CoreSystemService {
                 flowId,
                 version,
                 body.getBytes(StandardCharsets.UTF_8).length);
-        String response = OkHttpUtil.delete(url, body);
+        String response = OkHttpUtil.delete(url, workflowInternalHeaders(), body);
         ApiResult<?> result = parseApiResult(response, "workflow delete comparisons", url);
         log.info(
                 "workflow delete comparisons response, url = {}, flowId = {}, statusCode = {}",
@@ -451,6 +459,18 @@ public class CoreSystemService {
         if (result.code() != 0) {
             throw new BusinessException(ResponseEnum.RESPONSE_FAILED);
         }
+    }
+
+    private Map<String, String> workflowInternalHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        addWorkflowInternalApiKey(headers);
+        return headers;
+    }
+
+    private void addWorkflowInternalApiKey(Map<String, String> headers) {
+        headers.put(
+                WorkflowInternalApiKey.HEADER,
+                WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey));
     }
 
 

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/openapi/impl/OpenApiServiceImpl.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/openapi/impl/OpenApiServiceImpl.java
@@ -9,7 +9,6 @@ import com.iflytek.astron.console.commons.entity.workflow.Workflow;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.mapper.bot.ChatBotApiMapper;
 import com.iflytek.astron.console.toolkit.entity.biz.workflow.BizWorkflowData;
-import com.iflytek.astron.console.toolkit.entity.dto.external.AppInfoResponse;
 import com.iflytek.astron.console.toolkit.entity.dto.openapi.WorkflowIoTransRequest;
 import com.iflytek.astron.console.toolkit.service.external.ExternalApiService;
 import com.iflytek.astron.console.toolkit.service.openapi.OpenApiService;
@@ -41,10 +40,12 @@ public class OpenApiServiceImpl implements OpenApiService {
     @Override
     public List<JSONObject> getWorkflowIoTransformations(WorkflowIoTransRequest request) {
         try {
-            String appId = getAppIdByApiKey(request.getApiKey());
+            String appId = externalApiService
+                    .verifyAppCredentials(request.getApiKey(), request.getApiSecret())
+                    .orElseThrow(() -> new BusinessException(ResponseEnum.UNAUTHORIZED));
 
             if (!StringUtils.hasText(appId)) {
-                log.error("appId is empty, apiKey:{}", request.getApiKey());
+                log.error("Application credential verification returned an empty appId");
                 throw new BusinessException(ResponseEnum.UNAUTHORIZED);
             }
 
@@ -72,22 +73,6 @@ public class OpenApiServiceImpl implements OpenApiService {
         LambdaQueryWrapper<ChatBotApi> queryWrapper = new LambdaQueryWrapper<>();
         queryWrapper.eq(ChatBotApi::getAppId, appId);
         return chatBotApiMapper.selectList(queryWrapper);
-    }
-
-    /**
-     * Get appId by calling external API with apiKey
-     */
-    private String getAppIdByApiKey(String apiKey) {
-        AppInfoResponse appInfoResponse = externalApiService.getAppInfoByApiKey(apiKey);
-        if (appInfoResponse.getCode() != 0 || appInfoResponse.getData() == null) {
-            log.error("Failed to get app info from external API: code={}, message={}",
-                    appInfoResponse.getCode(), appInfoResponse.getMessage());
-            throw new BusinessException(ResponseEnum.DATA_NOT_FOUND);
-        }
-
-        String appId = appInfoResponse.getData().getAppid();
-        log.info("Successfully retrieved appId: {} for apiKey: {}", appId, apiKey);
-        return appId;
     }
 
     /**

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowAutomationService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowAutomationService.java
@@ -10,6 +10,7 @@ import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.iflytek.astron.console.commons.constant.ResponseEnum;
 import com.iflytek.astron.console.commons.entity.workflow.Workflow;
 import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import com.iflytek.astron.console.commons.util.space.SpaceInfoUtil;
 import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
@@ -33,6 +34,7 @@ import com.iflytek.astron.console.toolkit.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
@@ -72,6 +74,9 @@ public class WorkflowAutomationService
     private final RedisUtil redisUtil;
     private final ApiUrl apiUrl;
     private final AppService appService;
+
+    @Value("${workflow.internal-api-key:}")
+    private String workflowInternalApiKey;
 
     public PageData<WorkflowAutomationTask> pageTasks(Integer current, Integer pageSize, String search,
             Boolean enabled) {
@@ -390,6 +395,9 @@ public class WorkflowAutomationService
         Map<String, String> headerMap = new HashMap<>();
         headerMap.put(HttpHeaders.AUTHORIZATION, akSk.getApiKey() + ":" + akSk.getApiSecret());
         headerMap.put("X-Consumer-Username", workflow.getAppId());
+        headerMap.put(
+                WorkflowInternalApiKey.HEADER,
+                WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey));
 
         String response = callWorkflow(task, runId, headerMap, task.getVersion());
         Integer code = workflowResponseCode(response);

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowChatRunClient.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowChatRunClient.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.toolkit.service.workflow;
 
 import com.alibaba.fastjson2.JSONObject;
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
 import lombok.RequiredArgsConstructor;
 import okhttp3.MediaType;
@@ -35,11 +36,17 @@ public class WorkflowChatRunClient {
     @Value("${workflow.chatUrl}")
     private String chatUrl;
 
+    @Value("${workflow.internal-api-key:}")
+    private String workflowInternalApiKey;
+
     /** POST the chat request and return the raw response body (final LLMGenerate JSON frame). */
     public String chat(JSONObject requestBody) throws IOException {
         Request request = new Request.Builder()
                 .url(chatUrl)
                 .header("X-Consumer-Username", commonConfig.getAppId())
+                .header(
+                        WorkflowInternalApiKey.HEADER,
+                        WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey))
                 .header("Authorization", "Bearer " + commonConfig.getApiKey() + ":" + commonConfig.getApiSecret())
                 .post(RequestBody.create(requestBody.toJSONString(), JSON_MEDIA))
                 .build();

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowService.java
@@ -32,6 +32,7 @@ import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.mapper.UserLangChainInfoMapper;
 import com.iflytek.astron.console.commons.mapper.bot.ChatBotBaseMapper;
 import com.iflytek.astron.console.commons.response.ApiResult;
+import com.iflytek.astron.console.commons.security.WorkflowInternalApiKey;
 import com.iflytek.astron.console.commons.service.bot.BotMarketDataService;
 import com.iflytek.astron.console.commons.service.space.SpaceUserService;
 import com.iflytek.astron.console.commons.util.RequestContextUtil;
@@ -179,9 +180,6 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
     public static final String NODE_DEBUG_PATH = "/workflow/v1/node/debug/";
     public static final String PROTOCOL_BUILD_PATH = "/workflow/v1/protocol/build/";
     public static final String CODE_RUN_PATH = "/workflow/v1/run";
-    private static final String WORKFLOW_INTERNAL_API_KEY_HEADER = "X-Workflow-Internal-Key";
-    private static final String WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER =
-            "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY";
     public static final String CLONED_SUFFIX_PATTERN = "[(]\\d+[)]$";
 
     private static final String JSON_KEY_BOT_ID = "botId";
@@ -1368,7 +1366,13 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         String url = apiUrl.getWorkflow().concat(PROTOCOL_BUILD_PATH).concat(workflow.getFlowId());
         log.info("workflow protocol build, url = {}, flowId = {}", url, workflow.getFlowId());
 
-        Request request = new Request.Builder().url(url).post(Util.EMPTY_REQUEST).build();
+        Request request = new Request.Builder()
+                .url(url)
+                .header(
+                        WorkflowInternalApiKey.HEADER,
+                        WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey))
+                .post(Util.EMPTY_REQUEST)
+                .build();
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Integer> buildStatus = new AtomicReference<>();
         AtomicBoolean invalidResponse = new AtomicBoolean();
@@ -1853,7 +1857,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
                 url,
                 body.getBytes(StandardCharsets.UTF_8).length);
 
-        String response = OkHttpUtil.post(url, body);
+        String response = OkHttpUtil.post(url, workflowInternalHeaders(), body);
         Result<?> result = JSON.parseObject(response, Result.class);
         log.info(
                 "workflow protocol add response, url = {}, statusCode = {}",
@@ -1894,7 +1898,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
                 flowId,
                 body.getBytes(StandardCharsets.UTF_8).length);
 
-        String response = OkHttpUtil.post(url, body);
+        String response = OkHttpUtil.post(url, workflowInternalHeaders(), body);
         Result<?> result = JSON.parseObject(response, Result.class);
         log.info(
                 "workflow protocol delete response, url = {}, flowId = {}, statusCode = {}",
@@ -3489,7 +3493,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
         // body = StringEscapeUtils.unescapeJava(body);
 
         logWorkflowProtocolUpdate(url, flowId, body, protocolJson);
-        String response = OkHttpUtil.post(url, body);
+        String response = OkHttpUtil.post(url, workflowInternalHeaders(), body);
         Result<?> result = JSON.parseObject(response, Result.class);
         log.info(
                 "workflow protocol update response, url = {}, flowId = {}, statusCode = {}",
@@ -3656,13 +3660,9 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
     }
 
     private Map<String, String> workflowInternalHeaders() {
-        if (StringUtils.isBlank(workflowInternalApiKey)
-                || WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER.equals(workflowInternalApiKey)) {
-            throw new IllegalStateException(
-                    "WORKFLOW_INTERNAL_API_KEY must be configured before calling workflow debug APIs");
-        }
         return Collections.singletonMap(
-                WORKFLOW_INTERNAL_API_KEY_HEADER, workflowInternalApiKey);
+                WorkflowInternalApiKey.HEADER,
+                WorkflowInternalApiKey.requireConfigured(workflowInternalApiKey));
     }
 
     private void injectScriptSandboxIntoCodeNodes(List<BizWorkflowNode> nodes, String flowId) {
@@ -4300,6 +4300,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             Map<String, String> headerMap = new HashMap<>();
             headerMap.put(HttpHeaders.AUTHORIZATION, akSk.getApiKey() + ":" + akSk.getApiSecret());
             headerMap.put("X-Consumer-Username", workflow.getAppId());
+            headerMap.putAll(workflowInternalHeaders());
 
             ChatSysReq sysReq = new ChatSysReq();
             sysReq.setFlowId(flowId);
@@ -4367,6 +4368,7 @@ public class WorkflowService extends ServiceImpl<WorkflowMapper, Workflow> {
             Map<String, String> headerMap = new HashMap<>();
             headerMap.put(HttpHeaders.AUTHORIZATION, akSk.getApiKey() + ":" + akSk.getApiSecret());
             headerMap.put("X-Consumer-Username", workflow.getAppId());
+            headerMap.putAll(workflowInternalHeaders());
 
             JSONObject sysReq = new JSONObject();
             sysReq.put("event_id", bizReq.getEventId());

--- a/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/http/HeaderAuthHttpTool.java
+++ b/console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/tool/http/HeaderAuthHttpTool.java
@@ -1,6 +1,7 @@
 package com.iflytek.astron.console.toolkit.tool.http;
 
 import com.alibaba.fastjson2.JSON;
+import com.iflytek.astron.console.commons.security.TenantInternalApiKey;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 
@@ -54,10 +55,16 @@ public class HeaderAuthHttpTool {
         Request request = build.put(requestBody).build();
         OkHttpClient client = new OkHttpClient.Builder().build();
         String res;
+        int statusCode;
         try (Response resp = client.newCall(request).execute()) {
+            statusCode = resp.code();
             res = JSON.parse(Objects.requireNonNull(resp.body()).bytes()).toString();
         }
-        log.debug("HeaderAuthHttpTool [{}]url = {}, body = {}, resp = {}", param.getMethod(), url, body, res);
+        log.debug(
+                "HeaderAuthHttpTool {} completed, status={}, responseChars={}",
+                param.getMethod(),
+                statusCode,
+                res.length());
         return res;
     }
 
@@ -91,10 +98,16 @@ public class HeaderAuthHttpTool {
         Request request = build.delete(requestBody).build();
         OkHttpClient client = new OkHttpClient.Builder().build();
         String res;
+        int statusCode;
         try (Response resp = client.newCall(request).execute()) {
+            statusCode = resp.code();
             res = JSON.parse(Objects.requireNonNull(resp.body()).bytes()).toString();
         }
-        log.debug("HeaderAuthHttpTool [{}]url = {}, body = {}, resp = {}", param.getMethod(), url, body, res);
+        log.debug(
+                "HeaderAuthHttpTool {} completed, status={}, responseChars={}",
+                param.getMethod(),
+                statusCode,
+                res.length());
         return res;
     }
 
@@ -110,6 +123,26 @@ public class HeaderAuthHttpTool {
      * @throws IOException if the HTTP request fails
      */
     public static String get(String url, String apiKey, String apiSecret) throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+        return get(url, apiKey, apiSecret, null);
+    }
+
+    /**
+     * Executes an authenticated HTTP GET against core-tenant and attaches its internal service
+     * credential. Keeping this operation explicit prevents the Tenant credential from being sent to
+     * arbitrary callers of the generic HTTP methods.
+     */
+    public static String tenantGet(String url, String apiKey, String apiSecret)
+            throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+        return get(
+                url,
+                apiKey,
+                apiSecret,
+                TenantInternalApiKey.requireConfigured(apiSecret));
+    }
+
+    private static String get(
+            String url, String apiKey, String apiSecret, String tenantInternalKey)
+            throws NoSuchAlgorithmException, InvalidKeyException, IOException {
         AssembleParam param = new AssembleParam();
         param.setApiKey(apiKey);
         param.setApiSecret(apiSecret);
@@ -120,16 +153,23 @@ public class HeaderAuthHttpTool {
                 addHeader("Content-Type", "text/html").//
                 addHeader("Date", headMap.get("date")).//
                 addHeader("Host", headMap.get("host"));
+        if (tenantInternalKey != null) {
+            build.header(TenantInternalApiKey.HEADER, tenantInternalKey);
+        }
         build.addHeader("Authorization", headMap.get("authorization"));
         Request request = build.get().build();
         OkHttpClient client = new OkHttpClient.Builder().build();
         String res;
+        int statusCode;
         try (Response resp = client.newCall(request).execute()) {
-            log.info("HeaderAuthHttpTool get resp = {}", resp);
+            statusCode = resp.code();
             ResponseBody body = resp.body();
             res = JSON.parse(Objects.requireNonNull(body).bytes()).toString();
         }
-        log.debug(url + " call result: " + res);
+        log.debug(
+                "HeaderAuthHttpTool GET completed, status={}, responseChars={}",
+                statusCode,
+                res.length());
         return res;
     }
 
@@ -146,7 +186,6 @@ public class HeaderAuthHttpTool {
      * @throws InvalidKeyException if the API secret is invalid
      */
     public static String post(String url, String apiKey, String apiSecret, String body) throws IOException, NoSuchAlgorithmException, InvalidKeyException {
-        System.out.println(body);
         AssembleParam param = new AssembleParam();
         param.setApiKey(apiKey);
         param.setApiSecret(apiSecret);
@@ -164,10 +203,16 @@ public class HeaderAuthHttpTool {
         Request request = build.post(requestBody).build();
         OkHttpClient client = new OkHttpClient.Builder().build();
         String res;
+        int statusCode;
         try (Response resp = client.newCall(request).execute()) {
+            statusCode = resp.code();
             res = JSON.parse(Objects.requireNonNull(resp.body()).bytes()).toString();
         }
-        log.debug("HeaderAuthHttpTool [{}]url = {}, body = {}, resp = {}", param.getMethod(), url, body, res);
+        log.debug(
+                "HeaderAuthHttpTool {} completed, status={}, responseChars={}",
+                param.getMethod(),
+                statusCode,
+                res.length());
         return res;
     }
 
@@ -184,7 +229,6 @@ public class HeaderAuthHttpTool {
      * @throws InvalidKeyException if the API secret is invalid
      */
     public static String patch(String url, String apiKey, String apiSecret, String body) throws IOException, NoSuchAlgorithmException, InvalidKeyException {
-        System.out.println(body);
         AssembleParam param = new AssembleParam();
         param.setApiKey(apiKey);
         param.setApiSecret(apiSecret);
@@ -202,10 +246,16 @@ public class HeaderAuthHttpTool {
         Request request = build.patch(requestBody).build();
         OkHttpClient client = new OkHttpClient.Builder().build();
         String res;
+        int statusCode;
         try (Response resp = client.newCall(request).execute()) {
+            statusCode = resp.code();
             res = JSON.parse(Objects.requireNonNull(resp.body()).bytes()).toString();
         }
-        log.debug("HeaderAuthHttpTool [{}]url = {}, body = {}, resp = {}", param.getMethod(), url, body, res);
+        log.debug(
+                "HeaderAuthHttpTool {} completed, status={}, responseChars={}",
+                param.getMethod(),
+                statusCode,
+                res.length());
         return res;
     }
 
@@ -239,7 +289,6 @@ public class HeaderAuthHttpTool {
         if (headMap.containsKey("digest")) {
             builder.append("\n").append("digest: ").append(headMap.get("digest"));
         }
-        System.out.println("builder:" + builder.toString());
         Charset charset = StandardCharsets.UTF_8;
         Mac mac = Mac.getInstance("hmacsha256");
         SecretKeySpec spec = new SecretKeySpec(param.getApiSecret().getBytes(charset), "hmacsha256");
@@ -249,7 +298,6 @@ public class HeaderAuthHttpTool {
         if (headMap.containsKey("digest")) {
             String authorization = String.format("hmac username=\"%s\", algorithm=\"%s\", headers=\"%s\", signature=\"%s\"", //
                     param.getApiKey(), "hmac-sha256", "host date request-line digest", sign);
-            System.out.println(authorization);
             headMap.put("authorization", authorization);
             return headMap;
         }

--- a/console/backend/toolkit/src/main/resources/application-toolkit.yml
+++ b/console/backend/toolkit/src/main/resources/application-toolkit.yml
@@ -37,7 +37,7 @@ api:
     deleteXinghuoDatasetFileUrl: http://127.0.0.1:8080/dataset/deleteXinghuoDatasetFile
     deleteXinghuoDatasetUrl: http://127.0.0.1:8080/dataset/deleteXinghuoDataset
     rpaUrl: ${RPA_URL:https://newapi.iflyrpa.com}
-    appIdQryUrl: http://10.1.87.65:5052
+    appAuthVerifyUrl: ${TENANT_VERIFY_APP_AUTH:http://127.0.0.1:5052/v2/app/key/verify}
 
 # Business-specific configuration
 biz:

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/external/ExternalApiServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/external/ExternalApiServiceTest.java
@@ -1,0 +1,140 @@
+package com.iflytek.astron.console.toolkit.service.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import java.io.IOException;
+import java.util.Optional;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalApiServiceTest {
+
+    private static final String VERIFY_URL = "http://core-tenant:5052/v2/app/key/verify";
+    private static final String INTERNAL_KEY = "0123456789abcdef0123456789abcdef";
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json");
+
+    @Mock
+    private OkHttpClient httpClient;
+    @Mock
+    private Call call;
+    @Mock
+    private Response response;
+
+    private ExternalApiService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExternalApiService(httpClient, VERIFY_URL, INTERNAL_KEY);
+    }
+
+    @Test
+    void verifiesCompleteCredentialPairAndReturnsAppId() throws Exception {
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(jsonBody(
+                "{\"sid\":\"sid-1\",\"code\":0,\"data\":{\"appid\":\"app-123\"}}"));
+
+        Optional<String> appId = service.verifyAppCredentials("api-key", "api-secret");
+
+        assertThat(appId).contains("app-123");
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient).newCall(requestCaptor.capture());
+        Request request = requestCaptor.getValue();
+        assertThat(request.method()).isEqualTo("POST");
+        assertThat(request.url().toString()).isEqualTo(VERIFY_URL);
+        assertThat(request.headers("X-Tenant-Internal-Key"))
+                .containsExactly(INTERNAL_KEY);
+
+        Buffer buffer = new Buffer();
+        request.body().writeTo(buffer);
+        JSONObject payload = JSON.parseObject(buffer.readUtf8());
+        assertThat(payload).containsEntry("api_key", "api-key").containsEntry("api_secret", "api-secret");
+    }
+
+    @Test
+    void nonSuccessfulHttpResponseFailsClosedWithoutReadingBody() throws Exception {
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(false);
+        when(response.code()).thenReturn(503);
+
+        assertThat(service.verifyAppCredentials("api-key", "api-secret")).isEmpty();
+        verify(response, never()).body();
+    }
+
+    @Test
+    void tenantRejectionAndMalformedResponseFailClosed() throws Exception {
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body())
+                .thenReturn(jsonBody("{\"code\":10001,\"message\":\"invalid credentials\"}"))
+                .thenReturn(jsonBody("not-json"))
+                .thenReturn(jsonBody("{\"code\":0,\"data\":{}}"));
+
+        assertThat(service.verifyAppCredentials("api-key", "wrong-secret")).isEmpty();
+        assertThat(service.verifyAppCredentials("api-key", "api-secret")).isEmpty();
+        assertThat(service.verifyAppCredentials("api-key", "api-secret")).isEmpty();
+    }
+
+    @Test
+    void transportFailureFailsClosed() throws Exception {
+        when(httpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenThrow(new IOException("credential-bearing upstream failure"));
+
+        assertThat(service.verifyAppCredentials("api-key", "api-secret")).isEmpty();
+    }
+
+    @Test
+    void incompleteConfigurationOrCredentialsDoNotCallTenant() {
+        assertThat(service.verifyAppCredentials("", "api-secret")).isEmpty();
+        assertThat(service.verifyAppCredentials("api-key", " ")).isEmpty();
+        assertThat(new ExternalApiService(httpClient, " ", INTERNAL_KEY)
+                .verifyAppCredentials("api-key", "api-secret"))
+                .isEmpty();
+
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void missingOrInvalidInternalKeyFailsClosedWithoutCallingTenant() {
+        assertThat(new ExternalApiService(httpClient, VERIFY_URL, null)
+                .verifyAppCredentials("api-key", "api-secret"))
+                .isEmpty();
+        assertThat(new ExternalApiService(httpClient, VERIFY_URL, "short")
+                .verifyAppCredentials("api-key", "api-secret"))
+                .isEmpty();
+        assertThat(new ExternalApiService(
+                httpClient,
+                VERIFY_URL,
+                "0123456789abcdef0123456789abcde!")
+                .verifyAppCredentials("api-key", "api-secret"))
+                .isEmpty();
+
+        verifyNoInteractions(httpClient);
+    }
+
+    private static ResponseBody jsonBody(String body) {
+        return ResponseBody.create(body, JSON_MEDIA_TYPE);
+    }
+}

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/extra/AppServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/extra/AppServiceTest.java
@@ -1,17 +1,24 @@
 package com.iflytek.astron.console.toolkit.service.extra;
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
 import com.iflytek.astron.console.toolkit.config.properties.CommonConfig;
+import com.iflytek.astron.console.toolkit.entity.biz.external.app.AkSk;
 import com.iflytek.astron.console.toolkit.tool.CommonTool;
 import com.iflytek.astron.console.toolkit.tool.http.HeaderAuthHttpTool;
 import com.iflytek.astron.console.toolkit.util.RedisUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import static org.assertj.core.api.Assertions.*;
@@ -22,6 +29,24 @@ import static org.mockito.Mockito.*;
  */
 @ExtendWith(MockitoExtension.class)
 class AppServiceTest {
+
+    @BeforeAll
+    static void initializeCommonToolDependencies() throws Exception {
+        ConfigurableListableBeanFactory fakeBeanFactory =
+                mock(ConfigurableListableBeanFactory.class, withSettings()
+                        .defaultAnswer(invocation -> {
+                            if ("getBean".equals(invocation.getMethod().getName())) {
+                                Class<?> type = invocation.getArgument(0);
+                                return Mockito.mock(type);
+                            }
+                            return RETURNS_DEFAULTS.answer(invocation);
+                        }));
+        Class<?> springUtils =
+                Class.forName("com.iflytek.astron.console.toolkit.util.SpringUtils");
+        var beanFactoryField = springUtils.getDeclaredField("beanFactory");
+        beanFactoryField.setAccessible(true);
+        beanFactoryField.set(null, fakeBeanFactory);
+    }
 
     @InjectMocks
     private AppService appService;
@@ -49,28 +74,11 @@ class AppServiceTest {
         when(apiUrl.getApiKey()).thenReturn("ak");
         when(apiUrl.getApiSecret()).thenReturn("sk");
 
-        // ---- Key: Prepare an available BeanFactory for CommonTool static initialization ----
-        ConfigurableListableBeanFactory fakeBF = mock(ConfigurableListableBeanFactory.class, withSettings()
-                .defaultAnswer(invocation -> {
-                    if ("getBean".equals(invocation.getMethod().getName())) {
-                        Class<?> type = invocation.getArgument(0);
-                        // Return any type of mock to satisfy CommonTool.<clinit> dependencies
-                        return Mockito.mock(type);
-                    }
-                    return RETURNS_DEFAULTS.answer(invocation);
-                }));
-
-        Class<?> springUtils = Class.forName("com.iflytek.astron.console.toolkit.util.SpringUtils");
-        var bfField = springUtils.getDeclaredField("beanFactory");
-        bfField.setAccessible(true);
-        bfField.set(null, fakeBF);
-        // ----------------------------------------------------------------------
-
         // Static mock: HTTP returns placeholder response; parsing returns empty array "[]"
         try (MockedStatic<HeaderAuthHttpTool> http = mockStatic(HeaderAuthHttpTool.class);
                 MockedStatic<CommonTool> common = mockStatic(CommonTool.class)) {
 
-            http.when(() -> HeaderAuthHttpTool.get("http://api/key/" + appId, "ak", "sk"))
+            http.when(() -> HeaderAuthHttpTool.tenantGet("http://api/key/" + appId, "ak", "sk"))
                     .thenReturn("resp");
             common.when(() -> CommonTool.checkSystemCallResponse("resp"))
                     .thenReturn("[]");
@@ -81,7 +89,7 @@ class AppServiceTest {
 
             // Interaction verification (improve PIT killing power)
             verify(redisUtil).get("app_detail_cache:" + appId);
-            http.verify(() -> HeaderAuthHttpTool.get("http://api/key/" + appId, "ak", "sk"));
+            http.verify(() -> HeaderAuthHttpTool.tenantGet("http://api/key/" + appId, "ak", "sk"));
             common.verify(() -> CommonTool.checkSystemCallResponse("resp"));
         }
     }
@@ -90,7 +98,7 @@ class AppServiceTest {
     // =================
 
     @Test
-    @DisplayName("getAkSk - HeaderAuthHttpTool.get throws IOException: Should wrap as RuntimeException with cause")
+    @DisplayName("getAkSk - HeaderAuthHttpTool.tenantGet throws IOException: Should wrap as RuntimeException with cause")
     void getAkSk_shouldWrapHttpException() {
         String appId = "APP-6";
         when(redisUtil.get("app_detail_cache:" + appId)).thenReturn(null);
@@ -99,7 +107,7 @@ class AppServiceTest {
         when(apiUrl.getApiSecret()).thenReturn("sk");
 
         try (MockedStatic<HeaderAuthHttpTool> http = mockStatic(HeaderAuthHttpTool.class)) {
-            http.when(() -> HeaderAuthHttpTool.get("http://api/key/" + appId, "ak", "sk"))
+            http.when(() -> HeaderAuthHttpTool.tenantGet("http://api/key/" + appId, "ak", "sk"))
                     .thenThrow(new IOException("net down"));
 
             assertThatThrownBy(() -> appService.getAkSk(appId))
@@ -107,5 +115,45 @@ class AppServiceTest {
                     .hasCauseInstanceOf(IOException.class)
                     .hasRootCauseMessage("net down");
         }
+    }
+
+    @Test
+    void parsedTenantCredentialIsNotWrittenToLogs() {
+        String apiKey = "api-key-sentinel-must-not-be-logged";
+        String apiSecret = "api-secret-sentinel-must-not-be-logged";
+        String response = "{\"code\":0,\"data\":[{\"api_key\":\""
+                + apiKey
+                + "\",\"api_secret\":\""
+                + apiSecret
+                + "\"}]}";
+        Logger logger = (Logger) LoggerFactory.getLogger(AppService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        AkSk credential;
+        try {
+            credential = ReflectionTestUtils.invokeMethod(
+                    appService,
+                    "parseRemoteCredential",
+                    response,
+                    "APP-7",
+                    "uncached");
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertThat(credential.getApiKey()).isEqualTo(apiKey);
+        assertThat(credential.getApiSecret()).isEqualTo(apiSecret);
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .singleElement()
+                .asString()
+                .contains("APP credential query succeeded")
+                .contains("appId=APP-7")
+                .contains("mode=uncached")
+                .doesNotContain(apiKey)
+                .doesNotContain(apiSecret);
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/extra/CoreSystemServiceComparisonTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/extra/CoreSystemServiceComparisonTest.java
@@ -17,6 +17,8 @@ import org.mockito.MockedStatic;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -24,6 +26,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 
 class CoreSystemServiceComparisonTest {
+
+    private static final String INTERNAL_KEY =
+            "0123456789abcdef0123456789abcdef";
 
     private CoreSystemService coreSystemService;
 
@@ -38,6 +43,8 @@ class CoreSystemServiceComparisonTest {
         CommonConfig commonConfig = new CommonConfig();
         commonConfig.setAppId("console-app");
         ReflectionTestUtils.setField(coreSystemService, "commonConfig", commonConfig);
+        ReflectionTestUtils.setField(
+                coreSystemService, "workflowInternalApiKey", INTERNAL_KEY);
     }
 
     @Test
@@ -45,6 +52,7 @@ class CoreSystemServiceComparisonTest {
         try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
             okHttp.when(() -> OkHttpUtil.post(
                     "http://core/workflow/v1/protocol/compare/get",
+                    Map.of("X-Workflow-Internal-Key", INTERNAL_KEY),
                     "{\"flow_id\":\"flow-1\",\"version\":\"cmp-1\"}"))
                     .thenReturn("{\"code\":0,\"message\":\"success\","
                             + "\"data\":{\"data\":{\"nodes\":[],\"edges\":[]}}}");
@@ -60,6 +68,7 @@ class CoreSystemServiceComparisonTest {
         try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
             okHttp.when(() -> OkHttpUtil.post(
                     "http://core/workflow/v1/protocol/compare/get",
+                    Map.of("X-Workflow-Internal-Key", INTERNAL_KEY),
                     "{\"flow_id\":\"flow-1\",\"version\":\"missing\"}"))
                     .thenReturn("{\"code\":1001,\"message\":\"not found\"}");
 
@@ -80,6 +89,7 @@ class CoreSystemServiceComparisonTest {
         try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
             okHttp.when(() -> OkHttpUtil.post(
                     org.mockito.ArgumentMatchers.anyString(),
+                    anyMap(),
                     org.mockito.ArgumentMatchers.anyString()))
                     .thenReturn("{\"code\":0,\"message\":\""
                             + sentinel
@@ -115,7 +125,7 @@ class CoreSystemServiceComparisonTest {
                             ? "{\"code\":0,\"message\":\"" + sentinel
                                     + "\",\"data\":{\"database_id\":7000000000}}"
                             : "{\"code\":0,\"message\":\"" + sentinel + "\",\"data\":{}}");
-            okHttp.when(() -> OkHttpUtil.delete(anyString(), anyString()))
+            okHttp.when(() -> OkHttpUtil.delete(anyString(), anyMap(), anyString()))
                     .thenReturn("{\"code\":0,\"message\":\"" + sentinel + "\",\"data\":{}}");
 
             assertThat(coreSystemService.createDatabase(sentinel, "uid", 3L, sentinel))

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/openapi/impl/OpenApiServiceImplTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/openapi/impl/OpenApiServiceImplTest.java
@@ -1,0 +1,69 @@
+package com.iflytek.astron.console.toolkit.service.openapi.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.iflytek.astron.console.commons.constant.ResponseEnum;
+import com.iflytek.astron.console.commons.exception.BusinessException;
+import com.iflytek.astron.console.commons.mapper.bot.ChatBotApiMapper;
+import com.iflytek.astron.console.toolkit.entity.dto.openapi.WorkflowIoTransRequest;
+import com.iflytek.astron.console.toolkit.service.external.ExternalApiService;
+import com.iflytek.astron.console.toolkit.service.workflow.WorkflowService;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenApiServiceImplTest {
+
+    @Mock
+    private ExternalApiService externalApiService;
+    @Mock
+    private WorkflowService workflowService;
+    @Mock
+    private ChatBotApiMapper chatBotApiMapper;
+
+    @InjectMocks
+    private OpenApiServiceImpl service;
+
+    @Test
+    void passesCompleteCredentialPairToTenantVerification() {
+        WorkflowIoTransRequest request = request("api-key", "api-secret");
+        when(externalApiService.verifyAppCredentials("api-key", "api-secret"))
+                .thenReturn(Optional.of("app-123"));
+        when(chatBotApiMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        assertThat(service.getWorkflowIoTransformations(request)).isNull();
+
+        verify(externalApiService).verifyAppCredentials("api-key", "api-secret");
+    }
+
+    @Test
+    void rejectedCredentialPairIsUnauthorizedAndCannotReachDataLookup() {
+        WorkflowIoTransRequest request = request("api-key", "wrong-secret");
+        when(externalApiService.verifyAppCredentials("api-key", "wrong-secret"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getWorkflowIoTransformations(request))
+                .isInstanceOfSatisfying(BusinessException.class, exception -> assertThat(exception.getCode())
+                        .isEqualTo(ResponseEnum.UNAUTHORIZED.getCode()));
+
+        verify(externalApiService).verifyAppCredentials("api-key", "wrong-secret");
+        verifyNoInteractions(chatBotApiMapper, workflowService);
+    }
+
+    private static WorkflowIoTransRequest request(String apiKey, String apiSecret) {
+        WorkflowIoTransRequest request = new WorkflowIoTransRequest();
+        request.setApiKey(apiKey);
+        request.setApiSecret(apiSecret);
+        return request;
+    }
+}

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowAutomationServiceTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowAutomationServiceTest.java
@@ -3,6 +3,8 @@ package com.iflytek.astron.console.toolkit.service.workflow;
 import com.iflytek.astron.console.commons.exception.BusinessException;
 import com.iflytek.astron.console.commons.entity.workflow.Workflow;
 import com.iflytek.astron.console.toolkit.config.properties.ApiUrl;
+import com.iflytek.astron.console.toolkit.common.constant.WorkflowConst;
+import com.iflytek.astron.console.toolkit.entity.biz.external.app.AkSk;
 import com.iflytek.astron.console.toolkit.entity.core.workflow.sse.ChatSysReq;
 import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowAutomationRun;
 import com.iflytek.astron.console.toolkit.entity.table.workflow.WorkflowAutomationTask;
@@ -14,17 +16,20 @@ import com.iflytek.astron.console.toolkit.mapper.workflow.WorkflowVersionMapper;
 import com.iflytek.astron.console.toolkit.service.extra.AppService;
 import com.iflytek.astron.console.toolkit.tool.DataPermissionCheckTool;
 import com.iflytek.astron.console.toolkit.util.RedisUtil;
+import com.iflytek.astron.console.toolkit.util.OkHttpUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,11 +38,15 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WorkflowAutomationServiceTest {
+
+    private static final String INTERNAL_KEY =
+            "0123456789abcdef0123456789abcdef";
 
     @Mock
     private WorkflowAutomationTaskMapper taskMapper;
@@ -152,5 +161,45 @@ class WorkflowAutomationServiceTest {
 
         assertThat(url).isEqualTo("http://workflow/workflow/v1/chat/completions");
         assertThat(url).doesNotContain("/debug/");
+    }
+
+    @Test
+    void executeWorkflowSendsTrustedIdentityWithInternalKey() {
+        ReflectionTestUtils.setField(
+                service, "workflowInternalApiKey", INTERNAL_KEY);
+        when(apiUrl.getWorkflow()).thenReturn("http://workflow");
+        WorkflowAutomationTask task = new WorkflowAutomationTask();
+        task.setId(1L);
+        task.setFlowId("flow-1");
+        task.setUid("owner-1");
+        task.setInputParams("{}");
+        Workflow workflow = new Workflow();
+        workflow.setFlowId("flow-1");
+        workflow.setAppId("app-1");
+        workflow.setUid("owner-1");
+        workflow.setStatus(WorkflowConst.Status.PUBLISHED);
+        when(workflowMapper.selectOne(any())).thenReturn(workflow);
+        when(appService.remoteCallAkSk("app-1"))
+                .thenReturn(new AkSk("app-key", "app-secret"));
+
+        try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
+            okHttp.when(() -> OkHttpUtil.post(
+                    anyString(),
+                    any(Map.class),
+                    anyString()))
+                    .thenReturn("{\"code\":0}");
+
+            String response = ReflectionTestUtils.invokeMethod(
+                    service, "executeWorkflow", task, 9L);
+
+            assertThat(response).isEqualTo("{\"code\":0}");
+            okHttp.verify(() -> OkHttpUtil.post(
+                    eq("http://workflow/workflow/v1/chat/completions"),
+                    eq(Map.of(
+                            "Authorization", "app-key:app-secret",
+                            "X-Consumer-Username", "app-1",
+                            "X-Workflow-Internal-Key", INTERNAL_KEY)),
+                    org.mockito.ArgumentMatchers.anyString()));
+        }
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowChatRunClientTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowChatRunClientTest.java
@@ -25,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class WorkflowChatRunClientTest {
 
     private static final String CONTEXT_PATH = "/workflow/v1/chat/completions";
+    private static final String INTERNAL_KEY =
+            "0123456789abcdef0123456789abcdef";
 
     private HttpServer server;
 
@@ -49,6 +51,8 @@ class WorkflowChatRunClientTest {
         WorkflowChatRunClient client = new WorkflowChatRunClient(commonConfig);
         ReflectionTestUtils.setField(client, "chatUrl",
                 "http://127.0.0.1:" + server.getAddress().getPort() + CONTEXT_PATH);
+        ReflectionTestUtils.setField(
+                client, "workflowInternalApiKey", INTERNAL_KEY);
         return client;
     }
 
@@ -57,11 +61,14 @@ class WorkflowChatRunClientTest {
         String responseJson = "{\"code\":0,\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}";
         AtomicReference<String> capturedAuth = new AtomicReference<>();
         AtomicReference<String> capturedUser = new AtomicReference<>();
+        AtomicReference<String> capturedInternalKey = new AtomicReference<>();
         AtomicReference<String> capturedBody = new AtomicReference<>();
 
         WorkflowChatRunClient client = newClient(exchange -> {
             capturedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
             capturedUser.set(exchange.getRequestHeaders().getFirst("X-Consumer-Username"));
+            capturedInternalKey.set(
+                    exchange.getRequestHeaders().getFirst("X-Workflow-Internal-Key"));
             capturedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
 
             byte[] resp = responseJson.getBytes(StandardCharsets.UTF_8);
@@ -81,6 +88,7 @@ class WorkflowChatRunClientTest {
         assertThat(result).isEqualTo(responseJson);
         assertThat(capturedUser.get()).isEqualTo("app-id-1");
         assertThat(capturedAuth.get()).isEqualTo("Bearer key-1:secret-1");
+        assertThat(capturedInternalKey.get()).isEqualTo(INTERNAL_KEY);
 
         JSONObject sentBody = JSON.parseObject(capturedBody.get());
         assertThat(sentBody.getString("flow_id")).isEqualTo("flow123");
@@ -114,5 +122,20 @@ class WorkflowChatRunClientTest {
         String result = client.chat(new JSONObject().fluentPut("flow_id", "flow123"));
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void chatRejectsPublishedPlaceholderBeforeIssuingRequest() throws Exception {
+        WorkflowChatRunClient client = newClient(exchange -> {
+            throw new AssertionError("request must not be issued");
+        });
+        ReflectionTestUtils.setField(
+                client,
+                "workflowInternalApiKey",
+                "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY");
+
+        assertThatThrownBy(() -> client.chat(new JSONObject()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageNotContaining("CHANGE_ME_WORKFLOW_INTERNAL_API_KEY");
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowImportDependencyGuardTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowImportDependencyGuardTest.java
@@ -126,7 +126,9 @@ class WorkflowImportDependencyGuardTest {
         ReflectionTestUtils.setField(workflowService, "apiUrl", apiUrl);
         ReflectionTestUtils.setField(workflowService, "configInfoMapper", configInfoMapper);
         ReflectionTestUtils.setField(
-                workflowService, "workflowInternalApiKey", "internal-secret");
+                workflowService,
+                "workflowInternalApiKey",
+                "0123456789abcdef0123456789abcdef");
         ReflectionTestUtils.setField(
                 workflowService, "skillSandboxConfigService", skillSandboxConfigService);
         ConfigInfo multiRoundTypes = new ConfigInfo();
@@ -347,7 +349,9 @@ class WorkflowImportDependencyGuardTest {
         try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
             okHttp.when(() -> OkHttpUtil.post(
                     eq("http://core/workflow/v1/node/debug/"),
-                    eq(Map.of("X-Workflow-Internal-Key", "internal-secret")),
+                    eq(Map.of(
+                            "X-Workflow-Internal-Key",
+                            "0123456789abcdef0123456789abcdef")),
                     anyString()))
                     .thenReturn("{\"code\":0,\"data\":{\"result\":\"ok\"}}");
 
@@ -355,7 +359,9 @@ class WorkflowImportDependencyGuardTest {
 
             okHttp.verify(() -> OkHttpUtil.post(
                     eq("http://core/workflow/v1/node/debug/"),
-                    eq(Map.of("X-Workflow-Internal-Key", "internal-secret")),
+                    eq(Map.of(
+                            "X-Workflow-Internal-Key",
+                            "0123456789abcdef0123456789abcdef")),
                     anyString()), times(1));
         }
 
@@ -472,7 +478,9 @@ class WorkflowImportDependencyGuardTest {
         try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
             okHttp.when(() -> OkHttpUtil.post(
                     eq("http://core/workflow/v1/run"),
-                    eq(Map.of("X-Workflow-Internal-Key", "internal-secret")),
+                    eq(Map.of(
+                            "X-Workflow-Internal-Key",
+                            "0123456789abcdef0123456789abcdef")),
                     anyString()))
                     .thenAnswer(invocation -> {
                         forwardedBody.set(invocation.getArgument(2));

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceProtocolBoundaryTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceProtocolBoundaryTest.java
@@ -32,11 +32,16 @@ import static org.mockito.Mockito.mockStatic;
 
 class WorkflowServiceProtocolBoundaryTest {
 
+    private static final String INTERNAL_KEY =
+            "0123456789abcdef0123456789abcdef";
+
     private WorkflowService workflowService;
 
     @BeforeEach
     void setUp() {
         workflowService = new WorkflowService();
+        ReflectionTestUtils.setField(
+                workflowService, "workflowInternalApiKey", INTERNAL_KEY);
     }
 
     @Test
@@ -108,7 +113,10 @@ class WorkflowServiceProtocolBoundaryTest {
         appender.start();
         logger.addAppender(appender);
         try (MockedStatic<OkHttpUtil> okHttp = mockStatic(OkHttpUtil.class)) {
-            okHttp.when(() -> OkHttpUtil.post(anyString(), anyString()))
+            okHttp.when(() -> OkHttpUtil.post(
+                    anyString(),
+                    org.mockito.ArgumentMatchers.anyMap(),
+                    anyString()))
                     .thenReturn("{\"code\":0,\"message\":\""
                             + sentinel
                             + "\",\"data\":{\"flow_id\":\"flow-1\",\"echo\":\""

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceSandboxConfigTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/service/workflow/WorkflowServiceSandboxConfigTest.java
@@ -165,12 +165,29 @@ class WorkflowServiceSandboxConfigTest {
     @Test
     void workflowInternalHeadersUseConfiguredSecret() {
         ReflectionTestUtils.setField(
-                workflowService, "workflowInternalApiKey", "internal-secret");
+                workflowService,
+                "workflowInternalApiKey",
+                "0123456789abcdef0123456789abcdef");
 
         Map<String, String> headers = ReflectionTestUtils.invokeMethod(
                 workflowService, "workflowInternalHeaders");
 
         assertThat(headers)
-                .containsEntry("X-Workflow-Internal-Key", "internal-secret");
+                .containsEntry(
+                        "X-Workflow-Internal-Key",
+                        "0123456789abcdef0123456789abcdef");
+    }
+
+    @Test
+    void workflowInternalHeadersRejectPublishedPlaceholder() {
+        ReflectionTestUtils.setField(
+                workflowService,
+                "workflowInternalApiKey",
+                "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY");
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                workflowService, "workflowInternalHeaders"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageNotContaining("CHANGE_ME_WORKFLOW_INTERNAL_API_KEY");
     }
 }

--- a/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/http/HeaderAuthHttpToolSecurityTest.java
+++ b/console/backend/toolkit/src/test/java/com/iflytek/astron/console/toolkit/tool/http/HeaderAuthHttpToolSecurityTest.java
@@ -1,0 +1,97 @@
+package com.iflytek.astron.console.toolkit.tool.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class HeaderAuthHttpToolSecurityTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void authenticatedMethodsDoNotLogOrPrintCredentialsOrPayloads() throws Exception {
+        String apiKey = "tenant-api-key-sentinel";
+        String apiSecret = "tenant-api-secret-sentinel-0123456789abcdef";
+        String requestPayload = "{\"credential\":\"request-payload-sentinel\"}";
+        String responsePayload = "{\"code\":0,\"data\":[{\"api_key\":\""
+                + apiKey
+                + "\",\"api_secret\":\""
+                + apiSecret
+                + "\"}]}";
+        List<String> internalKeys = new CopyOnWriteArrayList<>();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/secure", exchange -> {
+            String internalKey =
+                    exchange.getRequestHeaders().getFirst("X-Tenant-Internal-Key");
+            internalKeys.add(internalKey == null ? "<missing>" : internalKey);
+            exchange.getRequestBody().readAllBytes();
+            byte[] response = responsePayload.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(response);
+            }
+        });
+        server.start();
+
+        Logger logger = (Logger) LoggerFactory.getLogger(HeaderAuthHttpTool.class);
+        Level originalLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.setLevel(Level.DEBUG);
+        logger.addAppender(appender);
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        List<String> results;
+        try {
+            System.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8));
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/secure";
+            results = List.of(
+                    HeaderAuthHttpTool.get(url, apiKey, apiSecret),
+                    HeaderAuthHttpTool.post(url, apiKey, apiSecret, requestPayload),
+                    HeaderAuthHttpTool.put(url, apiKey, apiSecret, requestPayload),
+                    HeaderAuthHttpTool.patch(url, apiKey, apiSecret, requestPayload),
+                    HeaderAuthHttpTool.delete(url, apiKey, apiSecret, requestPayload),
+                    HeaderAuthHttpTool.tenantGet(url, apiKey, apiSecret));
+        } finally {
+            System.setOut(originalOut);
+            logger.detachAppender(appender);
+            logger.setLevel(originalLevel);
+            appender.stop();
+        }
+
+        assertThat(results).allSatisfy(result -> assertThat(result).contains(apiKey, apiSecret));
+        assertThat(internalKeys).containsExactly(
+                "<missing>", "<missing>", "<missing>", "<missing>", "<missing>", apiSecret);
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .hasSize(6)
+                .allSatisfy(message -> assertThat(message)
+                        .contains("completed")
+                        .contains("status=200")
+                        .contains("responseChars=")
+                        .doesNotContain(apiKey, apiSecret, requestPayload, responsePayload));
+        assertThat(stdout.toString(StandardCharsets.UTF_8))
+                .doesNotContain(apiKey, apiSecret, requestPayload, responsePayload, "builder:");
+    }
+}

--- a/core/agent/api/v1/workflow_agent.py
+++ b/core/agent/api/v1/workflow_agent.py
@@ -16,7 +16,7 @@ from common.otlp.trace.langfuse import (
 )
 from common.otlp.trace.span import Span
 from common.otlp.trace.trace import Trace
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Depends, Header
 from opentelemetry.trace import Status, StatusCode
 from pydantic import ConfigDict
 from starlette.responses import StreamingResponse
@@ -24,10 +24,13 @@ from starlette.types import Receive, Scope, Send
 
 from agent.api.schemas.workflow_agent_inputs import CustomCompletionInputs
 from agent.api.v1.base_api import CompletionBase
+from agent.infra.workflow_internal_auth import require_workflow_internal_api_key
 from agent.service.builder.workflow_agent_builder import WorkflowAgentRunnerBuilder
 from agent.service.runner.workflow_agent_runner import WorkflowAgentRunner
 
-workflow_agent_router = APIRouter()
+workflow_agent_router = APIRouter(
+    dependencies=[Depends(require_workflow_internal_api_key)],
+)
 
 headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
 _STREAM_END = object()

--- a/core/agent/infra/app_auth.py
+++ b/core/agent/infra/app_auth.py
@@ -12,6 +12,21 @@ from common.otlp.trace.span import Span
 from pydantic import BaseModel, Field
 
 from agent.exceptions.middleware_exc import AppAuthFailedExc
+from agent.infra.credentials import credential_from_env_or_file
+
+APP_AUTH_API_KEY_PLACEHOLDERS = (
+    "YOUR_APP_AUTH_API_KEY",
+    "xxxx",
+    "7b709739e8da44536127a333c7603a83",
+)
+APP_AUTH_SECRET_PLACEHOLDERS = (
+    "YOUR_APP_AUTH_SECRET",
+    "xxxx",
+    "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy",
+)
+APP_AUTH_CREDENTIAL_MIN_LENGTH = 32
+APP_AUTH_CREDENTIAL_MAX_LENGTH = 50
+TENANT_INTERNAL_API_KEY_HEADER = "X-Tenant-Internal-Key"
 
 
 def http_date(dt: datetime.datetime) -> str:
@@ -74,8 +89,20 @@ class APPAuth:
             host=os.getenv("APP_AUTH_HOST", "") or "",
             route=os.getenv("APP_AUTH_ROUTER", "") or "",
             prot=os.getenv("APP_AUTH_PROT", "") or "",
-            api_key=os.getenv("APP_AUTH_API_KEY", "") or "",
-            secret=os.getenv("APP_AUTH_SECRET", "") or "",
+            api_key=credential_from_env_or_file(
+                "APP_AUTH_API_KEY",
+                "APP_AUTH_API_KEY_FILE",
+                min_length=APP_AUTH_CREDENTIAL_MIN_LENGTH,
+                max_length=APP_AUTH_CREDENTIAL_MAX_LENGTH,
+                placeholders=APP_AUTH_API_KEY_PLACEHOLDERS,
+            ),
+            secret=credential_from_env_or_file(
+                "APP_AUTH_SECRET",
+                "APP_AUTH_SECRET_FILE",
+                min_length=APP_AUTH_CREDENTIAL_MIN_LENGTH,
+                max_length=APP_AUTH_CREDENTIAL_MAX_LENGTH,
+                placeholders=APP_AUTH_SECRET_PLACEHOLDERS,
+            ),
         )
         # Set current time
         self.date = http_date(datetime.datetime.utcnow())
@@ -112,6 +139,7 @@ class APPAuth:
             "Date": self.date,
             "Digest": digest,
             "Authorization": auth_header,
+            TENANT_INTERNAL_API_KEY_HEADER: self.config.secret,
         }
         return headers
 
@@ -146,7 +174,25 @@ class MaasAuth(BaseModel):
             app_detail = await APPAuth().app_detail(self.app_id)
 
             sp.add_info_events(
-                {"kong-app-detail": json.dumps(app_detail, ensure_ascii=False)}
+                {
+                    "kong-app-detail": json.dumps(
+                        {
+                            "available": app_detail is not None,
+                            "code": (
+                                app_detail.get("code")
+                                if isinstance(app_detail, dict)
+                                else None
+                            ),
+                            "result_count": (
+                                len(app_detail.get("data", []))
+                                if isinstance(app_detail, dict)
+                                and isinstance(app_detail.get("data", []), list)
+                                else 0
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                }
             )
 
             if app_detail is None:
@@ -165,9 +211,11 @@ class MaasAuth(BaseModel):
 
             api_key = auth_list[0].get("api_key")
             api_secret = auth_list[0].get("api_secret")
+            if not api_key or not api_secret:
+                raise AppAuthFailedExc(self.app_id_not_found_msg)
 
             kong_sk = f"{api_key}:{api_secret}"
 
-            sp.add_info_events({"kong-sk": kong_sk})
+            sp.add_info_events({"kong-sk-retrieved": True})
 
             return kong_sk

--- a/core/agent/infra/credentials.py
+++ b/core/agent/infra/credentials.py
@@ -1,0 +1,73 @@
+"""Read deployment-managed credentials from environment variables or files."""
+
+import os
+import stat
+from typing import Collection
+
+MAX_CREDENTIAL_FILE_BYTES = 4096
+
+
+def read_credential_file(file_name: str) -> str:
+    """Read a bounded regular file through one non-following descriptor."""
+    if not file_name:
+        return ""
+    descriptor = -1
+    try:
+        before_open = os.lstat(file_name)
+        if stat.S_ISLNK(before_open.st_mode) or not stat.S_ISREG(before_open.st_mode):
+            return ""
+        if before_open.st_size > MAX_CREDENTIAL_FILE_BYTES:
+            return ""
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(file_name, flags)
+        after_open = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(after_open.st_mode)
+            or not os.path.samestat(before_open, after_open)
+            or after_open.st_size > MAX_CREDENTIAL_FILE_BYTES
+        ):
+            return ""
+        data = bytearray()
+        while len(data) <= MAX_CREDENTIAL_FILE_BYTES:
+            chunk = os.read(
+                descriptor,
+                min(1024, MAX_CREDENTIAL_FILE_BYTES + 1 - len(data)),
+            )
+            if not chunk:
+                break
+            data.extend(chunk)
+        if len(data) > MAX_CREDENTIAL_FILE_BYTES:
+            return ""
+        return bytes(data).decode("utf-8").strip()
+    except (OSError, UnicodeError):
+        return ""
+    finally:
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def credential_from_env_or_file(
+    value_env: str,
+    file_env: str,
+    *,
+    min_length: int = 1,
+    max_length: int = MAX_CREDENTIAL_FILE_BYTES,
+    placeholders: Collection[str] = (),
+) -> str:
+    def valid(candidate: str) -> bool:
+        return (
+            min_length <= len(candidate) <= max_length
+            and "\r" not in candidate
+            and "\n" not in candidate
+            and candidate not in placeholders
+        )
+
+    value = (os.getenv(value_env, "") or "").strip()
+    if valid(value):
+        return value
+    file_name = (os.getenv(file_env, "") or "").strip()
+    value = read_credential_file(file_name)
+    return value if valid(value) else ""

--- a/core/agent/infra/workflow_internal_auth.py
+++ b/core/agent/infra/workflow_internal_auth.py
@@ -1,0 +1,57 @@
+"""Authenticate deployment-internal callers of the Agent workflow endpoint."""
+
+import secrets
+from typing import Annotated
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+from agent.infra.credentials import credential_from_env_or_file
+
+WORKFLOW_INTERNAL_API_KEY_ENV = "WORKFLOW_INTERNAL_API_KEY"
+WORKFLOW_INTERNAL_API_KEY_FILE_ENV = "WORKFLOW_INTERNAL_API_KEY_FILE"
+WORKFLOW_INTERNAL_API_KEY_HEADER = "X-Workflow-Internal-Key"
+WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"
+WORKFLOW_INTERNAL_API_KEY_MIN_LENGTH = 32
+
+_workflow_internal_api_key_header = APIKeyHeader(
+    name=WORKFLOW_INTERNAL_API_KEY_HEADER,
+    auto_error=False,
+)
+
+
+def optional_workflow_internal_api_key() -> str:
+    """Return a valid deployment-internal key without accepting published defaults."""
+    return credential_from_env_or_file(
+        WORKFLOW_INTERNAL_API_KEY_ENV,
+        WORKFLOW_INTERNAL_API_KEY_FILE_ENV,
+        min_length=WORKFLOW_INTERNAL_API_KEY_MIN_LENGTH,
+        placeholders=(WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,),
+    )
+
+
+def configured_workflow_internal_api_key() -> str:
+    """Return the configured key or fail closed while deployment is incomplete."""
+    api_key = optional_workflow_internal_api_key()
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Workflow internal API authentication is not configured",
+        )
+    return api_key
+
+
+async def require_workflow_internal_api_key(
+    supplied_api_key: Annotated[
+        str | None, Security(_workflow_internal_api_key_header)
+    ],
+) -> None:
+    """Require the same internal credential shared by Workflow and Agent."""
+    expected_api_key = configured_workflow_internal_api_key()
+    if not supplied_api_key or not secrets.compare_digest(
+        supplied_api_key, expected_api_key
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid workflow internal API credentials",
+        )

--- a/core/agent/service/builder/base_builder.py
+++ b/core/agent/service/builder/base_builder.py
@@ -311,7 +311,7 @@ class BaseApiBuilder(BaseModel):
                     "model": model_name,
                     "base_url": normalized_base_url,
                     "provider": normalized_provider or "openai",
-                    "api_key": sk,
+                    "model_auth_configured": bool(sk),
                     "app_id": app_id,
                 }
             )

--- a/core/agent/service/plugin/workflow.py
+++ b/core/agent/service/plugin/workflow.py
@@ -17,7 +17,35 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
 from agent.exceptions.plugin_exc import RunWorkflowExc
+from agent.infra.credentials import credential_from_env_or_file
+from agent.infra.workflow_internal_auth import (
+    WORKFLOW_INTERNAL_API_KEY_HEADER,
+    WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,
+)
 from agent.service.plugin.base import BasePlugin, PluginResponse
+
+
+def _redact_workflow_request_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Remove internal authentication and signed trace headers from telemetry."""
+    trace_safe_headers = redact_trusted_trace_headers(headers)
+    return {
+        key: value
+        for key, value in trace_safe_headers.items()
+        if key.lower() != WORKFLOW_INTERNAL_API_KEY_HEADER.lower()
+    }
+
+
+def _configured_workflow_internal_api_key() -> str:
+    """Load the deployment key once per request and fail closed if unavailable."""
+    internal_api_key = credential_from_env_or_file(
+        "WORKFLOW_INTERNAL_API_KEY",
+        "WORKFLOW_INTERNAL_API_KEY_FILE",
+        min_length=32,
+        placeholders=(WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,),
+    )
+    if not internal_api_key:
+        raise RunWorkflowExc
+    return internal_api_key
 
 
 class _AgentConfig(BaseModel):
@@ -57,6 +85,7 @@ class WorkflowPluginRunner(BaseModel):
 
     def _build_request_params(self, action_input: dict) -> dict:
         """Build request parameters"""
+        internal_api_key = _configured_workflow_internal_api_key()
         return {
             "model": "",
             "messages": [],
@@ -69,6 +98,7 @@ class WorkflowPluginRunner(BaseModel):
             },
             "extra_headers": {
                 "X-consumer-username": self.app_id,
+                WORKFLOW_INTERNAL_API_KEY_HEADER: internal_api_key,
                 **inject_trusted_langfuse_context(
                     method="POST",
                     audience=WORKFLOW_TRACE_AUDIENCE,
@@ -129,7 +159,7 @@ class WorkflowPluginRunner(BaseModel):
             params = self._build_request_params(action_input)
             logged_params = {
                 **params,
-                "extra_headers": redact_trusted_trace_headers(
+                "extra_headers": _redact_workflow_request_headers(
                     params.get("extra_headers", {})
                 ),
             }
@@ -213,16 +243,25 @@ class WorkflowPluginFactory(BaseModel):
                     )
                 }
             )
+            internal_api_key = _configured_workflow_internal_api_key()
             async with aiohttp.ClientSession() as session:
                 async with session.post(
-                    agent_config.GET_WORKFLOWS_URL, json={"flow_id": workflow_id}
+                    agent_config.GET_WORKFLOWS_URL,
+                    json={"flow_id": workflow_id},
+                    headers={WORKFLOW_INTERNAL_API_KEY_HEADER: internal_api_key},
                 ) as response:
                     response.raise_for_status()
                     result = await response.json()
+                    telemetry_summary = {
+                        "code": result.get("code"),
+                        "sid": result.get("sid"),
+                        "flow_id": workflow_id,
+                        "has_data": result.get("data") is not None,
+                    }
                     sp.add_info_events(
                         attributes={
                             "workflow-plugin-do-query-workflow-schema-outputs": (
-                                json.dumps(result, ensure_ascii=False)
+                                json.dumps(telemetry_summary, ensure_ascii=False)
                             )
                         }
                     )

--- a/core/agent/tests/test_app_auth.py
+++ b/core/agent/tests/test_app_auth.py
@@ -14,7 +14,14 @@ from common.otlp.trace.span import Span
 
 import agent.infra.app_auth as app_auth
 from agent.exceptions import middleware_exc
-from agent.infra.app_auth import APPAuth, AuthConfig, MaasAuth, hashlib_256, http_date
+from agent.infra.app_auth import (
+    TENANT_INTERNAL_API_KEY_HEADER,
+    APPAuth,
+    AuthConfig,
+    MaasAuth,
+    hashlib_256,
+    http_date,
+)
 
 
 @dataclass
@@ -131,8 +138,8 @@ class TestAPPAuth:
                 "APP_AUTH_HOST": "test.example.com",
                 "APP_AUTH_ROUTER": "/api/auth",
                 "APP_AUTH_PROT": "https",
-                "APP_AUTH_API_KEY": "test_key",
-                "APP_AUTH_SECRET": "test_secret",
+                "APP_AUTH_API_KEY": "k" * 48,
+                "APP_AUTH_SECRET": "s" * 48,
             },
         ):
             return APPAuth()
@@ -151,6 +158,66 @@ class TestAPPAuth:
         except Exception:
             pytest.fail("Signature should be valid base64 encoded")
 
+    def test_loads_credentials_from_files(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        key_file = tmp_path / "tenant-key"
+        secret_file = tmp_path / "tenant-secret"
+        key_file.write_text("k" * 48 + "\n", encoding="utf-8")
+        secret_file.write_text("s" * 48 + "\n", encoding="utf-8")
+        monkeypatch.delenv("APP_AUTH_API_KEY", raising=False)
+        monkeypatch.delenv("APP_AUTH_SECRET", raising=False)
+        monkeypatch.setenv("APP_AUTH_API_KEY_FILE", str(key_file))
+        monkeypatch.setenv("APP_AUTH_SECRET_FILE", str(secret_file))
+
+        auth = APPAuth()
+
+        assert auth.config.api_key == "k" * 48
+        assert auth.config.secret == "s" * 48
+
+    def test_placeholder_environment_values_do_not_shadow_credential_files(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        key_file = tmp_path / "tenant-key"
+        secret_file = tmp_path / "tenant-secret"
+        key_file.write_text("k" * 48 + "\n", encoding="utf-8")
+        secret_file.write_text("s" * 48 + "\n", encoding="utf-8")
+        monkeypatch.setenv("APP_AUTH_API_KEY", "YOUR_APP_AUTH_API_KEY")
+        monkeypatch.setenv("APP_AUTH_SECRET", "YOUR_APP_AUTH_SECRET")
+        monkeypatch.setenv("APP_AUTH_API_KEY_FILE", str(key_file))
+        monkeypatch.setenv("APP_AUTH_SECRET_FILE", str(secret_file))
+
+        auth = APPAuth()
+
+        assert auth.config.api_key == "k" * 48
+        assert auth.config.secret == "s" * 48
+
+    @pytest.mark.parametrize(
+        ("api_key", "api_secret"),
+        [
+            (
+                "7b709739e8da44536127a333c7603a83",
+                "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy",
+            ),
+            ("short", "also-short"),
+        ],
+    )
+    def test_rejects_disclosed_or_weak_environment_credentials(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        api_key: str,
+        api_secret: str,
+    ) -> None:
+        monkeypatch.setenv("APP_AUTH_API_KEY", api_key)
+        monkeypatch.setenv("APP_AUTH_SECRET", api_secret)
+        monkeypatch.delenv("APP_AUTH_API_KEY_FILE", raising=False)
+        monkeypatch.delenv("APP_AUTH_SECRET_FILE", raising=False)
+
+        auth = APPAuth()
+
+        assert auth.config.api_key == ""
+        assert auth.config.secret == ""
+
     def test_init_header(self, app_auth: APPAuth) -> None:
         """Test request header initialization"""
         data = "test_data"
@@ -164,6 +231,7 @@ class TestAPPAuth:
         assert headers["Content-Type"] == "application/json"
         assert "api_key" in headers["Authorization"]
         assert "signature" in headers["Authorization"]
+        assert headers[TENANT_INTERNAL_API_KEY_HEADER] == "s" * 48
 
     @pytest.mark.asyncio
     async def test_app_detail_success(self, app_auth: APPAuth) -> None:
@@ -212,9 +280,7 @@ class TestAPPAuth:
     async def test_app_detail_timeout(self, app_auth: APPAuth) -> None:
         """Test timeout when retrieving app details"""
 
-        async def mock_get(
-            *args: Any, **kwargs: Any
-        ) -> AsyncMock:  # noqa: ANN001, D401
+        def mock_get(*args: Any, **kwargs: Any) -> AsyncMock:  # noqa: ANN001, D401
             raise aiohttp.ClientError("timeout")
 
         with patch("aiohttp.ClientSession.get", new=mock_get):
@@ -249,6 +315,36 @@ class TestMaasAuth:
             sk = await maas_auth.sk(span)
 
             assert sk == "test_key:test_secret"
+
+    @pytest.mark.asyncio
+    async def test_sk_does_not_record_credentials(self, maas_auth: MaasAuth) -> None:
+        mock_app_detail = {
+            "code": 0,
+            "data": [
+                {"auth_list": [{"api_key": "trace_key", "api_secret": "trace_secret"}]}
+            ],
+        }
+        span = MagicMock()
+        span_context = MagicMock()
+        span.start.return_value.__enter__.return_value = span_context
+
+        with patch.object(APPAuth, "app_detail", return_value=mock_app_detail):
+            sk = await maas_auth.sk(span)
+
+        assert sk == "trace_key:trace_secret"
+        recorded = repr(span_context.add_info_events.call_args_list)
+        assert "trace_key" not in recorded
+        assert "trace_secret" not in recorded
+
+    @pytest.mark.asyncio
+    async def test_sk_rejects_missing_credential_fields(
+        self, maas_auth: MaasAuth, span: Span
+    ) -> None:
+        mock_app_detail = {"code": 0, "data": [{"auth_list": [{}]}]}
+
+        with patch.object(APPAuth, "app_detail", return_value=mock_app_detail):
+            with pytest.raises(Exception):
+                await maas_auth.sk(span)
 
     @pytest.mark.asyncio
     async def test_sk_app_detail_none(self, maas_auth: MaasAuth, span: Span) -> None:

--- a/core/agent/tests/test_base_builder.py
+++ b/core/agent/tests/test_base_builder.py
@@ -275,6 +275,24 @@ class TestBaseApiBuilder:
         assert model.llm.api_key == "provided_key"
 
     @pytest.mark.asyncio
+    async def test_create_model_does_not_record_api_credentials(
+        self, builder: BaseApiBuilder
+    ) -> None:
+        credential = "tenant-key:tenant-secret-must-not-reach-telemetry"
+
+        with patch.object(builder.span, "add_info_events") as add_info_events:
+            await builder.create_model(
+                app_id="test_app",
+                model_name="test_model",
+                base_url="https://api.test.com",
+                api_key=credential,
+            )
+
+        recorded_events = repr(add_info_events.call_args_list)
+        assert credential not in recorded_events
+        assert "model_auth_configured" in recorded_events
+
+    @pytest.mark.asyncio
     async def test_create_anthropic_model(self, builder: BaseApiBuilder) -> None:
         model = await builder.create_model(
             app_id="test_app",

--- a/core/agent/tests/test_plugin_base_link_mcp_workflow.py
+++ b/core/agent/tests/test_plugin_base_link_mcp_workflow.py
@@ -3,6 +3,7 @@
 import json
 from dataclasses import dataclass
 from typing import Any
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -34,7 +35,7 @@ class _DummySidGen:
 
 
 @pytest.fixture(autouse=True)
-def _setup_test_environment() -> None:
+def _setup_test_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Automatically inject environment fixes for all tests.
 
     - Ensure `sid_generator2` is initialized to avoid `Span` construction failure.
@@ -42,6 +43,7 @@ def _setup_test_environment() -> None:
     # Initialize sid generator to avoid Span throwing "sid_generator2 is not initialized"
     if sid_module.sid_generator2 is None:
         sid_module.sid_generator2 = _DummySidGen()  # type: ignore[assignment]
+    monkeypatch.setenv("WORKFLOW_INTERNAL_API_KEY", "i" * 32)
 
 
 class TestPluginBase:
@@ -251,6 +253,7 @@ class TestWorkflowPluginRunnerAndFactory:
             "bot_id": "workflow",
             "caller": "agent",
         }
+        assert params["extra_headers"]["X-Workflow-Internal-Key"] == "i" * 32
         assert "extra_body" not in params["extra_body"]
 
     @pytest.mark.asyncio
@@ -319,6 +322,97 @@ class TestWorkflowPluginRunnerAndFactory:
         assert ok_resp.result["reasoning_content"] == "r"
 
     @pytest.mark.asyncio
+    async def test_query_workflow_schema_sends_internal_key_without_logging_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import aiohttp
+
+        import agent.service.plugin.workflow as workflow_module
+
+        configured_key = "q" * 32
+        monkeypatch.setenv("WORKFLOW_INTERNAL_API_KEY", configured_key)
+        monkeypatch.delenv("WORKFLOW_INTERNAL_API_KEY_FILE", raising=False)
+
+        class DummyConfig:
+            GET_WORKFLOWS_URL = "http://workflow/sparkflow/v1/protocol/get"
+
+        monkeypatch.setattr(workflow_module, "agent_config", DummyConfig())
+        captured: dict[str, Any] = {}
+        disclosed_api_key = "workflow-api-key-must-not-enter-telemetry"
+        disclosed_api_secret = "workflow-api-secret-must-not-enter-telemetry"
+        protocol_marker = "workflow-protocol-body-must-not-enter-telemetry"
+        payload = {
+            "code": 0,
+            "sid": "safe-request-id",
+            "data": {
+                "data": {
+                    "id": "flow-1",
+                    "apiKey": disclosed_api_key,
+                    "apiSecret": disclosed_api_secret,
+                    "data": {"nodes": [{"prompt": protocol_marker}]},
+                }
+            },
+        }
+
+        class ResponseContextManager:
+            async def __aenter__(self) -> "ResponseContextManager":
+                return self
+
+            async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+                return False
+
+            def raise_for_status(self) -> None:
+                return None
+
+            async def json(self) -> dict[str, Any]:
+                return payload
+
+        def fake_post(
+            _session: aiohttp.ClientSession, url: str, **kwargs: Any
+        ) -> ResponseContextManager:
+            captured.update({"url": url, **kwargs})
+            return ResponseContextManager()
+
+        monkeypatch.setattr(aiohttp.ClientSession, "post", fake_post)
+        span = MagicMock(spec=Span)
+        span_context = MagicMock()
+        span.start.return_value.__enter__.return_value = span_context
+
+        result = await WorkflowPluginFactory.do_query_workflow_schema("flow-1", span)
+
+        assert result == payload
+        assert captured["headers"] == {"X-Workflow-Internal-Key": configured_key}
+        telemetry_calls = span_context.add_info_events.call_args_list
+        telemetry_text = repr(telemetry_calls)
+        assert configured_key not in telemetry_text
+        assert disclosed_api_key not in telemetry_text
+        assert disclosed_api_secret not in telemetry_text
+        assert protocol_marker not in telemetry_text
+        output_attributes = telemetry_calls[1].kwargs["attributes"]
+        output_summary = json.loads(
+            output_attributes["workflow-plugin-do-query-workflow-schema-outputs"]
+        )
+        assert output_summary == {
+            "code": 0,
+            "sid": "safe-request-id",
+            "flow_id": "flow-1",
+            "has_data": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_query_workflow_schema_fails_closed_without_internal_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("WORKFLOW_INTERNAL_API_KEY", raising=False)
+        monkeypatch.delenv("WORKFLOW_INTERNAL_API_KEY_FILE", raising=False)
+        span = MagicMock(spec=Span)
+        span_context = MagicMock()
+        span.start.return_value.__enter__.return_value = span_context
+
+        with pytest.raises(PluginExc):
+            await WorkflowPluginFactory.do_query_workflow_schema("flow-1", span)
+
+    @pytest.mark.asyncio
     async def test_workflow_runner_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -382,6 +476,8 @@ class TestWorkflowPluginRunnerAndFactory:
             assert "baggage" not in logged_request
             assert "x-astron-langfuse-trace-timestamp" not in logged_request
             assert "x-astron-langfuse-trace-signature" not in logged_request
+            assert "X-Workflow-Internal-Key" not in logged_request
+            assert "i" * 32 not in logged_request
         finally:
             provider.shutdown()
 

--- a/core/agent/tests/test_workflow_internal_auth.py
+++ b/core/agent/tests/test_workflow_internal_auth.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from agent.api.v1.workflow_agent import workflow_agent_router
+from agent.infra.workflow_internal_auth import (
+    WORKFLOW_INTERNAL_API_KEY_ENV,
+    WORKFLOW_INTERNAL_API_KEY_FILE_ENV,
+    WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,
+    require_workflow_internal_api_key,
+)
+
+
+@pytest.mark.asyncio
+async def test_agent_internal_auth_accepts_configured_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured_key = "a" * 32
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, configured_key)
+    monkeypatch.delenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, raising=False)
+
+    await require_workflow_internal_api_key(configured_key)
+
+
+@pytest.mark.asyncio
+async def test_agent_internal_auth_accepts_persisted_key_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configured_key = "f" * 48
+    key_file = tmp_path / "workflow-internal-api-key"
+    key_file.write_text(f"{configured_key}\n", encoding="utf-8")
+    monkeypatch.setenv(
+        WORKFLOW_INTERNAL_API_KEY_ENV, WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER
+    )
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, str(key_file))
+
+    await require_workflow_internal_api_key(configured_key)
+
+
+@pytest.mark.asyncio
+async def test_agent_internal_auth_rejects_missing_or_wrong_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured_key = "a" * 32
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, configured_key)
+    monkeypatch.delenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, raising=False)
+
+    for supplied_key in (None, "", "wrong-secret"):
+        with pytest.raises(HTTPException) as exc_info:
+            await require_workflow_internal_api_key(supplied_key)
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("configured_key", ["", WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER])
+async def test_agent_internal_auth_fails_closed_when_not_configured(
+    monkeypatch: pytest.MonkeyPatch, configured_key: str
+) -> None:
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, configured_key)
+    monkeypatch.delenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, raising=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_workflow_internal_api_key(configured_key)
+
+    assert exc_info.value.status_code == 503
+
+
+def test_every_workflow_agent_route_requires_internal_auth() -> None:
+    for route in workflow_agent_router.routes:
+        assert any(
+            dependency.call is require_workflow_internal_api_key
+            for dependency in route.dependant.dependencies
+        ), route.path

--- a/core/tenant/app/server.go
+++ b/core/tenant/app/server.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
@@ -20,7 +19,6 @@ import (
 )
 
 func Run() error {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
 	configPath := flag.String("config", "./config/config.toml", "config file path")
 	flag.Parse()
 	cfg, err := config.LoadConfig(*configPath)
@@ -28,6 +26,11 @@ func Run() error {
 		log.Fatalf("config load failed: %s\n", err)
 		return err
 	}
+	tenantBootstrap, err := config.LoadTenantBootstrapCredentials()
+	if err != nil {
+		return fmt.Errorf("load tenant bootstrap credentials failed: %w", err)
+	}
+	cfg.TenantBootstrap = tenantBootstrap
 	err = initLog(cfg)
 	if err != nil {
 		return err

--- a/core/tenant/config/bootstrap_credentials.go
+++ b/core/tenant/config/bootstrap_credentials.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	BootstrapTenantID  = "680ab54f"
+	LegacyTenantKey    = "7b709739e8da44536127a333c7603a83"
+	LegacyTenantSecret = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+
+	tenantCredentialMinLength = 32
+	tenantCredentialMaxLength = 50
+	maxCredentialFileBytes    = 4096
+)
+
+// TenantBootstrapCredentials is the deployment-managed identity shared by
+// Tenant and its internal callers. The values must never be logged.
+type TenantBootstrapCredentials struct {
+	TenantID string
+	APIKey   string
+	Secret   string
+}
+
+// LoadTenantBootstrapCredentials loads credentials from direct environment
+// values or, when those are absent, bounded regular files. Direct values take
+// precedence so Helm Secret-backed environment variables remain supported.
+func LoadTenantBootstrapCredentials() (TenantBootstrapCredentials, error) {
+	tenantID := strings.TrimSpace(os.Getenv("TENANT_ID"))
+	if tenantID == "" {
+		tenantID = BootstrapTenantID
+	}
+
+	apiKey, err := credentialFromEnvironmentOrFile("TENANT_KEY", "TENANT_KEY_FILE")
+	if err != nil {
+		return TenantBootstrapCredentials{}, err
+	}
+	secret, err := credentialFromEnvironmentOrFile("TENANT_SECRET", "TENANT_SECRET_FILE")
+	if err != nil {
+		return TenantBootstrapCredentials{}, err
+	}
+
+	credentials := TenantBootstrapCredentials{
+		TenantID: tenantID,
+		APIKey:   apiKey,
+		Secret:   secret,
+	}
+	if err := credentials.Validate(); err != nil {
+		return TenantBootstrapCredentials{}, err
+	}
+	return credentials, nil
+}
+
+// Validate enforces the storage and HTTP-header constraints shared by every
+// bootstrap credential consumer.
+func (credentials TenantBootstrapCredentials) Validate() error {
+	if credentials.TenantID != BootstrapTenantID {
+		return fmt.Errorf(
+			"TENANT_ID must remain %s because persisted bootstrap data refers to it",
+			BootstrapTenantID,
+		)
+	}
+	if err := validateCredential("TENANT_KEY", credentials.APIKey); err != nil {
+		return err
+	}
+	if err := validateCredential("TENANT_SECRET", credentials.Secret); err != nil {
+		return err
+	}
+	if credentials.APIKey == credentials.Secret {
+		return errors.New("TENANT_KEY and TENANT_SECRET must be distinct values")
+	}
+	if credentials.APIKey == LegacyTenantKey || credentials.Secret == LegacyTenantSecret {
+		return errors.New("published legacy tenant credentials cannot be used")
+	}
+	return nil
+}
+
+func credentialFromEnvironmentOrFile(valueEnvironment, fileEnvironment string) (string, error) {
+	if value := strings.TrimSpace(os.Getenv(valueEnvironment)); value != "" {
+		if err := validateCredential(valueEnvironment, value); err != nil {
+			return "", err
+		}
+		return value, nil
+	}
+
+	fileName := strings.TrimSpace(os.Getenv(fileEnvironment))
+	if fileName == "" {
+		return "", fmt.Errorf("%s or %s is required", valueEnvironment, fileEnvironment)
+	}
+	value, err := readCredentialFile(fileName)
+	if err != nil {
+		return "", fmt.Errorf("load %s: %w", fileEnvironment, err)
+	}
+	if err := validateCredential(valueEnvironment, value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func readCredentialFile(fileName string) (string, error) {
+	file, err := openCredentialFileNoFollow(fileName)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return "", errors.New("credential file cannot be inspected")
+	}
+	if !openedInfo.Mode().IsRegular() {
+		return "", errors.New("credential file must be a regular non-symbolic-link file")
+	}
+	if openedInfo.Size() > maxCredentialFileBytes {
+		return "", errors.New("credential file is too large")
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, maxCredentialFileBytes+1))
+	if err != nil {
+		return "", errors.New("credential file cannot be read")
+	}
+	if len(data) > maxCredentialFileBytes {
+		return "", errors.New("credential file is too large")
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func validateCredential(name, value string) error {
+	length := utf8.RuneCountInString(value)
+	if !utf8.ValidString(value) || length < tenantCredentialMinLength || length > tenantCredentialMaxLength {
+		return fmt.Errorf("%s must contain 32-50 valid UTF-8 characters", name)
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return fmt.Errorf("%s must not contain control characters", name)
+		}
+		if !isSafeCredentialCharacter(character) {
+			return fmt.Errorf("%s must contain only ASCII letters, digits, '.', '_', '~', or '-'", name)
+		}
+	}
+	return nil
+}
+
+func isSafeCredentialCharacter(character rune) bool {
+	return character >= 'a' && character <= 'z' ||
+		character >= 'A' && character <= 'Z' ||
+		character >= '0' && character <= '9' ||
+		character == '.' || character == '_' || character == '~' || character == '-'
+}

--- a/core/tenant/config/bootstrap_credentials_test.go
+++ b/core/tenant/config/bootstrap_credentials_test.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func validTenantBootstrapCredentials() TenantBootstrapCredentials {
+	return TenantBootstrapCredentials{
+		TenantID: BootstrapTenantID,
+		APIKey:   strings.Repeat("k", 48),
+		Secret:   strings.Repeat("s", 48),
+	}
+}
+
+func clearTenantBootstrapEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"TENANT_ID",
+		"TENANT_KEY",
+		"TENANT_KEY_FILE",
+		"TENANT_SECRET",
+		"TENANT_SECRET_FILE",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestLoadTenantBootstrapCredentialsFromEnvironment(t *testing.T) {
+	clearTenantBootstrapEnvironment(t)
+	t.Setenv("TENANT_KEY", strings.Repeat("k", 48))
+	t.Setenv("TENANT_SECRET", strings.Repeat("s", 48))
+
+	credentials, err := LoadTenantBootstrapCredentials()
+	if err != nil {
+		t.Fatalf("LoadTenantBootstrapCredentials() error = %v", err)
+	}
+	if credentials != validTenantBootstrapCredentials() {
+		t.Fatalf("LoadTenantBootstrapCredentials() = %#v, want deployment credentials", credentials)
+	}
+}
+
+func TestLoadTenantBootstrapCredentialsFromFiles(t *testing.T) {
+	clearTenantBootstrapEnvironment(t)
+	directory := t.TempDir()
+	keyFile := filepath.Join(directory, "tenant-key")
+	secretFile := filepath.Join(directory, "tenant-secret")
+	if err := os.WriteFile(keyFile, []byte(strings.Repeat("k", 48)+"\n"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secretFile, []byte(strings.Repeat("s", 48)+"\n"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TENANT_KEY_FILE", keyFile)
+	t.Setenv("TENANT_SECRET_FILE", secretFile)
+
+	credentials, err := LoadTenantBootstrapCredentials()
+	if err != nil {
+		t.Fatalf("LoadTenantBootstrapCredentials() error = %v", err)
+	}
+	if credentials != validTenantBootstrapCredentials() {
+		t.Fatalf("LoadTenantBootstrapCredentials() = %#v, want file credentials", credentials)
+	}
+}
+
+func TestLoadTenantBootstrapCredentialsPrefersDirectValues(t *testing.T) {
+	clearTenantBootstrapEnvironment(t)
+	directory := t.TempDir()
+	keyFile := filepath.Join(directory, "tenant-key")
+	secretFile := filepath.Join(directory, "tenant-secret")
+	if err := os.WriteFile(keyFile, []byte(strings.Repeat("x", 48)), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secretFile, []byte(strings.Repeat("y", 48)), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TENANT_KEY", strings.Repeat("k", 48))
+	t.Setenv("TENANT_SECRET", strings.Repeat("s", 48))
+	t.Setenv("TENANT_KEY_FILE", keyFile)
+	t.Setenv("TENANT_SECRET_FILE", secretFile)
+
+	credentials, err := LoadTenantBootstrapCredentials()
+	if err != nil {
+		t.Fatalf("LoadTenantBootstrapCredentials() error = %v", err)
+	}
+	if credentials != validTenantBootstrapCredentials() {
+		t.Fatalf("direct environment credentials were not preferred: %#v", credentials)
+	}
+}
+
+func TestLoadTenantBootstrapCredentialsRejectsUnsafeFiles(t *testing.T) {
+	t.Run("symbolic link", func(t *testing.T) {
+		clearTenantBootstrapEnvironment(t)
+		directory := t.TempDir()
+		target := filepath.Join(directory, "target")
+		link := filepath.Join(directory, "tenant-key")
+		secretFile := filepath.Join(directory, "tenant-secret")
+		if err := os.WriteFile(target, []byte(strings.Repeat("k", 48)), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(secretFile, []byte(strings.Repeat("s", 48)), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("TENANT_KEY_FILE", link)
+		t.Setenv("TENANT_SECRET_FILE", secretFile)
+
+		if _, err := LoadTenantBootstrapCredentials(); err == nil || !strings.Contains(err.Error(), "non-symbolic-link") {
+			t.Fatalf("LoadTenantBootstrapCredentials() error = %v, want symbolic-link rejection", err)
+		}
+	})
+
+	t.Run("oversized", func(t *testing.T) {
+		clearTenantBootstrapEnvironment(t)
+		directory := t.TempDir()
+		keyFile := filepath.Join(directory, "tenant-key")
+		secretFile := filepath.Join(directory, "tenant-secret")
+		if err := os.WriteFile(keyFile, []byte(strings.Repeat("k", maxCredentialFileBytes+1)), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(secretFile, []byte(strings.Repeat("s", 48)), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("TENANT_KEY_FILE", keyFile)
+		t.Setenv("TENANT_SECRET_FILE", secretFile)
+
+		if _, err := LoadTenantBootstrapCredentials(); err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("LoadTenantBootstrapCredentials() error = %v, want size rejection", err)
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		clearTenantBootstrapEnvironment(t)
+		directory := t.TempDir()
+		secretFile := filepath.Join(directory, "tenant-secret")
+		if err := os.WriteFile(secretFile, []byte(strings.Repeat("s", 48)), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("TENANT_KEY_FILE", directory)
+		t.Setenv("TENANT_SECRET_FILE", secretFile)
+
+		if _, err := LoadTenantBootstrapCredentials(); err == nil || !strings.Contains(err.Error(), "regular") {
+			t.Fatalf("LoadTenantBootstrapCredentials() error = %v, want directory rejection", err)
+		}
+	})
+}
+
+func TestTenantBootstrapCredentialsValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials TenantBootstrapCredentials
+		errorText   string
+	}{
+		{
+			name:        "valid",
+			credentials: validTenantBootstrapCredentials(),
+		},
+		{
+			name: "wrong tenant id",
+			credentials: TenantBootstrapCredentials{
+				TenantID: "other",
+				APIKey:   strings.Repeat("k", 48),
+				Secret:   strings.Repeat("s", 48),
+			},
+			errorText: "must remain",
+		},
+		{
+			name: "short key",
+			credentials: TenantBootstrapCredentials{
+				TenantID: BootstrapTenantID,
+				APIKey:   strings.Repeat("k", 31),
+				Secret:   strings.Repeat("s", 48),
+			},
+			errorText: "32-50",
+		},
+		{
+			name: "line break",
+			credentials: TenantBootstrapCredentials{
+				TenantID: BootstrapTenantID,
+				APIKey:   strings.Repeat("k", 40) + "\n" + strings.Repeat("k", 7),
+				Secret:   strings.Repeat("s", 48),
+			},
+			errorText: "control",
+		},
+		{
+			name: "authorization separator",
+			credentials: TenantBootstrapCredentials{
+				TenantID: BootstrapTenantID,
+				APIKey:   strings.Repeat("k", 47) + ":",
+				Secret:   strings.Repeat("s", 48),
+			},
+			errorText: "ASCII letters",
+		},
+		{
+			name: "same values",
+			credentials: TenantBootstrapCredentials{
+				TenantID: BootstrapTenantID,
+				APIKey:   strings.Repeat("k", 48),
+				Secret:   strings.Repeat("k", 48),
+			},
+			errorText: "distinct",
+		},
+		{
+			name: "legacy pair",
+			credentials: TenantBootstrapCredentials{
+				TenantID: BootstrapTenantID,
+				APIKey:   LegacyTenantKey,
+				Secret:   LegacyTenantSecret,
+			},
+			errorText: "legacy",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.credentials.Validate()
+			if test.errorText == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.errorText) {
+				t.Fatalf("Validate() error = %v, want text %q", err, test.errorText)
+			}
+		})
+	}
+}
+
+func TestConfigStringOmitsTenantBootstrapCredentials(t *testing.T) {
+	configuration := &Config{TenantBootstrap: validTenantBootstrapCredentials()}
+	text := configuration.String()
+	if strings.Contains(text, configuration.TenantBootstrap.APIKey) ||
+		strings.Contains(text, configuration.TenantBootstrap.Secret) {
+		t.Fatal("Config.String() exposed tenant bootstrap credentials")
+	}
+}

--- a/core/tenant/config/config.go
+++ b/core/tenant/config/config.go
@@ -20,6 +20,11 @@ type Config struct {
 	Log struct {
 		LogFile string `toml:"path"`
 	} `toml:"log"`
+
+	// TenantBootstrap is loaded only from deployment-managed environment
+	// variables or credential files. It is intentionally omitted from String so
+	// credentials cannot be exposed by routine configuration logging.
+	TenantBootstrap TenantBootstrapCredentials
 }
 
 func (c *Config) String() string {

--- a/core/tenant/config/credential_file_other.go
+++ b/core/tenant/config/credential_file_other.go
@@ -1,0 +1,32 @@
+//go:build !linux && !darwin
+
+package config
+
+import (
+	"errors"
+	"os"
+)
+
+// openCredentialFileNoFollow is a portability fallback for platforms without
+// O_NOFOLLOW. Supported production images use the Unix implementation above.
+func openCredentialFileNoFollow(fileName string) (*os.File, error) {
+	pathInfo, err := os.Lstat(fileName)
+	if err != nil {
+		return nil, errors.New("credential file is unavailable")
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
+		return nil, errors.New(
+			"credential file must be a regular non-symbolic-link file",
+		)
+	}
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, errors.New("credential file is unavailable")
+	}
+	openedInfo, err := file.Stat()
+	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(pathInfo, openedInfo) {
+		_ = file.Close()
+		return nil, errors.New("credential file changed while being opened")
+	}
+	return file, nil
+}

--- a/core/tenant/config/credential_file_unix.go
+++ b/core/tenant/config/credential_file_unix.go
@@ -1,0 +1,31 @@
+//go:build linux || darwin
+
+package config
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openCredentialFileNoFollow resolves and opens the credential in one kernel
+// operation. O_NOFOLLOW prevents a path swap to a symbolic link between a
+// separate path inspection and open; O_NONBLOCK prevents a hostile FIFO from
+// blocking startup before the descriptor type is checked with fstat.
+func openCredentialFileNoFollow(fileName string) (*os.File, error) {
+	fd, err := unix.Open(
+		fileName,
+		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK,
+		0,
+	)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, errors.New(
+				"credential file must be a regular non-symbolic-link file",
+			)
+		}
+		return nil, errors.New("credential file is unavailable")
+	}
+	return os.NewFile(uintptr(fd), fileName), nil
+}

--- a/core/tenant/go.mod
+++ b/core/tenant/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
+	golang.org/x/sys v0.20.0
 )
 
 require (
@@ -34,7 +35,6 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/core/tenant/internal/handler/errors.go
+++ b/core/tenant/internal/handler/errors.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	Success  int = 0
-	ParamErr int = 14001
-	SidErr   int = 14002
+	Success         int = 0
+	ParamErr        int = 14001
+	SidErr          int = 14002
+	UnauthorizedErr int = 14003
 )
 
 type HandlerErr struct {

--- a/core/tenant/internal/handler/internal_auth_test.go
+++ b/core/tenant/internal/handler/internal_auth_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestTenantInternalAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	expectedKey := strings.Repeat("s", 48)
+
+	for name, suppliedKey := range map[string]string{
+		"missing": "",
+		"wrong":   strings.Repeat("x", 48),
+		"partial": strings.Repeat("s", 47),
+	} {
+		t.Run(name, func(t *testing.T) {
+			called := false
+			engine := gin.New()
+			engine.GET("/v2/app/list", tenantInternalAuth(expectedKey), func(c *gin.Context) {
+				called = true
+				c.Status(http.StatusNoContent)
+			})
+
+			request := httptest.NewRequest(http.MethodGet, "/v2/app/list", nil)
+			if suppliedKey != "" {
+				request.Header.Set(tenantInternalKeyHeader, suppliedKey)
+			}
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+
+			if response.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+			}
+			if called {
+				t.Fatal("protected handler was called")
+			}
+			if strings.Contains(response.Body.String(), expectedKey) ||
+				strings.Contains(response.Body.String(), suppliedKey) && suppliedKey != "" {
+				t.Fatal("credential value leaked in unauthorized response")
+			}
+		})
+	}
+}
+
+func TestTenantInternalAuthAcceptsConfiguredKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	expectedKey := strings.Repeat("s", 48)
+	engine := gin.New()
+	engine.GET("/v2/app/list", tenantInternalAuth(expectedKey), func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/v2/app/list", nil)
+	request.Header.Set(tenantInternalKeyHeader, expectedKey)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusNoContent)
+	}
+}
+
+func TestTenantInternalAuthFailsClosedWithoutServerCredential(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/v2/app/list", tenantInternalAuth(""), func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/v2/app/list", nil)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+	}
+}

--- a/core/tenant/internal/handler/router.go
+++ b/core/tenant/internal/handler/router.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"log"
 	"net/http"
 	"strconv"
@@ -22,13 +24,15 @@ var (
 	keySource     = "source"
 )
 
+const tenantInternalKeyHeader = "X-Tenant-Internal-Key"
+
 func InitRouter(e *gin.Engine, conf *config.Config) error {
 	err := initHandler(conf)
 	if err != nil {
 		return err
 	}
 	appGroup := e.Group("/v2/app")
-	appGroup.Use(preProcess)
+	appGroup.Use(tenantInternalAuth(conf.TenantBootstrap.Secret), preProcess)
 	appGroup.POST("", appHandler.SaveApp)
 	appGroup.PUT("", appHandler.ModifyApp)
 	appGroup.GET("/list", appHandler.ListApp)
@@ -37,7 +41,7 @@ func InitRouter(e *gin.Engine, conf *config.Config) error {
 	appGroup.DELETE("", appHandler.DeleteApp)
 
 	authGroup := e.Group("/v2/app/key")
-	authGroup.Use(preProcess)
+	authGroup.Use(tenantInternalAuth(conf.TenantBootstrap.Secret), preProcess)
 	authGroup.POST("", authHandler.SaveAuth)
 	authGroup.DELETE("", authHandler.DeleteAuth)
 	authGroup.POST("/verify", authHandler.VerifyAppAuth)
@@ -46,6 +50,24 @@ func InitRouter(e *gin.Engine, conf *config.Config) error {
 
 	sidGenerator2.Init(conf.Server.Location, generator.IP, strconv.Itoa(conf.Server.Port))
 	return nil
+}
+
+func tenantInternalAuth(expectedKey string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		suppliedKey := c.GetHeader(tenantInternalKeyHeader)
+		expectedDigest := sha256.Sum256([]byte(expectedKey))
+		suppliedDigest := sha256.Sum256([]byte(suppliedKey))
+		if expectedKey == "" || suppliedKey == "" || subtle.ConstantTimeCompare(
+			suppliedDigest[:], expectedDigest[:],
+		) != 1 {
+			c.AbortWithStatusJSON(
+				http.StatusUnauthorized,
+				newErrResp(UnauthorizedErr, "unauthorized", ""),
+			)
+			return
+		}
+		c.Next()
+	}
 }
 
 func initHandler(conf *config.Config) error {

--- a/core/tenant/internal/service/auth_service.go
+++ b/core/tenant/internal/service/auth_service.go
@@ -20,6 +20,7 @@ type authAppDao interface {
 	Count(bool, *sql.Tx, ...dao.SqlOption) (int64, error)
 	Select(...dao.SqlOption) ([]*models.App, error)
 	WithAppId(string) dao.SqlOption
+	WithIsDisable(bool) dao.SqlOption
 	WithIsDelete(bool) dao.SqlOption
 }
 
@@ -160,12 +161,16 @@ func (biz *AuthService) queryAppByAuth(data []*models.Auth) (*models.App, error)
 	if len(data[0].AppId) == 0 {
 		return nil, NewBizErr(AppIdNotExist, "app id not exist")
 	}
-	appList, err := biz.appDao.Select(biz.appDao.WithAppId(data[0].AppId), biz.appDao.WithIsDelete(false))
+	appList, err := biz.appDao.Select(
+		biz.appDao.WithAppId(data[0].AppId),
+		biz.appDao.WithIsDisable(false),
+		biz.appDao.WithIsDelete(false),
+	)
 	if err != nil {
 		log.Printf("query app  info by app id %s error: %v", data[0].AppId, err)
 		return nil, NewBizErr(ErrCodeSystem, err.Error())
 	}
-	if len(appList) == 0 || appList[0] == nil {
+	if len(appList) == 0 || appList[0] == nil || appList[0].IsDisable || appList[0].IsDelete {
 		return nil, NewBizErr(AppIdNotExist, "app id not exist")
 	}
 	return appList[0], nil

--- a/core/tenant/internal/service/auth_service_verify_test.go
+++ b/core/tenant/internal/service/auth_service_verify_test.go
@@ -31,6 +31,12 @@ func (m *verifyAuthAppDao) WithAppId(appId string) dao.SqlOption {
 	}
 }
 
+func (m *verifyAuthAppDao) WithIsDisable(isDisable bool) dao.SqlOption {
+	return func() (string, []interface{}) {
+		return "is_disable=?", []interface{}{isDisable}
+	}
+}
+
 func (m *verifyAuthAppDao) WithIsDelete(isDelete bool) dao.SqlOption {
 	return func() (string, []interface{}) {
 		return "is_delete=?", []interface{}{isDelete}
@@ -120,5 +126,32 @@ func TestAuthService_VerifyAppByAPIKeySecret_InvalidSecret(t *testing.T) {
 	}
 	if bizErr.Code() != ApiKeyNotExist {
 		t.Fatalf("Expected ApiKeyNotExist, got %d", bizErr.Code())
+	}
+}
+
+func TestAuthService_VerifyAppByAPIKeySecret_RejectsDisabledApp(t *testing.T) {
+	service := &AuthService{
+		authDao: &verifyAuthAuthDao{auths: []*models.Auth{{AppId: "app-123", ApiKey: "key", ApiSecret: "secret"}}},
+		appDao:  &verifyAuthAppDao{apps: []*models.App{{AppId: "app-123", IsDisable: true}}},
+	}
+
+	_, err := service.VerifyAppByAPIKeySecret("key", "secret")
+	if err == nil {
+		t.Fatal("Expected disabled app authentication to fail")
+	}
+	var bizErr BizErr
+	if !errors.As(err, &bizErr) || bizErr.Code() != AppIdNotExist {
+		t.Fatalf("Expected AppIdNotExist for disabled app, got %v", err)
+	}
+}
+
+func TestAuthService_QueryAppByAPIKey_RejectsDisabledApp(t *testing.T) {
+	service := &AuthService{
+		authDao: &verifyAuthAuthDao{auths: []*models.Auth{{AppId: "app-123", ApiKey: "key"}}},
+		appDao:  &verifyAuthAppDao{apps: []*models.App{{AppId: "app-123", IsDisable: true}}},
+	}
+
+	if _, err := service.QueryAppByAPIKey("key"); err == nil {
+		t.Fatal("Expected legacy API-key lookup to reject disabled app")
 	}
 }

--- a/core/tenant/tools/database/bootstrap_credentials.go
+++ b/core/tenant/tools/database/bootstrap_credentials.go
@@ -1,0 +1,241 @@
+package database
+
+import (
+	"context"
+	"crypto/subtle"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"tenant/config"
+)
+
+const tenantBootstrapManagedMarker = "astron-bootstrap-managed-v1"
+
+type bootstrapRowScanner interface {
+	Scan(dest ...any) error
+}
+
+type bootstrapTransaction interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) bootstrapRowScanner
+}
+
+type sqlBootstrapTransaction struct {
+	transaction *sql.Tx
+}
+
+func (transaction sqlBootstrapTransaction) ExecContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (sql.Result, error) {
+	return transaction.transaction.ExecContext(ctx, query, args...)
+}
+
+func (transaction sqlBootstrapTransaction) QueryRowContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) bootstrapRowScanner {
+	return transaction.transaction.QueryRowContext(ctx, query, args...)
+}
+
+func reconcileTenantBootstrap(
+	client *sql.DB,
+	credentials config.TenantBootstrapCredentials,
+) error {
+	if client == nil {
+		return errors.New("mysql client is nil")
+	}
+	if err := credentials.Validate(); err != nil {
+		return fmt.Errorf("invalid tenant bootstrap credentials: %w", err)
+	}
+
+	ctx := context.Background()
+	transaction, err := client.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tenant bootstrap transaction failed: %w", err)
+	}
+	defer func() {
+		_ = transaction.Rollback()
+	}()
+
+	if err := reconcileTenantBootstrapTransaction(
+		ctx,
+		sqlBootstrapTransaction{transaction: transaction},
+		credentials,
+	); err != nil {
+		return err
+	}
+	if err := transaction.Commit(); err != nil {
+		return fmt.Errorf("commit tenant bootstrap transaction failed: %w", err)
+	}
+	return nil
+}
+
+func reconcileTenantBootstrapTransaction(
+	ctx context.Context,
+	transaction bootstrapTransaction,
+	credentials config.TenantBootstrapCredentials,
+) error {
+	if transaction == nil {
+		return errors.New("tenant bootstrap transaction is nil")
+	}
+	if err := credentials.Validate(); err != nil {
+		return fmt.Errorf("invalid tenant bootstrap credentials: %w", err)
+	}
+
+	now := time.Now().Format("2006-01-02 15:04:05")
+	if _, err := transaction.ExecContext(
+		ctx,
+		`INSERT IGNORE INTO tb_app
+  (update_time, registration_time, app_id, app_name, dev_id, channel_id, source, is_disable, app_desc, is_delete, extend)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		now,
+		now,
+		credentials.TenantID,
+		"星辰租户",
+		1,
+		"0",
+		"admin",
+		false,
+		"星辰租户",
+		false,
+		"",
+	); err != nil {
+		return fmt.Errorf("ensure tenant bootstrap app failed: %w", err)
+	}
+
+	// Serialize reconciliation across replicas on the reserved app row before
+	// taking any auth-index gap locks or rotating managed credentials.
+	var lockedAppID string
+	var lockedAppDisabled sql.NullBool
+	var lockedAppDeleted sql.NullBool
+	if err := transaction.QueryRowContext(
+		ctx,
+		`SELECT app_id, is_disable, is_delete FROM tb_app WHERE app_id = ? FOR UPDATE`,
+		credentials.TenantID,
+	).Scan(&lockedAppID, &lockedAppDisabled, &lockedAppDeleted); err != nil {
+		return fmt.Errorf("lock tenant bootstrap app failed: %w", err)
+	}
+	if lockedAppID != credentials.TenantID {
+		return errors.New("locked tenant bootstrap app does not match the reserved tenant ID")
+	}
+	if !lockedAppDisabled.Valid || lockedAppDisabled.Bool ||
+		!lockedAppDeleted.Valid || lockedAppDeleted.Bool {
+		return errors.New("reserved tenant bootstrap app is disabled or deleted")
+	}
+
+	var collisionOwner string
+	err := transaction.QueryRowContext(
+		ctx,
+		`SELECT app_id
+FROM tb_auth
+WHERE api_key = ? AND app_id <> ? AND is_delete = 0
+LIMIT 1 FOR UPDATE`,
+		credentials.APIKey,
+		credentials.TenantID,
+	).Scan(&collisionOwner)
+	if err == nil {
+		return errors.New("tenant bootstrap API key is already assigned to another active app")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("check tenant bootstrap API key ownership failed: %w", err)
+	}
+
+	var unmanagedSecret sql.NullString
+	var unmanagedIsDelete sql.NullBool
+	err = transaction.QueryRowContext(
+		ctx,
+		`SELECT api_secret, is_delete
+	FROM tb_auth
+	WHERE app_id = ? AND api_key = ? AND COALESCE(extend, '') <> ?
+	LIMIT 1 FOR UPDATE`,
+		credentials.TenantID,
+		credentials.APIKey,
+		tenantBootstrapManagedMarker,
+	).Scan(&unmanagedSecret, &unmanagedIsDelete)
+	adoptExistingUnmanagedCredential := false
+	if err == nil {
+		if !unmanagedSecret.Valid || !unmanagedIsDelete.Valid || unmanagedIsDelete.Bool ||
+			subtle.ConstantTimeCompare([]byte(unmanagedSecret.String), []byte(credentials.Secret)) != 1 {
+			return errors.New("tenant bootstrap API key conflicts with an unmanaged credential")
+		}
+		// A strong pair explicitly configured by the deployment may already have
+		// been created through Tenant's public API on an older release. Because it
+		// belongs to the reserved app and exactly matches the current deployment
+		// Secret, adopt it into managed ownership so a later rotation can retire it.
+		adoptExistingUnmanagedCredential = true
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("check tenant bootstrap managed credential failed: %w", err)
+	}
+	if adoptExistingUnmanagedCredential {
+		if _, err := transaction.ExecContext(
+			ctx,
+			`UPDATE tb_auth
+SET extend = ?, update_time = ?
+WHERE app_id = ? AND api_key = ? AND api_secret = ? AND is_delete = 0
+  AND COALESCE(extend, '') <> ?`,
+			tenantBootstrapManagedMarker,
+			now,
+			credentials.TenantID,
+			credentials.APIKey,
+			credentials.Secret,
+			tenantBootstrapManagedMarker,
+		); err != nil {
+			return fmt.Errorf("adopt tenant bootstrap credential failed: %w", err)
+		}
+	}
+
+	if _, err := transaction.ExecContext(
+		ctx,
+		`UPDATE tb_auth
+SET is_delete = 1, update_time = ?
+WHERE api_key = ? AND api_secret = ?`,
+		now,
+		config.LegacyTenantKey,
+		config.LegacyTenantSecret,
+	); err != nil {
+		return fmt.Errorf("disable published legacy tenant credential failed: %w", err)
+	}
+
+	if _, err := transaction.ExecContext(
+		ctx,
+		`UPDATE tb_auth
+SET is_delete = 1, update_time = ?
+WHERE app_id = ? AND extend = ? AND api_key <> ?`,
+		now,
+		credentials.TenantID,
+		tenantBootstrapManagedMarker,
+		credentials.APIKey,
+	); err != nil {
+		return fmt.Errorf("retire previous managed tenant credential failed: %w", err)
+	}
+	if _, err := transaction.ExecContext(
+		ctx,
+		`INSERT INTO tb_auth
+  (update_time, registration_time, app_id, api_key, api_secret, source, is_delete, extend)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+  api_secret = VALUES(api_secret),
+  source = VALUES(source),
+  is_delete = VALUES(is_delete),
+  update_time = VALUES(update_time),
+  extend = VALUES(extend)`,
+		now,
+		now,
+		credentials.TenantID,
+		credentials.APIKey,
+		credentials.Secret,
+		0,
+		false,
+		tenantBootstrapManagedMarker,
+	); err != nil {
+		return fmt.Errorf("upsert managed tenant credential failed: %w", err)
+	}
+
+	return nil
+}

--- a/core/tenant/tools/database/bootstrap_credentials_test.go
+++ b/core/tenant/tools/database/bootstrap_credentials_test.go
@@ -1,0 +1,307 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"tenant/config"
+)
+
+type recordedBootstrapExecution struct {
+	query string
+	args  []any
+}
+
+type fakeBootstrapTransaction struct {
+	rows       []bootstrapRowScanner
+	executions []recordedBootstrapExecution
+	execError  error
+}
+
+func (transaction *fakeBootstrapTransaction) ExecContext(
+	_ context.Context,
+	query string,
+	args ...any,
+) (sql.Result, error) {
+	transaction.executions = append(transaction.executions, recordedBootstrapExecution{
+		query: query,
+		args:  args,
+	})
+	if transaction.execError != nil {
+		return nil, transaction.execError
+	}
+	return fakeBootstrapResult(1), nil
+}
+
+func (transaction *fakeBootstrapTransaction) QueryRowContext(
+	_ context.Context,
+	_ string,
+	_ ...any,
+) bootstrapRowScanner {
+	if len(transaction.rows) == 0 {
+		return fakeBootstrapRow{err: sql.ErrNoRows}
+	}
+	row := transaction.rows[0]
+	transaction.rows = transaction.rows[1:]
+	return row
+}
+
+type fakeBootstrapRow struct {
+	value  string
+	values []any
+	err    error
+}
+
+func (row fakeBootstrapRow) Scan(dest ...any) error {
+	if row.err != nil {
+		return row.err
+	}
+	values := row.values
+	if values == nil {
+		values = []any{row.value}
+	}
+	if len(dest) != len(values) {
+		return errors.New("unexpected scan destination count")
+	}
+	for index, destination := range dest {
+		switch target := destination.(type) {
+		case *string:
+			value, ok := values[index].(string)
+			if !ok {
+				return errors.New("unexpected string scan value")
+			}
+			*target = value
+		case *sql.NullString:
+			value, ok := values[index].(string)
+			if !ok {
+				return errors.New("unexpected nullable string scan value")
+			}
+			*target = sql.NullString{String: value, Valid: true}
+		case *sql.NullBool:
+			value, ok := values[index].(bool)
+			if !ok {
+				return errors.New("unexpected nullable bool scan value")
+			}
+			*target = sql.NullBool{Bool: value, Valid: true}
+		default:
+			return errors.New("unexpected scan destination type")
+		}
+	}
+	return nil
+}
+
+type fakeBootstrapResult int64
+
+func (result fakeBootstrapResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (result fakeBootstrapResult) RowsAffected() (int64, error) {
+	return int64(result), nil
+}
+
+func testBootstrapCredentials() config.TenantBootstrapCredentials {
+	return config.TenantBootstrapCredentials{
+		TenantID: config.BootstrapTenantID,
+		APIKey:   strings.Repeat("k", 48),
+		Secret:   strings.Repeat("s", 48),
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionCreatesAndRotatesManagedCredential(t *testing.T) {
+	transaction := &fakeBootstrapTransaction{
+		rows: []bootstrapRowScanner{
+			fakeBootstrapRow{values: []any{config.BootstrapTenantID, false, false}},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+		},
+	}
+	credentials := testBootstrapCredentials()
+
+	if err := reconcileTenantBootstrapTransaction(context.Background(), transaction, credentials); err != nil {
+		t.Fatalf("reconcileTenantBootstrapTransaction() error = %v", err)
+	}
+	if len(transaction.executions) != 4 {
+		t.Fatalf("execution count = %d, want app insert and three targeted auth writes", len(transaction.executions))
+	}
+
+	for _, execution := range transaction.executions {
+		if strings.Contains(execution.query, credentials.APIKey) ||
+			strings.Contains(execution.query, credentials.Secret) ||
+			strings.Contains(execution.query, config.LegacyTenantKey) ||
+			strings.Contains(execution.query, config.LegacyTenantSecret) {
+			t.Fatal("credential value was interpolated into SQL instead of passed as a parameter")
+		}
+	}
+
+	legacyDisable := transaction.executions[1]
+	if strings.Contains(legacyDisable.query, "app_id") {
+		t.Fatal("published legacy credential revocation must apply globally, not only to the reserved app")
+	}
+	if legacyDisable.args[1] != config.LegacyTenantKey || legacyDisable.args[2] != config.LegacyTenantSecret {
+		t.Fatalf("legacy disable arguments = %#v, want exact published pair", legacyDisable.args)
+	}
+	managedRetirement := transaction.executions[2]
+	if managedRetirement.args[1] != config.BootstrapTenantID ||
+		managedRetirement.args[2] != tenantBootstrapManagedMarker ||
+		managedRetirement.args[3] != credentials.APIKey {
+		t.Fatalf("managed retirement arguments = %#v, want reserved app and marker", managedRetirement.args)
+	}
+	upsert := transaction.executions[3]
+	if upsert.args[2] != config.BootstrapTenantID ||
+		upsert.args[3] != credentials.APIKey ||
+		upsert.args[4] != credentials.Secret ||
+		upsert.args[7] != tenantBootstrapManagedMarker {
+		t.Fatalf("managed upsert arguments = %#v, want current managed credential", upsert.args)
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionRejectsOtherAppKeyCollision(t *testing.T) {
+	transaction := &fakeBootstrapTransaction{
+		rows: []bootstrapRowScanner{
+			fakeBootstrapRow{values: []any{config.BootstrapTenantID, false, false}},
+			fakeBootstrapRow{value: "user-app"},
+		},
+	}
+
+	err := reconcileTenantBootstrapTransaction(context.Background(), transaction, testBootstrapCredentials())
+	if err == nil || !strings.Contains(err.Error(), "another active app") {
+		t.Fatalf("reconcileTenantBootstrapTransaction() error = %v, want collision rejection", err)
+	}
+	if len(transaction.executions) != 1 {
+		t.Fatalf("execution count = %d, want only rolled-back app ensure before collision", len(transaction.executions))
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionRejectsUnavailableReservedApp(t *testing.T) {
+	for name, state := range map[string][]any{
+		"disabled": {config.BootstrapTenantID, true, false},
+		"deleted":  {config.BootstrapTenantID, false, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			transaction := &fakeBootstrapTransaction{
+				rows: []bootstrapRowScanner{fakeBootstrapRow{values: state}},
+			}
+
+			err := reconcileTenantBootstrapTransaction(
+				context.Background(),
+				transaction,
+				testBootstrapCredentials(),
+			)
+			if err == nil || !strings.Contains(err.Error(), "disabled or deleted") {
+				t.Fatalf(
+					"reconcileTenantBootstrapTransaction() error = %v, want unavailable app rejection",
+					err,
+				)
+			}
+			if len(transaction.executions) != 1 {
+				t.Fatalf(
+					"execution count = %d, want no auth writes for unavailable app",
+					len(transaction.executions),
+				)
+			}
+		})
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionRejectsUnmanagedReservedKey(t *testing.T) {
+	transaction := &fakeBootstrapTransaction{
+		rows: []bootstrapRowScanner{
+			fakeBootstrapRow{values: []any{config.BootstrapTenantID, false, false}},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+			fakeBootstrapRow{values: []any{strings.Repeat("x", 48), false}},
+		},
+	}
+
+	err := reconcileTenantBootstrapTransaction(context.Background(), transaction, testBootstrapCredentials())
+	if err == nil || !strings.Contains(err.Error(), "unmanaged credential") {
+		t.Fatalf("reconcileTenantBootstrapTransaction() error = %v, want unmanaged-row rejection", err)
+	}
+	if len(transaction.executions) != 1 {
+		t.Fatalf("execution count = %d, want no auth writes after unmanaged collision", len(transaction.executions))
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionAdoptsMatchingUnmanagedPair(t *testing.T) {
+	credentials := testBootstrapCredentials()
+	transaction := &fakeBootstrapTransaction{
+		rows: []bootstrapRowScanner{
+			fakeBootstrapRow{values: []any{config.BootstrapTenantID, false, false}},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+			fakeBootstrapRow{values: []any{credentials.Secret, false}},
+		},
+	}
+
+	if err := reconcileTenantBootstrapTransaction(context.Background(), transaction, credentials); err != nil {
+		t.Fatalf("reconcileTenantBootstrapTransaction() error = %v", err)
+	}
+	if len(transaction.executions) != 5 {
+		t.Fatalf("execution count = %d, want app ensure, adoption, revocations, and managed upsert", len(transaction.executions))
+	}
+	adoption := transaction.executions[1]
+	if !strings.Contains(adoption.query, "SET extend = ?") ||
+		adoption.args[0] != tenantBootstrapManagedMarker ||
+		adoption.args[2] != credentials.TenantID ||
+		adoption.args[3] != credentials.APIKey ||
+		adoption.args[4] != credentials.Secret {
+		t.Fatalf("adoption execution = %#v, want exact pair marked as managed", adoption)
+	}
+	if !strings.Contains(transaction.executions[4].query, "ON DUPLICATE KEY UPDATE") {
+		t.Fatal("adopted credential was not converged through the managed upsert")
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionRetiresAdoptedPairOnNextRotation(t *testing.T) {
+	rotatedCredentials := testBootstrapCredentials()
+	rotatedCredentials.APIKey = strings.Repeat("n", 48)
+	rotatedCredentials.Secret = strings.Repeat("z", 48)
+	transaction := &fakeBootstrapTransaction{
+		rows: []bootstrapRowScanner{
+			fakeBootstrapRow{values: []any{config.BootstrapTenantID, false, false}},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+		},
+	}
+
+	if err := reconcileTenantBootstrapTransaction(
+		context.Background(), transaction, rotatedCredentials,
+	); err != nil {
+		t.Fatalf("reconcileTenantBootstrapTransaction() error = %v", err)
+	}
+	managedRetirement := transaction.executions[2]
+	if managedRetirement.args[1] != config.BootstrapTenantID ||
+		managedRetirement.args[2] != tenantBootstrapManagedMarker ||
+		managedRetirement.args[3] != rotatedCredentials.APIKey {
+		t.Fatalf(
+			"managed retirement arguments = %#v, want all prior adopted keys retired",
+			managedRetirement.args,
+		)
+	}
+}
+
+func TestReconcileTenantBootstrapTransactionRejectsDeletedMatchingUnmanagedPair(t *testing.T) {
+	credentials := testBootstrapCredentials()
+	transaction := &fakeBootstrapTransaction{
+		rows: []bootstrapRowScanner{
+			fakeBootstrapRow{values: []any{config.BootstrapTenantID, false, false}},
+			fakeBootstrapRow{err: sql.ErrNoRows},
+			fakeBootstrapRow{values: []any{credentials.Secret, true}},
+		},
+	}
+
+	err := reconcileTenantBootstrapTransaction(context.Background(), transaction, credentials)
+	if err == nil || !strings.Contains(err.Error(), "unmanaged credential") {
+		t.Fatalf("reconcileTenantBootstrapTransaction() error = %v, want deleted-row rejection", err)
+	}
+}
+
+func TestTenantInitialSchemaDoesNotSeedPublishedCredential(t *testing.T) {
+	initialSchema := strings.Join(tenantInitStatements, "\n")
+	if strings.Contains(initialSchema, config.LegacyTenantKey) ||
+		strings.Contains(initialSchema, config.LegacyTenantSecret) {
+		t.Fatal("tenant initialization still seeds the published credential")
+	}
+}

--- a/core/tenant/tools/database/database.go
+++ b/core/tenant/tools/database/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"tenant/config"
@@ -51,6 +52,9 @@ func (db *Database) buildMysql(conf *config.Config) error {
 	if len(conf.DataBase.Url) == 0 {
 		return errors.New("mysql url is empty")
 	}
+	if err := conf.TenantBootstrap.Validate(); err != nil {
+		return fmt.Errorf("invalid tenant bootstrap credentials: %w", err)
+	}
 
 	dsn := fmt.Sprintf("%s:%s@tcp%s", conf.DataBase.UserName, conf.DataBase.Password, conf.DataBase.Url)
 	parsedDsn, err := mysql.ParseDSN(dsn)
@@ -77,6 +81,11 @@ func (db *Database) buildMysql(conf *config.Config) error {
 		_ = client.Close()
 		return err
 	}
+	if err := reconcileTenantBootstrap(client, conf.TenantBootstrap); err != nil {
+		_ = client.Close()
+		return err
+	}
+	log.Printf("tenant bootstrap credentials reconciled")
 
 	db.mysql = client
 	return nil

--- a/core/tenant/tools/database/tenant_schema.go
+++ b/core/tenant/tools/database/tenant_schema.go
@@ -32,6 +32,4 @@ var tenantInitStatements = []string{
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='应用关联的鉴权表'`,
 	`INSERT IGNORE INTO tb_app (update_time, registration_time, app_id, app_name, dev_id, channel_id, source, is_disable, app_desc, is_delete, extend)
 VALUES ('2025-09-20 00:00:00', '2025-09-20 00:00:00', '680ab54f', '星辰租户', 1, '0', 'admin', 0, '星辰租户', 0, '')`,
-	`INSERT IGNORE INTO tb_auth (update_time, registration_time, app_id, api_key, api_secret, source, is_delete, extend)
-VALUES ('2025-09-20 00:00:00', '2025-09-20 00:00:00', '680ab54f', '7b709739e8da44536127a333c7603a83', 'NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy', 0, 0, '')`,
 }

--- a/core/tenant/tools/generator/app.go
+++ b/core/tenant/tools/generator/app.go
@@ -2,16 +2,20 @@ package generator
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
-	"math/rand"
+	"io"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+var credentialRandomReader io.Reader = cryptorand.Reader
 
 func GenCurrTime(format string) string {
 	if len(format) == 0 {
@@ -24,20 +28,22 @@ func GenTimeByAdd(time time.Time, d time.Duration) string {
 	return time.Add(d).Format("2006-01-02 15:04:05")
 }
 
-func GenKey(appid string) string {
-	bf := bytes.Buffer{}
-	bf.WriteString(appid)
-	bf.WriteString(time.Now().String())
-	bf.WriteString(strconv.Itoa(rand.Int()))
-	return fmt.Sprintf("%x", sha256.Sum256(bf.Bytes()))[:32]
+func GenKey(_ string) string {
+	return hex.EncodeToString(mustReadCredentialRandomBytes(16))
 }
 
 func GenSecret() string {
-	bf := bytes.Buffer{}
-	for i := 0; i < 64; i++ {
-		bf.WriteByte(byte(rand.Int()))
+	// 24 bytes provide 192 bits of entropy and encode to exactly 32 URL-safe
+	// characters without padding or truncation.
+	return base64.RawURLEncoding.EncodeToString(mustReadCredentialRandomBytes(24))
+}
+
+func mustReadCredentialRandomBytes(length int) []byte {
+	data := make([]byte, length)
+	if _, err := io.ReadFull(credentialRandomReader, data); err != nil {
+		panic("secure credential random source failed")
 	}
-	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%x", sha256.Sum256(bf.Bytes()))))[:32]
+	return data
 }
 
 func GenAppId(num int) string {

--- a/core/tenant/tools/generator/app_test.go
+++ b/core/tenant/tools/generator/app_test.go
@@ -1,6 +1,9 @@
 package generator
 
 import (
+	"bytes"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"regexp"
 	"testing"
@@ -217,9 +220,8 @@ func TestGenSecret(t *testing.T) {
 			t.Error("Generated secret should not be empty")
 		}
 
-		// Verify the result contains base64-like characters
-		// Since it's base64 encoded, it should contain A-Z, a-z, 0-9, +, /
-		matched, err := regexp.MatchString("^[A-Za-z0-9+/]+$", result)
+		// Raw URL-safe base64 is safe in HTTP credentials without escaping.
+		matched, err := regexp.MatchString("^[A-Za-z0-9_-]{32}$", result)
 		if err != nil {
 			t.Errorf("Regex error: %v", err)
 		}
@@ -245,6 +247,55 @@ func TestGenSecret(t *testing.T) {
 			t.Errorf("Expected %d unique secrets, got %d", iterations, len(secrets))
 		}
 	})
+}
+
+func TestCredentialGeneratorsUseSecureRandomReader(t *testing.T) {
+	originalReader := credentialRandomReader
+	defer func() {
+		credentialRandomReader = originalReader
+	}()
+
+	credentialRandomReader = bytes.NewReader([]byte{
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	})
+	if key := GenKey("ignored-but-compatible"); key != "000102030405060708090a0b0c0d0e0f" {
+		t.Fatalf("GenKey() = %q, want crypto-reader bytes encoded as lowercase hex", key)
+	}
+
+	secretBytes := bytes.Repeat([]byte{0x01}, 24)
+	credentialRandomReader = bytes.NewReader(secretBytes)
+	if secret := GenSecret(); secret != base64.RawURLEncoding.EncodeToString(secretBytes) {
+		t.Fatalf("GenSecret() = %q, want crypto-reader bytes encoded as base64", secret)
+	}
+}
+
+type failingCredentialReader struct{}
+
+func (failingCredentialReader) Read([]byte) (int, error) {
+	return 0, errors.New("entropy unavailable")
+}
+
+func TestCredentialGeneratorsFailClosedWhenEntropyUnavailable(t *testing.T) {
+	for name, generate := range map[string]func(){
+		"key":    func() { _ = GenKey("test-app") },
+		"secret": func() { _ = GenSecret() },
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalReader := credentialRandomReader
+			defer func() {
+				credentialRandomReader = originalReader
+			}()
+			credentialRandomReader = failingCredentialReader{}
+
+			defer func() {
+				if recovered := recover(); recovered == nil {
+					t.Fatalf("Gen%s() did not fail closed when secure entropy was unavailable", name)
+				}
+			}()
+			generate()
+		})
+	}
 }
 
 func TestGenAppId(t *testing.T) {

--- a/core/workflow/alembic/versions/2026_01_23_0929-b13356244aea_init_tables.py
+++ b/core/workflow/alembic/versions/2026_01_23_0929-b13356244aea_init_tables.py
@@ -188,26 +188,6 @@ def upgrade() -> None:
     # ### end Alembic commands ###
 
     # Insert initial data
-    app_table = sa.table(
-        "app",
-        sa.column("id", sa.BigInteger),
-        sa.column("name", sa.String),
-        sa.column("alias_id", sa.String),
-        sa.column("api_key", sa.String),
-        sa.column("api_secret", sa.String),
-        sa.column("description", sa.String),
-        sa.column("is_tenant", sa.SmallInteger),
-        sa.column("source", sa.SmallInteger),
-        sa.column("actual_source", sa.SmallInteger),
-        sa.column("plat_release_auth", sa.SmallInteger),
-        sa.column("status", sa.SmallInteger),
-        sa.column("audit_policy", sa.SmallInteger),
-        sa.column("create_by", sa.BigInteger),
-        sa.column("update_by", sa.BigInteger),
-        sa.column("create_at", sa.DateTime),
-        sa.column("update_at", sa.DateTime),
-    )
-
     app_source_table = sa.table(
         "app_source",
         sa.column("id", sa.BigInteger),
@@ -216,31 +196,6 @@ def upgrade() -> None:
         sa.column("description", sa.String),
         sa.column("create_at", sa.DateTime),
         sa.column("update_at", sa.DateTime),
-    )
-
-    # Insert default app
-    op.bulk_insert(
-        app_table,
-        [
-            {
-                "id": 1,
-                "name": "星辰",
-                "alias_id": "680ab54f",
-                "api_key": "7b709739e8da44536127a333c7603a83",
-                "api_secret": "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy",
-                "description": "星辰",
-                "is_tenant": 1,
-                "source": 1,
-                "actual_source": 1,
-                "plat_release_auth": 1,
-                "status": 1,
-                "audit_policy": 0,
-                "create_by": 1,
-                "update_by": 1,
-                "create_at": datetime(2025, 9, 20, 14, 10, 48),
-                "update_at": datetime(2025, 9, 20, 14, 10, 51),
-            }
-        ],
     )
 
     # Insert default app_source

--- a/core/workflow/alembic/versions/2026_08_27_1000-a91e02d64b77_disable_legacy_bootstrap_credentials.py
+++ b/core/workflow/alembic/versions/2026_08_27_1000-a91e02d64b77_disable_legacy_bootstrap_credentials.py
@@ -1,0 +1,54 @@
+"""sanitize published legacy bootstrap credentials from workflow protocols
+
+Revision ID: a91e02d64b77
+Revises: c7e8a4f19d32
+Create Date: 2026-08-27 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "a91e02d64b77"
+down_revision: Union[str, None] = "c7e8a4f19d32"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_LEGACY_KEY = "7b709739e8da44536127a333c7603a83"
+_LEGACY_SECRET = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+
+
+def upgrade() -> None:
+    flow = sa.table(
+        "flow",
+        sa.column("data", sa.Text),
+        sa.column("release_data", sa.Text),
+    )
+    for column_name in ("data", "release_data"):
+        column = getattr(flow.c, column_name)
+        op.execute(
+            flow.update()
+            .where(
+                sa.or_(
+                    column.like(f"%{_LEGACY_KEY}%"),
+                    column.like(f"%{_LEGACY_SECRET}%"),
+                )
+            )
+            .values(
+                **{
+                    column_name: sa.func.replace(
+                        sa.func.replace(column, _LEGACY_KEY, ""),
+                        _LEGACY_SECRET,
+                        "",
+                    )
+                }
+            )
+        )
+
+
+def downgrade() -> None:
+    # Never restore a credential that has been publicly disclosed.
+    pass

--- a/core/workflow/api/v1/chat/debug.py
+++ b/core/workflow/api/v1/chat/debug.py
@@ -11,7 +11,7 @@ import os
 from typing import Annotated, Optional, Union
 
 from common.utils.snowfake import get_id
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Depends, Header
 from starlette.responses import JSONResponse, StreamingResponse
 
 from workflow.cache.event_registry import Event, EventRegistry
@@ -23,12 +23,18 @@ from workflow.domain.entities.response import Streaming
 from workflow.engine.callbacks.openai_types_sse import LLMGenerate
 from workflow.exception.e import CustomException
 from workflow.exception.errors.err_code import CodeEnum
+from workflow.extensions.fastapi.middleware.auth import (
+    require_workflow_internal_api_key,
+)
 from workflow.extensions.middleware.database.utils import session_getter
 from workflow.extensions.otlp.metric.meter import Meter
 from workflow.extensions.otlp.trace.span import Span
 from workflow.service import app_service, audit_service, chat_service, flow_service
 
-router = APIRouter(tags=["SSE_DEBUG_CHAT"])
+router = APIRouter(
+    tags=["SSE_DEBUG_CHAT"],
+    dependencies=[Depends(require_workflow_internal_api_key)],
+)
 
 
 @router.post("/debug/chat/completions", response_model=None)

--- a/core/workflow/api/v1/flow/file.py
+++ b/core/workflow/api/v1/flow/file.py
@@ -8,18 +8,23 @@ to the workflow system with proper validation and storage handling.
 import uuid
 from typing import Annotated, List
 
-from fastapi import APIRouter, File, Header, UploadFile
+from fastapi import APIRouter, Depends, File, Header, UploadFile
 from fastapi.responses import JSONResponse
 
 from workflow.domain.entities.response import Resp
 from workflow.exception.e import CustomException
 from workflow.exception.errors.err_code import CodeEnum
+from workflow.extensions.fastapi.middleware.auth import (
+    require_workflow_internal_api_key,
+)
 from workflow.extensions.middleware.getters import get_oss_service
 from workflow.extensions.otlp.metric.meter import Meter
 from workflow.extensions.otlp.trace.span import Span
 from workflow.service import file_service
 
-router = APIRouter(tags=["SSE_OPENAPI"])
+router = APIRouter(
+    tags=["SSE_OPENAPI"], dependencies=[Depends(require_workflow_internal_api_key)]
+)
 
 
 @router.post("/upload_file")

--- a/core/workflow/api/v1/flow/layout.py
+++ b/core/workflow/api/v1/flow/layout.py
@@ -35,6 +35,9 @@ from workflow.engine.dsl_engine import WorkflowEngineFactory
 from workflow.engine.entities.workflow_dsl import WorkflowDSL
 from workflow.exception.e import CustomException
 from workflow.exception.errors.err_code import CodeEnum
+from workflow.extensions.fastapi.middleware.auth import (
+    require_workflow_internal_api_key,
+)
 from workflow.extensions.middleware.cache.base import BaseCacheService
 from workflow.extensions.middleware.getters import get_cache_service, get_session
 from workflow.extensions.otlp.metric.meter import Meter
@@ -45,7 +48,9 @@ from workflow.utils.protocol_sanitization import (
     sanitize_protocol_document_for_use,
 )
 
-router = APIRouter(tags=["Flows"])
+router = APIRouter(
+    tags=["Flows"], dependencies=[Depends(require_workflow_internal_api_key)]
+)
 
 
 def _protocol_validation_exception(error: ValidationError) -> CustomException:

--- a/core/workflow/cache/app.py
+++ b/core/workflow/cache/app.py
@@ -9,7 +9,7 @@ from workflow.domain.models.ai_app import App
 from workflow.extensions.middleware.getters import get_cache_service
 
 # Redis key prefix for application information
-REDIS_APP_INFO_HEAD = "workflow:app_info"
+REDIS_APP_INFO_HEAD = "workflow:app_info:v2"
 
 
 def get_app_by_app_id(app_id: str) -> App | None:

--- a/core/workflow/cache/flow.py
+++ b/core/workflow/cache/flow.py
@@ -10,7 +10,7 @@ from workflow.extensions.middleware.getters import get_cache_service
 from workflow.utils.protocol_sanitization import sanitize_protocol_document_for_use
 
 # Redis key prefix for flow information
-REDIS_FLOW_INFO_HEAD = "workflow:flow_info:v2"
+REDIS_FLOW_INFO_HEAD = "workflow:flow_info:v3"
 
 
 def _sanitize_cached_flow(flow: Flow | None) -> Flow | None:

--- a/core/workflow/config.env
+++ b/core/workflow/config.env
@@ -145,7 +145,7 @@ CODE_EXEC_URL=
 CODE_EXEC_TIMEOUT_SEC=10
 CODE_EXEC_API_KEY=
 CODE_EXEC_API_SECRET=
-WORKFLOW_INTERNAL_API_KEY=CHANGE_ME_WORKFLOW_INTERNAL_API_KEY
+WORKFLOW_INTERNAL_API_KEY=
 
 # Image Understanding Model Configuration
 # Spark image model domain specifications for visual AI processing

--- a/core/workflow/engine/nodes/agent/agent_node.py
+++ b/core/workflow/engine/nodes/agent/agent_node.py
@@ -32,7 +32,21 @@ from workflow.exception.errors.err_code import CodeEnum
 from workflow.extensions.otlp.log_trace.node_log import NodeLog
 from workflow.extensions.otlp.trace.span import Span
 from workflow.infra.providers.llm.iflytek_spark.schemas import StreamOutputMsg
+from workflow.utils.credentials import credential_from_env_or_file
 from workflow.utils.trace_sanitization import serialize_trace_payload
+
+WORKFLOW_INTERNAL_API_KEY_HEADER = "X-Workflow-Internal-Key"
+WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"
+
+
+def _redact_agent_request_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Remove deployment credentials and signed trace context from telemetry."""
+    trace_safe_headers = redact_trusted_trace_headers(headers)
+    return {
+        key: value
+        for key, value in trace_safe_headers.items()
+        if key.lower() != WORKFLOW_INTERNAL_API_KEY_HEADER.lower()
+    }
 
 
 # Temporarily unused
@@ -261,6 +275,33 @@ class AgentNode(BaseNode):
     )
     source: str = Field(default=ModelProviderEnum.XINGHUO.value)
 
+    def _build_agent_request_headers(self) -> dict[str, str]:
+        """Build an authenticated request for the deployment-internal Agent API."""
+        internal_api_key = credential_from_env_or_file(
+            "WORKFLOW_INTERNAL_API_KEY",
+            "WORKFLOW_INTERNAL_API_KEY_FILE",
+            min_length=32,
+            placeholders=(WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,),
+        )
+        if not internal_api_key:
+            raise CustomException(
+                err_code=CodeEnum.AGENT_NODE_EXECUTION_ERROR,
+                err_msg="Workflow internal API authentication is not configured",
+            )
+        headers = {
+            "Content-Type": "application/json",
+            "x-consumer-username": self.appId,
+            WORKFLOW_INTERNAL_API_KEY_HEADER: internal_api_key,
+        }
+        headers.update(
+            inject_trusted_langfuse_context(
+                method="POST",
+                audience=AGENT_TRACE_AUDIENCE,
+                tenant_id=self.appId,
+            )
+        )
+        return headers
+
     async def _call_agent(
         self,
         inputs: dict,
@@ -293,22 +334,12 @@ class AgentNode(BaseNode):
         self._normalize_tools()
 
         # Construct request headers
-        headers = {
-            "Content-Type": "application/json",
-            "x-consumer-username": self.appId,
-        }
-        headers.update(
-            inject_trusted_langfuse_context(
-                method="POST",
-                audience=AGENT_TRACE_AUDIENCE,
-                tenant_id=self.appId,
-            )
-        )
+        headers = self._build_agent_request_headers()
 
         req_body = self._generate_agent_request(
             reasoning_instruction, answer_instruction, messages, variable_pool, span
         )
-        logged_headers = redact_trusted_trace_headers(headers)
+        logged_headers = _redact_agent_request_headers(headers)
         sanitized_req_body = serialize_trace_payload(req_body)
         await span.add_info_event_async(f"req header: {logged_headers}")
         await span.add_info_event_async(f"req body: {sanitized_req_body}")

--- a/core/workflow/engine/nodes/flow/flow_node.py
+++ b/core/workflow/engine/nodes/flow/flow_node.py
@@ -34,6 +34,9 @@ from workflow.exception.errors.err_code import CodeEnum
 from workflow.extensions.middleware.database.utils import session_getter
 from workflow.extensions.otlp.log_trace.node_log import NodeLog
 from workflow.extensions.otlp.trace.span import Span
+from workflow.utils.credentials import credential_from_env_or_file
+
+WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"
 
 
 class FlowNode(BaseNode):
@@ -405,8 +408,21 @@ class FlowNode(BaseNode):
             # Use bearer token for production environments
             headers["Authorization"] = authorization
         else:
-            # Use consumer username for local environments
+            # Development/test calls use a trusted identity only when the same
+            # deployment-internal credential is present.
+            internal_api_key = credential_from_env_or_file(
+                "WORKFLOW_INTERNAL_API_KEY",
+                "WORKFLOW_INTERNAL_API_KEY_FILE",
+                min_length=32,
+                placeholders=(WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,),
+            )
+            if not internal_api_key:
+                raise CustomException(
+                    err_code=CodeEnum.WORKFLOW_EXECUTION_ERROR,
+                    err_msg="Workflow internal API authentication is not configured",
+                )
             headers["X-Consumer-Username"] = self.appId
+            headers["X-Workflow-Internal-Key"] = internal_api_key
 
         return headers, req_body
 

--- a/core/workflow/extensions/fastapi/lifespan/bootstrap_credentials.py
+++ b/core/workflow/extensions/fastapi/lifespan/bootstrap_credentials.py
@@ -1,0 +1,190 @@
+"""Synchronize the deployment-managed tenant identity into Workflow storage."""
+
+import hashlib
+import os
+from dataclasses import dataclass
+from datetime import datetime
+
+from loguru import logger
+from sqlmodel import Session, select  # type: ignore
+
+from workflow.domain.models.ai_app import App
+from workflow.domain.models.app_source import AppSource
+from workflow.extensions.middleware.database.utils import session_getter
+from workflow.extensions.middleware.getters import get_cache_service
+from workflow.utils.credentials import credential_from_env_or_file
+
+BOOTSTRAP_TENANT_ID = "680ab54f"
+LEGACY_TENANT_KEY = "7b709739e8da44536127a333c7603a83"
+LEGACY_TENANT_SECRET = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+_LEGACY_VERIFIED_CACHE_PREFIX = "workflow:app:verified_credential"
+_CURRENT_VERIFIED_CACHE_PREFIX = "workflow:app:verified_credential:v2"
+_OLDEST_API_KEY_CACHE_PREFIX = "workflow:app:api_key"
+_LEGACY_APP_INFO_CACHE_PREFIX = "workflow:app_info"
+_CURRENT_APP_INFO_CACHE_PREFIX = "workflow:app_info:v2"
+_LEGACY_FLOW_CACHE_PATTERN = "workflow:flow_info:v2:*"
+
+
+@dataclass(frozen=True)
+class TenantBootstrapCredentials:
+    tenant_id: str
+    api_key: str
+    api_secret: str
+
+
+def load_tenant_bootstrap_credentials() -> TenantBootstrapCredentials:
+    tenant_id = os.getenv("TENANT_ID", BOOTSTRAP_TENANT_ID).strip()
+    api_key = credential_from_env_or_file(
+        "TENANT_KEY", "TENANT_KEY_FILE", min_length=32, max_length=50
+    )
+    api_secret = credential_from_env_or_file(
+        "TENANT_SECRET", "TENANT_SECRET_FILE", min_length=32, max_length=50
+    )
+    if tenant_id != BOOTSTRAP_TENANT_ID:
+        raise RuntimeError(
+            "TENANT_ID must remain 680ab54f because persisted bootstrap data refers to it"
+        )
+    if not api_key or not api_secret or api_key == api_secret:
+        raise RuntimeError("Tenant bootstrap credentials are missing or invalid")
+    if api_key == LEGACY_TENANT_KEY or api_secret == LEGACY_TENANT_SECRET:
+        raise RuntimeError("Published legacy tenant credentials cannot be used")
+    if not all(_is_safe_credential_character(character) for character in api_key):
+        raise RuntimeError(
+            "TENANT_KEY contains characters that are unsafe in authentication headers"
+        )
+    if not all(_is_safe_credential_character(character) for character in api_secret):
+        raise RuntimeError(
+            "TENANT_SECRET contains characters that are unsafe in authentication headers"
+        )
+    return TenantBootstrapCredentials(tenant_id, api_key, api_secret)
+
+
+def _is_safe_credential_character(character: str) -> bool:
+    return character.isascii() and (character.isalnum() or character in "._~-")
+
+
+def synchronize_bootstrap_app(
+    session: Session,
+    credentials: TenantBootstrapCredentials,
+    credential_digests_to_revoke: set[str] | None = None,
+) -> None:
+    """Update only the reserved bootstrap row; never touch user-created apps."""
+    # app_source id=1 is immutable bootstrap seed data and provides an existing
+    # InnoDB row that can serialize first-start reconciliation even while app id=1
+    # does not exist yet. This avoids concurrent replicas racing the unique app keys.
+    bootstrap_source = session.exec(
+        select(AppSource).where(AppSource.id == 1).with_for_update()
+    ).first()
+    if bootstrap_source is None:
+        raise RuntimeError("Reserved Workflow bootstrap source row is missing")
+
+    bootstrap_app = session.exec(
+        select(App).where(App.id == 1).with_for_update()
+    ).first()
+    alias_owner = session.exec(
+        select(App).where(App.alias_id == credentials.tenant_id)
+    ).first()
+
+    if bootstrap_app is not None and bootstrap_app.alias_id != credentials.tenant_id:
+        raise RuntimeError("Reserved Workflow bootstrap app id is owned by another app")
+    if alias_owner is not None and alias_owner.id != 1:
+        raise RuntimeError("Reserved Workflow bootstrap tenant alias is already in use")
+
+    now = datetime.now()
+    if bootstrap_app is None:
+        bootstrap_app = App(
+            id=1,
+            name="星辰",
+            alias_id=credentials.tenant_id,
+            description="星辰",
+            is_tenant=1,
+            source=1,
+            actual_source=1,
+            plat_release_auth=1,
+            status=1,
+            audit_policy=0,
+            create_by=1,
+            update_by=1,
+            create_at=now,
+            update_at=now,
+        )
+
+    expected_identity = {
+        "is_tenant": 1,
+        "source": 1,
+        "actual_source": 1,
+        "plat_release_auth": 1,
+        "status": 1,
+    }
+    mismatched_fields = [
+        field
+        for field, expected_value in expected_identity.items()
+        if getattr(bootstrap_app, field) != expected_value
+    ]
+    if mismatched_fields:
+        raise RuntimeError(
+            "Reserved Workflow bootstrap app identity is invalid: "
+            + ", ".join(mismatched_fields)
+        )
+
+    desired_pair = (credentials.api_key, credentials.api_secret)
+    existing_pair = (bootstrap_app.api_key, bootstrap_app.api_secret)
+    if (
+        credential_digests_to_revoke is not None
+        and existing_pair != desired_pair
+        and all(existing_pair)
+    ):
+        credential_digests_to_revoke.add(
+            hashlib.sha256(
+                f"{existing_pair[0]}:{existing_pair[1]}".encode()
+            ).hexdigest()
+        )
+    # This row is deployment-owned once all reserved identity fields match.
+    # Always converge it to the Secret so explicit rotations and regenerated
+    # credential volumes recover without manual database edits.
+    bootstrap_app.api_key, bootstrap_app.api_secret = desired_pair
+    bootstrap_app.update_at = now
+    session.add(bootstrap_app)
+
+
+def invalidate_legacy_bootstrap_caches(
+    credentials: TenantBootstrapCredentials,
+    credential_digests_to_revoke: set[str] | None = None,
+) -> None:
+    """Revoke disclosed authentication entries and abandon secret-bearing flow caches."""
+    cache_service = get_cache_service()
+    legacy_digest = hashlib.sha256(
+        f"{LEGACY_TENANT_KEY}:{LEGACY_TENANT_SECRET}".encode("utf-8")
+    ).hexdigest()
+    keys = {
+        f"{_OLDEST_API_KEY_CACHE_PREFIX}:{LEGACY_TENANT_KEY}",
+        f"{_LEGACY_VERIFIED_CACHE_PREFIX}:{legacy_digest}",
+        f"{_CURRENT_VERIFIED_CACHE_PREFIX}:{legacy_digest}",
+        f"{_LEGACY_APP_INFO_CACHE_PREFIX}:{credentials.tenant_id}",
+        f"{_CURRENT_APP_INFO_CACHE_PREFIX}:{credentials.tenant_id}",
+    }
+    keys.update(
+        f"{_CURRENT_VERIFIED_CACHE_PREFIX}:{digest}"
+        for digest in credential_digests_to_revoke or ()
+    )
+    keys.update(cache_service.scan_keys(_LEGACY_FLOW_CACHE_PATTERN))
+    for key in keys:
+        cache_service.delete(key)
+
+
+def synchronize_deployment_bootstrap_app(
+    credentials: TenantBootstrapCredentials | None = None,
+) -> None:
+    credentials = credentials or load_tenant_bootstrap_credentials()
+    credential_digests_to_revoke: set[str] = set()
+    with session_getter() as session:
+        synchronize_bootstrap_app(
+            session,
+            credentials,
+            credential_digests_to_revoke=credential_digests_to_revoke,
+        )
+    # session_getter commits before returning. Cache revocation is deliberately
+    # fail-closed: a replica must not become ready while disclosed positive auth
+    # entries or old secret-bearing flow objects remain usable.
+    invalidate_legacy_bootstrap_caches(credentials, credential_digests_to_revoke)
+    logger.info("Workflow tenant bootstrap credentials synchronized")

--- a/core/workflow/extensions/fastapi/lifespan/database_migration.py
+++ b/core/workflow/extensions/fastapi/lifespan/database_migration.py
@@ -23,6 +23,11 @@ MYSQL_ERROR_ACCESS_DENIED = 1227
 MYSQL_ERROR_EXECUTE_DENIED = 1370
 MYSQL_ERROR_TABLE_EXISTS = 1050
 
+MIGRATION_LOCK_KEY = "workflow_database_migration_lock"
+MIGRATION_LOCK_TTL_SECONDS = 900.0
+MIGRATION_LOCK_WAIT_SECONDS = 930.0
+MIGRATION_LOCK_POLL_SECONDS = 0.25
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s | %(levelname)s | %(name)s:%(funcName)s:%(lineno)d | %(message)s",
@@ -49,31 +54,38 @@ def run_database_migration() -> None:
     config.set_main_option("script_location", str(alembic_dir))
 
     cache_service = get_cache_service()
-    is_locked = cache_service.setnx("workflow_database_migration_lock", "locked", ex=60)
-    if is_locked:
+    migration_lock = cache_service.distributed_lock(
+        MIGRATION_LOCK_KEY,
+        timeout=MIGRATION_LOCK_TTL_SECONDS,
+        blocking_timeout=MIGRATION_LOCK_WAIT_SECONDS,
+        sleep=MIGRATION_LOCK_POLL_SECONDS,
+    )
+    if not migration_lock.acquire():
+        raise TimeoutError("timed out waiting for Workflow database migration lock")
+    try:
         try:
             command.upgrade(config, "head")
-        except OperationalError as e:
-            db_error_code = getattr(e.orig, "args", [None])[0]
+        except OperationalError as error:
+            db_error_code = getattr(error.orig, "args", [None])[0]
             if db_error_code in (
                 MYSQL_ERROR_SELECT_DENIED,
                 MYSQL_ERROR_ACCESS_DENIED,
                 MYSQL_ERROR_EXECUTE_DENIED,
             ):
-                logging.warning(
-                    f"Skip database migration due to insufficient permissions: {e}"
+                logging.error(
+                    "Database migration permissions are insufficient; refusing to start"
                 )
-                return
-            elif db_error_code == MYSQL_ERROR_TABLE_EXISTS:
+                raise
+            if db_error_code == MYSQL_ERROR_TABLE_EXISTS:
                 logging.warning("Detected legacy database, stamping to init version...")
-                try:
-                    command.stamp(config, INIT_VERSION)
-                    command.upgrade(config, "head")
-                except Exception as stamp_error:
-                    logging.error(
-                        f"Failed to stamp and upgrade legacy database: {stamp_error}"
-                    )
-            else:
-                logging.error(f"Database migration failed: {e}")
-        except Exception as e:
-            logging.error(f"Database migration failed: {e}")
+                command.stamp(config, INIT_VERSION)
+                command.upgrade(config, "head")
+                return
+            logging.error("Database migration failed", exc_info=True)
+            raise
+    finally:
+        # All replicas run upgrade after acquiring the lock. Losers therefore wait
+        # for the winner instead of touching a partially migrated fresh schema.
+        # redis-py releases with an atomic token compare-and-delete. If this
+        # owner lost the lock, release raises rather than deleting a newer lock.
+        migration_lock.release()

--- a/core/workflow/extensions/fastapi/middleware/auth.py
+++ b/core/workflow/extensions/fastapi/middleware/auth.py
@@ -1,7 +1,10 @@
 import asyncio
+import hashlib
+import hmac
 import json
 import os
 import secrets
+import time
 from typing import Annotated, Any
 
 import httpx
@@ -20,10 +23,26 @@ from workflow.extensions.fastapi.base import (
 )
 from workflow.extensions.middleware.getters import get_cache_service
 from workflow.extensions.otlp.trace.span import Span
+from workflow.utils.credentials import (
+    MAX_CREDENTIAL_FILE_BYTES,
+    TENANT_INTERNAL_API_KEY_HEADER,
+    credential_from_env_or_file,
+)
 
 WORKFLOW_INTERNAL_API_KEY_ENV = "WORKFLOW_INTERNAL_API_KEY"
+WORKFLOW_INTERNAL_API_KEY_FILE_ENV = "WORKFLOW_INTERNAL_API_KEY_FILE"
 WORKFLOW_INTERNAL_API_KEY_HEADER = "X-Workflow-Internal-Key"
 WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"
+WORKFLOW_INTERNAL_API_KEY_MIN_LENGTH = 32
+WORKFLOW_INTERNAL_API_KEY_MAX_FILE_BYTES = MAX_CREDENTIAL_FILE_BYTES
+WORKFLOW_GATEWAY_TIMESTAMP_HEADER = "X-Workflow-Gateway-Timestamp"
+WORKFLOW_GATEWAY_SIGNATURE_HEADER = "X-Workflow-Gateway-Signature"
+WORKFLOW_GATEWAY_SIGNATURE_MAX_AGE_SECONDS = 60
+VERIFIED_CREDENTIAL_CACHE_PREFIX = "workflow:app:verified_credential:v2"
+APP_MANAGE_CREDENTIAL_MIN_LENGTH = 32
+APP_MANAGE_CREDENTIAL_MAX_LENGTH = 50
+PUBLISHED_LEGACY_TENANT_API_KEY = "7b709739e8da44536127a333c7603a83"
+PUBLISHED_LEGACY_TENANT_API_SECRET = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
 
 _workflow_internal_api_key_header = APIKeyHeader(
     name=WORKFLOW_INTERNAL_API_KEY_HEADER,
@@ -31,9 +50,60 @@ _workflow_internal_api_key_header = APIKeyHeader(
 )
 
 
+def _replace_trusted_identity_headers(request: Request, app_id: str) -> None:
+    """Expose one verified identity downstream and discard the internal secret."""
+    excluded_headers = {
+        b"x-consumer-username",
+        WORKFLOW_INTERNAL_API_KEY_HEADER.lower().encode("ascii"),
+        WORKFLOW_GATEWAY_TIMESTAMP_HEADER.lower().encode("ascii"),
+        WORKFLOW_GATEWAY_SIGNATURE_HEADER.lower().encode("ascii"),
+    }
+    headers = [
+        (name, value)
+        for name, value in request.scope["headers"]
+        if name.lower() not in excluded_headers
+    ]
+    headers.append((b"x-consumer-username", app_id.encode()))
+    # Starlette may already have cached a Headers view backed by this exact list.
+    request.scope["headers"][:] = headers
+
+
+def _valid_gateway_identity_signature(request: Request, app_id: str) -> bool:
+    """Validate the short-lived identity assertion returned to a public gateway."""
+    if request.url.path not in CHAT_OPEN_API_PATHS:
+        return False
+    internal_api_key = _optional_workflow_internal_api_key()
+    timestamp = request.headers.get(WORKFLOW_GATEWAY_TIMESTAMP_HEADER, "")
+    supplied_signature = request.headers.get(WORKFLOW_GATEWAY_SIGNATURE_HEADER, "")
+    if not internal_api_key or not timestamp or not supplied_signature:
+        return False
+    try:
+        issued_at = int(timestamp)
+    except ValueError:
+        return False
+    if abs(int(time.time()) - issued_at) > WORKFLOW_GATEWAY_SIGNATURE_MAX_AGE_SECONDS:
+        return False
+    payload = (
+        f"{request.method.upper()}\n{request.url.path}\n{app_id}\n{timestamp}"
+    ).encode("utf-8")
+    expected_signature = hmac.new(
+        internal_api_key.encode("utf-8"), payload, hashlib.sha256
+    ).hexdigest()
+    return secrets.compare_digest(supplied_signature, expected_signature)
+
+
+def _optional_workflow_internal_api_key() -> str:
+    return credential_from_env_or_file(
+        WORKFLOW_INTERNAL_API_KEY_ENV,
+        WORKFLOW_INTERNAL_API_KEY_FILE_ENV,
+        min_length=WORKFLOW_INTERNAL_API_KEY_MIN_LENGTH,
+        placeholders=(WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,),
+    )
+
+
 def _configured_workflow_internal_api_key() -> str:
-    api_key = os.getenv(WORKFLOW_INTERNAL_API_KEY_ENV, "").strip()
-    if not api_key or api_key == WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER:
+    api_key = _optional_workflow_internal_api_key()
+    if not api_key:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Workflow internal API authentication is not configured",
@@ -70,14 +140,28 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         super().__init__(app)
         self.need_auth_paths = CHAT_OPEN_API_PATHS + AUTH_OPEN_API_PATHS
-        self.api_key = os.getenv("APP_MANAGE_PLAT_KEY", "")
-        self.api_secret = os.getenv("APP_MANAGE_PLAT_SECRET", "")
+        self.api_key = credential_from_env_or_file(
+            "APP_MANAGE_PLAT_KEY",
+            "APP_MANAGE_PLAT_KEY_FILE",
+            min_length=APP_MANAGE_CREDENTIAL_MIN_LENGTH,
+            max_length=APP_MANAGE_CREDENTIAL_MAX_LENGTH,
+            placeholders=(PUBLISHED_LEGACY_TENANT_API_KEY,),
+        )
+        self.api_secret = credential_from_env_or_file(
+            "APP_MANAGE_PLAT_SECRET",
+            "APP_MANAGE_PLAT_SECRET_FILE",
+            min_length=APP_MANAGE_CREDENTIAL_MIN_LENGTH,
+            max_length=APP_MANAGE_CREDENTIAL_MAX_LENGTH,
+            placeholders=(PUBLISHED_LEGACY_TENANT_API_SECRET,),
+        )
 
     async def dispatch(self, request: Request, call_next: Any) -> Any:
         """
-        Dispatch the request, if the path is in the exclude paths, skip the authentication,
-        if the x-consumer-username header is present, skip the authentication,
-        otherwise, get the authentication header, and get the app source detail with api key,
+        Dispatch the request, if the path is in the exclude paths, skip the authentication.
+        A caller-provided consumer identity is trusted only when accompanied by the
+        deployment's internal workflow credential. Otherwise, verify the complete
+        bearer key/secret pair with the tenant service and replace any untrusted
+        identity header with the verified application ID.
         if the app source detail is not found, return the error response,
         otherwise, add the authentication information to the request state,
         and call the next function.
@@ -90,9 +174,22 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if request.url.path not in self.need_auth_paths:
             return await call_next(request)
 
-        # Get the authentication header
+        # A consumer identity is authoritative only for authenticated internal peers.
         x_consumer_username = request.headers.get("x-consumer-username")
-        if x_consumer_username:
+        supplied_internal_key = request.headers.get(WORKFLOW_INTERNAL_API_KEY_HEADER)
+        expected_internal_key = _optional_workflow_internal_api_key()
+        trusted_internal_identity = bool(
+            x_consumer_username
+            and supplied_internal_key
+            and expected_internal_key
+            and secrets.compare_digest(supplied_internal_key, expected_internal_key)
+        )
+        trusted_gateway_identity = bool(
+            x_consumer_username
+            and _valid_gateway_identity_signature(request, x_consumer_username)
+        )
+        if trusted_internal_identity or trusted_gateway_identity:
+            _replace_trusted_identity_headers(request, x_consumer_username)
             return await call_next(request)
 
         span = Span()
@@ -122,10 +219,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR.code,
                 )
 
-            # Add the authentication information to the request state
-            headers = list(request.scope["headers"])
-            headers.append((b"x-consumer-username", x_consumer_username.encode()))
-            request.scope["headers"] = headers
+            # Replace every caller-supplied identity with the verified value. Keeping
+            # both headers would let framework header ordering decide which identity
+            # downstream code observes.
+            _replace_trusted_identity_headers(request, x_consumer_username)
 
         return await call_next(request)
 
@@ -142,11 +239,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if not self.api_key or not self.api_secret:
             return {}
 
-        return HMACAuth.build_auth_header(
+        headers = HMACAuth.build_auth_header(
             request_url=url,
             api_key=self.api_key,
             api_secret=self.api_secret,
         )
+        headers[TENANT_INTERNAL_API_KEY_HEADER] = self.api_secret
+        return headers
 
     async def _get_app_source_detail_with_api_key(
         self, authorization: str, span: Span
@@ -159,24 +258,40 @@ class AuthMiddleware(BaseHTTPMiddleware):
         :return: The app source detail
         """
 
-        url = f"{os.getenv('APP_MANAGE_PLAT_BASE_URL')}/v2/app/key/api_key"
-
-        api_key = authorization.split(" ")[1].split(":")[0]
-        if not api_key:
+        try:
+            scheme, credential = authorization.split(" ", 1)
+            api_key, api_secret = credential.strip().split(":", 1)
+        except ValueError as exc:
+            raise CustomException(
+                CodeEnum.PARAM_ERROR,
+                err_msg="authorization header is invalid",
+            ) from exc
+        if scheme.lower() != "bearer" or not api_key or not api_secret:
             raise CustomException(
                 CodeEnum.PARAM_ERROR,
                 err_msg="authorization header is invalid",
             )
 
-        app_id = await asyncio.to_thread(self._get_app_id_with_cache, api_key)
+        credential_cache_key = hashlib.sha256(
+            credential.strip().encode("utf-8")
+        ).hexdigest()
+
+        app_id = await asyncio.to_thread(
+            self._get_app_id_with_cache, credential_cache_key
+        )
         if app_id:
             return app_id
 
-        url = f"{url}/{api_key}"
+        base_url = os.getenv("APP_MANAGE_PLAT_BASE_URL", "").rstrip("/")
+        url = f"{base_url}/v2/app/key/verify"
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._gen_app_auth_header(url))
+            resp = await client.post(
+                url,
+                json={"api_key": api_key, "api_secret": api_secret},
+                headers=self._gen_app_auth_header(url),
+            )
         await span.add_info_event_async(
-            f"Application management platform response: {resp.text}"
+            "Application management platform credential verification completed"
         )
         if resp.status_code != 200:
             raise CustomException(
@@ -210,26 +325,32 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 err_msg="appid is null",
                 cause_error=json.dumps(resp.json(), ensure_ascii=False),
             )
-        await asyncio.to_thread(self._set_app_id_with_cache, api_key, app_id)
+        await asyncio.to_thread(
+            self._set_app_id_with_cache, credential_cache_key, app_id
+        )
         return app_id
 
-    def _get_app_id_with_cache(self, api_key: str) -> str:
+    def _get_app_id_with_cache(self, credential_cache_key: str) -> str:
         """
         Get the app id with cache
 
-        :param api_key: The api key
+        :param credential_cache_key: SHA-256 digest of the complete credential pair
         :return: The app id
         """
         cache_service = get_cache_service()
-        app_id: str = cache_service[f"workflow:app:api_key:{api_key}"]
+        app_id: str = cache_service[
+            f"{VERIFIED_CREDENTIAL_CACHE_PREFIX}:{credential_cache_key}"
+        ]
         return app_id
 
-    def _set_app_id_with_cache(self, api_key: str, app_id: str) -> None:
+    def _set_app_id_with_cache(self, credential_cache_key: str, app_id: str) -> None:
         """
         Set the app id with cache
 
-        :param api_key: The api key
+        :param credential_cache_key: SHA-256 digest of the complete credential pair
         :param app_id: The app id
         """
         cache_service = get_cache_service()
-        cache_service[f"workflow:app:api_key:{api_key}"] = app_id
+        cache_service[f"{VERIFIED_CREDENTIAL_CACHE_PREFIX}:{credential_cache_key}"] = (
+            app_id
+        )

--- a/core/workflow/extensions/middleware/cache/base.py
+++ b/core/workflow/extensions/middleware/cache/base.py
@@ -213,3 +213,14 @@ class BaseCacheService(abc.ABC):
         Returns:
             True if the key was set, False if the key already exists.
         """
+
+    def distributed_lock(
+        self,
+        key: str,
+        *,
+        timeout: float,
+        blocking_timeout: float,
+        sleep: float,
+    ) -> Any:
+        """Return an ownership-safe Redis distributed lock."""
+        raise NotImplementedError("distributed locks are not supported")

--- a/core/workflow/extensions/middleware/cache/manager.py
+++ b/core/workflow/extensions/middleware/cache/manager.py
@@ -376,6 +376,23 @@ class RedisCache(BaseCacheService, Service):
         )
         return bool(result)
 
+    def distributed_lock(
+        self,
+        key: str,
+        *,
+        timeout: float,
+        blocking_timeout: float,
+        sleep: float,
+    ) -> Any:
+        """Use redis-py's tokenized Lua-release lock across replicas."""
+        return self._client.lock(
+            name=key,
+            timeout=timeout,
+            sleep=sleep,
+            blocking_timeout=blocking_timeout,
+            thread_local=False,
+        )
+
     def __repr__(self) -> str:
         """
         Return a string representation of the RedisCache instance.

--- a/core/workflow/main.py
+++ b/core/workflow/main.py
@@ -21,6 +21,10 @@ from starlette.middleware.cors import CORSMiddleware
 from workflow.api.v1.router import old_auth_router, sparkflow_router, workflow_router
 from workflow.cache.event_registry import EventRegistry
 from workflow.extensions.fastapi.handler.validation import validation_exception_handler
+from workflow.extensions.fastapi.lifespan.bootstrap_credentials import (
+    load_tenant_bootstrap_credentials,
+    synchronize_deployment_bootstrap_app,
+)
 from workflow.extensions.fastapi.lifespan.database_migration import (
     run_database_migration,
 )
@@ -63,8 +67,12 @@ def create_app() -> FastAPI:
             ]
         )
 
+        # Validate deployment credentials before a migration can change shared state.
+        tenant_bootstrap_credentials = load_tenant_bootstrap_credentials()
+
         # Run database migration before starting the service
         run_database_migration()
+        synchronize_deployment_bootstrap_app(tenant_bootstrap_credentials)
 
         # Initialize the http connection pool when the entire service starts
         await HttpClient.setup()

--- a/core/workflow/service/app_service.py
+++ b/core/workflow/service/app_service.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from common.utils.hmac_auth import HMACAuth
@@ -10,6 +9,10 @@ from workflow.domain.models.app_source import AppSource
 from workflow.exception.e import CustomException
 from workflow.exception.errors.err_code import CodeEnum
 from workflow.extensions.otlp.trace.span import Span
+from workflow.utils.credentials import (
+    TENANT_INTERNAL_API_KEY_HEADER,
+    credential_from_env_or_file,
+)
 
 
 def _gen_app_auth_header(url: str) -> dict[str, str]:
@@ -20,19 +23,26 @@ def _gen_app_auth_header(url: str) -> dict[str, str]:
     :return: Dictionary containing authentication headers,
              empty dict if credentials are missing
     """
-    # Retrieve API credentials from environment variables
-    api_key = os.getenv("APP_MANAGE_PLAT_KEY", "")
-    api_secret = os.getenv("APP_MANAGE_PLAT_SECRET", "")
+    # Compose supplies the same credentials through read-only files so users do
+    # not have to copy generated secrets into .env.
+    api_key = credential_from_env_or_file(
+        "APP_MANAGE_PLAT_KEY", "APP_MANAGE_PLAT_KEY_FILE"
+    )
+    api_secret = credential_from_env_or_file(
+        "APP_MANAGE_PLAT_SECRET", "APP_MANAGE_PLAT_SECRET_FILE"
+    )
 
     # Return empty dict if credentials are not configured
     if not api_key or not api_secret:
         return {}
 
-    return HMACAuth.build_auth_header(
+    headers = HMACAuth.build_auth_header(
         request_url=url,
         api_key=api_key,
         api_secret=api_secret,
     )
+    headers[TENANT_INTERNAL_API_KEY_HEADER] = api_secret
+    return headers
 
 
 async def get_app_source_id(app_id: str, span: Span) -> str:
@@ -59,7 +69,8 @@ async def get_app_source_id(app_id: str, span: Span) -> str:
     # Check HTTP response status
     if resp.status_code != 200:
         raise CustomException(
-            CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR, cause_error=resp.text
+            CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR,
+            cause_error=f"management platform status={resp.status_code}",
         )
 
     # Check API response code
@@ -67,14 +78,10 @@ async def get_app_source_id(app_id: str, span: Span) -> str:
     if code != 0:
         raise CustomException(
             CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR,
-            cause_error=json.dumps(resp.json(), ensure_ascii=False),
+            cause_error=f"management platform code={code}",
         )
 
-    # Log the response data for debugging
-    await span.add_info_event_async(
-        "Application management platform response: "
-        + json.dumps(resp.json(), ensure_ascii=False)
-    )
+    await span.add_info_event_async("Application source lookup completed")
 
     # Extract and return the source ID from the response
     return resp.json().get("data", [{}])[0].get("source", "")
@@ -104,7 +111,8 @@ async def get_app_source_detail(app_id: str, span: Span) -> tuple[str, str, str,
     # Check HTTP response status
     if resp.status_code != 200:
         raise CustomException(
-            CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR, cause_error=resp.text
+            CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR,
+            cause_error=f"management platform status={resp.status_code}",
         )
 
     # Check API response code
@@ -112,7 +120,7 @@ async def get_app_source_detail(app_id: str, span: Span) -> tuple[str, str, str,
     if code != 0:
         raise CustomException(
             CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR,
-            cause_error=json.dumps(resp.json(), ensure_ascii=False),
+            cause_error=f"management platform code={code}",
         )
 
     # Extract response data and validate
@@ -122,11 +130,8 @@ async def get_app_source_detail(app_id: str, span: Span) -> tuple[str, str, str,
             CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR, cause_error="data is null"
         )
 
-    # Log the response data for debugging
-    await span.add_info_event_async(
-        "Application management platform response: "
-        + json.dumps(resp.json(), ensure_ascii=False)
-    )
+    # The response contains API credentials; record only non-sensitive outcome data.
+    await span.add_info_event_async("Application detail lookup completed")
 
     # Extract application basic information
     name = data[0].get("name")

--- a/core/workflow/tests/alembic/test_legacy_bootstrap_credential_sanitization.py
+++ b/core/workflow/tests/alembic/test_legacy_bootstrap_credential_sanitization.py
@@ -1,0 +1,79 @@
+"""Migration tests for removal of the disclosed tenant credential pair."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "alembic"
+    / "versions"
+    / "2026_08_27_1000-a91e02d64b77_disable_legacy_bootstrap_credentials.py"
+)
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "disable_legacy_bootstrap_credentials", MIGRATION_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Unable to load migration: {MIGRATION_PATH}")
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def test_revision_chain_and_downgrade_never_restores_disclosed_values() -> None:
+    migration = _load_migration()
+
+    assert migration.revision == "a91e02d64b77"
+    assert migration.down_revision == "c7e8a4f19d32"
+    assert migration.downgrade() is None
+
+
+def test_upgrade_removes_only_exact_disclosed_values_from_both_protocols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    flow = sa.Table(
+        "flow",
+        metadata,
+        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("data", sa.Text),
+        sa.Column("release_data", sa.Text),
+    )
+    metadata.create_all(engine)
+
+    disclosed = (
+        f'{{"apiKey":"{migration._LEGACY_KEY}",'
+        f'"apiSecret":"{migration._LEGACY_SECRET}"}}'
+    )
+    custom = '{"apiKey":"customer-key","apiSecret":"customer-secret"}'
+    with engine.begin() as connection:
+        connection.execute(
+            flow.insert(),
+            [
+                {"id": 1, "data": disclosed, "release_data": disclosed},
+                {"id": 2, "data": custom, "release_data": custom},
+            ],
+        )
+        monkeypatch.setattr(migration.op, "execute", connection.execute)
+
+        migration.upgrade()
+
+        rows = {
+            row.id: row
+            for row in connection.execute(sa.select(flow).order_by(flow.c.id))
+        }
+
+    assert migration._LEGACY_KEY not in rows[1].data
+    assert migration._LEGACY_SECRET not in rows[1].data
+    assert migration._LEGACY_KEY not in rows[1].release_data
+    assert migration._LEGACY_SECRET not in rows[1].release_data
+    assert rows[2].data == custom
+    assert rows[2].release_data == custom

--- a/core/workflow/tests/engine/nodes/test_agent_node.py
+++ b/core/workflow/tests/engine/nodes/test_agent_node.py
@@ -1,6 +1,13 @@
+import pytest
+
 from workflow.consts.engine.model_provider import ModelProviderEnum
 from workflow.engine.entities.variable_pool import ParamKey, VariablePool
-from workflow.engine.nodes.agent.agent_node import AgentNode
+from workflow.engine.nodes.agent.agent_node import (
+    WORKFLOW_INTERNAL_API_KEY_HEADER,
+    AgentNode,
+    _redact_agent_request_headers,
+)
+from workflow.exception.e import CustomException
 from workflow.extensions.otlp.trace.span import Span
 
 
@@ -90,3 +97,31 @@ def test_generate_agent_request_includes_runtime_metadata() -> None:
     assert "runtimeConfigUrl" not in sandbox
     assert "artifactUploadToken" not in sandbox
     assert "runtimeCredentialToken" not in sandbox
+
+
+def test_agent_request_headers_require_and_forward_internal_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    internal_key = "w" * 48
+    monkeypatch.setenv("WORKFLOW_INTERNAL_API_KEY", internal_key)
+    monkeypatch.delenv("WORKFLOW_INTERNAL_API_KEY_FILE", raising=False)
+
+    headers = build_agent_node()._build_agent_request_headers()
+
+    assert headers["x-consumer-username"] == "app-id"
+    assert headers[WORKFLOW_INTERNAL_API_KEY_HEADER] == internal_key
+    assert internal_key not in str(_redact_agent_request_headers(headers))
+    assert WORKFLOW_INTERNAL_API_KEY_HEADER not in _redact_agent_request_headers(
+        headers
+    )
+
+
+@pytest.mark.parametrize("configured_key", ["", "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"])
+def test_agent_request_headers_fail_closed_without_internal_key(
+    monkeypatch: pytest.MonkeyPatch, configured_key: str
+) -> None:
+    monkeypatch.setenv("WORKFLOW_INTERNAL_API_KEY", configured_key)
+    monkeypatch.delenv("WORKFLOW_INTERNAL_API_KEY_FILE", raising=False)
+
+    with pytest.raises(CustomException):
+        build_agent_node()._build_agent_request_headers()

--- a/core/workflow/tests/extensions/fastapi/test_auth.py
+++ b/core/workflow/tests/extensions/fastapi/test_auth.py
@@ -6,7 +6,10 @@ covering all core functionality including authentication flow, header validation
 API key verification, cache operations, and error handling scenarios.
 """
 
+import hashlib
+import hmac
 import os
+import time
 from typing import List
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -16,10 +19,32 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from workflow.exception.e import CustomException
 from workflow.exception.errors.err_code import CodeEnum
-from workflow.extensions.fastapi.base import AUTH_OPEN_API_PATHS, JSONResponseBase
-from workflow.extensions.fastapi.middleware.auth import AuthMiddleware
+from workflow.extensions.fastapi.base import (
+    AUTH_OPEN_API_PATHS,
+    CHAT_OPEN_API_PATHS,
+    JSONResponseBase,
+)
+from workflow.extensions.fastapi.middleware.auth import (
+    WORKFLOW_GATEWAY_SIGNATURE_HEADER,
+    WORKFLOW_GATEWAY_TIMESTAMP_HEADER,
+    WORKFLOW_INTERNAL_API_KEY_ENV,
+    WORKFLOW_INTERNAL_API_KEY_HEADER,
+    AuthMiddleware,
+)
+from workflow.utils.credentials import TENANT_INTERNAL_API_KEY_HEADER
 
 pytestmark = pytest.mark.asyncio
+
+
+def credential_cache_key(credential: str) -> str:
+    return hashlib.sha256(credential.encode("utf-8")).hexdigest()
+
+
+def gateway_signature(
+    key: str, method: str, path: str, app_id: str, timestamp: str
+) -> str:
+    payload = f"{method.upper()}\n{path}\n{app_id}\n{timestamp}".encode()
+    return hmac.new(key.encode(), payload, hashlib.sha256).hexdigest()
 
 
 def create_mock_span_context() -> tuple[Mock, Mock]:
@@ -88,14 +113,44 @@ class TestAuthMiddleware:
 
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_KEY": "test_key", "APP_MANAGE_PLAT_SECRET": "test_secret"},
+        {"APP_MANAGE_PLAT_KEY": "k" * 32, "APP_MANAGE_PLAT_SECRET": "s" * 32},
+        clear=True,
     )
     def test_init_with_env_vars(self, mock_app: ASGIApp) -> None:
         """Test AuthMiddleware initialization with environment variables."""
         middleware = AuthMiddleware(mock_app)
 
-        assert middleware.api_key == "test_key"
-        assert middleware.api_secret == "test_secret"
+        assert middleware.api_key == "k" * 32
+        assert middleware.api_secret == "s" * 32
+
+    @pytest.mark.parametrize(
+        ("api_key", "api_secret"),
+        [
+            ("short", "also-short"),
+            (
+                "7b709739e8da44536127a333c7603a83",
+                "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy",
+            ),
+        ],
+    )
+    def test_init_rejects_weak_or_published_management_credentials(
+        self,
+        mock_app: ASGIApp,
+        api_key: str,
+        api_secret: str,
+    ) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "APP_MANAGE_PLAT_KEY": api_key,
+                "APP_MANAGE_PLAT_SECRET": api_secret,
+            },
+            clear=True,
+        ):
+            middleware = AuthMiddleware(mock_app)
+
+        assert middleware.api_key == ""
+        assert middleware.api_secret == ""
 
     @patch.dict(os.environ, {}, clear=True)
     def test_init_without_env_vars(self, mock_app: ASGIApp) -> None:
@@ -124,23 +179,157 @@ class TestAuthMiddleware:
             assert result == mock_call_next.return_value
             mock_call_next.assert_called_once_with(mock_request)
 
-    async def test_dispatch_with_x_consumer_username(
+    async def test_dispatch_rejects_untrusted_x_consumer_username(
         self,
         auth_middleware: AuthMiddleware,
         mock_request: Mock,
         mock_call_next: AsyncMock,
     ) -> None:
-        """Test dispatch bypasses auth when x-consumer-username header is present."""
+        """A caller cannot bypass a protected route with a forged identity header."""
         mock_request.headers = {"x-consumer-username": "test_user"}
+        mock_request.url.path = AUTH_OPEN_API_PATHS[0]
 
         with patch("workflow.extensions.otlp.trace.span.Span") as mock_span_class:
             mock_span, mock_span_ctx = create_mock_span_context()
             mock_span_class.return_value = mock_span
+            with patch.object(
+                JSONResponseBase, "generate_error_response"
+            ) as mock_error_response:
+                mock_error_response.return_value = {"error": "authorization required"}
 
+                result = await auth_middleware.dispatch(mock_request, mock_call_next)
+
+                assert result == {"error": "authorization required"}
+                mock_call_next.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {WORKFLOW_INTERNAL_API_KEY_ENV: "i" * 32},
+        clear=False,
+    )
+    async def test_dispatch_trusts_consumer_from_authenticated_internal_peer(
+        self,
+        auth_middleware: AuthMiddleware,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+    ) -> None:
+        mock_request.headers = {
+            "x-consumer-username": "test_user",
+            WORKFLOW_INTERNAL_API_KEY_HEADER: "i" * 32,
+        }
+        mock_request.scope["headers"] = [
+            (b"x-consumer-username", b"test_user"),
+            (WORKFLOW_INTERNAL_API_KEY_HEADER.lower().encode(), b"i" * 32),
+        ]
+        mock_request.url.path = AUTH_OPEN_API_PATHS[0]
+
+        result = await auth_middleware.dispatch(mock_request, mock_call_next)
+
+        assert result == mock_call_next.return_value
+        mock_call_next.assert_called_once_with(mock_request)
+        assert mock_request.scope["headers"] == [(b"x-consumer-username", b"test_user")]
+
+    @patch.dict(
+        os.environ,
+        {WORKFLOW_INTERNAL_API_KEY_ENV: "g" * 32},
+        clear=False,
+    )
+    async def test_dispatch_trusts_short_lived_gateway_identity_signature(
+        self,
+        auth_middleware: AuthMiddleware,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+    ) -> None:
+        timestamp = "1700000000"
+        app_id = "gateway-app"
+        path = CHAT_OPEN_API_PATHS[0]
+        signature = gateway_signature("g" * 32, "POST", path, app_id, timestamp)
+        assert (
+            signature
+            == "6261d5595286ac9407951e6c4c690bd1c50c2fbfe4f29addc50e3f437ef6a871"
+        )
+        mock_request.method = "POST"
+        mock_request.url.path = path
+        mock_request.headers = {
+            "x-consumer-username": app_id,
+            WORKFLOW_GATEWAY_TIMESTAMP_HEADER: timestamp,
+            WORKFLOW_GATEWAY_SIGNATURE_HEADER: signature,
+        }
+        mock_request.scope["headers"] = [
+            (b"x-consumer-username", app_id.encode()),
+            (WORKFLOW_GATEWAY_TIMESTAMP_HEADER.lower().encode(), timestamp.encode()),
+            (WORKFLOW_GATEWAY_SIGNATURE_HEADER.lower().encode(), signature.encode()),
+        ]
+
+        with patch(
+            "workflow.extensions.fastapi.middleware.auth.time.time",
+            return_value=1700000000,
+        ):
             result = await auth_middleware.dispatch(mock_request, mock_call_next)
 
-            assert result == mock_call_next.return_value
-            mock_call_next.assert_called_once_with(mock_request)
+        assert result == mock_call_next.return_value
+        assert mock_request.scope["headers"] == [
+            (b"x-consumer-username", app_id.encode())
+        ]
+
+    @pytest.mark.parametrize("invalid_assertion", ["expired", "wrong-signature"])
+    @patch.dict(
+        os.environ,
+        {WORKFLOW_INTERNAL_API_KEY_ENV: "g" * 32},
+        clear=False,
+    )
+    async def test_dispatch_rejects_invalid_gateway_identity_signature(
+        self,
+        auth_middleware: AuthMiddleware,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+        invalid_assertion: str,
+    ) -> None:
+        timestamp = str(
+            int(time.time()) - 120
+            if invalid_assertion == "expired"
+            else int(time.time())
+        )
+        path = CHAT_OPEN_API_PATHS[0]
+        signature = gateway_signature("g" * 32, "POST", path, "forged-app", timestamp)
+        if invalid_assertion == "wrong-signature":
+            signature = "0" * 64
+        mock_request.method = "POST"
+        mock_request.url.path = path
+        mock_request.headers = {
+            "authorization": "Bearer public-key:public-secret",
+            "x-consumer-username": "forged-app",
+            WORKFLOW_GATEWAY_TIMESTAMP_HEADER: timestamp,
+            WORKFLOW_GATEWAY_SIGNATURE_HEADER: signature,
+        }
+        mock_request.scope["headers"] = [
+            (b"authorization", b"Bearer public-key:public-secret"),
+            (b"x-consumer-username", b"forged-app"),
+            (WORKFLOW_GATEWAY_TIMESTAMP_HEADER.lower().encode(), timestamp.encode()),
+            (WORKFLOW_GATEWAY_SIGNATURE_HEADER.lower().encode(), signature.encode()),
+        ]
+
+        with patch.object(
+            auth_middleware,
+            "_get_app_source_detail_with_api_key",
+            new=AsyncMock(return_value="verified-app"),
+        ):
+            await auth_middleware.dispatch(mock_request, mock_call_next)
+
+        assert (b"x-consumer-username", b"verified-app") in mock_request.scope[
+            "headers"
+        ]
+        assert (b"x-consumer-username", b"forged-app") not in mock_request.scope[
+            "headers"
+        ]
+        assert not any(
+            name.lower()
+            in {
+                WORKFLOW_GATEWAY_TIMESTAMP_HEADER.lower().encode(),
+                WORKFLOW_GATEWAY_SIGNATURE_HEADER.lower().encode(),
+            }
+            for name, _ in mock_request.scope["headers"]
+        )
 
     async def test_dispatch_missing_authorization_header(
         self,
@@ -214,7 +403,10 @@ class TestAuthMiddleware:
                 "https://api.test.com/endpoint"
             )
 
-            assert result == {"Authorization": "test_auth_header"}
+            assert result == {
+                "Authorization": "test_auth_header",
+                TENANT_INTERNAL_API_KEY_HEADER: "test_secret",
+            }
             mock_build_auth.assert_called_once_with(
                 request_url="https://api.test.com/endpoint",
                 api_key="test_key",
@@ -252,10 +444,12 @@ class TestAuthMiddleware:
         with patch(
             "workflow.extensions.fastapi.middleware.auth.get_cache_service"
         ) as mock_get_cache:
-            mock_cache = {"workflow:app:api_key:test_key": "cached_app_id"}
+            mock_cache = {
+                "workflow:app:verified_credential:v2:test_digest": "cached_app_id"
+            }
             mock_get_cache.return_value = mock_cache
 
-            result = auth_middleware._get_app_id_with_cache("test_key")
+            result = auth_middleware._get_app_id_with_cache("test_digest")
 
             assert result == "cached_app_id"
 
@@ -267,9 +461,12 @@ class TestAuthMiddleware:
             mock_cache: dict = {}
             mock_get_cache.return_value = mock_cache
 
-            auth_middleware._set_app_id_with_cache("test_key", "test_app_id")
+            auth_middleware._set_app_id_with_cache("test_digest", "test_app_id")
 
-            assert mock_cache["workflow:app:api_key:test_key"] == "test_app_id"
+            assert (
+                mock_cache["workflow:app:verified_credential:v2:test_digest"]
+                == "test_app_id"
+            )
 
     @pytest.mark.parametrize(
         "need_auth_paths,request_path,should_skip",
@@ -324,6 +521,11 @@ class TestAuthMiddleware:
             "123456",
         ],
     )
+    @patch.dict(
+        os.environ,
+        {WORKFLOW_INTERNAL_API_KEY_ENV: "t" * 32},
+        clear=False,
+    )
     async def test_dispatch_x_consumer_username_values(
         self,
         auth_middleware: AuthMiddleware,
@@ -331,8 +533,16 @@ class TestAuthMiddleware:
         mock_call_next: AsyncMock,
         x_consumer_username: str,
     ) -> None:
-        """Test dispatch with various x-consumer-username header values."""
-        mock_request.headers = {"x-consumer-username": x_consumer_username}
+        """Authenticated internal peers may supply supported consumer ID values."""
+        mock_request.headers = {
+            "x-consumer-username": x_consumer_username,
+            WORKFLOW_INTERNAL_API_KEY_HEADER: "t" * 32,
+        }
+        mock_request.scope["headers"] = [
+            (b"x-consumer-username", x_consumer_username.encode()),
+            (WORKFLOW_INTERNAL_API_KEY_HEADER.lower().encode(), b"t" * 32),
+        ]
+        mock_request.url.path = AUTH_OPEN_API_PATHS[0]
 
         with patch("workflow.extensions.otlp.trace.span.Span") as mock_span_class:
             mock_span, mock_span_ctx = create_mock_span_context()
@@ -342,6 +552,42 @@ class TestAuthMiddleware:
 
             assert result == mock_call_next.return_value
             mock_call_next.assert_called_once_with(mock_request)
+            assert mock_request.scope["headers"] == [
+                (b"x-consumer-username", x_consumer_username.encode())
+            ]
+
+    async def test_dispatch_wrong_internal_key_uses_verified_bearer_identity(
+        self,
+        auth_middleware: AuthMiddleware,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+    ) -> None:
+        mock_request.headers = {
+            "authorization": "Bearer public-key:public-secret",
+            "x-consumer-username": "forged-app",
+            WORKFLOW_INTERNAL_API_KEY_HEADER: "wrong-internal-key",
+        }
+        mock_request.scope["headers"] = [
+            (b"authorization", b"Bearer public-key:public-secret"),
+            (b"x-consumer-username", b"forged-app"),
+            (WORKFLOW_INTERNAL_API_KEY_HEADER.lower().encode(), b"wrong-internal-key"),
+        ]
+        mock_request.url.path = AUTH_OPEN_API_PATHS[0]
+
+        with patch.object(
+            auth_middleware,
+            "_get_app_source_detail_with_api_key",
+            new=AsyncMock(return_value="verified-app"),
+        ):
+            await auth_middleware.dispatch(mock_request, mock_call_next)
+
+        raw_headers = mock_request.scope["headers"]
+        assert raw_headers.count((b"x-consumer-username", b"verified-app")) == 1
+        assert not any(
+            name.lower() == WORKFLOW_INTERNAL_API_KEY_HEADER.lower().encode()
+            for name, _ in raw_headers
+        )
+        assert (b"x-consumer-username", b"forged-app") not in raw_headers
 
     async def test_dispatch_x_consumer_username_empty_string(
         self,
@@ -452,16 +698,16 @@ class TestAuthMiddleware:
                     mock_call_next.assert_not_called()
 
     @pytest.mark.parametrize(
-        "authorization_header,expected_api_key",
+        "authorization_header,expected_api_key,expected_api_secret",
         [
-            ("Bearer test_key:test_secret", "test_key"),
-            ("Bearer api_key_123:secret_456", "api_key_123"),
-            ("Bearer key:value:extra", "key"),
+            ("Bearer test_key:test_secret", "test_key", "test_secret"),
+            ("Bearer api_key_123:secret_456", "api_key_123", "secret_456"),
+            ("Bearer key:value:extra", "key", "value:extra"),
         ],
     )
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
         clear=False,
     )
     async def test_get_app_source_detail_api_key_parsing(
@@ -469,6 +715,7 @@ class TestAuthMiddleware:
         auth_middleware: AuthMiddleware,
         authorization_header: str,
         expected_api_key: str,
+        expected_api_secret: str,
     ) -> None:
         """Test API key parsing from authorization header."""
         mock_span = Mock()
@@ -477,7 +724,7 @@ class TestAuthMiddleware:
         with patch.object(auth_middleware, "_get_app_id_with_cache") as mock_get_cache:
             mock_get_cache.return_value = None
 
-            with patch("httpx.AsyncClient.get") as mock_get:
+            with patch("httpx.AsyncClient.post") as mock_post:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {
@@ -485,7 +732,7 @@ class TestAuthMiddleware:
                     "data": {"appid": "test_app_id"},
                 }
                 mock_response.text = "success"
-                mock_get.return_value = mock_response
+                mock_post.return_value = mock_response
 
                 with patch.object(auth_middleware, "_set_app_id_with_cache"):
                     result = await auth_middleware._get_app_source_detail_with_api_key(
@@ -493,7 +740,18 @@ class TestAuthMiddleware:
                     )
 
                     assert result == "test_app_id"
-                    mock_get_cache.assert_called_once_with(expected_api_key)
+                    credential = authorization_header.split(" ", 1)[1]
+                    mock_get_cache.assert_called_once_with(
+                        credential_cache_key(credential)
+                    )
+                    mock_post.assert_called_once_with(
+                        "https://api.example.com/v2/app/key/verify",
+                        json={
+                            "api_key": expected_api_key,
+                            "api_secret": expected_api_secret,
+                        },
+                        headers={},
+                    )
 
     @pytest.mark.parametrize(
         "authorization_header",
@@ -513,35 +771,17 @@ class TestAuthMiddleware:
 
         with patch.dict(
             os.environ,
-            {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+            {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
             clear=False,
         ):
-            # For "Bearer key:" case, this will not raise an exception as api_key will be "key"
-            if authorization_header == "Bearer key:":
-                with patch.object(
-                    auth_middleware, "_get_app_id_with_cache"
-                ) as mock_get_cache:
-                    mock_get_cache.return_value = None
-
-                    with patch("httpx.AsyncClient.get") as mock_get:
-                        mock_response = Mock()
-                        mock_response.status_code = 404
-                        mock_response.text = "Not found"
-                        mock_get.return_value = mock_response
-
-                        with pytest.raises(CustomException):
-                            await auth_middleware._get_app_source_detail_with_api_key(
-                                authorization_header, mock_span
-                            )
-            else:
-                with pytest.raises((CustomException, IndexError)):
-                    await auth_middleware._get_app_source_detail_with_api_key(
-                        authorization_header, mock_span
-                    )
+            with pytest.raises(CustomException):
+                await auth_middleware._get_app_source_detail_with_api_key(
+                    authorization_header, mock_span
+                )
 
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
         clear=False,
     )
     async def test_get_app_source_detail_with_cache_hit(
@@ -558,11 +798,48 @@ class TestAuthMiddleware:
             )
 
             assert result == "cached_app_id"
-            mock_get_cache.assert_called_once_with("test_key")
+            mock_get_cache.assert_called_once_with(
+                credential_cache_key("test_key:test_secret")
+            )
 
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
+        clear=False,
+    )
+    async def test_cache_does_not_accept_wrong_secret_for_cached_key(
+        self, auth_middleware: AuthMiddleware
+    ) -> None:
+        mock_span = Mock()
+        mock_span.add_info_event_async = AsyncMock()
+        valid_digest = credential_cache_key("same-key:valid-secret")
+
+        def cache_lookup(digest: str):
+            return "cached-app" if digest == valid_digest else None
+
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"code": 10003, "message": "invalid credential"}
+        response.text = "invalid credential"
+
+        with patch.object(
+            auth_middleware, "_get_app_id_with_cache", side_effect=cache_lookup
+        ) as mock_get_cache, patch(
+            "httpx.AsyncClient.post", new=AsyncMock(return_value=response)
+        ) as mock_post:
+            with pytest.raises(CustomException):
+                await auth_middleware._get_app_source_detail_with_api_key(
+                    "Bearer same-key:wrong-secret", mock_span
+                )
+
+        wrong_digest = credential_cache_key("same-key:wrong-secret")
+        assert wrong_digest != valid_digest
+        mock_get_cache.assert_called_once_with(wrong_digest)
+        mock_post.assert_awaited_once()
+
+    @patch.dict(
+        os.environ,
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
         clear=False,
     )
     async def test_get_app_source_detail_http_error_status(
@@ -575,7 +852,7 @@ class TestAuthMiddleware:
         with patch.object(auth_middleware, "_get_app_id_with_cache") as mock_get_cache:
             mock_get_cache.return_value = None
 
-            with patch("httpx.AsyncClient.get") as mock_get:
+            with patch("httpx.AsyncClient.post") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 404
                 mock_response.text = "Not found"
@@ -591,7 +868,7 @@ class TestAuthMiddleware:
                     == CodeEnum.APP_GET_WITH_REMOTE_FAILED_ERROR.code
                 )
                 mock_span.add_info_event_async.assert_called_once_with(
-                    "Application management platform response: Not found"
+                    "Application management platform credential verification completed"
                 )
 
     @pytest.mark.parametrize(
@@ -604,7 +881,7 @@ class TestAuthMiddleware:
     )
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
         clear=False,
     )
     async def test_get_app_source_detail_api_error_codes(
@@ -617,7 +894,7 @@ class TestAuthMiddleware:
         with patch.object(auth_middleware, "_get_app_id_with_cache") as mock_get_cache:
             mock_get_cache.return_value = None
 
-            with patch("httpx.AsyncClient.get") as mock_get:
+            with patch("httpx.AsyncClient.post") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {
@@ -646,7 +923,7 @@ class TestAuthMiddleware:
     )
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
         clear=False,
     )
     async def test_get_app_source_detail_valid_responses(
@@ -659,7 +936,7 @@ class TestAuthMiddleware:
         with patch.object(auth_middleware, "_get_app_id_with_cache") as mock_get_cache:
             mock_get_cache.return_value = None
 
-            with patch("httpx.AsyncClient.get") as mock_get:
+            with patch("httpx.AsyncClient.post") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {"code": 0, **response_data}
@@ -674,7 +951,9 @@ class TestAuthMiddleware:
                     )
 
                     assert result == expected_appid
-                    mock_set_cache.assert_called_once_with("test_key", expected_appid)
+                    mock_set_cache.assert_called_once_with(
+                        credential_cache_key("test_key:test_secret"), expected_appid
+                    )
 
     @pytest.mark.parametrize(
         "response_data",
@@ -687,7 +966,7 @@ class TestAuthMiddleware:
     )
     @patch.dict(
         os.environ,
-        {"APP_MANAGE_PLAT_APP_DETAILS_WITH_API_KEY": "https://api.example.com/app"},
+        {"APP_MANAGE_PLAT_BASE_URL": "https://api.example.com"},
         clear=False,
     )
     async def test_get_app_source_detail_missing_appid(
@@ -700,7 +979,7 @@ class TestAuthMiddleware:
         with patch.object(auth_middleware, "_get_app_id_with_cache") as mock_get_cache:
             mock_get_cache.return_value = None
 
-            with patch("httpx.AsyncClient.get") as mock_get:
+            with patch("httpx.AsyncClient.post") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {"code": 0, **response_data}
@@ -751,7 +1030,7 @@ class TestAuthMiddleware:
             with patch.object(auth_middleware, "_gen_app_auth_header") as mock_gen_auth:
                 mock_gen_auth.return_value = {"Authorization": "test_header"}
 
-                with patch("httpx.AsyncClient.get") as mock_get:
+                with patch("httpx.AsyncClient.post") as mock_get:
                     mock_response = Mock()
                     mock_response.status_code = 200
                     mock_response.json.return_value = {
@@ -767,9 +1046,10 @@ class TestAuthMiddleware:
                         )
 
                         mock_gen_auth.assert_called_once_with(
-                            "https://api.example.com/v2/app/key/api_key/test_key"
+                            "https://api.example.com/v2/app/key/verify"
                         )
                         mock_get.assert_called_once_with(
-                            "https://api.example.com/v2/app/key/api_key/test_key",
+                            "https://api.example.com/v2/app/key/verify",
+                            json={"api_key": "test_key", "api_secret": "test_secret"},
                             headers={"Authorization": "test_header"},
                         )

--- a/core/workflow/tests/extensions/fastapi/test_bootstrap_credentials.py
+++ b/core/workflow/tests/extensions/fastapi/test_bootstrap_credentials.py
@@ -1,0 +1,300 @@
+import hashlib
+from contextlib import contextmanager
+from datetime import datetime
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select  # type: ignore
+
+from workflow.domain.models.ai_app import App
+from workflow.domain.models.app_source import AppSource
+from workflow.extensions.fastapi.lifespan import (
+    bootstrap_credentials as bootstrap_module,
+)
+from workflow.extensions.fastapi.lifespan.bootstrap_credentials import (
+    BOOTSTRAP_TENANT_ID,
+    LEGACY_TENANT_KEY,
+    LEGACY_TENANT_SECRET,
+    TenantBootstrapCredentials,
+    invalidate_legacy_bootstrap_caches,
+    load_tenant_bootstrap_credentials,
+    synchronize_bootstrap_app,
+    synchronize_deployment_bootstrap_app,
+)
+
+
+@pytest.fixture
+def engine():
+    database_engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(
+        database_engine, tables=[AppSource.__table__, App.__table__]
+    )
+    with Session(database_engine) as session:
+        session.add(
+            AppSource(
+                id=1,
+                source=1,
+                source_id="admin",
+                description="星辰",
+                create_at=datetime.now(),
+                update_at=datetime.now(),
+            )
+        )
+        session.commit()
+    return database_engine
+
+
+def credentials() -> TenantBootstrapCredentials:
+    return TenantBootstrapCredentials(BOOTSTRAP_TENANT_ID, "k" * 48, "s" * 48)
+
+
+def deployment_owned_app(**overrides) -> App:
+    values = {
+        "id": 1,
+        "name": "星辰",
+        "alias_id": BOOTSTRAP_TENANT_ID,
+        "is_tenant": 1,
+        "source": 1,
+        "actual_source": 1,
+        "plat_release_auth": 1,
+        "status": 1,
+        "create_by": 1,
+        "update_by": 1,
+    }
+    values.update(overrides)
+    return App(**values)
+
+
+def test_synchronize_bootstrap_app_creates_reserved_row(engine) -> None:
+    with Session(engine) as session:
+        synchronize_bootstrap_app(session, credentials())
+        session.commit()
+
+        app = session.get(App, 1)
+        assert app is not None
+        assert app.alias_id == BOOTSTRAP_TENANT_ID
+        assert app.api_key == "k" * 48
+        assert app.api_secret == "s" * 48
+
+
+def test_synchronize_bootstrap_app_rotates_only_reserved_row(engine) -> None:
+    with Session(engine) as session:
+        session.add(
+            deployment_owned_app(
+                api_key=LEGACY_TENANT_KEY,
+                api_secret=LEGACY_TENANT_SECRET,
+                create_at=datetime.now(),
+                update_at=datetime.now(),
+            )
+        )
+        session.add(
+            App(
+                id=2,
+                name="user-app",
+                alias_id="user-app",
+                api_key="user-key",
+                create_by=2,
+                update_by=2,
+            )
+        )
+        session.commit()
+
+        synchronize_bootstrap_app(session, credentials())
+        session.commit()
+
+        bootstrap = session.get(App, 1)
+        user_app = session.get(App, 2)
+        assert bootstrap is not None and bootstrap.api_key == "k" * 48
+        assert user_app is not None and user_app.api_key == "user-key"
+
+
+def test_synchronize_bootstrap_app_rejects_alias_collision(engine) -> None:
+    with Session(engine) as session:
+        session.add(
+            App(
+                id=2,
+                name="user-app",
+                alias_id=BOOTSTRAP_TENANT_ID,
+                create_by=2,
+                update_by=2,
+            )
+        )
+        session.commit()
+
+        with pytest.raises(RuntimeError, match="alias is already in use"):
+            synchronize_bootstrap_app(session, credentials())
+
+
+def test_synchronize_bootstrap_app_rotates_strong_custom_pair(engine) -> None:
+    with Session(engine) as session:
+        session.add(
+            deployment_owned_app(
+                api_key="x" * 48,
+                api_secret="y" * 48,
+            )
+        )
+        session.commit()
+
+        synchronize_bootstrap_app(session, credentials())
+        session.commit()
+
+        app = session.get(App, 1)
+        assert app is not None
+        assert app.api_key == "k" * 48
+        assert app.api_secret == "s" * 48
+
+
+def test_second_rotation_revokes_old_digest_only_after_commit(
+    engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_key = "x" * 48
+    old_secret = "y" * 48
+    with Session(engine) as session:
+        session.add(deployment_owned_app(api_key=old_key, api_secret=old_secret))
+        session.commit()
+
+    commit_state = {"committed": False}
+
+    @contextmanager
+    def committed_session():
+        with Session(engine) as session:
+            yield session
+            session.commit()
+            commit_state["committed"] = True
+
+    class _CommitAwareCache(_RecordingCache):
+        def delete(self, key: str) -> None:
+            assert commit_state["committed"]
+            super().delete(key)
+
+    cache = _CommitAwareCache()
+    monkeypatch.setattr(bootstrap_module, "session_getter", committed_session)
+    monkeypatch.setattr(bootstrap_module, "get_cache_service", lambda: cache)
+
+    synchronize_deployment_bootstrap_app(credentials())
+
+    old_digest = hashlib.sha256(f"{old_key}:{old_secret}".encode()).hexdigest()
+    assert f"workflow:app:verified_credential:v2:{old_digest}" in cache.deleted
+    with Session(engine) as session:
+        app = session.get(App, 1)
+        assert app is not None
+        assert (app.api_key, app.api_secret) == ("k" * 48, "s" * 48)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("is_tenant", 0),
+        ("source", 0),
+        ("actual_source", 0),
+        ("plat_release_auth", 0),
+        ("status", 0),
+    ],
+)
+def test_synchronize_bootstrap_app_rejects_tampered_reserved_identity(
+    engine, field: str, value: int
+) -> None:
+    with Session(engine) as session:
+        session.add(deployment_owned_app(**{field: value}))
+        session.commit()
+
+        with pytest.raises(RuntimeError, match="identity is invalid"):
+            synchronize_bootstrap_app(session, credentials())
+
+
+def test_synchronize_bootstrap_app_accepts_matching_custom_pair(engine) -> None:
+    configured = credentials()
+    with Session(engine) as session:
+        session.add(
+            deployment_owned_app(
+                api_key=configured.api_key,
+                api_secret=configured.api_secret,
+            )
+        )
+        session.commit()
+
+        synchronize_bootstrap_app(session, configured)
+        session.commit()
+
+        app = session.get(App, 1)
+        assert app is not None
+        assert (app.api_key, app.api_secret) == (
+            configured.api_key,
+            configured.api_secret,
+        )
+
+
+def test_load_tenant_bootstrap_credentials_from_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    key_file = tmp_path / "tenant-key"
+    secret_file = tmp_path / "tenant-secret"
+    key_file.write_text("k" * 48 + "\n", encoding="utf-8")
+    secret_file.write_text("s" * 48 + "\n", encoding="utf-8")
+    monkeypatch.setenv("TENANT_ID", BOOTSTRAP_TENANT_ID)
+    monkeypatch.delenv("TENANT_KEY", raising=False)
+    monkeypatch.delenv("TENANT_SECRET", raising=False)
+    monkeypatch.setenv("TENANT_KEY_FILE", str(key_file))
+    monkeypatch.setenv("TENANT_SECRET_FILE", str(secret_file))
+
+    loaded = load_tenant_bootstrap_credentials()
+
+    assert loaded == credentials()
+
+
+def test_load_tenant_bootstrap_credentials_rejects_legacy_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TENANT_ID", BOOTSTRAP_TENANT_ID)
+    monkeypatch.setenv("TENANT_KEY", LEGACY_TENANT_KEY)
+    monkeypatch.setenv("TENANT_SECRET", LEGACY_TENANT_SECRET)
+
+    with pytest.raises(RuntimeError, match="legacy"):
+        load_tenant_bootstrap_credentials()
+
+
+def test_load_tenant_bootstrap_credentials_rejects_header_separator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TENANT_ID", BOOTSTRAP_TENANT_ID)
+    monkeypatch.setenv("TENANT_KEY", "k" * 47 + ":")
+    monkeypatch.setenv("TENANT_SECRET", "s" * 48)
+
+    with pytest.raises(RuntimeError, match="unsafe"):
+        load_tenant_bootstrap_credentials()
+
+
+class _RecordingCache:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    def scan_keys(self, pattern: str) -> list[str]:
+        assert pattern == "workflow:flow_info:v2:*"
+        return [
+            "workflow:flow_info:v2:1",
+            "workflow:flow_info:v2:1:latest",
+        ]
+
+    def delete(self, key: str) -> None:
+        self.deleted.append(key)
+
+
+def test_invalidate_legacy_bootstrap_caches_revokes_all_old_namespaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _RecordingCache()
+    monkeypatch.setattr(bootstrap_module, "get_cache_service", lambda: cache)
+
+    invalidate_legacy_bootstrap_caches(credentials())
+
+    assert "workflow:app_info:680ab54f" in cache.deleted
+    assert "workflow:app_info:v2:680ab54f" in cache.deleted
+    assert "workflow:app:api_key:7b709739e8da44536127a333c7603a83" in cache.deleted
+    assert "workflow:flow_info:v2:1" in cache.deleted
+    assert "workflow:flow_info:v2:1:latest" in cache.deleted
+    assert any(
+        key.startswith("workflow:app:verified_credential:")
+        and key.endswith(
+            "8f36ac6b8a917de90c78ca6828908790c0f0df33a319e3b793a35e2dc988f18f"
+        )
+        for key in cache.deleted
+    )

--- a/core/workflow/tests/extensions/fastapi/test_database_migration_lock.py
+++ b/core/workflow/tests/extensions/fastapi/test_database_migration_lock.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+import pytest
+
+from workflow.extensions.fastapi.lifespan import database_migration
+from workflow.extensions.middleware.cache.manager import RedisCache
+
+
+class _FakeLock:
+    def __init__(self, acquired: bool = True, release_error: Exception | None = None):
+        self.acquired = acquired
+        self.release_error = release_error
+        self.released = False
+
+    def acquire(self) -> bool:
+        return self.acquired
+
+    def release(self) -> None:
+        if self.release_error is not None:
+            raise self.release_error
+        self.released = True
+
+
+class _LockingCache:
+    def __init__(self, lock: _FakeLock):
+        self.lock = lock
+        self.arguments: tuple[object, ...] | None = None
+
+    def distributed_lock(
+        self,
+        key: str,
+        *,
+        timeout: float,
+        blocking_timeout: float,
+        sleep: float,
+    ) -> _FakeLock:
+        self.arguments = (key, timeout, blocking_timeout, sleep)
+        return self.lock
+
+
+def _patch_runtime(monkeypatch: pytest.MonkeyPatch, cache: _LockingCache) -> None:
+    monkeypatch.setattr(database_migration, "get_cache_service", lambda: cache)
+    monkeypatch.setattr(database_migration.command, "upgrade", lambda *_args: None)
+    monkeypatch.setattr(Path, "exists", lambda _self: True)
+
+
+def test_migration_loser_blocks_until_ownership_safe_lock_is_acquired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = _FakeLock()
+    cache = _LockingCache(lock)
+    _patch_runtime(monkeypatch, cache)
+
+    database_migration.run_database_migration()
+
+    assert cache.arguments == (
+        database_migration.MIGRATION_LOCK_KEY,
+        database_migration.MIGRATION_LOCK_TTL_SECONDS,
+        database_migration.MIGRATION_LOCK_WAIT_SECONDS,
+        database_migration.MIGRATION_LOCK_POLL_SECONDS,
+    )
+    assert lock.released
+
+
+def test_migration_lock_timeout_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = _LockingCache(_FakeLock(acquired=False))
+    _patch_runtime(monkeypatch, cache)
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        database_migration.run_database_migration()
+
+
+def test_expired_owner_cannot_silently_release_new_owner_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _LockingCache(
+        _FakeLock(release_error=RuntimeError("lock is no longer owned"))
+    )
+    _patch_runtime(monkeypatch, cache)
+
+    with pytest.raises(RuntimeError, match="no longer owned"):
+        database_migration.run_database_migration()
+
+
+def test_redis_lock_uses_redis_3_5_compatible_arguments() -> None:
+    class _RecordingRedisClient:
+        def __init__(self) -> None:
+            self.kwargs: dict[str, object] | None = None
+
+        def lock(self, **kwargs):
+            self.kwargs = kwargs
+            return "lock"
+
+    client = _RecordingRedisClient()
+    cache = RedisCache.__new__(RedisCache)
+    cache._client = client
+
+    lock = cache.distributed_lock(
+        "migration-lock", timeout=10.0, blocking_timeout=12.0, sleep=0.2
+    )
+
+    assert lock == "lock"
+    assert client.kwargs == {
+        "name": "migration-lock",
+        "timeout": 10.0,
+        "sleep": 0.2,
+        "blocking_timeout": 12.0,
+        "thread_local": False,
+    }

--- a/core/workflow/tests/extensions/fastapi/test_internal_api_auth.py
+++ b/core/workflow/tests/extensions/fastapi/test_internal_api_auth.py
@@ -1,9 +1,16 @@
 import pytest
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 
+from workflow.api.v1.chat.debug import router as chat_debug_router
 from workflow.api.v1.chat.node_debug import router as node_debug_router
+from workflow.api.v1.flow.auth import router as auth_router
+from workflow.api.v1.flow.file import router as file_router
+from workflow.api.v1.flow.layout import router as layout_router
+from workflow.extensions.fastapi.base import AUTH_OPEN_API_PATHS
 from workflow.extensions.fastapi.middleware.auth import (
     WORKFLOW_INTERNAL_API_KEY_ENV,
+    WORKFLOW_INTERNAL_API_KEY_FILE_ENV,
+    WORKFLOW_INTERNAL_API_KEY_MAX_FILE_BYTES,
     WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER,
     require_workflow_internal_api_key,
 )
@@ -13,16 +20,20 @@ from workflow.extensions.fastapi.middleware.auth import (
 async def test_internal_api_auth_accepts_configured_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, "server-secret")
+    configured_key = "s" * 32
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, configured_key)
+    monkeypatch.delenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, raising=False)
 
-    await require_workflow_internal_api_key("server-secret")
+    await require_workflow_internal_api_key(configured_key)
 
 
 @pytest.mark.asyncio
 async def test_internal_api_auth_rejects_missing_or_wrong_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, "server-secret")
+    configured_key = "s" * 32
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_ENV, configured_key)
+    monkeypatch.delenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, raising=False)
 
     for supplied_key in (None, "", "wrong-secret"):
         with pytest.raises(HTTPException) as exc_info:
@@ -44,9 +55,78 @@ async def test_internal_api_auth_fails_closed_when_not_configured(
     assert exc_info.value.status_code == 503
 
 
+@pytest.mark.asyncio
+async def test_internal_api_auth_reads_persisted_key_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    configured_key = "f" * 48
+    key_file = tmp_path / "workflow-internal-api-key"
+    key_file.write_text(f"{configured_key}\n", encoding="utf-8")
+    monkeypatch.setenv(
+        WORKFLOW_INTERNAL_API_KEY_ENV, WORKFLOW_INTERNAL_API_KEY_PLACEHOLDER
+    )
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, str(key_file))
+
+    await require_workflow_internal_api_key(configured_key)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("file_state", ["missing", "short", "oversized", "symlink"])
+async def test_internal_api_auth_rejects_invalid_key_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, file_state: str
+) -> None:
+    key_file = tmp_path / "workflow-internal-api-key"
+    if file_state == "short":
+        key_file.write_text("too-short", encoding="utf-8")
+    elif file_state == "oversized":
+        key_file.write_text(
+            "x" * (WORKFLOW_INTERNAL_API_KEY_MAX_FILE_BYTES + 1), encoding="utf-8"
+        )
+    elif file_state == "symlink":
+        target = tmp_path / "target"
+        target.write_text("f" * 48, encoding="utf-8")
+        key_file.symlink_to(target)
+
+    monkeypatch.delenv(WORKFLOW_INTERNAL_API_KEY_ENV, raising=False)
+    monkeypatch.setenv(WORKFLOW_INTERNAL_API_KEY_FILE_ENV, str(key_file))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_workflow_internal_api_key("f" * 48)
+
+    assert exc_info.value.status_code == 503
+
+
 def test_every_node_debug_route_requires_internal_auth() -> None:
     for route in node_debug_router.routes:
         assert any(
             dependency.call is require_workflow_internal_api_key
             for dependency in route.dependant.dependencies
         ), route.path
+
+
+def test_every_chat_debug_route_requires_internal_auth() -> None:
+    for route in chat_debug_router.routes:
+        assert any(
+            dependency.call is require_workflow_internal_api_key
+            for dependency in route.dependant.dependencies
+        ), route.path
+
+
+@pytest.mark.parametrize("protected_router", [layout_router, file_router])
+def test_every_workflow_management_route_requires_internal_auth(
+    protected_router: APIRouter,
+) -> None:
+    for route in protected_router.routes:
+        assert any(
+            dependency.call is require_workflow_internal_api_key
+            for dependency in route.dependant.dependencies
+        ), route.path
+
+
+def test_publish_and_binding_routes_remain_middleware_authenticated() -> None:
+    mounted_paths = {
+        f"{prefix}{route.path}"
+        for prefix in ("/workflow/v1", "/v1")
+        for route in auth_router.routes
+    }
+    assert mounted_paths == set(AUTH_OPEN_API_PATHS)

--- a/core/workflow/tests/service/test_app_service_internal_auth.py
+++ b/core/workflow/tests/service/test_app_service_internal_auth.py
@@ -1,0 +1,42 @@
+"""Tenant management calls must include the deployment-managed internal key."""
+
+from unittest.mock import patch
+
+from workflow.service.app_service import _gen_app_auth_header
+from workflow.utils.credentials import TENANT_INTERNAL_API_KEY_HEADER
+
+
+def test_gen_app_auth_header_includes_tenant_internal_key(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("APP_MANAGE_PLAT_KEY", "k" * 48)
+    monkeypatch.setenv("APP_MANAGE_PLAT_SECRET", "s" * 48)
+    monkeypatch.delenv("APP_MANAGE_PLAT_KEY_FILE", raising=False)
+    monkeypatch.delenv("APP_MANAGE_PLAT_SECRET_FILE", raising=False)
+
+    with patch(
+        "workflow.service.app_service.HMACAuth.build_auth_header",
+        return_value={"Authorization": "signed"},
+    ) as build_auth_header:
+        headers = _gen_app_auth_header("http://core-tenant:5052/v2/app/details")
+
+    assert headers == {
+        "Authorization": "signed",
+        TENANT_INTERNAL_API_KEY_HEADER: "s" * 48,
+    }
+    build_auth_header.assert_called_once_with(
+        request_url="http://core-tenant:5052/v2/app/details",
+        api_key="k" * 48,
+        api_secret="s" * 48,
+    )
+
+
+def test_gen_app_auth_header_fails_closed_without_complete_credentials(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("APP_MANAGE_PLAT_KEY", "k" * 48)
+    monkeypatch.delenv("APP_MANAGE_PLAT_SECRET", raising=False)
+    monkeypatch.delenv("APP_MANAGE_PLAT_KEY_FILE", raising=False)
+    monkeypatch.delenv("APP_MANAGE_PLAT_SECRET_FILE", raising=False)
+
+    assert _gen_app_auth_header("http://core-tenant:5052/v2/app/list") == {}

--- a/core/workflow/tests/service/test_flow_protocol_boundaries.py
+++ b/core/workflow/tests/service/test_flow_protocol_boundaries.py
@@ -127,14 +127,14 @@ def test_get_latest_published_sanitizes_cached_release_protocol() -> None:
     }
 
 
-def test_cache_uses_v2_namespace_and_never_receives_unsanitized_flow() -> None:
+def test_cache_uses_v3_namespace_and_never_receives_unsanitized_flow() -> None:
     cache_service = MagicMock()
     source = Flow(id=101, group_id=101, data=_legacy_protocol())
 
     with patch.object(flow_cache, "get_cache_service", return_value=cache_service):
         flow_cache.set_flow_by_id("101", source)
 
-    assert cache_service.set.call_args.kwargs["key"] == "workflow:flow_info:v2:101"
+    assert cache_service.set.call_args.kwargs["key"] == "workflow:flow_info:v3:101"
     cached = cache_service.set.call_args.kwargs["value"]
     assert cached is not source
     assert cached.data["data"]["nodes"][0]["sandbox"] == {

--- a/core/workflow/tests/test_protocol_sanitization.py
+++ b/core/workflow/tests/test_protocol_sanitization.py
@@ -92,6 +92,29 @@ def test_sanitizer_handles_embedded_json_and_preserves_invalid_storage_text() ->
     assert sanitize_protocol(invalid) == invalid
 
 
+def test_sanitizer_removes_only_the_exact_disclosed_bootstrap_values() -> None:
+    legacy_key = "7b709739e8da44536127a333c7603a83"
+    legacy_secret = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+    protocol = {
+        "apiKey": legacy_key,
+        "apiSecret": legacy_secret,
+        "customApiKey": "customer-key",
+        "embedded": json.dumps(
+            {"api_key": legacy_key, "api_secret": "customer-secret"}
+        ),
+    }
+
+    sanitized = sanitize_protocol(protocol)
+
+    assert sanitized["apiKey"] == ""
+    assert sanitized["apiSecret"] == ""
+    assert sanitized["customApiKey"] == "customer-key"
+    assert json.loads(sanitized["embedded"]) == {
+        "api_key": "",
+        "api_secret": "customer-secret",
+    }
+
+
 def test_runtime_document_sanitizer_fails_closed_for_invalid_json() -> None:
     assert sanitize_protocol_document_for_use('{"sandbox":') == {}
     assert sanitize_protocol_document_for_use('"not-a-protocol"') == {}

--- a/core/workflow/utils/credentials.py
+++ b/core/workflow/utils/credentials.py
@@ -1,0 +1,75 @@
+"""Small, fail-closed helpers for deployment-managed credential files."""
+
+import os
+import stat
+from typing import Collection
+
+MAX_CREDENTIAL_FILE_BYTES = 4096
+TENANT_INTERNAL_API_KEY_HEADER = "X-Tenant-Internal-Key"
+
+
+def read_credential_file(file_name: str) -> str:
+    """Read a bounded regular file through one non-following file descriptor."""
+    if not file_name:
+        return ""
+    descriptor = -1
+    try:
+        before_open = os.lstat(file_name)
+        if stat.S_ISLNK(before_open.st_mode) or not stat.S_ISREG(before_open.st_mode):
+            return ""
+        if before_open.st_size > MAX_CREDENTIAL_FILE_BYTES:
+            return ""
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(file_name, flags)
+        after_open = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(after_open.st_mode)
+            or not os.path.samestat(before_open, after_open)
+            or after_open.st_size > MAX_CREDENTIAL_FILE_BYTES
+        ):
+            return ""
+        data = bytearray()
+        while len(data) <= MAX_CREDENTIAL_FILE_BYTES:
+            chunk = os.read(
+                descriptor,
+                min(1024, MAX_CREDENTIAL_FILE_BYTES + 1 - len(data)),
+            )
+            if not chunk:
+                break
+            data.extend(chunk)
+        if len(data) > MAX_CREDENTIAL_FILE_BYTES:
+            return ""
+        return bytes(data).decode("utf-8").strip()
+    except (OSError, UnicodeError):
+        return ""
+    finally:
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def credential_from_env_or_file(
+    value_env: str,
+    file_env: str,
+    *,
+    min_length: int = 1,
+    max_length: int = MAX_CREDENTIAL_FILE_BYTES,
+    placeholders: Collection[str] = (),
+) -> str:
+    """Prefer a valid environment value, then a deployment-managed file."""
+
+    def valid(value: str) -> bool:
+        return (
+            min_length <= len(value) <= max_length
+            and "\r" not in value
+            and "\n" not in value
+            and value not in placeholders
+        )
+
+    value = os.getenv(value_env, "").strip()
+    if valid(value):
+        return value
+    value = read_credential_file(os.getenv(file_env, "").strip())
+    return value if valid(value) else ""

--- a/core/workflow/utils/protocol_sanitization.py
+++ b/core/workflow/utils/protocol_sanitization.py
@@ -27,6 +27,14 @@ _SANDBOX_ALLOWED_KEYS = {
     "nodeid",
 }
 
+# These exact bootstrap credentials were published in historical deployment
+# examples. They are deployment secrets, not legitimate model credentials, so
+# remove only these disclosed values wherever an old protocol copy is loaded.
+_DISCLOSED_BOOTSTRAP_VALUES = {
+    "7b709739e8da44536127a333c7603a83",
+    "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy",
+}
+
 # These fields were previously copied from deployment configuration into persisted
 # workflow JSON.  Match their camelCase, snake_case, kebab-case, and case variants by
 # comparing normalized keys.  Deliberately do not include apiKey/api_key: those names
@@ -103,6 +111,8 @@ def _sanitize_value(value: Any) -> Any:
     if isinstance(value, list):
         return [_sanitize_value(item) for item in value]
     if isinstance(value, str):
+        if value in _DISCLOSED_BOOTSTRAP_VALUES:
+            return ""
         return _sanitize_json_string(value)
     return copy.deepcopy(value)
 

--- a/docker/astronAgent/.env.example
+++ b/docker/astronAgent/.env.example
@@ -52,11 +52,11 @@ KAFKA_TIMEOUT=60
 KAFKA_SERVERS=kafka:29092
 
 # MinIO Configuration
-# Required: choose a unique username (at least 8 characters) and a random
-# password (at least 16 characters). Known defaults and CHANGE_ME placeholders
-# are rejected before MinIO starts. Example generator: openssl rand -hex 24
-MINIO_ROOT_USER=
-MINIO_ROOT_PASSWORD=
+# The bundled Compose stack keeps zero-configuration credentials, matching the
+# other private middleware services. Override them when exposing MinIO beyond
+# the default host-loopback/private-network boundary.
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin123
 # Local maintenance access is bound to 127.0.0.1 by docker-compose.yaml. These
 # variables select the loopback ports; they do not expose MinIO on other hosts.
 EXPOSE_MINIO_PORT=18998
@@ -68,9 +68,9 @@ EXPOSE_MINIO_CONSOLE_PORT=18999
 # Use an explicit Compose override when replacing bundled MinIO with external S3.
 OSS_TYPE=s3
 OSS_ENDPOINT=http://minio:${EXPOSE_MINIO_PORT}
-# Required and intentionally derived from the bundled MinIO credentials.
-OSS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
-OSS_ACCESS_KEY_SECRET=${MINIO_ROOT_PASSWORD}
+# Derived from the bundled MinIO credentials by default.
+OSS_ACCESS_KEY_ID=${MINIO_ROOT_USER:-minioadmin}
+OSS_ACCESS_KEY_SECRET=${MINIO_ROOT_PASSWORD:-minioadmin123}
 OSS_BUCKET_NAME=workflow
 OSS_TTL=157788000
 OSS_DOWNLOAD_HOST=http://minio.localhost:${EXPOSE_MINIO_PORT}
@@ -100,10 +100,9 @@ LANGFUSE_MAX_ATTRIBUTE_LENGTH=8192
 LANGFUSE_ENVIRONMENT=default
 LANGFUSE_RELEASE=
 
-# Required for console-hub to call privileged workflow debug APIs.
-# Replace this placeholder with at least 32 random bytes before deployment,
-# for example: openssl rand -hex 32
-WORKFLOW_INTERNAL_API_KEY=CHANGE_ME_WORKFLOW_INTERNAL_API_KEY
+# Generated and persisted automatically on first startup. Leave empty for the
+# zero-configuration path, or provide a 32-128 character safe override.
+WORKFLOW_INTERNAL_API_KEY=
 
 # Nginx configuration
 EXPOSE_NGINX_PORT=80
@@ -198,8 +197,7 @@ RUN_MCP_PLUGIN_URL=http://core-link:18888/api/v1/mcp/call_tool
 # Application authentication configuration
 APP_AUTH_HOST=core-tenant:${CORE_TENANT_PORT:-5052}
 APP_AUTH_PROT=http
-APP_AUTH_API_KEY=7b709739e8da44536127a333c7603a83
-APP_AUTH_SECRET=NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy
+# APP_AUTH credentials are derived from the generated tenant bootstrap Secret.
 
 # - Workflow-specific Configuration
 WORKFLOW_MYSQL_DB=workflow
@@ -262,16 +260,15 @@ WORKFLOW_CHAT_URL=http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/c
 WORKFLOW_DEBUG_URL=http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/debug/chat/completions
 WORKFLOW_RESUME_URL=http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/resume
 
-# Toolkit tenant systemWhen calling the flow system, it is necessary.
-# The value here is pre-written to the database when the core-tenant component is started, see: core/tenant/sql/tenant.sql
+# The ID remains stable for persisted data. Key and secret are generated and
+# persisted automatically on first startup; optional strong overrides are
+# accepted without changing the normal startup flow.
 TENANT_ID=680ab54f
-TENANT_KEY=7b709739e8da44536127a333c7603a83
-TENANT_SECRET=NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy
+TENANT_KEY=
+TENANT_SECRET=
 
-# Common appId, requiring Spark Model authorization
-COMMON_APPID=${TENANT_ID}
-COMMON_APIKEY=${TENANT_KEY}
-COMMON_API_SECRET=${TENANT_SECRET}
+# Console common/MaaS credentials are derived from the same generated tenant
+# bootstrap Secret inside the deployment.
 
 # Toolkit Admin uid The plugin created by this user ID defaults to the official plugin
 ADMIN_UID=9999
@@ -288,14 +285,6 @@ SPARK_DB_URL=http://core-database:${CORE_DATABASE_PORT:-7990}
 LOCAL_MODEL_URL=http://127.0.0.1:33778
 
 # MaaS Platform Configuration
-MAAS_APP_ID=${TENANT_ID}
-MAAS_API_KEY=${TENANT_KEY}
-MAAS_API_SECRET=${TENANT_SECRET}
-
-MAAS_CONSUMER_ID=${TENANT_ID}
-MAAS_CONSUMER_KEY=${TENANT_KEY}
-MAAS_CONSUMER_SECRET=${TENANT_SECRET}
-
 MAAS_WORKFLOW_VERSION=http://127.0.0.1:8080/workflow/version
 MAAS_SYNCHRONIZE_WORK_FLOW=http://127.0.0.1:8080/workflow
 MAAS_PUBLISH=http://127.0.0.1:8080/workflow/publish

--- a/docker/astronAgent/astronRPA/docker-compose.yml
+++ b/docker/astronAgent/astronRPA/docker-compose.yml
@@ -50,13 +50,8 @@ services:
     healthcheck:
       test:
         [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u${DATABASE_USERNAME}',
-          '-p${DATABASE_PASSWORD}',
+          'CMD-SHELL',
+          'mysqladmin ping -h localhost -u"$${DATABASE_USERNAME}" -p"$${DATABASE_PASSWORD}"',
         ]
       interval: 10s
       timeout: 5s

--- a/docker/astronAgent/config/agent/config.env
+++ b/docker/astronAgent/config/agent/config.env
@@ -100,10 +100,11 @@ RUN_MCP_PLUGIN_URL=http://YOUR_MCP_HOST:18888/api/v1/mcp/call_tool
 
 # App Authentication Configuration
 APP_AUTH_HOST=YOUR_APP_AUTH_HOST
-APP_AUTH_ROUTER=/api-services/v2/app/details
+APP_AUTH_ROUTER=/v2/app/details
 APP_AUTH_PROT=http
-APP_AUTH_API_KEY=YOUR_APP_AUTH_API_KEY
-APP_AUTH_SECRET=YOUR_APP_AUTH_SECRET
+# Deployment-managed credentials are supplied through APP_AUTH_*_FILE.
+APP_AUTH_API_KEY=
+APP_AUTH_SECRET=
 
 # LLM Request Configuration
 # Skip SSL certificate verification (only for development/testing)

--- a/docker/astronAgent/config/workflow/config.env
+++ b/docker/astronAgent/config/workflow/config.env
@@ -144,7 +144,7 @@ CODE_EXEC_URL=
 CODE_EXEC_TIMEOUT_SEC=10
 CODE_EXEC_API_KEY=
 CODE_EXEC_API_SECRET=
-WORKFLOW_INTERNAL_API_KEY=CHANGE_ME_WORKFLOW_INTERNAL_API_KEY
+WORKFLOW_INTERNAL_API_KEY=
 
 # Image Understanding Model Configuration
 # Spark image model domain specifications for visual AI processing

--- a/docker/astronAgent/docker-compose.yaml
+++ b/docker/astronAgent/docker-compose.yaml
@@ -3,6 +3,144 @@ services:
   # Infrastructure Services
   # ============================================================================
 
+  # Generate deployment-internal credentials once and persist them in named
+  # volumes. Existing strong .env overrides are preserved; published legacy
+  # defaults are rotated automatically so upgrades remain zero-configuration.
+  internal-credentials-init:
+    image: busybox:1.35
+    container_name: astron-agent-internal-credentials-init
+    environment:
+      CONFIGURED_WORKFLOW_INTERNAL_API_KEY: "${WORKFLOW_INTERNAL_API_KEY:-}"
+      CONFIGURED_TENANT_KEY: "${TENANT_KEY:-}"
+      CONFIGURED_TENANT_SECRET: "${TENANT_SECRET:-}"
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        umask 077
+        legacy_tenant_key='7b709739e8da44536127a333c7603a83'
+        legacy_tenant_secret='NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy'
+        workflow_placeholder='CHANGE_ME_WORKFLOW_INTERNAL_API_KEY'
+
+        safe_token() {
+          value="$$1"
+          min_length="$$2"
+          max_length="$$3"
+          [ "$${#value}" -ge "$$min_length" ] || return 1
+          [ "$${#value}" -le "$$max_length" ] || return 1
+          case "$$value" in *[!A-Za-z0-9._~-]*) return 1 ;; esac
+        }
+
+        read_valid_file() {
+          file="$$1"
+          min_length="$$2"
+          max_length="$$3"
+          [ -f "$$file" ] && [ ! -L "$$file" ] || return 1
+          value="$$(sed -n '1p' "$$file")"
+          safe_token "$$value" "$$min_length" "$$max_length" || return 1
+          printf '%s' "$$value"
+        }
+
+        generate_hex() {
+          byte_count="$$1"
+          value="$$(dd if=/dev/urandom bs="$$byte_count" count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+          [ "$${#value}" -eq "$$((byte_count * 2))" ] || {
+            echo 'Unable to generate internal credentials.' >&2
+            exit 1
+          }
+          printf '%s' "$$value"
+        }
+
+        write_secret() {
+          directory="$$1"
+          name="$$2"
+          value="$$3"
+          temporary="$$directory/.$$name.tmp.$$$$"
+          mkdir -p "$$directory"
+          printf '%s\n' "$$value" > "$$temporary"
+          chmod 0444 "$$temporary"
+          mv -f "$$temporary" "$$directory/$$name"
+        }
+
+        workflow_key="$$CONFIGURED_WORKFLOW_INTERNAL_API_KEY"
+        if [ "$$workflow_key" = "$$workflow_placeholder" ]; then
+          workflow_key=''
+        fi
+        if [ -n "$$workflow_key" ]; then
+          safe_token "$$workflow_key" 32 128 || {
+            echo 'WORKFLOW_INTERNAL_API_KEY must contain 32-128 safe characters.' >&2
+            exit 1
+          }
+        else
+          workflow_key="$$(read_valid_file /secrets/workflow/workflow-internal-api-key 32 128 || true)"
+          if [ "$$workflow_key" = "$$workflow_placeholder" ]; then
+            workflow_key=''
+          fi
+          [ -n "$$workflow_key" ] || workflow_key="$$(generate_hex 32)"
+        fi
+
+        tenant_key="$$CONFIGURED_TENANT_KEY"
+        tenant_secret="$$CONFIGURED_TENANT_SECRET"
+        if [ "$$tenant_key" = "$$legacy_tenant_key" ] && [ "$$tenant_secret" = "$$legacy_tenant_secret" ]; then
+          tenant_key=''
+          tenant_secret=''
+        fi
+        if [ -n "$$tenant_key" ] || [ -n "$$tenant_secret" ]; then
+          safe_token "$$tenant_key" 32 50 && safe_token "$$tenant_secret" 32 50 && \
+            [ "$$tenant_key" != "$$tenant_secret" ] && \
+            [ "$$tenant_key" != "$$legacy_tenant_key" ] && \
+            [ "$$tenant_secret" != "$$legacy_tenant_secret" ] || {
+            echo 'TENANT_KEY and TENANT_SECRET must be distinct 32-50 character safe values.' >&2
+            exit 1
+          }
+        else
+          tenant_key="$$(read_valid_file /secrets/tenant/tenant-key 32 50 || true)"
+          tenant_secret="$$(read_valid_file /secrets/tenant/tenant-secret 32 50 || true)"
+          if [ "$$tenant_key" = "$$legacy_tenant_key" ] || [ "$$tenant_secret" = "$$legacy_tenant_secret" ] || [ "$$tenant_key" = "$$tenant_secret" ]; then
+            tenant_key=''
+            tenant_secret=''
+          fi
+          if [ -z "$$tenant_key" ] || [ -z "$$tenant_secret" ]; then
+            tenant_key="$$(generate_hex 24)"
+            tenant_secret="$$(generate_hex 24)"
+          fi
+        fi
+
+        write_secret /secrets/workflow workflow-internal-api-key "$$workflow_key"
+        write_secret /secrets/tenant tenant-key "$$tenant_key"
+        write_secret /secrets/tenant tenant-secret "$$tenant_secret"
+
+        workflow_properties="/secrets/workflow/.workflow-internal.properties.tmp.$$$$"
+        printf 'workflow.internal-api-key=%s\n' "$$workflow_key" > "$$workflow_properties"
+        chmod 0444 "$$workflow_properties"
+        mv -f "$$workflow_properties" /secrets/workflow/workflow-internal.properties
+
+        tenant_properties="/secrets/tenant/.tenant-bootstrap.properties.tmp.$$$$"
+        {
+          printf 'api.url.tenantId=680ab54f\n'
+          printf 'api.url.tenantKey=%s\n' "$$tenant_key"
+          printf 'api.url.tenantSecret=%s\n' "$$tenant_secret"
+          printf 'api.url.apiKey=%s\n' "$$tenant_key"
+          printf 'api.url.apiSecret=%s\n' "$$tenant_secret"
+          printf 'common.appid=680ab54f\n'
+          printf 'common.apiKey=%s\n' "$$tenant_key"
+          printf 'common.apiSecret=%s\n' "$$tenant_secret"
+          printf 'maas.appId=680ab54f\n'
+          printf 'maas.apiKey=%s\n' "$$tenant_key"
+          printf 'maas.apiSecret=%s\n' "$$tenant_secret"
+          printf 'maas.consumerId=680ab54f\n'
+          printf 'maas.consumerKey=%s\n' "$$tenant_key"
+          printf 'maas.consumerSecret=%s\n' "$$tenant_secret"
+        } > "$$tenant_properties"
+        chmod 0444 "$$tenant_properties"
+        mv -f "$$tenant_properties" /secrets/tenant/tenant-bootstrap.properties
+        echo 'Internal credentials are initialized.'
+    network_mode: none
+    volumes:
+      - workflow_internal_secrets:/secrets/workflow
+      - tenant_bootstrap_secrets:/secrets/tenant
+    restart: "no"
+
   # PostgreSQL Database
   postgres:
     image: postgres:14
@@ -122,38 +260,35 @@ services:
 #      timeout: ${HEALTH_CHECK_TIMEOUT:-10s}
 #      retries: ${HEALTH_CHECK_RETRIES:-60}
 
-  # Validate object-storage credentials before MinIO starts. Docker Compose can
-  # require non-empty variables during interpolation; this one-shot check also
-  # rejects weak or well-known values without ever printing the credentials.
+  # Validate object-storage configuration before MinIO starts. The bundled
+  # stack has zero-configuration credentials like the other private middleware
+  # services; this one-shot check keeps all consumers aligned without printing
+  # the credentials.
   # The bundled MinIO image does not provision a second application user, so
   # the OSS client credentials must match the configured MinIO root account.
   minio-credentials-check:
     image: busybox:1.35
     container_name: astron-agent-minio-credentials-check
     environment:
-      MINIO_ROOT_USER: "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER to a unique value of at least 8 characters}"
-      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD to a random value of at least 16 characters}"
-      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:?Set OSS_ACCESS_KEY_ID explicitly}"
-      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:?Set OSS_ACCESS_KEY_SECRET explicitly}"
-      OSS_REMOTE_ENDPOINT: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT to an exact http(s) origin}"
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:-minioadmin}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:-minioadmin123}"
+      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}"
+      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:-${MINIO_ROOT_PASSWORD:-minioadmin123}}"
+      OSS_REMOTE_ENDPOINT: "${OSS_REMOTE_ENDPOINT:-http://minio.localhost:${EXPOSE_MINIO_PORT:-18998}}"
     command:
       - /bin/sh
       - -ec
       - |
-        reject_credential() {
-          echo "Object-storage credentials are empty, weak, or use a known default." >&2
+        reject_configuration() {
+          echo "Object-storage credential configuration is invalid." >&2
           exit 1
         }
-        root_user_lower="$$(printf '%s' "$${MINIO_ROOT_USER}" | tr '[:upper:]' '[:lower:]')"
-        root_password_lower="$$(printf '%s' "$${MINIO_ROOT_PASSWORD}" | tr '[:upper:]' '[:lower:]')"
-        access_key_lower="$$(printf '%s' "$${OSS_ACCESS_KEY_ID}" | tr '[:upper:]' '[:lower:]')"
-        access_secret_lower="$$(printf '%s' "$${OSS_ACCESS_KEY_SECRET}" | tr '[:upper:]' '[:lower:]')"
-        [ "$${#MINIO_ROOT_USER}" -ge 8 ] || reject_credential
-        [ "$${#MINIO_ROOT_PASSWORD}" -ge 16 ] || reject_credential
-        [ "$${#OSS_ACCESS_KEY_ID}" -ge 8 ] || reject_credential
-        [ "$${#OSS_ACCESS_KEY_SECRET}" -ge 16 ] || reject_credential
-        [ "$${MINIO_ROOT_USER}" != "$${MINIO_ROOT_PASSWORD}" ] || reject_credential
-        [ "$${OSS_ACCESS_KEY_ID}" != "$${OSS_ACCESS_KEY_SECRET}" ] || reject_credential
+        [ -n "$${MINIO_ROOT_USER}" ] || reject_configuration
+        [ -n "$${MINIO_ROOT_PASSWORD}" ] || reject_configuration
+        [ -n "$${OSS_ACCESS_KEY_ID}" ] || reject_configuration
+        [ -n "$${OSS_ACCESS_KEY_SECRET}" ] || reject_configuration
+        [ "$${MINIO_ROOT_USER}" != "$${MINIO_ROOT_PASSWORD}" ] || reject_configuration
+        [ "$${OSS_ACCESS_KEY_ID}" != "$${OSS_ACCESS_KEY_SECRET}" ] || reject_configuration
         if [ "$${MINIO_ROOT_USER}" != "$${OSS_ACCESS_KEY_ID}" ] || \
            [ "$${MINIO_ROOT_PASSWORD}" != "$${OSS_ACCESS_KEY_SECRET}" ]; then
           echo "Bundled MinIO requires OSS credentials to match MINIO_ROOT credentials." >&2
@@ -168,11 +303,7 @@ services:
           echo "OSS_REMOTE_ENDPOINT must not contain credentials, a path, query, or fragment." >&2
           exit 1
         esac
-        case "$${root_user_lower}" in minioadmin|admin|administrator|root|changeme|change_me*) reject_credential ;; esac
-        case "$${root_password_lower}" in minioadmin|minioadmin123|admin|admin123|password|password123|changeme|change_me*) reject_credential ;; esac
-        case "$${access_key_lower}" in minioadmin|admin|administrator|root|changeme|change_me*) reject_credential ;; esac
-        case "$${access_secret_lower}" in minioadmin|minioadmin123|admin|admin123|password|password123|changeme|change_me*) reject_credential ;; esac
-        echo "Object-storage credential policy check passed."
+        echo "Object-storage configuration check passed."
     network_mode: none
     restart: "no"
 
@@ -182,9 +313,9 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     container_name: astron-agent-minio
     environment:
-      MINIO_ROOT_USER: "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER to a unique value of at least 8 characters}"
-      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD to a random value of at least 16 characters}"
-      MINIO_SERVER_URL: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT to the API URL reachable by intended clients}"
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:-minioadmin}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:-minioadmin123}"
+      MINIO_SERVER_URL: "${OSS_REMOTE_ENDPOINT:-http://minio.localhost:${EXPOSE_MINIO_PORT:-18998}}"
     ports:
       - "127.0.0.1:${EXPOSE_MINIO_PORT:-18998}:${EXPOSE_MINIO_PORT:-18998}"
       - "127.0.0.1:${EXPOSE_MINIO_CONSOLE_PORT:-18999}:${EXPOSE_MINIO_CONSOLE_PORT:-18999}"
@@ -237,7 +368,12 @@ services:
       DATABASE_MAX_OPEN_CONNS: "${DATABASE_MAX_OPEN_CONNS:-5}"
       DATABASE_MAX_IDLE_CONNS: "${DATABASE_MAX_IDLE_CONNS:-5}"
       LOG_PATH: "${LOG_PATH:-log.txt}"
+      TENANT_ID: "680ab54f"
+      TENANT_KEY_FILE: "/app/secrets/tenant/tenant-key"
+      TENANT_SECRET_FILE: "/app/secrets/tenant/tenant-secret"
     depends_on:
+      internal-credentials-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       mysql:
@@ -250,6 +386,7 @@ services:
       - ./config/tenant/logs:/opt/tenant/logs
       - ./config/tenant/config.toml:/opt/tenant/config/config.toml
       - /etc/localtime:/etc/localtime
+      - tenant_bootstrap_secrets:/app/secrets/tenant:ro
     networks:
       - astron-agent-network
     restart: always
@@ -364,10 +501,10 @@ services:
       SERVICE_PORT: "${CORE_AITOOLS_PORT:-18668}"
       OSS_TYPE: "${OSS_TYPE:-s3}"
       OSS_ENDPOINT: "${OSS_ENDPOINT:-http://minio:${EXPOSE_MINIO_PORT:-18998}}"
-      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:?Set OSS_ACCESS_KEY_ID explicitly}"
-      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:?Set OSS_ACCESS_KEY_SECRET explicitly}"
+      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}"
+      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:-${MINIO_ROOT_PASSWORD:-minioadmin123}}"
       OSS_BUCKET_NAME: "${OSS_BUCKET_NAME}"
-      OSS_DOWNLOAD_HOST: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT explicitly}"
+      OSS_DOWNLOAD_HOST: "${OSS_REMOTE_ENDPOINT:-http://minio.localhost:${EXPOSE_MINIO_PORT:-18998}}"
       OSS_TTL: "${OSS_TTL:-157788000}"
       KAFKA_ENABLE: "${KAFKA_ENABLE:-0}"
       KAFKA_SERVERS: "${KAFKA_SERVERS:-kafka:29092}"
@@ -453,17 +590,20 @@ services:
       RUN_MCP_PLUGIN_URL: "${RUN_MCP_PLUGIN_URL:-http://core-link:18888/api/v1/mcp/call_tool}"
       APP_AUTH_HOST: "${APP_AUTH_HOST:-core-tenant}"
       APP_AUTH_PROT: "${APP_AUTH_PROT:-http}"
-      APP_AUTH_API_KEY: "${APP_AUTH_API_KEY:-YOUR_APP_AUTH_API_KEY}"
-      APP_AUTH_SECRET: "${APP_AUTH_SECRET:-YOUR_APP_AUTH_SECRET}"
+      APP_AUTH_API_KEY_FILE: "/app/secrets/tenant/tenant-key"
+      APP_AUTH_SECRET_FILE: "/app/secrets/tenant/tenant-secret"
+      WORKFLOW_INTERNAL_API_KEY_FILE: "/app/secrets/workflow/workflow-internal-api-key"
       SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN: "${SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN:-}"
       SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN_FILE: "/app/secrets/artifact/artifact-upload-token"
       SKILL_SANDBOX_ARTIFACT_UPLOAD_URL: "http://console-hub:8080/workflow/artifacts/internal-upload"
       SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN: "${SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN:-}"
       SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE: "/app/secrets/runtime/sandbox-runtime-credential-token"
       SKILL_SANDBOX_RUNTIME_CONFIG_URL: "http://console-hub:8080/skill-sandbox/internal-runtime-config"
-      SKILL_RESOURCE_TRUSTED_ORIGIN: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT to the exact origin used by presigned URLs}"
-      SKILL_RESOURCE_TRUSTED_BUCKET: "${OSS_BUCKET_CONSOLE:?Set OSS_BUCKET_CONSOLE explicitly}"
+      SKILL_RESOURCE_TRUSTED_ORIGIN: "${OSS_REMOTE_ENDPOINT:-http://minio.localhost:${EXPOSE_MINIO_PORT:-18998}}"
+      SKILL_RESOURCE_TRUSTED_BUCKET: "${OSS_BUCKET_CONSOLE:-console-oss}"
     depends_on:
+      internal-credentials-init:
+        condition: service_completed_successfully
       console-hub:
         condition: service_healthy
       postgres:
@@ -478,6 +618,8 @@ services:
       - ./config/agent/config.env:/opt/core/agent/config.env
       - artifact_upload_secrets:/app/secrets/artifact:ro
       - sandbox_runtime_credential_secrets:/app/secrets/runtime:ro
+      - tenant_bootstrap_secrets:/app/secrets/tenant:ro
+      - workflow_internal_secrets:/app/secrets/workflow:ro
     networks:
       - astron-agent-network
     healthcheck:
@@ -534,7 +676,12 @@ services:
     container_name: astron-agent-core-workflow
     environment:
       RUNTIME_ENV: "${RUNTIME_ENV:-dev}"
-      WORKFLOW_INTERNAL_API_KEY: "${WORKFLOW_INTERNAL_API_KEY:-CHANGE_ME_WORKFLOW_INTERNAL_API_KEY}"
+      WORKFLOW_INTERNAL_API_KEY_FILE: "/app/secrets/workflow/workflow-internal-api-key"
+      TENANT_ID: "680ab54f"
+      TENANT_KEY_FILE: "/app/secrets/tenant/tenant-key"
+      TENANT_SECRET_FILE: "/app/secrets/tenant/tenant-secret"
+      APP_MANAGE_PLAT_KEY_FILE: "/app/secrets/tenant/tenant-key"
+      APP_MANAGE_PLAT_SECRET_FILE: "/app/secrets/tenant/tenant-secret"
       SERVICE_PORT: "${CORE_WORKFLOW_PORT:-7880}"
       MYSQL_HOST: "${MYSQL_HOST:-mysql}"
       MYSQL_PORT: "${MYSQL_PORT:-3306}"
@@ -568,10 +715,10 @@ services:
       OTLP_TRACE_EXPORT_TIMEOUT_MILLIS: "${OTLP_TRACE_EXPORT_TIMEOUT_MILLIS:-3000}"
       OSS_TYPE: "${OSS_TYPE:-s3}"
       OSS_ENDPOINT: "${OSS_ENDPOINT:-http://minio:${EXPOSE_MINIO_PORT:-18998}}"
-      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:?Set OSS_ACCESS_KEY_ID explicitly}"
-      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:?Set OSS_ACCESS_KEY_SECRET explicitly}"
+      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}"
+      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:-${MINIO_ROOT_PASSWORD:-minioadmin123}}"
       OSS_BUCKET_NAME: "${OSS_BUCKET_NAME}"
-      OSS_DOWNLOAD_HOST: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT explicitly}"
+      OSS_DOWNLOAD_HOST: "${OSS_REMOTE_ENDPOINT:-http://minio.localhost:${EXPOSE_MINIO_PORT:-18998}}"
       OSS_TTL: "${OSS_TTL:-157788000}"
       KAFKA_ENABLE: "${KAFKA_ENABLE:-0}"
       KAFKA_SERVERS: "${KAFKA_SERVERS:-kafka:29092}"
@@ -592,6 +739,8 @@ services:
       SKILL_SANDBOX_RUNTIME_CREDENTIAL_TOKEN_FILE: "/app/secrets/runtime/sandbox-runtime-credential-token"
       SKILL_SANDBOX_RUNTIME_CONFIG_URL: "http://console-hub:8080/skill-sandbox/internal-runtime-config"
     depends_on:
+      internal-credentials-init:
+        condition: service_completed_successfully
       console-hub:
         condition: service_healthy
       postgres:
@@ -607,6 +756,8 @@ services:
       - ./config/workflow/logs/:/opt/core/logs
       - artifact_upload_secrets:/app/secrets/artifact:ro
       - sandbox_runtime_credential_secrets:/app/secrets/runtime:ro
+      - workflow_internal_secrets:/app/secrets/workflow:ro
+      - tenant_bootstrap_secrets:/app/secrets/tenant:ro
     networks:
       - astron-agent-network
     healthcheck:
@@ -668,7 +819,6 @@ services:
     extra_hosts:
       - "localhost:host-gateway"
     environment:
-      WORKFLOW_INTERNAL_API_KEY: "${WORKFLOW_INTERNAL_API_KEY:-CHANGE_ME_WORKFLOW_INTERNAL_API_KEY}"
       CONSOLE_CASDOOR_URL: "${CONSOLE_CASDOOR_URL:-}"
       CONSOLE_CASDOOR_ID: "${CONSOLE_CASDOOR_ID:-}"
       CONSOLE_CASDOOR_APP: "${CONSOLE_CASDOOR_APP:-}"
@@ -682,10 +832,10 @@ services:
       REDIS_PASSWORD: "${REDIS_PASSWORD}"
       REDIS_DATABASE_CONSOLE: "${REDIS_DATABASE_CONSOLE:-0}"
       OSS_ENDPOINT: "${OSS_ENDPOINT:-http://minio:${EXPOSE_MINIO_PORT:-18998}}"
-      OSS_REMOTE_ENDPOINT: "${OSS_REMOTE_ENDPOINT:?Set OSS_REMOTE_ENDPOINT explicitly}"
-      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:?Set OSS_ACCESS_KEY_ID explicitly}"
-      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:?Set OSS_ACCESS_KEY_SECRET explicitly}"
-      OSS_BUCKET_CONSOLE: "${OSS_BUCKET_CONSOLE:?Set OSS_BUCKET_CONSOLE explicitly}"
+      OSS_REMOTE_ENDPOINT: "${OSS_REMOTE_ENDPOINT:-http://minio.localhost:${EXPOSE_MINIO_PORT:-18998}}"
+      OSS_ACCESS_KEY_ID: "${OSS_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}"
+      OSS_ACCESS_KEY_SECRET: "${OSS_ACCESS_KEY_SECRET:-${MINIO_ROOT_PASSWORD:-minioadmin123}}"
+      OSS_BUCKET_CONSOLE: "${OSS_BUCKET_CONSOLE:-console-oss}"
       OSS_PRESIGN_EXPIRY_SECONDS_CONSOLE: "${OSS_PRESIGN_EXPIRY_SECONDS_CONSOLE:-600}"
       OAUTH2_ISSUER_URI: "${OAUTH2_ISSUER_URI:-http://auth-server:8000}"
       OAUTH2_JWK_SET_URI: "${OAUTH2_JWK_SET_URI:-http://auth-server:8000/.well-known/jwks}"
@@ -697,12 +847,6 @@ services:
       WORKFLOW_CHAT_URL: "${WORKFLOW_CHAT_URL:-http://core-workflow:7880/workflow/v1/chat/completions}"
       WORKFLOW_DEBUG_URL: "${WORKFLOW_DEBUG_URL:-http://core-workflow:7880/workflow/v1/debug/chat/completions}"
       WORKFLOW_RESUME_URL: "${WORKFLOW_RESUME_URL:-http://core-workflow:7880/workflow/v1/resume}"
-      COMMON_APPID: "${COMMON_APPID:-appid}"
-      COMMON_APIKEY: "${COMMON_APIKEY:-apiKey}"
-      COMMON_API_SECRET: "${COMMON_API_SECRET:-apiSecret}"
-      TENANT_ID: "${TENANT_ID:-tenantId}"
-      TENANT_KEY: "${TENANT_KEY:-tenantKey}"
-      TENANT_SECRET: "${TENANT_SECRET:-tenantSecret}"
       ADMIN_UID: "${ADMIN_UID:-9999}"
       APP_URL: "${APP_URL:-}"
       KNOWLEDGE_URL: "${KNOWLEDGE_URL:-}"
@@ -714,12 +858,6 @@ services:
       SPARK_DB_TYPE: "${SPARK_DB_TYPE:-postgresql}"
       LOCAL_MODEL_URL: "${LOCAL_MODEL_URL:-}"
       RPA_URL: "${RPA_URL_INTERNAL:-${RPA_URL}}"
-      MAAS_APP_ID: "${MAAS_APP_ID:-your-maas-app-id}"
-      MAAS_API_KEY: "${MAAS_API_KEY:-your-maas-api-key}"
-      MAAS_API_SECRET: "${MAAS_API_SECRET:-your-maas-api-secret}"
-      MAAS_CONSUMER_ID: "${MAAS_CONSUMER_ID:-your-maas-consumer-id}"
-      MAAS_CONSUMER_SECRET: "${MAAS_CONSUMER_SECRET:-your-maas-consumer-secret}"
-      MAAS_CONSUMER_KEY: "${MAAS_CONSUMER_KEY:-your-maas-consumer-key}"
       MAAS_WORKFLOW_VERSION: "${MAAS_WORKFLOW_VERSION:-}"
       MAAS_SYNCHRONIZE_WORK_FLOW: "${MAAS_SYNCHRONIZE_WORK_FLOW:-}"
       MAAS_PUBLISH: "${MAAS_PUBLISH:-}"
@@ -747,10 +885,14 @@ services:
     volumes:
       - artifact_upload_secrets:/app/secrets/artifact
       - sandbox_runtime_credential_secrets:/app/secrets/runtime
+      - workflow_internal_secrets:/app/secrets/workflow:ro
+      - tenant_bootstrap_secrets:/app/secrets/tenant:ro
 
     expose:
       - "8080"
     depends_on:
+      internal-credentials-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       mysql:
@@ -796,4 +938,8 @@ volumes:
   artifact_upload_secrets:
     driver: local
   sandbox_runtime_credential_secrets:
+    driver: local
+  workflow_internal_secrets:
+    driver: local
+  tenant_bootstrap_secrets:
     driver: local

--- a/docker/astronAgent/nginx/nginx.conf
+++ b/docker/astronAgent/nginx/nginx.conf
@@ -84,6 +84,10 @@ http {
             proxy_pass_request_body off;
             proxy_set_header Content-Length "";
             proxy_set_header Authorization $http_authorization;
+            proxy_set_header X-Consumer-Username "";
+            proxy_set_header X-Workflow-Internal-Key "";
+            proxy_set_header X-Workflow-Gateway-Timestamp "";
+            proxy_set_header X-Workflow-Gateway-Signature "";
             proxy_set_header X-Original-URI $request_uri;
             proxy_set_header X-Original-Method $request_method;
             proxy_set_header X-Real-IP $remote_addr;
@@ -95,6 +99,8 @@ http {
         location = /workflow/v1/chat/completions {
             auth_request /_gateway_auth/workflow;
             auth_request_set $auth_app_id $upstream_http_x_consumer_username;
+            auth_request_set $auth_workflow_gateway_timestamp $upstream_http_x_workflow_gateway_timestamp;
+            auth_request_set $auth_workflow_gateway_signature $upstream_http_x_workflow_gateway_signature;
 
             proxy_pass http://core-workflow:7880/workflow/v1/chat/completions;
             proxy_set_header Host $host;
@@ -102,7 +108,13 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Consumer-Username $auth_app_id;
+            proxy_set_header X-Workflow-Internal-Key "";
+            proxy_set_header X-Workflow-Gateway-Timestamp $auth_workflow_gateway_timestamp;
+            proxy_set_header X-Workflow-Gateway-Signature $auth_workflow_gateway_signature;
             proxy_set_header Authorization "";
+            proxy_hide_header X-Workflow-Internal-Key;
+            proxy_hide_header X-Workflow-Gateway-Timestamp;
+            proxy_hide_header X-Workflow-Gateway-Signature;
 
             # SSE specific settings
             proxy_buffering off;                    # Disable buffering for real-time data transmission
@@ -128,6 +140,8 @@ http {
         location = /workflow/v1/resume {
             auth_request /_gateway_auth/workflow;
             auth_request_set $auth_app_id $upstream_http_x_consumer_username;
+            auth_request_set $auth_workflow_gateway_timestamp $upstream_http_x_workflow_gateway_timestamp;
+            auth_request_set $auth_workflow_gateway_signature $upstream_http_x_workflow_gateway_signature;
 
             proxy_pass http://core-workflow:7880/workflow/v1/resume;
             proxy_set_header Host $host;
@@ -135,7 +149,13 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Consumer-Username $auth_app_id;
+            proxy_set_header X-Workflow-Internal-Key "";
+            proxy_set_header X-Workflow-Gateway-Timestamp $auth_workflow_gateway_timestamp;
+            proxy_set_header X-Workflow-Gateway-Signature $auth_workflow_gateway_signature;
             proxy_set_header Authorization "";
+            proxy_hide_header X-Workflow-Internal-Key;
+            proxy_hide_header X-Workflow-Gateway-Timestamp;
+            proxy_hide_header X-Workflow-Gateway-Signature;
 
             # SSE specific settings
             proxy_http_version 1.1;

--- a/docker/astronAgent/scripts/verify_security_contract.py
+++ b/docker/astronAgent/scripts/verify_security_contract.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""Verify the rendered Compose contract for sandbox credential handoff."""
+"""Verify rendered Compose security and internal-credential contracts."""
 
 import argparse
 import copy
+import hashlib
 import json
 import os
-from pathlib import Path
+import re
+import shutil
 import subprocess
 import sys
+import tempfile
+import uuid
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -19,9 +24,83 @@ from typing import (
     Tuple,
 )
 
-
 SERVICES = ("console-hub", "core-agent", "core-workflow")
 CONSUMERS = ("core-agent", "core-workflow")
+INTERNAL_CREDENTIAL_INIT = "internal-credentials-init"
+INTERNAL_CREDENTIAL_CONSUMERS = (
+    "core-tenant",
+    "core-agent",
+    "core-workflow",
+    "console-hub",
+)
+
+LEGACY_TENANT_KEY = "7b709739e8da44536127a333c7603a83"
+LEGACY_TENANT_SECRET = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+WORKFLOW_PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"
+
+GENERATED_CREDENTIALS = (
+    {
+        "volume": "workflow_internal_secrets",
+        "init_target": "/secrets/workflow",
+        "consumer_target": "/app/secrets/workflow",
+        "consumers": {
+            "core-agent": {
+                "WORKFLOW_INTERNAL_API_KEY_FILE": (
+                    "/app/secrets/workflow/workflow-internal-api-key"
+                ),
+            },
+            "core-workflow": {
+                "WORKFLOW_INTERNAL_API_KEY_FILE": (
+                    "/app/secrets/workflow/workflow-internal-api-key"
+                ),
+            },
+            "console-hub": {},
+        },
+    },
+    {
+        "volume": "tenant_bootstrap_secrets",
+        "init_target": "/secrets/tenant",
+        "consumer_target": "/app/secrets/tenant",
+        "consumers": {
+            "core-tenant": {
+                "TENANT_KEY_FILE": "/app/secrets/tenant/tenant-key",
+                "TENANT_SECRET_FILE": "/app/secrets/tenant/tenant-secret",
+            },
+            "core-agent": {
+                "APP_AUTH_API_KEY_FILE": "/app/secrets/tenant/tenant-key",
+                "APP_AUTH_SECRET_FILE": "/app/secrets/tenant/tenant-secret",
+            },
+            "core-workflow": {
+                "TENANT_KEY_FILE": "/app/secrets/tenant/tenant-key",
+                "TENANT_SECRET_FILE": "/app/secrets/tenant/tenant-secret",
+                "APP_MANAGE_PLAT_KEY_FILE": "/app/secrets/tenant/tenant-key",
+                "APP_MANAGE_PLAT_SECRET_FILE": ("/app/secrets/tenant/tenant-secret"),
+            },
+            "console-hub": {},
+        },
+    },
+)
+
+FORBIDDEN_INLINE_CREDENTIALS = {
+    "core-tenant": ("TENANT_KEY", "TENANT_SECRET"),
+    "core-agent": (
+        "APP_AUTH_API_KEY",
+        "APP_AUTH_SECRET",
+        "WORKFLOW_INTERNAL_API_KEY",
+    ),
+    "core-workflow": (
+        "TENANT_KEY",
+        "TENANT_SECRET",
+        "APP_MANAGE_PLAT_KEY",
+        "APP_MANAGE_PLAT_SECRET",
+        "WORKFLOW_INTERNAL_API_KEY",
+    ),
+    "console-hub": (
+        "TENANT_KEY",
+        "TENANT_SECRET",
+        "WORKFLOW_INTERNAL_API_KEY",
+    ),
+}
 
 CREDENTIALS = (
     {
@@ -52,66 +131,59 @@ HUB_HEALTHCHECK_TEST = [
     "curl --fail --silent --show-error http://localhost:8080/health >/dev/null",
 ]
 
-# CI has no deployment .env. These deliberately non-secret values satisfy only
-# Compose's required-variable interpolation so the rendered topology can be
-# checked. Deployment preflight must omit --ci-placeholder-required-env.
-CI_PLACEHOLDER_ENV = {
-    "MINIO_ROOT_USER": "ci-contract-user",
-    "MINIO_ROOT_PASSWORD": "ci-contract-password-2026",
-    "OSS_REMOTE_ENDPOINT": "http://minio.localhost:18998",
-    "OSS_ACCESS_KEY_ID": "ci-contract-access-key",
-    "OSS_ACCESS_KEY_SECRET": "ci-contract-credential-value",
-    "OSS_BUCKET_CONSOLE": "ci-contract-bucket",
-}
-
 
 class GateError(RuntimeError):
     """A safe-to-print gate error which never contains rendered values."""
 
 
-def _render_compose(
-    compose_file: Path, *, ci_placeholder_required_env: bool
-) -> Mapping[str, Any]:
-    environment = os.environ.copy()
-    if ci_placeholder_required_env:
-        for name, value in CI_PLACEHOLDER_ENV.items():
-            environment.setdefault(name, value)
+def _compose_commands() -> Sequence[Sequence[str]]:
+    commands: List[Sequence[str]] = []
+    if shutil.which("docker"):
+        commands.append(("docker", "compose"))
+    if shutil.which("docker-compose"):
+        commands.append(("docker-compose",))
+    return commands
 
-    command = [
-        "docker",
-        "compose",
-        "-f",
-        compose_file.name,
-        "config",
-        "--format",
-        "json",
-    ]
-    try:
+
+def _select_compose_command(compose_file: Path) -> Sequence[str]:
+    for base_command in _compose_commands():
         completed = subprocess.run(
-            command,
+            list(base_command)
+            + ["-f", compose_file.name, "config", "--format", "json"],
             cwd=str(compose_file.parent),
-            env=environment,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
             check=False,
         )
-    except FileNotFoundError as exc:
-        raise GateError("Docker CLI is unavailable") from exc
+        if completed.returncode == 0:
+            return base_command
+    if not _compose_commands():
+        raise GateError("Docker Compose is unavailable")
+    # Compose stderr can contain interpolated deployment data. Do not echo it.
+    raise GateError(
+        "Docker Compose config failed; a Compose implementation supporting "
+        "'config --format json' is required"
+    )
 
-    if completed.returncode != 0:
-        # Compose stderr can contain interpolated deployment data. Do not echo it.
-        raise GateError(
-            "docker compose config failed; Docker Compose v2 with "
-            "'config --format json' and all required deployment variables is required"
-        )
+
+def _render_compose(compose_file: Path) -> Mapping[str, Any]:
+    base_command = _select_compose_command(compose_file)
+    completed = subprocess.run(
+        list(base_command) + ["-f", compose_file.name, "config", "--format", "json"],
+        cwd=str(compose_file.parent),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
 
     try:
         rendered = json.loads(completed.stdout)
     except (json.JSONDecodeError, TypeError) as exc:
-        raise GateError("docker compose config did not return valid JSON") from exc
+        raise GateError("Docker Compose config did not return valid JSON") from exc
     if not isinstance(rendered, dict):
-        raise GateError("docker compose config returned an unexpected JSON root")
+        raise GateError("Docker Compose config returned an unexpected JSON root")
     return rendered
 
 
@@ -130,6 +202,14 @@ def _mounts(service: Mapping[str, Any], target: str) -> List[Mapping[str, Any]]:
     ]
 
 
+def _safe_token(value: Any, minimum: int, maximum: int) -> bool:
+    return (
+        isinstance(value, str)
+        and minimum <= len(value) <= maximum
+        and re.fullmatch(r"[A-Za-z0-9._~-]+", value) is not None
+    )
+
+
 def validate_contract(config: Mapping[str, Any]) -> List[str]:
     """Return field-only contract errors without including configured values."""
 
@@ -140,25 +220,151 @@ def validate_contract(config: Mapping[str, Any]) -> List[str]:
     for service_name in SERVICES:
         if not isinstance(services.get(service_name), dict):
             errors.append(f"services.{service_name}: missing")
+    for service_name in (INTERNAL_CREDENTIAL_INIT,) + INTERNAL_CREDENTIAL_CONSUMERS:
+        if not isinstance(services.get(service_name), dict):
+            errors.append(f"services.{service_name}: missing")
 
     for credential in CREDENTIALS:
         volume_name = credential["volume"]
         if not isinstance(volumes.get(volume_name), dict):
             errors.append(f"volumes.{volume_name}: missing named volume")
+    for credential in GENERATED_CREDENTIALS:
+        volume_name = credential["volume"]
+        if not isinstance(volumes.get(volume_name), dict):
+            errors.append(f"volumes.{volume_name}: missing named volume")
 
     resolved_volume_names: List[str] = []
-    for credential in CREDENTIALS:
+    for credential in CREDENTIALS + GENERATED_CREDENTIALS:
         volume_name = credential["volume"]
         definition = volumes.get(volume_name)
         if isinstance(definition, dict):
             resolved_name = definition.get("name", volume_name)
             if isinstance(resolved_name, str) and resolved_name:
                 resolved_volume_names.append(resolved_name)
-    if (
-        len(resolved_volume_names) == len(CREDENTIALS)
-        and len(set(resolved_volume_names)) != len(CREDENTIALS)
-    ):
+    if len(resolved_volume_names) == len(CREDENTIALS + GENERATED_CREDENTIALS) and len(
+        set(resolved_volume_names)
+    ) != len(CREDENTIALS + GENERATED_CREDENTIALS):
         errors.append("volumes.*.name: credential volumes must be independent")
+
+    init_service = _mapping(services.get(INTERNAL_CREDENTIAL_INIT))
+    init_environment = _mapping(init_service.get("environment"))
+    if init_service.get("network_mode") != "none":
+        errors.append(
+            f"services.{INTERNAL_CREDENTIAL_INIT}.network_mode: expected none"
+        )
+    if str(init_service.get("restart", "")).lower() != "no":
+        errors.append(f"services.{INTERNAL_CREDENTIAL_INIT}.restart: expected no")
+
+    configured_workflow_key = init_environment.get(
+        "CONFIGURED_WORKFLOW_INTERNAL_API_KEY", ""
+    )
+    if configured_workflow_key and configured_workflow_key != WORKFLOW_PLACEHOLDER:
+        if not _safe_token(configured_workflow_key, 32, 128):
+            errors.append(
+                f"services.{INTERNAL_CREDENTIAL_INIT}.environment."
+                "CONFIGURED_WORKFLOW_INTERNAL_API_KEY: invalid"
+            )
+
+    configured_tenant_key = init_environment.get("CONFIGURED_TENANT_KEY", "")
+    configured_tenant_secret = init_environment.get("CONFIGURED_TENANT_SECRET", "")
+    is_exact_legacy_pair = (
+        configured_tenant_key == LEGACY_TENANT_KEY
+        and configured_tenant_secret == LEGACY_TENANT_SECRET
+    )
+    if (configured_tenant_key or configured_tenant_secret) and not is_exact_legacy_pair:
+        if not (
+            _safe_token(configured_tenant_key, 32, 50)
+            and _safe_token(configured_tenant_secret, 32, 50)
+            and configured_tenant_key != configured_tenant_secret
+            and configured_tenant_key != LEGACY_TENANT_KEY
+            and configured_tenant_secret != LEGACY_TENANT_SECRET
+        ):
+            errors.append(
+                f"services.{INTERNAL_CREDENTIAL_INIT}.environment."
+                "CONFIGURED_TENANT_KEY/CONFIGURED_TENANT_SECRET: invalid pair"
+            )
+
+    command = init_service.get("command")
+    command_text = (
+        "\n".join(command) if isinstance(command, list) else str(command or "")
+    )
+    for required_fragment in (
+        "umask 077",
+        "/dev/urandom",
+        "workflow-internal-api-key",
+        "tenant-bootstrap.properties",
+        "api.url.apiKey=%s",
+        "api.url.apiSecret=%s",
+    ):
+        if required_fragment not in command_text:
+            errors.append(
+                f"services.{INTERNAL_CREDENTIAL_INIT}.command: missing security primitive"
+            )
+            break
+
+    for credential in GENERATED_CREDENTIALS:
+        volume_name = credential["volume"]
+        init_target = credential["init_target"]
+        init_mounts = _mounts(init_service, init_target)
+        init_mount_field = f"services.{INTERNAL_CREDENTIAL_INIT}.volumes[{init_target}]"
+        if len(init_mounts) != 1:
+            errors.append(f"{init_mount_field}: missing or duplicated")
+        else:
+            mount = init_mounts[0]
+            if mount.get("type") != "volume" or mount.get("source") != volume_name:
+                errors.append(
+                    f"{init_mount_field}.source/type: unexpected named volume"
+                )
+            if mount.get("read_only", False) is True:
+                errors.append(f"{init_mount_field}.mode: expected rw")
+
+        consumer_target = credential["consumer_target"]
+        credential_consumers = _mapping(credential["consumers"])
+        for service_name, expected_environment_value in credential_consumers.items():
+            service = _mapping(services.get(service_name))
+            environment = _mapping(service.get("environment"))
+            matching_mounts = _mounts(service, consumer_target)
+            mount_field = f"services.{service_name}.volumes[{consumer_target}]"
+            if len(matching_mounts) != 1:
+                errors.append(f"{mount_field}: missing or duplicated")
+            else:
+                mount = matching_mounts[0]
+                if mount.get("type") != "volume" or mount.get("source") != volume_name:
+                    errors.append(f"{mount_field}.source/type: unexpected named volume")
+                if mount.get("read_only", False) is not True:
+                    errors.append(f"{mount_field}.mode: expected ro")
+
+            expected_environment = _mapping(expected_environment_value)
+            for env_name, expected_path in expected_environment.items():
+                if environment.get(env_name) != expected_path:
+                    errors.append(
+                        f"services.{service_name}.environment.{env_name}: "
+                        "missing or unexpected"
+                    )
+
+    for service_name in INTERNAL_CREDENTIAL_CONSUMERS:
+        service = _mapping(services.get(service_name))
+        environment = _mapping(service.get("environment"))
+        for env_name in FORBIDDEN_INLINE_CREDENTIALS[service_name]:
+            if env_name in environment:
+                errors.append(
+                    f"services.{service_name}.environment.{env_name}: "
+                    "must use generated Secret file/property binding"
+                )
+
+        init_dependency = _mapping(
+            _mapping(service.get("depends_on")).get(INTERNAL_CREDENTIAL_INIT)
+        )
+        if init_dependency.get("condition") != "service_completed_successfully":
+            errors.append(
+                f"services.{service_name}.depends_on.{INTERNAL_CREDENTIAL_INIT}: "
+                "expected service_completed_successfully"
+            )
+        if init_dependency.get("required") is False:
+            errors.append(
+                f"services.{service_name}.depends_on.{INTERNAL_CREDENTIAL_INIT}."
+                "required: must not be false"
+            )
 
     for service_name in SERVICES:
         service = _mapping(services.get(service_name))
@@ -202,7 +408,9 @@ def validate_contract(config: Mapping[str, Any]) -> List[str]:
                     "missing or unexpected"
                 )
 
-        hub_dependency = _mapping(_mapping(service.get("depends_on")).get("console-hub"))
+        hub_dependency = _mapping(
+            _mapping(service.get("depends_on")).get("console-hub")
+        )
         if hub_dependency.get("condition") != "service_healthy":
             errors.append(
                 f"services.{service_name}.depends_on.console-hub: "
@@ -247,9 +455,9 @@ def _set_mount_mode(
     raise GateError("negative self-test fixture is incomplete")
 
 
-def _negative_cases() -> Sequence[
-    Tuple[str, Callable[[MutableMapping[str, Any], str], None], str]
-]:
+def _negative_cases() -> (
+    Sequence[Tuple[str, Callable[[MutableMapping[str, Any], str], None], str]]
+):
     def wrong_token_path(config: MutableMapping[str, Any], marker: str) -> None:
         config["services"]["core-agent"]["environment"][
             "SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN_FILE"
@@ -275,9 +483,65 @@ def _negative_cases() -> Sequence[
         artifact_name = config["volumes"]["artifact_upload_secrets"].get(
             "name", "artifact_upload_secrets"
         )
-        config["volumes"]["sandbox_runtime_credential_secrets"][
-            "name"
-        ] = artifact_name
+        config["volumes"]["sandbox_runtime_credential_secrets"]["name"] = artifact_name
+
+    def missing_credential_init(config: MutableMapping[str, Any], _marker: str) -> None:
+        config["services"].pop(INTERNAL_CREDENTIAL_INIT, None)
+
+    def networked_credential_init(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        config["services"][INTERNAL_CREDENTIAL_INIT]["network_mode"] = "default"
+
+    def readonly_credential_init_volume(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        _set_mount_mode(config, INTERNAL_CREDENTIAL_INIT, "/secrets/workflow", True)
+
+    def writable_generated_consumer(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        _set_mount_mode(config, "core-agent", "/app/secrets/tenant", False)
+
+    def wrong_generated_file_path(
+        config: MutableMapping[str, Any], marker: str
+    ) -> None:
+        config["services"]["core-workflow"]["environment"][
+            "APP_MANAGE_PLAT_SECRET_FILE"
+        ] = marker
+
+    def inline_generated_credential(
+        config: MutableMapping[str, Any], marker: str
+    ) -> None:
+        config["services"]["core-agent"]["environment"]["APP_AUTH_SECRET"] = marker
+
+    def missing_credential_init_dependency(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        config["services"]["core-tenant"]["depends_on"].pop(
+            INTERNAL_CREDENTIAL_INIT, None
+        )
+
+    def wrong_credential_init_dependency(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        config["services"]["console-hub"]["depends_on"][INTERNAL_CREDENTIAL_INIT][
+            "condition"
+        ] = "service_started"
+
+    def merged_generated_volumes(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        workflow_name = config["volumes"]["workflow_internal_secrets"].get(
+            "name", "workflow_internal_secrets"
+        )
+        config["volumes"]["tenant_bootstrap_secrets"]["name"] = workflow_name
+
+    def missing_hub_app_api_binding(
+        config: MutableMapping[str, Any], _marker: str
+    ) -> None:
+        command = config["services"][INTERNAL_CREDENTIAL_INIT]["command"]
+        command[-1] = command[-1].replace("api.url.apiKey=%s", "api.url.otherKey=%s")
 
     def disabled_healthcheck(config: MutableMapping[str, Any], _marker: str) -> None:
         config["services"]["console-hub"]["healthcheck"] = {"disable": True}
@@ -332,6 +596,56 @@ def _negative_cases() -> Sequence[
         ),
         ("merged-named-volumes", merged_volumes, "volumes.*.name"),
         (
+            "missing-credential-init",
+            missing_credential_init,
+            f"services.{INTERNAL_CREDENTIAL_INIT}",
+        ),
+        (
+            "networked-credential-init",
+            networked_credential_init,
+            f"services.{INTERNAL_CREDENTIAL_INIT}.network_mode",
+        ),
+        (
+            "readonly-credential-init-volume",
+            readonly_credential_init_volume,
+            f"services.{INTERNAL_CREDENTIAL_INIT}.volumes[/secrets/workflow].mode",
+        ),
+        (
+            "writable-generated-consumer",
+            writable_generated_consumer,
+            "services.core-agent.volumes[/app/secrets/tenant].mode",
+        ),
+        (
+            "wrong-generated-file-path",
+            wrong_generated_file_path,
+            "services.core-workflow.environment.APP_MANAGE_PLAT_SECRET_FILE",
+        ),
+        (
+            "inline-generated-credential",
+            inline_generated_credential,
+            "services.core-agent.environment.APP_AUTH_SECRET",
+        ),
+        (
+            "missing-credential-init-dependency",
+            missing_credential_init_dependency,
+            f"services.core-tenant.depends_on.{INTERNAL_CREDENTIAL_INIT}",
+        ),
+        (
+            "wrong-credential-init-dependency",
+            wrong_credential_init_dependency,
+            f"services.console-hub.depends_on.{INTERNAL_CREDENTIAL_INIT}",
+        ),
+        (
+            "merged-generated-volumes",
+            merged_generated_volumes,
+            "volumes.*.name",
+        ),
+        (
+            "missing-hub-app-api-binding",
+            missing_hub_app_api_binding,
+            f"services.{INTERNAL_CREDENTIAL_INIT}.command",
+        ),
+        (
             "disabled-hub-healthcheck",
             disabled_healthcheck,
             "services.console-hub.healthcheck",
@@ -379,6 +693,406 @@ def run_negative_self_tests(config: Mapping[str, Any]) -> None:
             raise GateError(f"negative self-test diagnostics were unsafe: {case_name}")
 
 
+def exercise_shell_credential_lifecycle(config: Mapping[str, Any]) -> None:
+    """Run the rendered initializer logic against an isolated temporary directory."""
+
+    service = _mapping(_mapping(config.get("services")).get(INTERNAL_CREDENTIAL_INIT))
+    command = service.get("command")
+    if (
+        not isinstance(command, list)
+        or len(command) < 3
+        or not isinstance(command[2], str)
+    ):
+        raise GateError("credential lifecycle shell command is incomplete")
+
+    with tempfile.TemporaryDirectory(prefix="astron-credential-") as temporary:
+        root = Path(temporary)
+        workflow_directory = root / "workflow"
+        tenant_directory = root / "tenant"
+        script = command[2].replace("$$", "$")
+        script = script.replace("/secrets/workflow", str(workflow_directory))
+        script = script.replace("/secrets/tenant", str(tenant_directory))
+
+        def run_initializer(
+            environment: Mapping[str, str], should_succeed: bool
+        ) -> None:
+            completed = subprocess.run(
+                ["/bin/sh", "-ec", script],
+                cwd=temporary,
+                env={**os.environ, **environment},
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+                check=False,
+            )
+            if (completed.returncode == 0) != should_succeed:
+                expectation = "succeed" if should_succeed else "fail"
+                raise GateError(
+                    f"credential shell lifecycle initializer did not {expectation}"
+                )
+
+        def read_single_line(path: Path) -> str:
+            if not path.is_file() or path.is_symlink():
+                raise GateError("credential shell lifecycle file is missing")
+            if path.stat().st_mode & 0o777 != 0o444:
+                raise GateError("credential shell lifecycle file mode is not read-only")
+            lines = path.read_text().splitlines()
+            if len(lines) != 1:
+                raise GateError("credential shell lifecycle token file is malformed")
+            return lines[0]
+
+        def read_properties(path: Path) -> Mapping[str, str]:
+            if not path.is_file() or path.is_symlink():
+                raise GateError("credential shell lifecycle properties are missing")
+            if path.stat().st_mode & 0o777 != 0o444:
+                raise GateError("credential shell lifecycle properties are writable")
+            result = {}
+            for line in path.read_text().splitlines():
+                if "=" not in line:
+                    raise GateError(
+                        "credential shell lifecycle properties are malformed"
+                    )
+                key, value = line.split("=", 1)
+                if not key or key in result:
+                    raise GateError(
+                        "credential shell lifecycle properties are duplicated"
+                    )
+                result[key] = value
+            return result
+
+        def snapshot() -> Tuple[str, str, str]:
+            workflow_key = read_single_line(
+                workflow_directory / "workflow-internal-api-key"
+            )
+            tenant_key = read_single_line(tenant_directory / "tenant-key")
+            tenant_secret = read_single_line(tenant_directory / "tenant-secret")
+            if not _safe_token(workflow_key, 32, 128):
+                raise GateError("credential shell lifecycle workflow key is invalid")
+            if not (
+                _safe_token(tenant_key, 32, 50)
+                and _safe_token(tenant_secret, 32, 50)
+                and tenant_key != tenant_secret
+                and tenant_key != LEGACY_TENANT_KEY
+                and tenant_secret != LEGACY_TENANT_SECRET
+            ):
+                raise GateError("credential shell lifecycle tenant pair is invalid")
+            if workflow_key == WORKFLOW_PLACEHOLDER:
+                raise GateError(
+                    "credential shell lifecycle reused workflow placeholder"
+                )
+
+            workflow_properties = read_properties(
+                workflow_directory / "workflow-internal.properties"
+            )
+            tenant_properties = read_properties(
+                tenant_directory / "tenant-bootstrap.properties"
+            )
+            if workflow_properties != {"workflow.internal-api-key": workflow_key}:
+                raise GateError("credential shell lifecycle workflow binding mismatch")
+            expected_tenant_properties = {
+                "api.url.tenantId": "680ab54f",
+                "api.url.tenantKey": tenant_key,
+                "api.url.tenantSecret": tenant_secret,
+                "api.url.apiKey": tenant_key,
+                "api.url.apiSecret": tenant_secret,
+                "common.appid": "680ab54f",
+                "common.apiKey": tenant_key,
+                "common.apiSecret": tenant_secret,
+                "maas.appId": "680ab54f",
+                "maas.apiKey": tenant_key,
+                "maas.apiSecret": tenant_secret,
+                "maas.consumerId": "680ab54f",
+                "maas.consumerKey": tenant_key,
+                "maas.consumerSecret": tenant_secret,
+            }
+            if tenant_properties != expected_tenant_properties:
+                raise GateError("credential shell lifecycle tenant binding mismatch")
+            return (
+                hashlib.sha256(workflow_key.encode()).hexdigest(),
+                hashlib.sha256(tenant_key.encode()).hexdigest(),
+                hashlib.sha256(tenant_secret.encode()).hexdigest(),
+            )
+
+        empty_environment = {
+            "CONFIGURED_WORKFLOW_INTERNAL_API_KEY": "",
+            "CONFIGURED_TENANT_KEY": "",
+            "CONFIGURED_TENANT_SECRET": "",
+        }
+        run_initializer(empty_environment, True)
+        initial_snapshot = snapshot()
+        run_initializer(empty_environment, True)
+        if snapshot() != initial_snapshot:
+            raise GateError("credential shell lifecycle did not reuse generated values")
+
+        legacy_files = (
+            (workflow_directory / "workflow-internal-api-key", WORKFLOW_PLACEHOLDER),
+            (tenant_directory / "tenant-key", LEGACY_TENANT_KEY),
+            (tenant_directory / "tenant-secret", LEGACY_TENANT_SECRET),
+        )
+        for path, value in legacy_files:
+            path.chmod(0o600)
+            path.write_text(f"{value}\n")
+        legacy_environment = {
+            "CONFIGURED_WORKFLOW_INTERNAL_API_KEY": WORKFLOW_PLACEHOLDER,
+            "CONFIGURED_TENANT_KEY": LEGACY_TENANT_KEY,
+            "CONFIGURED_TENANT_SECRET": LEGACY_TENANT_SECRET,
+        }
+        run_initializer(legacy_environment, True)
+        snapshot()
+
+        workflow_override = "W" * 64
+        tenant_key_override = "K" * 48
+        tenant_secret_override = "S" * 48
+        override_environment = {
+            "CONFIGURED_WORKFLOW_INTERNAL_API_KEY": workflow_override,
+            "CONFIGURED_TENANT_KEY": tenant_key_override,
+            "CONFIGURED_TENANT_SECRET": tenant_secret_override,
+        }
+        override_snapshot = (
+            hashlib.sha256(workflow_override.encode()).hexdigest(),
+            hashlib.sha256(tenant_key_override.encode()).hexdigest(),
+            hashlib.sha256(tenant_secret_override.encode()).hexdigest(),
+        )
+        run_initializer(override_environment, True)
+        if snapshot() != override_snapshot:
+            raise GateError("credential shell lifecycle did not persist overrides")
+        run_initializer(empty_environment, True)
+        if snapshot() != override_snapshot:
+            raise GateError("credential shell lifecycle did not reuse overrides")
+
+        invalid_environment = {
+            "CONFIGURED_WORKFLOW_INTERNAL_API_KEY": "",
+            "CONFIGURED_TENANT_KEY": tenant_key_override,
+            "CONFIGURED_TENANT_SECRET": "",
+        }
+        run_initializer(invalid_environment, False)
+        if snapshot() != override_snapshot:
+            raise GateError("incomplete tenant pair changed persisted credentials")
+
+        mixed_legacy_environment = {
+            "CONFIGURED_WORKFLOW_INTERNAL_API_KEY": "",
+            "CONFIGURED_TENANT_KEY": LEGACY_TENANT_KEY,
+            "CONFIGURED_TENANT_SECRET": tenant_secret_override,
+        }
+        run_initializer(mixed_legacy_environment, False)
+        if snapshot() != override_snapshot:
+            raise GateError("mixed legacy tenant pair changed persisted credentials")
+
+
+def _run_quiet(
+    command: Sequence[str],
+    cwd: Path,
+    environment: Optional[Mapping[str, str]] = None,
+) -> subprocess.CompletedProcess[str]:
+    merged_environment = os.environ.copy()
+    if environment:
+        merged_environment.update(environment)
+    return subprocess.run(
+        list(command),
+        cwd=str(cwd),
+        env=merged_environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+        timeout=180,
+    )
+
+
+def _credential_environment(
+    workflow_key: str = "", tenant_key: str = "", tenant_secret: str = ""
+) -> Mapping[str, str]:
+    return {
+        "WORKFLOW_INTERNAL_API_KEY": workflow_key,
+        "TENANT_KEY": tenant_key,
+        "TENANT_SECRET": tenant_secret,
+    }
+
+
+_SNAPSHOT_SCRIPT = r"""
+safe_token() {
+  value="$1"
+  min_length="$2"
+  max_length="$3"
+  [ "${#value}" -ge "$min_length" ] || return 1
+  [ "${#value}" -le "$max_length" ] || return 1
+  case "$value" in *[!A-Za-z0-9._~-]*) return 1 ;; esac
+}
+
+workflow_file=/secrets/workflow/workflow-internal-api-key
+workflow_properties=/secrets/workflow/workflow-internal.properties
+tenant_key_file=/secrets/tenant/tenant-key
+tenant_secret_file=/secrets/tenant/tenant-secret
+tenant_properties=/secrets/tenant/tenant-bootstrap.properties
+
+for file in \
+  "$workflow_file" "$workflow_properties" "$tenant_key_file" \
+  "$tenant_secret_file" "$tenant_properties"
+do
+  [ -f "$file" ] && [ ! -L "$file" ] || exit 20
+  [ "$(stat -c '%a' "$file")" = 444 ] || exit 21
+done
+
+workflow_key="$(sed -n '1p' "$workflow_file")"
+tenant_key="$(sed -n '1p' "$tenant_key_file")"
+tenant_secret="$(sed -n '1p' "$tenant_secret_file")"
+safe_token "$workflow_key" 32 128 || exit 22
+safe_token "$tenant_key" 32 50 || exit 23
+safe_token "$tenant_secret" 32 50 || exit 24
+[ "$tenant_key" != "$tenant_secret" ] || exit 25
+[ "$workflow_key" != 'CHANGE_ME_WORKFLOW_INTERNAL_API_KEY' ] || exit 26
+[ "$tenant_key" != '7b709739e8da44536127a333c7603a83' ] || exit 27
+[ "$tenant_secret" != 'NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy' ] || exit 28
+
+grep -Fqx "workflow.internal-api-key=$workflow_key" "$workflow_properties" || exit 29
+grep -Fqx 'api.url.tenantId=680ab54f' "$tenant_properties" || exit 30
+grep -Fqx "api.url.tenantKey=$tenant_key" "$tenant_properties" || exit 31
+grep -Fqx "api.url.tenantSecret=$tenant_secret" "$tenant_properties" || exit 32
+grep -Fqx "api.url.apiKey=$tenant_key" "$tenant_properties" || exit 33
+grep -Fqx "api.url.apiSecret=$tenant_secret" "$tenant_properties" || exit 34
+grep -Fqx 'common.appid=680ab54f' "$tenant_properties" || exit 35
+grep -Fqx "common.apiKey=$tenant_key" "$tenant_properties" || exit 36
+grep -Fqx "common.apiSecret=$tenant_secret" "$tenant_properties" || exit 37
+grep -Fqx 'maas.appId=680ab54f' "$tenant_properties" || exit 38
+grep -Fqx "maas.apiKey=$tenant_key" "$tenant_properties" || exit 39
+grep -Fqx "maas.apiSecret=$tenant_secret" "$tenant_properties" || exit 40
+grep -Fqx 'maas.consumerId=680ab54f' "$tenant_properties" || exit 41
+grep -Fqx "maas.consumerKey=$tenant_key" "$tenant_properties" || exit 42
+grep -Fqx "maas.consumerSecret=$tenant_secret" "$tenant_properties" || exit 43
+
+token_hash() {
+  printf '%s' "$1" | sha256sum | cut -d ' ' -f 1
+}
+token_hash "$workflow_key"
+token_hash "$tenant_key"
+token_hash "$tenant_secret"
+"""
+
+
+def exercise_credential_lifecycle(compose_file: Path) -> None:
+    """Exercise generated credential volumes without starting the full stack."""
+
+    compose_command = list(_select_compose_command(compose_file))
+    project_name = f"astroncredentialtest{uuid.uuid4().hex[:12]}"
+    prefix = compose_command + [
+        "--project-name",
+        project_name,
+        "-f",
+        compose_file.name,
+    ]
+    cwd = compose_file.parent
+
+    def run_initializer(environment: Mapping[str, str], should_succeed: bool) -> None:
+        completed = _run_quiet(
+            prefix + ["run", "--rm", "--no-deps", INTERNAL_CREDENTIAL_INIT],
+            cwd,
+            environment,
+        )
+        if (completed.returncode == 0) != should_succeed:
+            expectation = "succeed" if should_succeed else "fail"
+            raise GateError(
+                f"credential lifecycle initializer did not {expectation} as expected"
+            )
+
+    def run_volume_script(script: str) -> subprocess.CompletedProcess[str]:
+        return _run_quiet(
+            prefix
+            + [
+                "run",
+                "--rm",
+                "--no-deps",
+                "--entrypoint",
+                "/bin/sh",
+                INTERNAL_CREDENTIAL_INIT,
+                "-ec",
+                script,
+            ],
+            cwd,
+            _credential_environment(),
+        )
+
+    def snapshot() -> Tuple[str, str, str]:
+        completed = run_volume_script(_SNAPSHOT_SCRIPT)
+        if completed.returncode != 0:
+            raise GateError("credential lifecycle volume validation failed")
+        hashes = [
+            line.strip()
+            for line in completed.stdout.splitlines()
+            if re.fullmatch(r"[0-9a-f]{64}", line.strip())
+        ]
+        if len(hashes) != 3:
+            raise GateError("credential lifecycle snapshot was incomplete")
+        return hashes[0], hashes[1], hashes[2]
+
+    empty_environment = _credential_environment()
+    try:
+        run_initializer(empty_environment, True)
+        first_snapshot = snapshot()
+        run_initializer(empty_environment, True)
+        if snapshot() != first_snapshot:
+            raise GateError("generated credentials were not reused on restart")
+
+        seed_legacy = f"""
+umask 077
+mkdir -p /secrets/workflow /secrets/tenant
+printf '%s\\n' '{WORKFLOW_PLACEHOLDER}' > /secrets/workflow/workflow-internal-api-key
+printf '%s\\n' '{LEGACY_TENANT_KEY}' > /secrets/tenant/tenant-key
+printf '%s\\n' '{LEGACY_TENANT_SECRET}' > /secrets/tenant/tenant-secret
+"""
+        seeded = run_volume_script(seed_legacy)
+        if seeded.returncode != 0:
+            raise GateError("credential lifecycle legacy fixture setup failed")
+        run_initializer(
+            _credential_environment(
+                WORKFLOW_PLACEHOLDER, LEGACY_TENANT_KEY, LEGACY_TENANT_SECRET
+            ),
+            True,
+        )
+        rotated_snapshot = snapshot()
+        legacy_hashes = (
+            hashlib.sha256(WORKFLOW_PLACEHOLDER.encode()).hexdigest(),
+            hashlib.sha256(LEGACY_TENANT_KEY.encode()).hexdigest(),
+            hashlib.sha256(LEGACY_TENANT_SECRET.encode()).hexdigest(),
+        )
+        if rotated_snapshot == legacy_hashes:
+            raise GateError("published legacy credentials were not rotated")
+
+        workflow_override = "W" * 64
+        tenant_key_override = "K" * 48
+        tenant_secret_override = "S" * 48
+        override_environment = _credential_environment(
+            workflow_override, tenant_key_override, tenant_secret_override
+        )
+        expected_override_hashes = (
+            hashlib.sha256(workflow_override.encode()).hexdigest(),
+            hashlib.sha256(tenant_key_override.encode()).hexdigest(),
+            hashlib.sha256(tenant_secret_override.encode()).hexdigest(),
+        )
+        run_initializer(override_environment, True)
+        if snapshot() != expected_override_hashes:
+            raise GateError("explicit credential overrides were not persisted")
+        run_initializer(empty_environment, True)
+        if snapshot() != expected_override_hashes:
+            raise GateError("persisted credential overrides were not reused")
+
+        run_initializer(_credential_environment("", tenant_key_override, ""), False)
+        if snapshot() != expected_override_hashes:
+            raise GateError("an incomplete tenant override changed persisted data")
+
+        run_initializer(
+            _credential_environment("", LEGACY_TENANT_KEY, tenant_secret_override),
+            False,
+        )
+        if snapshot() != expected_override_hashes:
+            raise GateError("a mixed legacy tenant override changed persisted data")
+    finally:
+        _run_quiet(
+            prefix + ["down", "--volumes", "--remove-orphans"],
+            cwd,
+            empty_environment,
+        )
+
+
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     default_compose_file = (
         Path(__file__).resolve().parent.parent / "docker-compose-with-auth.yaml"
@@ -393,9 +1107,12 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help="Compose entrypoint (default: docker-compose-with-auth.yaml next to scripts/)",
     )
     parser.add_argument(
-        "--ci-placeholder-required-env",
+        "--exercise-credential-lifecycle",
         action="store_true",
-        help="Use non-secret placeholders for required deployment variables in CI only",
+        help=(
+            "Use a temporary Compose project to verify generation, reuse, "
+            "legacy rotation, explicit overrides, and invalid-pair rejection"
+        ),
     )
     return parser.parse_args(argv)
 
@@ -408,27 +1125,36 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     try:
-        config = _render_compose(
-            compose_file,
-            ci_placeholder_required_env=args.ci_placeholder_required_env,
-        )
+        config = _render_compose(compose_file)
         errors = validate_contract(config)
         if errors:
             for error in errors:
                 print(f"security contract gate: FAIL: {error}", file=sys.stderr)
             return 1
         run_negative_self_tests(config)
+        exercise_shell_credential_lifecycle(config)
+        if args.exercise_credential_lifecycle:
+            exercise_credential_lifecycle(compose_file)
     except GateError as exc:
         print(f"security contract gate: FAIL: {exc}", file=sys.stderr)
         return 1
     except Exception:
         # Never serialize an unexpected object which could include rendered env.
-        print("security contract gate: FAIL: internal validation error", file=sys.stderr)
+        print(
+            "security contract gate: FAIL: internal validation error", file=sys.stderr
+        )
         return 1
 
     print(
         "security contract gate: PASS "
-        f"(3 services, 2 independent credential volumes, {len(_negative_cases())} negative cases)"
+        f"(5 services, 4 independent credential volumes, "
+        f"{len(_negative_cases())} negative cases, shell lifecycle exercised"
+        + (
+            ", credential lifecycle exercised"
+            if args.exercise_credential_lifecycle
+            else ""
+        )
+        + ")"
     )
     return 0
 

--- a/docker/ragflow/.env
+++ b/docker/ragflow/.env
@@ -18,8 +18,8 @@ STACK_VERSION=8.11.3
 # The hostname where the Elasticsearch service is exposed
 ES_HOST=es01
 
-# The port used to expose the Elasticsearch service to the host machine,
-# allowing EXTERNAL access to the service running inside the Docker container.
+# The host-loopback maintenance port for Elasticsearch. Container-to-container
+# traffic uses ES_HOST on the private Compose network.
 ES_PORT=1200
 
 # The password for Elasticsearch.
@@ -59,19 +59,18 @@ MYSQL_PASSWORD=infini_rag_flow
 MYSQL_HOST=mysql
 # The database of the MySQL service to use
 MYSQL_DBNAME=rag_flow
-# The port used to expose the MySQL service to the host machine,
-# allowing EXTERNAL access to the MySQL database running inside the Docker container.
+# The host-loopback maintenance port for MySQL. Container-to-container traffic
+# uses MYSQL_HOST on the private Compose network.
 MYSQL_PORT=5455
 # The maximum size of communication packets sent to the MySQL server
 MYSQL_MAX_PACKET=1073741824
 
 # The hostname where the MinIO service is exposed
 MINIO_HOST=minio
-# The port used to expose the MinIO console interface to the host machine,
-# allowing EXTERNAL access to the web-based console running inside the Docker container.
+# The host-loopback maintenance port for the MinIO console.
 MINIO_CONSOLE_PORT=9001
-# The port used to expose the MinIO API service to the host machine,
-# allowing EXTERNAL access to the MinIO object storage service running inside the Docker container.
+# The host-loopback maintenance port for the MinIO API. RAGFlow containers use
+# MINIO_HOST on the private Compose network.
 MINIO_PORT=9000
 # The username for MinIO.
 # When updated, you must revise the `minio.user` entry in service_conf.yaml accordingly.
@@ -82,8 +81,8 @@ MINIO_PASSWORD=infini_rag_flow
 
 # The hostname where the Redis service is exposed
 REDIS_HOST=redis
-# The port used to expose the Redis service to the host machine,
-# allowing EXTERNAL access to the Redis service running inside the Docker container.
+# The host-loopback maintenance port for Redis. Container-to-container traffic
+# uses REDIS_HOST on the private Compose network.
 REDIS_PORT=6379
 # The password for Redis.
 REDIS_PASSWORD=infini_rag_flow

--- a/docker/ragflow/README.md
+++ b/docker/ragflow/README.md
@@ -29,7 +29,7 @@ The [.env](./.env) file contains important environment variables for Docker.
 - `STACK_VERSION`  
   The version of Elasticsearch. Defaults to `8.11.3`
 - `ES_PORT`  
-  The port used to expose the Elasticsearch service to the host machine, allowing **external** access to the service running inside the Docker container.  Defaults to `1200`.
+  The host-loopback maintenance port for Elasticsearch. Defaults to `1200`. Containers use the private Compose network.
 - `ELASTIC_PASSWORD`  
   The password for Elasticsearch.
 
@@ -52,14 +52,14 @@ The [.env](./.env) file contains important environment variables for Docker.
 - `MYSQL_PASSWORD`  
   The password for MySQL.
 - `MYSQL_PORT`  
-  The port used to expose the MySQL service to the host machine, allowing **external** access to the MySQL database running inside the Docker container. Defaults to `5455`.
+  The host-loopback maintenance port for MySQL. Defaults to `5455`. Containers use the private Compose network.
 
 ### MinIO
 
 - `MINIO_CONSOLE_PORT`  
-  The port used to expose the MinIO console interface to the host machine, allowing **external** access to the web-based console running inside the Docker container. Defaults to `9001`
+  The host-loopback maintenance port for the MinIO console. Defaults to `9001`.
 - `MINIO_PORT`  
-  The port used to expose the MinIO API service to the host machine, allowing **external** access to the MinIO object storage service running inside the Docker container. Defaults to `9000`.
+  The host-loopback maintenance port for the MinIO API. Defaults to `9000`. Containers use the private Compose network.
 - `MINIO_USER`  
   The username for MinIO.
 - `MINIO_PASSWORD`  
@@ -68,7 +68,7 @@ The [.env](./.env) file contains important environment variables for Docker.
 ### Redis
 
 - `REDIS_PORT`  
-  The port used to expose the Redis service to the host machine, allowing **external** access to the Redis service running inside the Docker container. Defaults to `6379`.
+  The host-loopback maintenance port for Redis. Defaults to `6379`. Containers use the private Compose network.
 - `REDIS_PASSWORD`  
   The password for Redis.
 

--- a/docker/ragflow/docker-compose-base.yml
+++ b/docker/ragflow/docker-compose-base.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - esdata01:/usr/share/elasticsearch/data
     ports:
-      - ${ES_PORT}:9200
+      - "127.0.0.1:${ES_PORT}:9200"
     env_file: .env
     environment:
       - node.name=es01
@@ -43,7 +43,7 @@ services:
     volumes:
       - osdata01:/usr/share/opensearch/data
     ports:
-      - ${OS_PORT}:9201
+      - "127.0.0.1:${OS_PORT}:9201"
     env_file: .env
     environment:
       - node.name=opensearch01
@@ -83,9 +83,9 @@ services:
       - ./infinity_conf.toml:/infinity_conf.toml
     command: ["-f", "/infinity_conf.toml"]
     ports:
-      - ${INFINITY_THRIFT_PORT}:23817
-      - ${INFINITY_HTTP_PORT}:23820
-      - ${INFINITY_PSQL_PORT}:5432
+      - "127.0.0.1:${INFINITY_THRIFT_PORT}:23817"
+      - "127.0.0.1:${INFINITY_HTTP_PORT}:23820"
+      - "127.0.0.1:${INFINITY_PSQL_PORT}:5432"
     env_file: .env
     environment:
       - TZ=${TIMEZONE}
@@ -110,7 +110,7 @@ services:
     image: ${SANDBOX_EXECUTOR_MANAGER_IMAGE-infiniflow/sandbox-executor-manager:latest}
     privileged: true
     ports:
-      - ${SANDBOX_EXECUTOR_MANAGER_PORT-9385}:9385
+      - "127.0.0.1:${SANDBOX_EXECUTOR_MANAGER_PORT-9385}:9385"
     env_file: .env
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -150,7 +150,7 @@ services:
       --init-file /data/application/init.sql
       --binlog_expire_logs_seconds=604800
     ports:
-      - ${MYSQL_PORT}:3306
+      - "127.0.0.1:${MYSQL_PORT}:3306"
     volumes:
       - mysql_data:/var/lib/mysql
       - ./init.sql:/data/application/init.sql
@@ -168,8 +168,8 @@ services:
     container_name: ragflow-minio
     command: server --console-address ":9001" /data
     ports:
-      - ${MINIO_PORT}:9000
-      - ${MINIO_CONSOLE_PORT}:9001
+      - "127.0.0.1:${MINIO_PORT}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT}:9001"
     env_file: .env
     environment:
       - MINIO_ROOT_USER=${MINIO_USER}
@@ -193,7 +193,7 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 128mb --maxmemory-policy allkeys-lru
     env_file: .env
     ports:
-      - ${REDIS_PORT}:6379
+      - "127.0.0.1:${REDIS_PORT}:6379"
     volumes:
       - redis_data:/data
     networks:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,10 +17,18 @@ Before deploying with Docker Compose, the following environment variables **must
 - **Host Address Configuration**:
   - `HOST_BASE_ADDRESS` - Set to your server address or domain name
 
-- **Workflow Internal Authentication**:
-  - `WORKFLOW_INTERNAL_API_KEY` - Generate at least 32 random bytes and use
-    the same value for console-hub and core-workflow. The placeholder value is
-    rejected. The Helm chart generates and preserves this Secret automatically.
+- **Deployment-internal authentication (no manual configuration)**:
+  - Docker Compose generates and persists `WORKFLOW_INTERNAL_API_KEY`,
+    `TENANT_KEY`, and `TENANT_SECRET` on first startup when their `.env` values
+    are empty. Helm generates and reuses the corresponding Secrets on live
+    installs and upgrades. Strong explicit overrides remain available, but are
+    not required for the normal startup path.
+
+- **Sandbox Internal Authentication**:
+  - Docker Compose generates and persists the artifact-upload and runtime tokens
+    when their `.env` values are empty. Helm does the same when both `token` and
+    `existingSecret` are empty; offline GitOps rendering should use pre-created
+    independent Secrets so their values remain stable between renders.
 
 **Business capability accounts configured after startup in Platform Account Management** (not written to `.env`):
 
@@ -52,8 +60,8 @@ Configuration items in this document are marked as follows:
 >   - Kafka related: `KAFKA_SERVERS` and authentication information (if needed)
 >   - MinIO related: `OSS_ENDPOINT`, `OSS_DOWNLOAD_HOST`, `OSS_ACCESS_KEY_ID`, `OSS_ACCESS_KEY_SECRET`, etc.
 >
-> **MinIO security defaults**:
-> - Docker Compose has no built-in MinIO credential. Set a unique `MINIO_ROOT_USER`/`OSS_ACCESS_KEY_ID` (at least 8 characters) and random `MINIO_ROOT_PASSWORD`/`OSS_ACCESS_KEY_SECRET` (at least 16 characters). Empty, short, placeholder, and well-known default values are rejected before MinIO starts.
+> **MinIO defaults**:
+> - To preserve one-command Docker Compose startup, the bundled MinIO uses `minioadmin`/`minioadmin123` by default and OSS clients derive their credentials from the same values. No manual credential entry is required. Replacing bundled MinIO with external object storage requires an explicit Compose override that replaces the bundled MinIO and its configuration check, then configures the external endpoint, access key, and secret key together.
 > - The bundled MinIO API and administrative console bind only to `127.0.0.1` on the host. Application containers use the configured API port over the private Compose network; `minio.localhost` gives local browsers and containers one identical signed hostname. Remote access must be an explicit decision through a separately protected TLS proxy; do not publish MinIO directly to an untrusted network.
 > - The Helm chart does not render MinIO credentials. Pre-create `minio.auth.existingSecret`; the bundled API and console Services default to separate `ClusterIP` Services. `NodePort`/`LoadBalancer` exposure is opt-in, and exposing the API never implicitly exposes the console.
 
@@ -84,14 +92,14 @@ Configuration items in this document are marked as follows:
 | KAFKA_CLUSTER_ID | Use Default | string | Kafka cluster ID | MkU3OEVBNTcwNTJENDM2Qk |
 | KAFKA_TIMEOUT | Use Default | int | Kafka connection timeout (seconds) | 60 |
 | KAFKA_SERVERS | Use Default | string | Kafka server address list | kafka:29092 |
-| MINIO_ROOT_USER | User Required | string | Unique MinIO administrator username; at least 8 characters, with no built-in default | (no default) |
-| MINIO_ROOT_PASSWORD | User Required | string | Random MinIO administrator password; at least 16 characters, with no built-in default | (no default) |
+| MINIO_ROOT_USER | Use Default | string | Bundled MinIO administrator username; override when exposing MinIO externally | minioadmin |
+| MINIO_ROOT_PASSWORD | Use Default | string | Bundled MinIO administrator password; override when exposing MinIO externally | minioadmin123 |
 | EXPOSE_MINIO_PORT | Use Default | int | Host loopback-only MinIO API maintenance port (`127.0.0.1` binding is fixed by Compose) | 18998 |
 | EXPOSE_MINIO_CONSOLE_PORT | Use Default | int | Host loopback-only MinIO console maintenance port (`127.0.0.1` binding is fixed by Compose) | 18999 |
 | OSS_TYPE | Use Default | string | Object storage type (s3/oss/obs, etc.) | s3 |
 | OSS_ENDPOINT | Use Default | url | Object storage service endpoint address | http://minio:${EXPOSE_MINIO_PORT} |
-| OSS_ACCESS_KEY_ID | User Required | string | Explicit object-storage access key ID; normally the configured MinIO user for the bundled service | ${MINIO_ROOT_USER} |
-| OSS_ACCESS_KEY_SECRET | User Required | string | Explicit random object-storage access key secret | ${MINIO_ROOT_PASSWORD} |
+| OSS_ACCESS_KEY_ID | Use Default | string | Object-storage access key ID; bundled MinIO derives it from the administrator username | ${MINIO_ROOT_USER:-minioadmin} |
+| OSS_ACCESS_KEY_SECRET | Use Default | string | Object-storage access key secret; bundled MinIO derives it from the administrator password | ${MINIO_ROOT_PASSWORD:-minioadmin123} |
 | OSS_BUCKET_NAME | Use Default | string | Object storage bucket name | workflow |
 | OSS_TTL | Use Default | int | Object storage URL validity period (seconds) | 157788000 |
 | OSS_DOWNLOAD_HOST | Use Default | url | Endpoint embedded in download URLs; `minio.localhost` resolves to host loopback for local browsers and to MinIO's private-network alias for containers, preserving the signed Host | http://minio.localhost:${EXPOSE_MINIO_PORT} |
@@ -230,8 +238,8 @@ See the [Langfuse observability guide](/guide/observability) for privacy behavio
 | RUN_MCP_PLUGIN_URL | Required | url | API address to run MCP plugin | http://core-link:18888/api/v1/mcp/call_tool |
 | APP_AUTH_HOST | Required | string | Application authentication service host address (port defaults from CORE_TENANT_PORT) | core-tenant:${CORE_TENANT_PORT:-5052} |
 | APP_AUTH_PROT | Required | string | Application authentication service protocol (http/https) | http |
-| APP_AUTH_API_KEY | Required | string | Application authentication API Key | 7b709739e8da44536127a333c7603a83 |
-| APP_AUTH_SECRET | Required | string | Application authentication Secret | NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy |
+| APP_AUTH_API_KEY | Derived | secret | Application authentication API Key, loaded from the generated tenant bootstrap credential | generated and persisted |
+| APP_AUTH_SECRET | Derived | secret | Application authentication Secret, loaded from the generated tenant bootstrap credential | generated and persisted |
 | SKILL_RESOURCE_TRUSTED_ORIGIN | Derived | url origin | Only remote origin from which Core Agent may fetch Skill resources; Compose derives it from `OSS_REMOTE_ENDPOINT`, Helm from `minio.publicEndpoint`/the effective MinIO public endpoint; no other URL origin is trusted | http://minio.localhost:${EXPOSE_MINIO_PORT} |
 | SKILL_RESOURCE_TRUSTED_BUCKET | Derived | string | Only bucket accepted for remote Skill resources; Compose/Helm derive it from `OSS_BUCKET_CONSOLE`/`consoleHub.env.ossBucketConsole`, and Core Agent additionally restricts keys to `skill-files/` with complete SigV4 parameters | console-oss |
 
@@ -263,7 +271,7 @@ See the [Langfuse observability guide](/guide/observability) for privacy behavio
 | WORKFLOW_KAFKA_TOPIC | Required | string | Kafka topic name used by Workflow | spark-agent-builder |
 | RUNTIME_ENV | Required | string | Runtime environment (dev/test/prod) | dev |
 | CODE_EXEC_TYPE | Required | string | Isolated code executor. The default is `disabled`; `local` is rejected. Configure E2B, iFly, iFly-v2, or the network-disabled LangChain sandbox before enabling code nodes. | disabled |
-| WORKFLOW_INTERNAL_API_KEY | User Required | secret | Authenticates privileged console-hub calls to workflow node-debug and code-run APIs. Use at least 32 random bytes. | generated secret |
+| WORKFLOW_INTERNAL_API_KEY | Auto-generated | secret | Authenticates trusted internal calls to privileged Workflow APIs. Compose and Helm generate and persist it; an optional explicit override must contain 32-128 safe characters. | generated and persisted |
 
 When no isolated executor is configured, code nodes fail closed. Running
 user-provided code inside the core-workflow process is not supported.
@@ -291,8 +299,8 @@ user-provided code inside the core-workflow process is not supported.
 | WORKFLOW_DEBUG_URL | Required | url | Workflow debug API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/debug/chat/completions |
 | WORKFLOW_RESUME_URL | Required | url | Workflow resume API address (port defaults from CORE_WORKFLOW_PORT) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/resume |
 | TENANT_ID | Required | string | Tenant ID | 680ab54f |
-| TENANT_KEY | Required | string | Tenant API Key | 7b709739e8da44536127a333c7603a83 |
-| TENANT_SECRET | Required | string | Tenant Secret | NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy |
+| TENANT_KEY | Auto-generated | secret | Tenant API Key generated and persisted by Compose or Helm; leave empty for normal startup | generated and persisted |
+| TENANT_SECRET | Auto-generated | secret | Tenant Secret generated and persisted by Compose or Helm; leave empty for normal startup | generated and persisted |
 | COMMON_APPID | Required | string | Common application ID (defaults from TENANT_ID) | ${TENANT_ID} |
 | COMMON_APIKEY | Required | string | Common API Key (defaults from TENANT_KEY) | ${TENANT_KEY} |
 | COMMON_API_SECRET | Required | string | Common API Secret (defaults from TENANT_SECRET) | ${TENANT_SECRET} |

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -207,13 +207,23 @@ payloads regardless of this setting.
 3. Note the imported flow ID and the test application's ID.
 4. Send a synthetic request through the real debug route:
 
+The debug route is internal-only. For Docker Compose, load the automatically
+generated key from the running Workflow container into the current shell. For
+source or Helm deployments, load the same key from the configured environment
+or Secret instead; it does not need to be copied into `.env`.
+
 ```bash
 DEMO_FLOW_ID="<imported-flow-id>"
 DEMO_APP_ID="<test-application-id>"
+DEMO_WORKFLOW_INTERNAL_KEY="$(
+  docker compose exec -T core-workflow \
+    sh -c 'tr -d "\r\n" < "$WORKFLOW_INTERNAL_API_KEY_FILE"'
+)"
 
 curl --no-buffer \
   --header "Content-Type: application/json" \
   --header "x-consumer-username: ${DEMO_APP_ID}" \
+  --header "X-Workflow-Internal-Key: ${DEMO_WORKFLOW_INTERNAL_KEY}" \
   --data "{\"flow_id\":\"${DEMO_FLOW_ID}\",\"uid\":\"langfuse-demo-user\",\"chat_id\":\"langfuse-demo-1\",\"stream\":true,\"parameters\":{\"AGENT_USER_INPUT\":\"Synthetic request: summarize why tracing helps debugging.\"},\"ext\":{},\"history\":[]}" \
   http://127.0.0.1:7880/workflow/v1/debug/chat/completions
 ```

--- a/docs/zh/CONFIGURATION.md
+++ b/docs/zh/CONFIGURATION.md
@@ -17,6 +17,17 @@
 - **主机地址配置**:
   - `HOST_BASE_ADDRESS` - 设置为您的服务器地址或域名
 
+- **部署内部认证（无需手动配置）**：
+  - `.env` 中 `WORKFLOW_INTERNAL_API_KEY`、`TENANT_KEY`、`TENANT_SECRET`
+    留空时，Docker Compose 会在首次启动时自动生成并持久化；Helm 在安装和在线
+    升级时会自动生成并复用对应 Secret。仍可显式提供高强度值覆盖，但正常启动
+    不需要用户填写。
+
+- **Sandbox 内部认证**：
+  - `.env` 中 artifact-upload 与 runtime token 留空时，Docker Compose 会自动生成
+    并持久化。Helm 的 `token` 与 `existingSecret` 均留空时同样自动生成；离线
+    GitOps 渲染应使用两个预创建且相互独立的 Secret，确保多次渲染时值保持稳定。
+
 **启动后在平台账号管理中配置的业务能力账号**（不写入 `.env`）：
 
 - **讯飞开放平台**：`PLATFORM_APP_ID`、`PLATFORM_API_KEY`、`PLATFORM_API_SECRET`、`SPARK_API_PASSWORD`、`SPARK_RTASR_API_KEY`
@@ -47,8 +58,8 @@
 >   - Kafka 相关：`KAFKA_SERVERS` 及认证信息（如需要）
 >   - MinIO 相关：`OSS_ENDPOINT`、`OSS_DOWNLOAD_HOST`、`OSS_ACCESS_KEY_ID`、`OSS_ACCESS_KEY_SECRET` 等
 >
-> **MinIO 安全默认值**：
-> - Docker Compose 不再内置 MinIO 凭据。必须设置唯一的 `MINIO_ROOT_USER`/`OSS_ACCESS_KEY_ID`（至少 8 个字符）和随机的 `MINIO_ROOT_PASSWORD`/`OSS_ACCESS_KEY_SECRET`（至少 16 个字符）；MinIO 启动前会拒绝空值、短值、占位符及已知默认值。
+> **MinIO 默认配置**：
+> - 为保持 Docker Compose 一键部署体验，内置 MinIO 默认使用 `minioadmin`/`minioadmin123`，OSS 客户端凭据自动从同一组值派生，无需手动填写。替换为外部对象存储时，需通过显式 Compose override 同时替换内置 MinIO 及其配置检查，并同步配置外部 endpoint、access key 和 secret key。
 > - 内置 MinIO API 与管理控制台在宿主机上只绑定 `127.0.0.1`，应用容器通过私有 Compose 网络访问配置的 API 端口；`minio.localhost` 让本地浏览器与容器使用同一个签名主机名。远程访问必须显式通过单独保护的 TLS 代理提供，禁止将 MinIO 直接发布到不可信网络。
 > - Helm Chart 不渲染 MinIO 凭据，需预先创建 `minio.auth.existingSecret`。内置 API 与控制台默认为相互独立的 `ClusterIP` Service；`NodePort`/`LoadBalancer` 必须显式启用，开放 API 不会连带开放控制台。
 
@@ -79,14 +90,14 @@
 | KAFKA_CLUSTER_ID | 使用默认 | string | Kafka 集群 ID | MkU3OEVBNTcwNTJENDM2Qk |
 | KAFKA_TIMEOUT | 使用默认 | int | Kafka 连接超时时间(秒) | 60 |
 | KAFKA_SERVERS | 使用默认 | string | Kafka 服务器地址列表 | kafka:29092 |
-| MINIO_ROOT_USER | 用户必填 | string | 唯一的 MinIO 管理员用户名，至少 8 个字符且无内置默认值 | （无默认值） |
-| MINIO_ROOT_PASSWORD | 用户必填 | string | 随机的 MinIO 管理员密码，至少 16 个字符且无内置默认值 | （无默认值） |
+| MINIO_ROOT_USER | 使用默认 | string | 内置 MinIO 管理员用户名；对外提供 MinIO 服务时应覆盖 | minioadmin |
+| MINIO_ROOT_PASSWORD | 使用默认 | string | 内置 MinIO 管理员密码；对外提供 MinIO 服务时应覆盖 | minioadmin123 |
 | EXPOSE_MINIO_PORT | 使用默认 | int | 仅绑定宿主机回环地址的 MinIO API 运维端口（Compose 固定绑定 `127.0.0.1`） | 18998 |
 | EXPOSE_MINIO_CONSOLE_PORT | 使用默认 | int | 仅绑定宿主机回环地址的 MinIO 控制台运维端口（Compose 固定绑定 `127.0.0.1`） | 18999 |
 | OSS_TYPE | 使用默认 | string | 对象存储类型(s3/oss/obs 等) | s3 |
 | OSS_ENDPOINT | 使用默认 | url | 对象存储服务端点地址 | http://minio:${EXPOSE_MINIO_PORT} |
-| OSS_ACCESS_KEY_ID | 用户必填 | string | 显式配置的对象存储访问密钥 ID；使用内置 MinIO 时通常等于已配置的 MinIO 用户名 | ${MINIO_ROOT_USER} |
-| OSS_ACCESS_KEY_SECRET | 用户必填 | string | 显式配置的随机对象存储访问密钥 Secret | ${MINIO_ROOT_PASSWORD} |
+| OSS_ACCESS_KEY_ID | 使用默认 | string | 对象存储访问密钥 ID；内置 MinIO 默认从管理员用户名派生 | ${MINIO_ROOT_USER:-minioadmin} |
+| OSS_ACCESS_KEY_SECRET | 使用默认 | string | 对象存储访问密钥 Secret；内置 MinIO 默认从管理员密码派生 | ${MINIO_ROOT_PASSWORD:-minioadmin123} |
 | OSS_BUCKET_NAME | 使用默认 | string | 对象存储桶名称 | workflow |
 | OSS_TTL | 使用默认 | int | 对象存储 URL 有效期(秒) | 157788000 |
 | OSS_DOWNLOAD_HOST | 使用默认 | url | 下载 URL 使用的端点；`minio.localhost` 在本地浏览器解析为宿主机回环地址，在容器内解析为 MinIO 私有网络别名，从而保持签名 Host 一致 | http://minio.localhost:${EXPOSE_MINIO_PORT} |
@@ -225,8 +236,8 @@
 | RUN_MCP_PLUGIN_URL | 必填 | url | 运行 MCP 插件的接口地址 | http://core-link:18888/api/v1/mcp/call_tool |
 | APP_AUTH_HOST | 必填 | string | 应用认证服务主机地址(默认从 CORE_TENANT_PORT 获取端口) | core-tenant:${CORE_TENANT_PORT:-5052} |
 | APP_AUTH_PROT | 必填 | string | 应用认证服务协议(http/https) | http |
-| APP_AUTH_API_KEY | 必填 | string | 应用认证 API Key | 7b709739e8da44536127a333c7603a83 |
-| APP_AUTH_SECRET | 必填 | string | 应用认证 Secret | NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy |
+| APP_AUTH_API_KEY | 自动派生 | secret | 从自动生成的租户 bootstrap 凭据加载的应用认证 API Key | 自动生成并持久化 |
+| APP_AUTH_SECRET | 自动派生 | secret | 从自动生成的租户 bootstrap 凭据加载的应用认证 Secret | 自动生成并持久化 |
 | SKILL_RESOURCE_TRUSTED_ORIGIN | 自动派生 | URL origin | Core Agent 仅允许从该远程 origin 获取 Skill 资源；Compose 从 `OSS_REMOTE_ENDPOINT` 派生，Helm 从 `minio.publicEndpoint`/最终生效的 MinIO 公共端点派生，其他 URL origin 默认均不受信任 | http://minio.localhost:${EXPOSE_MINIO_PORT} |
 | SKILL_RESOURCE_TRUSTED_BUCKET | 自动派生 | string | Core Agent 仅接受该存储桶中的远程 Skill 资源；Compose/Helm 从 `OSS_BUCKET_CONSOLE`/`consoleHub.env.ossBucketConsole` 派生，并进一步限制对象键必须位于 `skill-files/` 且包含完整 SigV4 参数 | console-oss |
 
@@ -257,6 +268,7 @@
 | WORKFLOW_MYSQL_DB | 必填 | string | Workflow 模块使用的 MySQL 数据库名称 | workflow |
 | WORKFLOW_KAFKA_TOPIC | 必填 | string | Workflow 使用的 Kafka 主题名称 | spark-agent-builder |
 | RUNTIME_ENV | 必填 | string | 运行环境(dev/test/prod) | dev |
+| WORKFLOW_INTERNAL_API_KEY | 自动生成 | secret | 用于可信内部调用访问 Workflow 特权接口；Compose 与 Helm 会自动生成并持久化，显式覆盖值需为 32-128 个安全字符 | 自动生成并持久化 |
 
 ---
 
@@ -281,8 +293,8 @@
 | WORKFLOW_DEBUG_URL | 必填 | url | 工作流调试接口地址(默认从 CORE_WORKFLOW_PORT 获取端口) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/debug/chat/completions |
 | WORKFLOW_RESUME_URL | 必填 | url | 工作流恢复接口地址(默认从 CORE_WORKFLOW_PORT 获取端口) | http://core-workflow:${CORE_WORKFLOW_PORT:-7880}/workflow/v1/resume |
 | TENANT_ID | 必填 | string | 租户 ID | 680ab54f |
-| TENANT_KEY | 必填 | string | 租户 API Key | 7b709739e8da44536127a333c7603a83 |
-| TENANT_SECRET | 必填 | string | 租户 Secret | NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy |
+| TENANT_KEY | 自动生成 | secret | Compose 或 Helm 自动生成并持久化的租户 API Key；正常启动时保持留空 | 自动生成并持久化 |
+| TENANT_SECRET | 自动生成 | secret | Compose 或 Helm 自动生成并持久化的租户 Secret；正常启动时保持留空 | 自动生成并持久化 |
 | COMMON_APPID | 必填 | string | 通用应用 ID(默认从 TENANT_ID 获取) | ${TENANT_ID} |
 | COMMON_APIKEY | 必填 | string | 通用 API Key(默认从 TENANT_KEY 获取) | ${TENANT_KEY} |
 | COMMON_API_SECRET | 必填 | string | 通用 API Secret(默认从 TENANT_SECRET 获取) | ${TENANT_SECRET} |

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -178,13 +178,22 @@ Observation 的 input 和 output 时，也必须显式开启该选项。无论�
 3. 记录导入后的 Flow ID 和测试应用 ID。
 4. 通过真实 debug 路由发送合成请求：
 
+debug 路由仅供内部调用。Docker Compose 部署可以从正在运行的 Workflow 容器
+读取自动生成的密钥到当前 shell；源码或 Helm 部署则从已配置的环境或 Secret
+读取同一个密钥，无需把它再复制到 `.env`。
+
 ```bash
 DEMO_FLOW_ID="<imported-flow-id>"
 DEMO_APP_ID="<test-application-id>"
+DEMO_WORKFLOW_INTERNAL_KEY="$(
+  docker compose exec -T core-workflow \
+    sh -c 'tr -d "\r\n" < "$WORKFLOW_INTERNAL_API_KEY_FILE"'
+)"
 
 curl --no-buffer \
   --header "Content-Type: application/json" \
   --header "x-consumer-username: ${DEMO_APP_ID}" \
+  --header "X-Workflow-Internal-Key: ${DEMO_WORKFLOW_INTERNAL_KEY}" \
   --data "{\"flow_id\":\"${DEMO_FLOW_ID}\",\"uid\":\"langfuse-demo-user\",\"chat_id\":\"langfuse-demo-1\",\"stream\":true,\"parameters\":{\"AGENT_USER_INPUT\":\"Synthetic request: summarize why tracing helps debugging.\"},\"ext\":{},\"history\":[]}" \
   http://127.0.0.1:7880/workflow/v1/debug/chat/completions
 ```

--- a/helm/astron-agent/files/config/agent/config.env
+++ b/helm/astron-agent/files/config/agent/config.env
@@ -100,10 +100,11 @@ RUN_MCP_PLUGIN_URL=http://YOUR_MCP_HOST:18888/api/v1/mcp/call_tool
 
 # App Authentication Configuration
 APP_AUTH_HOST=YOUR_APP_AUTH_HOST
-APP_AUTH_ROUTER=/api-services/v2/app/details
+APP_AUTH_ROUTER=/v2/app/details
 APP_AUTH_PROT=http
-APP_AUTH_API_KEY=YOUR_APP_AUTH_API_KEY
-APP_AUTH_SECRET=YOUR_APP_AUTH_SECRET
+# Deployment-managed credentials are injected from tenantBootstrap.
+APP_AUTH_API_KEY=
+APP_AUTH_SECRET=
 
 # LLM Request Configuration
 # Skip SSL certificate verification (only for development/testing)

--- a/helm/astron-agent/files/config/workflow/config.env
+++ b/helm/astron-agent/files/config/workflow/config.env
@@ -144,7 +144,7 @@ CODE_EXEC_URL=
 CODE_EXEC_TIMEOUT_SEC=10
 CODE_EXEC_API_KEY=
 CODE_EXEC_API_SECRET=
-WORKFLOW_INTERNAL_API_KEY=CHANGE_ME_WORKFLOW_INTERNAL_API_KEY
+WORKFLOW_INTERNAL_API_KEY=
 
 # Image Understanding Model Configuration
 # Spark image model domain specifications for visual AI processing

--- a/helm/astron-agent/files/mysql/tenant.sql
+++ b/helm/astron-agent/files/mysql/tenant.sql
@@ -49,7 +49,4 @@ CREATE TABLE `tb_auth` (
   KEY `idx_api_key` (`api_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='应用关联的鉴权表';
 
-INSERT INTO `tenant`.`tb_auth` (`update_time`, `registration_time`, `app_id`, `api_key`, `api_secret`, `source`, `is_delete`, `extend`)
-    VALUES ('2025-09-20 00:00:00', '2025-09-20 00:00:00', '680ab54f', '7b709739e8da44536127a333c7603a83', 'NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy', 0, 0, '');
-
 select 'tenant DATABASE initialization completed' as '';

--- a/helm/astron-agent/files/mysql/workflow.sql
+++ b/helm/astron-agent/files/mysql/workflow.sql
@@ -107,8 +107,5 @@ CREATE TABLE `workflow_node_history` (
 
 SET FOREIGN_KEY_CHECKS = 1;
 
-INSERT INTO `workflow`.`app` (`id`, `name`, `alias_id`, `api_key`, `api_secret`, `description`, `is_tenant`, `source`, `actual_source`, `plat_release_auth`, `status`, `audit_policy`, `create_by`, `update_by`, `create_at`, `update_at`)
-VALUES (1, '星辰', '680ab54f', '7b709739e8da44536127a333c7603a83', 'NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy', '星辰', 1, 1, 1, 1, 1, 0, 1, 1, '2025-09-20 14:10:48', '2025-09-20 14:10:51');
-
 INSERT INTO `workflow`.`app_source` (`id`, `source`, `source_id`, `description`, `create_at`, `update_at`)
 VALUES (1, 1, 'admin', '星辰', '2025-10-11 09:21:11', '2025-10-11 09:21:11');

--- a/helm/astron-agent/templates/_helpers.tpl
+++ b/helm/astron-agent/templates/_helpers.tpl
@@ -138,50 +138,38 @@ Core service URLs - 用于生成完整的服务 URL（包括协议和端口）
 {{- printf "http://%s-core-workflow:%d" (include "astron-agent.fullname" .) (.Values.coreWorkflow.service.port | int) }}
 {{- end }}
 
-{{/*
-Resolve the single pre-created object-storage Secret shared by MinIO and all S3
-clients. Inline credentials are intentionally unsupported: Helm stores rendered
-Secrets in release state, so even a Kubernetes Secret manifest would disclose
-the credential to every release-manifest reader.
-*/}}
+{{/* Resolve the single managed or external Secret shared by MinIO and S3 clients. */}}
 {{- define "astron-agent.minioSecretName" -}}
 {{- $auth := default (dict) .Values.minio.auth -}}
 {{- $existing := default "" (get $auth "existingSecret") | toString | trim -}}
-{{- $inlineUser := default "" (get $auth "rootUser") | toString | trim -}}
-{{- $inlinePassword := default "" (get $auth "rootPassword") | toString | trim -}}
 {{- if $existing -}}
 {{- $existing -}}
 {{- else -}}
-{{- if or $inlineUser $inlinePassword -}}
-{{- $userLower := lower $inlineUser -}}
-{{- $passwordLower := lower $inlinePassword -}}
-{{- if or (has $userLower (list "minioadmin" "admin" "administrator" "root" "changeme")) (has $passwordLower (list "minioadmin" "minioadmin123" "admin" "admin123" "password" "password123" "changeme")) -}}
-{{- fail "minio.auth contains a well-known default credential; create a strong Kubernetes Secret and set minio.auth.existingSecret" -}}
-{{- end -}}
-{{- if or (lt (len $inlineUser) 8) (lt (len $inlinePassword) 16) -}}
-{{- fail "minio.auth inline credentials are empty or weak; create a Kubernetes Secret with a user of at least 8 characters and a password of at least 16 characters" -}}
-{{- end -}}
-{{- fail "minio.auth inline credentials are not rendered because Helm release manifests would disclose them; set minio.auth.existingSecret" -}}
-{{- else -}}
-{{- fail "minio.auth.existingSecret is required; inline or empty MinIO credentials are not allowed" -}}
-{{- end -}}
+{{- printf "%s-minio-credentials" (include "astron-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end }}
 
 {{- define "astron-agent.minioSecretUserKey" -}}
 {{- $auth := default (dict) .Values.minio.auth -}}
-{{- required "minio.auth.rootUserKey is required when using minio.auth.existingSecret" (get $auth "rootUserKey") -}}
+{{- required "minio.auth.rootUserKey is required" (get $auth "rootUserKey") -}}
 {{- end }}
 
 {{- define "astron-agent.minioSecretPasswordKey" -}}
 {{- $auth := default (dict) .Values.minio.auth -}}
-{{- required "minio.auth.rootPasswordKey is required when using minio.auth.existingSecret" (get $auth "rootPasswordKey") -}}
+{{- required "minio.auth.rootPasswordKey is required" (get $auth "rootPasswordKey") -}}
 {{- end }}
 
 {{/* Stable non-secret rollout marker for the shared object-storage Secret. */}}
 {{- define "astron-agent.minioSecretChecksum" -}}
 {{- $auth := default (dict) .Values.minio.auth -}}
-{{- printf "%s:%s:%s:%s" (include "astron-agent.minioSecretName" .) (include "astron-agent.minioSecretUserKey" .) (include "astron-agent.minioSecretPasswordKey" .) (default "" (get $auth "existingSecretChecksum")) | sha256sum -}}
+{{- $existing := default "" (get $auth "existingSecret") | toString | trim -}}
+{{- if $existing -}}
+{{- printf "%s:%s:%s:%s" $existing (include "astron-agent.minioSecretUserKey" .) (include "astron-agent.minioSecretPasswordKey" .) (default "" (get $auth "existingSecretChecksum")) | sha256sum -}}
+{{- else -}}
+{{- $rootUser := required "minio.auth.rootUser is required when minio.auth.existingSecret is empty" (get $auth "rootUser") | toString -}}
+{{- $rootPassword := required "minio.auth.rootPassword is required when minio.auth.existingSecret is empty" (get $auth "rootPassword") | toString -}}
+{{- printf "%s:%s:%s:%s:%s" (include "astron-agent.minioSecretName" .) (include "astron-agent.minioSecretUserKey" .) (include "astron-agent.minioSecretPasswordKey" .) $rootUser $rootPassword | sha256sum -}}
+{{- end -}}
 {{- end }}
 
 {{/* Cluster-internal S3 endpoint, or an explicit endpoint when MinIO is external. */}}
@@ -214,36 +202,302 @@ the credential to every release-manifest reader.
 {{- $configured | trimSuffix "/" -}}
 {{- end }}
 
-{{/* Resolve the artifact-upload credential Secret without cluster lookup. */}}
+{{/* Resolve chart-managed or external Workflow internal authentication. */}}
+{{- define "astron-agent.workflowInternalAuthValidate" -}}
+{{- $config := default (dict) .Values.workflowInternalAuth -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if $externalName -}}
+{{- $externalKey := required "workflowInternalAuth.existingSecret.key is required when using an existing Secret" (get $external "key") | toString -}}
+{{- if not (regexMatch "^[A-Za-z0-9._-]+$" $externalKey) -}}
+{{- fail "workflowInternalAuth.existingSecret.key may contain only letters, digits, '.', '_' or '-'" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "astron-agent.workflowInternalAuthSecretName" -}}
+{{- include "astron-agent.workflowInternalAuthValidate" . -}}
+{{- $config := default (dict) .Values.workflowInternalAuth -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if $externalName -}}
+{{- $externalName -}}
+{{- else -}}
+{{- printf "%s-workflow-internal-auth" (include "astron-agent.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{- define "astron-agent.workflowInternalAuthSecretKey" -}}
+{{- $config := default (dict) .Values.workflowInternalAuth -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if $externalName -}}
+{{- required "workflowInternalAuth.existingSecret.key is required when using an existing Secret" (get $external "key") -}}
+{{- else -}}
+workflow-internal-api-key
+{{- end -}}
+{{- end }}
+
+{{/*
+Hash a valid persisted managed key so upgrades remain stable. Missing, short,
+oversized, multiline, or published-placeholder values receive a random rollout
+marker and are replaced by the managed Secret template. External Secrets are
+never read; operators advance their non-secret checksum marker when rotating.
+*/}}
+{{- define "astron-agent.workflowInternalAuthSecretChecksum" -}}
+{{- include "astron-agent.workflowInternalAuthValidate" . -}}
+{{- $config := default (dict) .Values.workflowInternalAuth -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- $secretName := include "astron-agent.workflowInternalAuthSecretName" . -}}
+{{- $secretKey := include "astron-agent.workflowInternalAuthSecretKey" . -}}
+{{- if $externalName -}}
+{{- printf "%s:%s:%s" $secretName $secretKey (default "" (get $external "checksum")) | sha256sum -}}
+{{- else -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := dict -}}
+{{- if $existingSecret -}}
+{{- $existingData = default (dict) (get $existingSecret "data") -}}
+{{- end -}}
+{{- $resolvedKey := "" -}}
+{{- if hasKey $existingData $secretKey -}}
+{{- $candidateKey := index $existingData $secretKey | b64dec -}}
+{{- if and (ge (len $candidateKey) 32) (le (len $candidateKey) 128) (not (contains "\r" $candidateKey)) (not (contains "\n" $candidateKey)) (ne $candidateKey "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY") -}}
+{{- $resolvedKey = $candidateKey -}}
+{{- end -}}
+{{- end -}}
+{{- if not $resolvedKey -}}
+{{- $resolvedKey = randAlphaNum 64 -}}
+{{- end -}}
+{{- printf "%s:%s" $secretName $resolvedKey | sha256sum -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate the shared tenant bootstrap configuration. Credentials are capped at
+50 characters because Workflow's legacy app schema stores each value in a
+varchar(50). Exact published legacy defaults are never accepted as overrides.
+*/}}
+{{- define "astron-agent.tenantBootstrapConfiguredKey" -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $rawKey := default "" (get $config "key") | toString -}}
+{{- $rawSecret := default "" (get $config "secret") | toString -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- $key := $rawKey -}}
+{{- if and (not $rawKey) (not $rawSecret) (not $externalName) -}}
+{{- $consoleHub := default (dict) .Values.consoleHub -}}
+{{- $legacyEnv := default (dict) (get $consoleHub "env") -}}
+{{- $legacyKey := default "" (get $legacyEnv "tenantKey") | toString -}}
+{{- $legacySecret := default "" (get $legacyEnv "tenantSecret") | toString -}}
+{{- if not (and (eq $legacyKey "7b709739e8da44536127a333c7603a83") (eq $legacySecret "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy")) -}}
+{{- $key = $legacyKey -}}
+{{- end -}}
+{{- end -}}
+{{- $key -}}
+{{- end }}
+
+{{- define "astron-agent.tenantBootstrapConfiguredSecret" -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $rawKey := default "" (get $config "key") | toString -}}
+{{- $rawSecret := default "" (get $config "secret") | toString -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- $secret := $rawSecret -}}
+{{- if and (not $rawKey) (not $rawSecret) (not $externalName) -}}
+{{- $consoleHub := default (dict) .Values.consoleHub -}}
+{{- $legacyEnv := default (dict) (get $consoleHub "env") -}}
+{{- $legacyKey := default "" (get $legacyEnv "tenantKey") | toString -}}
+{{- $legacySecret := default "" (get $legacyEnv "tenantSecret") | toString -}}
+{{- if not (and (eq $legacyKey "7b709739e8da44536127a333c7603a83") (eq $legacySecret "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy")) -}}
+{{- $secret = $legacySecret -}}
+{{- end -}}
+{{- end -}}
+{{- $secret -}}
+{{- end }}
+
+{{- define "astron-agent.tenantBootstrapValidate" -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $tenantID := default "680ab54f" (get $config "tenantId") | toString -}}
+{{- if ne $tenantID "680ab54f" -}}
+{{- fail "tenantBootstrap.tenantId must remain 680ab54f because persisted bootstrap data refers to this stable ID" -}}
+{{- end -}}
+{{- $rawKey := default "" (get $config "key") | toString -}}
+{{- $rawSecret := default "" (get $config "secret") | toString -}}
+{{- if ne (not $rawKey) (not $rawSecret) -}}
+{{- fail "tenantBootstrap.key and tenantBootstrap.secret must be set together" -}}
+{{- end -}}
+{{- $key := include "astron-agent.tenantBootstrapConfiguredKey" . -}}
+{{- $secret := include "astron-agent.tenantBootstrapConfiguredSecret" . -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if and $key (not $secret) -}}
+{{- fail "tenantBootstrap.key and tenantBootstrap.secret must be set together" -}}
+{{- end -}}
+{{- if and $secret (not $key) -}}
+{{- fail "tenantBootstrap.key and tenantBootstrap.secret must be set together" -}}
+{{- end -}}
+{{- if $key -}}
+{{- if or (lt (len $key) 32) (gt (len $key) 50) (not (regexMatch "^[A-Za-z0-9._~-]+$" $key)) -}}
+{{- fail "tenantBootstrap.key must contain 32-50 safe characters" -}}
+{{- end -}}
+{{- if or (lt (len $secret) 32) (gt (len $secret) 50) (not (regexMatch "^[A-Za-z0-9._~-]+$" $secret)) -}}
+{{- fail "tenantBootstrap.secret must contain 32-50 safe characters" -}}
+{{- end -}}
+{{- if eq $key $secret -}}
+{{- fail "tenantBootstrap.key and tenantBootstrap.secret must be independent values" -}}
+{{- end -}}
+{{- if or (eq $key "7b709739e8da44536127a333c7603a83") (eq $secret "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy") -}}
+{{- fail "tenantBootstrap contains a published legacy credential; leave both values empty to let Helm rotate it automatically" -}}
+{{- end -}}
+{{- else if $externalName -}}
+{{- $keyKey := required "tenantBootstrap.existingSecret.keyKey is required when using an existing Secret" (get $external "keyKey") | toString -}}
+{{- $secretKey := required "tenantBootstrap.existingSecret.secretKey is required when using an existing Secret" (get $external "secretKey") | toString -}}
+{{- if or (not (regexMatch "^[A-Za-z0-9._-]+$" $keyKey)) (not (regexMatch "^[A-Za-z0-9._-]+$" $secretKey)) -}}
+{{- fail "tenantBootstrap existing Secret keys may contain only letters, digits, '.', '_' or '-'" -}}
+{{- end -}}
+{{- if eq $keyKey $secretKey -}}
+{{- fail "tenantBootstrap.existingSecret.keyKey and secretKey must be different" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "astron-agent.tenantBootstrapID" -}}
+{{- include "astron-agent.tenantBootstrapValidate" . -}}
+680ab54f
+{{- end }}
+
+{{- define "astron-agent.tenantBootstrapSecretName" -}}
+{{- include "astron-agent.tenantBootstrapValidate" . -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $key := include "astron-agent.tenantBootstrapConfiguredKey" . -}}
+{{- $secret := include "astron-agent.tenantBootstrapConfiguredSecret" . -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if or $key $secret (not $externalName) -}}
+{{- printf "%s-tenant-bootstrap" (include "astron-agent.fullname" .) -}}
+{{- else -}}
+{{- $externalName -}}
+{{- end -}}
+{{- end }}
+
+{{- define "astron-agent.tenantBootstrapSecretKeyKey" -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $key := include "astron-agent.tenantBootstrapConfiguredKey" . -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if or $key (not $externalName) -}}tenant-key{{- else -}}
+{{- required "tenantBootstrap.existingSecret.keyKey is required when using an existing Secret" (get $external "keyKey") -}}
+{{- end -}}
+{{- end }}
+
+{{- define "astron-agent.tenantBootstrapSecretSecretKey" -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $secret := include "astron-agent.tenantBootstrapConfiguredSecret" . -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- if or $secret (not $externalName) -}}tenant-secret{{- else -}}
+{{- required "tenantBootstrap.existingSecret.secretKey is required when using an existing Secret" (get $external "secretKey") -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Roll consumers when explicit credentials change, when an operator advances the
+external Secret checksum, or when a missing/invalid chart-managed Secret must
+be regenerated. A valid managed pair is hashed and reused across live upgrades.
+*/}}
+{{- define "astron-agent.tenantBootstrapSecretChecksum" -}}
+{{- include "astron-agent.tenantBootstrapValidate" . -}}
+{{- $config := default (dict) .Values.tenantBootstrap -}}
+{{- $key := include "astron-agent.tenantBootstrapConfiguredKey" . -}}
+{{- $secret := include "astron-agent.tenantBootstrapConfiguredSecret" . -}}
+{{- $external := default (dict) (get $config "existingSecret") -}}
+{{- $externalName := default "" (get $external "name") | toString | trim -}}
+{{- $secretName := include "astron-agent.tenantBootstrapSecretName" . -}}
+{{- $keyKey := include "astron-agent.tenantBootstrapSecretKeyKey" . -}}
+{{- $secretKey := include "astron-agent.tenantBootstrapSecretSecretKey" . -}}
+{{- if $key -}}
+{{- printf "%s:%s:%s" $secretName $key $secret | sha256sum -}}
+{{- else if $externalName -}}
+{{- printf "%s:%s:%s:%s" $secretName $keyKey $secretKey (default "" (get $config "existingSecretChecksum")) | sha256sum -}}
+{{- else -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := dict -}}
+{{- if $existingSecret -}}
+{{- $existingData = default (dict) (get $existingSecret "data") -}}
+{{- end -}}
+{{- $persistedKey := "" -}}
+{{- $persistedSecret := "" -}}
+{{- if and (hasKey $existingData $keyKey) (hasKey $existingData $secretKey) -}}
+{{- $candidateKey := index $existingData $keyKey | b64dec -}}
+{{- $candidateSecret := index $existingData $secretKey | b64dec -}}
+{{- if and (ge (len $candidateKey) 32) (le (len $candidateKey) 50) (ge (len $candidateSecret) 32) (le (len $candidateSecret) 50) (regexMatch "^[A-Za-z0-9._~-]+$" $candidateKey) (regexMatch "^[A-Za-z0-9._~-]+$" $candidateSecret) (ne $candidateKey $candidateSecret) (ne $candidateKey "7b709739e8da44536127a333c7603a83") (ne $candidateSecret "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy") -}}
+{{- $persistedKey = $candidateKey -}}
+{{- $persistedSecret = $candidateSecret -}}
+{{- end -}}
+{{- end -}}
+{{- if not $persistedKey -}}
+{{- $persistedKey = randAlphaNum 48 -}}
+{{- $persistedSecret = randAlphaNum 48 -}}
+{{- end -}}
+{{- printf "%s:%s:%s" $secretName $persistedKey $persistedSecret | sha256sum -}}
+{{- end -}}
+{{- end }}
+
+{{/* Resolve the managed or externally supplied artifact-upload Secret. */}}
 {{- define "astron-agent.artifactUploadSecretName" -}}
 {{- $config := default (dict) .Values.consoleHub.artifactUpload -}}
 {{- $token := default "" (get $config "token") | toString | trim -}}
-{{- if $token -}}
+{{- $existingSecret := default "" (get $config "existingSecret") | toString | trim -}}
+{{- if or $token (not $existingSecret) -}}
 {{- printf "%s-console-hub-artifact-upload" (include "astron-agent.fullname" .) -}}
 {{- else -}}
-{{- required "consoleHub.artifactUpload.existingSecret is required when consoleHub.artifactUpload.token is empty" (get $config "existingSecret") -}}
+{{- $existingSecret -}}
 {{- end -}}
 {{- end }}
 
 {{- define "astron-agent.artifactUploadSecretKey" -}}
 {{- $config := default (dict) .Values.consoleHub.artifactUpload -}}
 {{- $token := default "" (get $config "token") | toString | trim -}}
-{{- if $token -}}artifact-upload-token{{- else -}}
+{{- $existingSecret := default "" (get $config "existingSecret") | toString | trim -}}
+{{- if or $token (not $existingSecret) -}}artifact-upload-token{{- else -}}
 {{- required "consoleHub.artifactUpload.existingSecretKey is required when using an existing Secret" (get $config "existingSecretKey") -}}
 {{- end -}}
 {{- end }}
 
 {{/*
-Hash either the explicit credential or the external Secret identity plus an
-operator-supplied rotation checksum. This is stable for offline GitOps renders.
+Hash the explicit credential, a persisted chart-managed credential, or the
+external Secret identity plus an operator-supplied rotation checksum.
+When a managed Secret cannot be looked up (including offline rendering), use a
+random marker so applying a newly generated Secret also rolls every consumer.
 */}}
 {{- define "astron-agent.artifactUploadSecretChecksum" -}}
 {{- $config := default (dict) .Values.consoleHub.artifactUpload -}}
 {{- $token := default "" (get $config "token") | toString | trim -}}
+{{- $existingSecretName := default "" (get $config "existingSecret") | toString | trim -}}
 {{- if $token -}}
 {{- printf "%s:%s" (include "astron-agent.artifactUploadSecretName" .) $token | sha256sum -}}
-{{- else -}}
+{{- else if $existingSecretName -}}
 {{- printf "%s:%s:%s" (include "astron-agent.artifactUploadSecretName" .) (include "astron-agent.artifactUploadSecretKey" .) (default "" (get $config "existingSecretChecksum")) | sha256sum -}}
+{{- else -}}
+{{- $secretName := include "astron-agent.artifactUploadSecretName" . -}}
+{{- $secretKey := include "astron-agent.artifactUploadSecretKey" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := dict -}}
+{{- if $existingSecret -}}
+{{- $existingData = default (dict) (get $existingSecret "data") -}}
+{{- end -}}
+{{- $persistedToken := "" -}}
+{{- if hasKey $existingData $secretKey -}}
+{{- $candidateToken := index $existingData $secretKey | b64dec -}}
+{{- if and (ge (len $candidateToken) 32) (not (contains "\r" $candidateToken)) (not (contains "\n" $candidateToken)) -}}
+{{- $persistedToken = $candidateToken -}}
+{{- end -}}
+{{- end -}}
+{{- if not $persistedToken -}}
+{{- $persistedToken = randAlphaNum 64 -}}
+{{- end -}}
+{{- printf "%s:%s" $secretName $persistedToken | sha256sum -}}
 {{- end -}}
 {{- end }}
 
@@ -251,17 +505,19 @@ operator-supplied rotation checksum. This is stable for offline GitOps renders.
 {{- define "astron-agent.sandboxRuntimeCredentialSecretName" -}}
 {{- $config := default (dict) .Values.consoleHub.sandboxRuntimeCredential -}}
 {{- $token := default "" (get $config "token") | toString | trim -}}
-{{- if $token -}}
+{{- $existingSecret := default "" (get $config "existingSecret") | toString | trim -}}
+{{- if or $token (not $existingSecret) -}}
 {{- printf "%s-console-hub-sandbox-runtime-credential" (include "astron-agent.fullname" .) -}}
 {{- else -}}
-{{- required "consoleHub.sandboxRuntimeCredential.existingSecret is required when consoleHub.sandboxRuntimeCredential.token is empty" (get $config "existingSecret") -}}
+{{- $existingSecret -}}
 {{- end -}}
 {{- end }}
 
 {{- define "astron-agent.sandboxRuntimeCredentialSecretKey" -}}
 {{- $config := default (dict) .Values.consoleHub.sandboxRuntimeCredential -}}
 {{- $token := default "" (get $config "token") | toString | trim -}}
-{{- if $token -}}sandbox-runtime-credential-token{{- else -}}
+{{- $existingSecret := default "" (get $config "existingSecret") | toString | trim -}}
+{{- if or $token (not $existingSecret) -}}sandbox-runtime-credential-token{{- else -}}
 {{- required "consoleHub.sandboxRuntimeCredential.existingSecretKey is required when using an existing Secret" (get $config "existingSecretKey") -}}
 {{- end -}}
 {{- end }}
@@ -269,9 +525,29 @@ operator-supplied rotation checksum. This is stable for offline GitOps renders.
 {{- define "astron-agent.sandboxRuntimeCredentialSecretChecksum" -}}
 {{- $config := default (dict) .Values.consoleHub.sandboxRuntimeCredential -}}
 {{- $token := default "" (get $config "token") | toString | trim -}}
+{{- $existingSecretName := default "" (get $config "existingSecret") | toString | trim -}}
 {{- if $token -}}
 {{- printf "%s:%s" (include "astron-agent.sandboxRuntimeCredentialSecretName" .) $token | sha256sum -}}
-{{- else -}}
+{{- else if $existingSecretName -}}
 {{- printf "%s:%s:%s" (include "astron-agent.sandboxRuntimeCredentialSecretName" .) (include "astron-agent.sandboxRuntimeCredentialSecretKey" .) (default "" (get $config "existingSecretChecksum")) | sha256sum -}}
+{{- else -}}
+{{- $secretName := include "astron-agent.sandboxRuntimeCredentialSecretName" . -}}
+{{- $secretKey := include "astron-agent.sandboxRuntimeCredentialSecretKey" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := dict -}}
+{{- if $existingSecret -}}
+{{- $existingData = default (dict) (get $existingSecret "data") -}}
+{{- end -}}
+{{- $persistedToken := "" -}}
+{{- if hasKey $existingData $secretKey -}}
+{{- $candidateToken := index $existingData $secretKey | b64dec -}}
+{{- if and (ge (len $candidateToken) 32) (not (contains "\r" $candidateToken)) (not (contains "\n" $candidateToken)) -}}
+{{- $persistedToken = $candidateToken -}}
+{{- end -}}
+{{- end -}}
+{{- if not $persistedToken -}}
+{{- $persistedToken = randAlphaNum 64 -}}
+{{- end -}}
+{{- printf "%s:%s" $secretName $persistedToken | sha256sum -}}
 {{- end -}}
 {{- end }}

--- a/helm/astron-agent/templates/console/console-hub-artifact-upload-secret.yaml
+++ b/helm/astron-agent/templates/console/console-hub-artifact-upload-secret.yaml
@@ -6,6 +6,7 @@
 {{- end }}
 {{- $config := default (dict) .Values.consoleHub.artifactUpload }}
 {{- $configuredToken := default "" (get $config "token") | toString | trim }}
+{{- $externalSecretName := default "" (get $config "existingSecret") | toString | trim }}
 {{- if and $configuredToken (or (lt (len $configuredToken) 32) (contains "\r" $configuredToken) (contains "\n" $configuredToken)) }}
 {{- fail "consoleHub.artifactUpload.token must contain at least 32 characters and no line breaks when set" }}
 {{- end }}
@@ -17,15 +18,32 @@
 {{- if eq (include "astron-agent.artifactUploadSecretName" .) (include "astron-agent.sandboxRuntimeCredentialSecretName" .) }}
 {{- fail "artifact-upload and sandbox runtime credentials must use independent Secrets" }}
 {{- end }}
-{{- if $configuredToken }}
+{{- if or $configuredToken (not $externalSecretName) }}
+{{- $secretName := include "astron-agent.artifactUploadSecretName" . }}
+{{- $secretKey := include "astron-agent.artifactUploadSecretKey" . }}
+{{- $resolvedToken := $configuredToken }}
+{{- if not $resolvedToken }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingData := dict }}
+{{- if $existingSecret }}
+{{- $existingData = default (dict) (get $existingSecret "data") }}
+{{- end }}
+{{- $resolvedToken = randAlphaNum 64 }}
+{{- if hasKey $existingData $secretKey }}
+{{- $candidateToken := index $existingData $secretKey | b64dec }}
+{{- if and (ge (len $candidateToken) 32) (not (contains "\r" $candidateToken)) (not (contains "\n" $candidateToken)) }}
+{{- $resolvedToken = $candidateToken }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "astron-agent.artifactUploadSecretName" . }}
+  name: {{ $secretName }}
   labels:
     {{- include "astron-agent.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  artifact-upload-token: {{ $configuredToken | quote }}
+  {{ $secretKey }}: {{ $resolvedToken | quote }}
 {{- end }}
 {{- end }}

--- a/helm/astron-agent/templates/console/console-hub-deployment.yaml
+++ b/helm/astron-agent/templates/console/console-hub-deployment.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.consoleHub.enabled }}
-{{- $workflowAuth := default (dict) .Values.workflowInternalAuth }}
-{{- $workflowAuthExisting := default (dict) (get $workflowAuth "existingSecret") }}
-{{- $workflowAuthSecretName := default (printf "%s-workflow-internal-auth" (include "astron-agent.fullname" .)) (get $workflowAuthExisting "name") }}
-{{- $workflowAuthSecretKey := default "workflow-internal-api-key" (get $workflowAuthExisting "key") }}
+{{- $workflowAuthSecretName := include "astron-agent.workflowInternalAuthSecretName" . }}
+{{- $workflowAuthSecretKey := include "astron-agent.workflowInternalAuthSecretKey" . }}
+{{- $tenantBootstrapSecretName := include "astron-agent.tenantBootstrapSecretName" . }}
+{{- $tenantBootstrapKeyKey := include "astron-agent.tenantBootstrapSecretKeyKey" . }}
+{{- $tenantBootstrapSecretKey := include "astron-agent.tenantBootstrapSecretSecretKey" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,6 +25,10 @@ spec:
         checksum/sandbox-runtime-credential-secret: {{ include "astron-agent.sandboxRuntimeCredentialSecretChecksum" . | quote }}
         internal-secret-name/sandbox-runtime-credential: {{ include "astron-agent.sandboxRuntimeCredentialSecretName" . | quote }}
         checksum/object-storage-secret: {{ include "astron-agent.minioSecretChecksum" . | quote }}
+        checksum/workflow-internal-auth-secret: {{ include "astron-agent.workflowInternalAuthSecretChecksum" . | quote }}
+        internal-secret-name/workflow-internal-auth: {{ $workflowAuthSecretName | quote }}
+        checksum/tenant-bootstrap-secret: {{ include "astron-agent.tenantBootstrapSecretChecksum" . | quote }}
+        internal-secret-name/tenant-bootstrap: {{ $tenantBootstrapSecretName | quote }}
       labels:
         {{- include "astron-agent.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: console-hub
@@ -127,11 +132,50 @@ spec:
             secretKeyRef:
               name: {{ include "astron-agent.minioSecretName" $ }}
               key: {{ include "astron-agent.minioSecretPasswordKey" $ }}
+        {{- else if has $key (list "tenantId" "tenantKey" "tenantSecret" "appApikey" "appApiSecret") }}
+        {{/* The canonical TENANT_* variables are injected once below. */}}
+        {{- else if has $key (list "commonAppid" "maasAppId" "maasConsumerId") }}
+        - name: {{ upper (snakecase $key) }}
+          value: {{ include "astron-agent.tenantBootstrapID" $ | quote }}
+        {{- else if has $key (list "commonApikey" "maasApiKey" "maasConsumerKey") }}
+        - name: {{ upper (snakecase $key) }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapKeyKey }}
+        {{- else if has $key (list "commonApiSecret" "maasApiSecret" "maasConsumerSecret") }}
+        - name: {{ upper (snakecase $key) }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapSecretKey }}
         {{- else }}
         - name: {{ upper (snakecase $key) }}
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        - name: TENANT_ID
+          value: {{ include "astron-agent.tenantBootstrapID" . | quote }}
+        - name: TENANT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapKeyKey }}
+        - name: TENANT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapSecretKey }}
+        - name: APP_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapKeyKey }}
+        - name: APP_API_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapSecretKey }}
         - name: SKILL_SANDBOX_ARTIFACT_UPLOAD_TOKEN
           valueFrom:
             secretKeyRef:

--- a/helm/astron-agent/templates/console/console-hub-sandbox-runtime-credential-secret.yaml
+++ b/helm/astron-agent/templates/console/console-hub-sandbox-runtime-credential-secret.yaml
@@ -1,18 +1,36 @@
 {{- if .Values.consoleHub.enabled }}
 {{- $config := default (dict) .Values.consoleHub.sandboxRuntimeCredential }}
 {{- $configuredToken := default "" (get $config "token") | toString | trim }}
+{{- $externalSecretName := default "" (get $config "existingSecret") | toString | trim }}
 {{- if and $configuredToken (or (lt (len $configuredToken) 32) (contains "\r" $configuredToken) (contains "\n" $configuredToken)) }}
 {{- fail "consoleHub.sandboxRuntimeCredential.token must contain at least 32 characters and no line breaks when set" }}
 {{- end }}
-{{- if $configuredToken }}
+{{- if or $configuredToken (not $externalSecretName) }}
+{{- $secretName := include "astron-agent.sandboxRuntimeCredentialSecretName" . }}
+{{- $secretKey := include "astron-agent.sandboxRuntimeCredentialSecretKey" . }}
+{{- $resolvedToken := $configuredToken }}
+{{- if not $resolvedToken }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingData := dict }}
+{{- if $existingSecret }}
+{{- $existingData = default (dict) (get $existingSecret "data") }}
+{{- end }}
+{{- $resolvedToken = randAlphaNum 64 }}
+{{- if hasKey $existingData $secretKey }}
+{{- $candidateToken := index $existingData $secretKey | b64dec }}
+{{- if and (ge (len $candidateToken) 32) (not (contains "\r" $candidateToken)) (not (contains "\n" $candidateToken)) }}
+{{- $resolvedToken = $candidateToken }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "astron-agent.sandboxRuntimeCredentialSecretName" . }}
+  name: {{ $secretName }}
   labels:
     {{- include "astron-agent.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  sandbox-runtime-credential-token: {{ $configuredToken | quote }}
+  {{ $secretKey }}: {{ $resolvedToken | quote }}
 {{- end }}
 {{- end }}

--- a/helm/astron-agent/templates/core/core-services.yaml
+++ b/helm/astron-agent/templates/core/core-services.yaml
@@ -10,14 +10,17 @@
 {{- $langfusePublicKeyKey := default "public-key" (get $langfuseSecret "publicKeyKey") }}
 {{- $langfuseSecretKeyKey := default "secret-key" (get $langfuseSecret "secretKeyKey") }}
 {{- $langfuseTraceContextSecretKey := default "trace-context-secret" (get $langfuseSecret "traceContextSecretKey") }}
-{{- $workflowAuth := default (dict) $.Values.workflowInternalAuth }}
-{{- $workflowAuthExisting := default (dict) (get $workflowAuth "existingSecret") }}
-{{- $workflowAuthSecretName := default (printf "%s-workflow-internal-auth" (include "astron-agent.fullname" $)) (get $workflowAuthExisting "name") }}
-{{- $workflowAuthSecretKey := default "workflow-internal-api-key" (get $workflowAuthExisting "key") }}
+{{- $workflowAuthSecretName := include "astron-agent.workflowInternalAuthSecretName" $ }}
+{{- $workflowAuthSecretKey := include "astron-agent.workflowInternalAuthSecretKey" $ }}
+{{- $tenantBootstrapSecretName := include "astron-agent.tenantBootstrapSecretName" $ }}
+{{- $tenantBootstrapKeyKey := include "astron-agent.tenantBootstrapSecretKeyKey" $ }}
+{{- $tenantBootstrapSecretKey := include "astron-agent.tenantBootstrapSecretSecretKey" $ }}
 {{- range $serviceName := $services }}
 {{- $serviceConfig := index $.Values $serviceName }}
 {{- $usesObjectStorage := or (eq $serviceName "coreAitools") (eq $serviceName "coreWorkflow") }}
 {{- $usesInternalCredentials := and $.Values.consoleHub.enabled (or (eq $serviceName "coreAgent") (eq $serviceName "coreWorkflow")) }}
+{{- $usesWorkflowInternalAuth := or (eq $serviceName "coreAgent") (eq $serviceName "coreWorkflow") }}
+{{- $usesTenantBootstrap := or (eq $serviceName "coreTenant") (eq $serviceName "coreAgent") (eq $serviceName "coreWorkflow") }}
 {{- if $serviceConfig.enabled }}
 ---
 apiVersion: apps/v1
@@ -35,7 +38,7 @@ spec:
       app.kubernetes.io/component: {{ kebabcase $serviceName }}
   template:
     metadata:
-      {{- if or $usesObjectStorage $usesInternalCredentials }}
+      {{- if or $usesObjectStorage $usesInternalCredentials $usesWorkflowInternalAuth $usesTenantBootstrap }}
       annotations:
         {{- if $usesInternalCredentials }}
         checksum/artifact-upload-secret: {{ include "astron-agent.artifactUploadSecretChecksum" $ | quote }}
@@ -45,6 +48,14 @@ spec:
         {{- end }}
         {{- if $usesObjectStorage }}
         checksum/object-storage-secret: {{ include "astron-agent.minioSecretChecksum" $ | quote }}
+        {{- end }}
+        {{- if $usesWorkflowInternalAuth }}
+        checksum/workflow-internal-auth-secret: {{ include "astron-agent.workflowInternalAuthSecretChecksum" $ | quote }}
+        internal-secret-name/workflow-internal-auth: {{ $workflowAuthSecretName | quote }}
+        {{- end }}
+        {{- if $usesTenantBootstrap }}
+        checksum/tenant-bootstrap-secret: {{ include "astron-agent.tenantBootstrapSecretChecksum" $ | quote }}
+        internal-secret-name/tenant-bootstrap: {{ $tenantBootstrapSecretName | quote }}
         {{- end }}
       {{- end }}
       labels:
@@ -150,12 +161,56 @@ spec:
             secretKeyRef:
               name: {{ include "astron-agent.minioSecretName" $ }}
               key: {{ include "astron-agent.minioSecretPasswordKey" $ }}
+        {{- else if and $usesTenantBootstrap (has $key (list "tenantId" "tenantKey" "tenantSecret")) }}
+        {{/* Canonical values are injected from tenantBootstrap below. */}}
+        {{- else if and (eq $serviceName "coreAgent") (has $key (list "appAuthApiKey" "appAuthSecret")) }}
+        {{/* Canonical values are injected from tenantBootstrap below. */}}
+        {{- else if and (eq $serviceName "coreWorkflow") (has $key (list "appManagePlatKey" "appManagePlatSecret")) }}
+        {{/* Canonical values are injected from tenantBootstrap below. */}}
         {{- else }}
         - name: {{ upper (snakecase $key) }}
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        {{- if $usesTenantBootstrap }}
+        - name: TENANT_ID
+          value: {{ include "astron-agent.tenantBootstrapID" $ | quote }}
+        - name: TENANT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapKeyKey }}
+        - name: TENANT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapSecretKey }}
+        {{- end }}
+        {{- if eq $serviceName "coreAgent" }}
+        - name: APP_AUTH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapKeyKey }}
+        - name: APP_AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapSecretKey }}
+        {{- end }}
         {{- if eq $serviceName "coreWorkflow" }}
+        - name: APP_MANAGE_PLAT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapKeyKey }}
+        - name: APP_MANAGE_PLAT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tenantBootstrapSecretName }}
+              key: {{ $tenantBootstrapSecretKey }}
+        {{- end }}
+        {{- if or (eq $serviceName "coreAgent") (eq $serviceName "coreWorkflow") }}
         - name: WORKFLOW_INTERNAL_API_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/astron-agent/templates/infrastructure/minio-secret.yaml
+++ b/helm/astron-agent/templates/infrastructure/minio-secret.yaml
@@ -1,0 +1,14 @@
+{{- $auth := default (dict) .Values.minio.auth -}}
+{{- $existingSecret := default "" (get $auth "existingSecret") | toString | trim -}}
+{{- if not $existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "astron-agent.minioSecretName" . }}
+  labels:
+    {{- include "astron-agent.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ include "astron-agent.minioSecretUserKey" . }}: {{ required "minio.auth.rootUser is required when minio.auth.existingSecret is empty" (get $auth "rootUser") | toString | quote }}
+  {{ include "astron-agent.minioSecretPasswordKey" . }}: {{ required "minio.auth.rootPassword is required when minio.auth.existingSecret is empty" (get $auth "rootPassword") | toString | quote }}
+{{- end }}

--- a/helm/astron-agent/templates/ingress.yaml
+++ b/helm/astron-agent/templates/ingress.yaml
@@ -70,7 +70,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/auth-url: "http://{{ include "astron-agent.fullname" . }}-console-hub.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.consoleHub.service.port }}/internal/gateway/auth/workflow"
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Consumer-Username"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Consumer-Username,X-Workflow-Gateway-Timestamp,X-Workflow-Gateway-Signature"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm/astron-agent/templates/secrets.yaml
+++ b/helm/astron-agent/templates/secrets.yaml
@@ -1,11 +1,20 @@
 {{- $workflowAuth := default (dict) .Values.workflowInternalAuth }}
 {{- $workflowAuthExisting := default (dict) (get $workflowAuth "existingSecret") }}
-{{- if not (get $workflowAuthExisting "name") }}
-{{- $workflowAuthSecretName := printf "%s-workflow-internal-auth" (include "astron-agent.fullname" .) }}
+{{- $workflowAuthExternalName := default "" (get $workflowAuthExisting "name") | toString | trim }}
+{{- if not $workflowAuthExternalName }}
+{{- $workflowAuthSecretName := include "astron-agent.workflowInternalAuthSecretName" . }}
+{{- $workflowAuthSecretKey := include "astron-agent.workflowInternalAuthSecretKey" . }}
 {{- $existingWorkflowAuthSecret := lookup "v1" "Secret" .Release.Namespace $workflowAuthSecretName }}
 {{- $workflowInternalApiKey := randAlphaNum 64 }}
-{{- if and $existingWorkflowAuthSecret (hasKey $existingWorkflowAuthSecret.data "workflow-internal-api-key") }}
-{{- $workflowInternalApiKey = (index $existingWorkflowAuthSecret.data "workflow-internal-api-key" | b64dec) }}
+{{- $existingWorkflowAuthData := dict }}
+{{- if $existingWorkflowAuthSecret }}
+{{- $existingWorkflowAuthData = default (dict) (get $existingWorkflowAuthSecret "data") }}
+{{- end }}
+{{- if hasKey $existingWorkflowAuthData $workflowAuthSecretKey }}
+{{- $candidateWorkflowInternalApiKey := index $existingWorkflowAuthData $workflowAuthSecretKey | b64dec }}
+{{- if and (ge (len $candidateWorkflowInternalApiKey) 32) (le (len $candidateWorkflowInternalApiKey) 128) (not (contains "\r" $candidateWorkflowInternalApiKey)) (not (contains "\n" $candidateWorkflowInternalApiKey)) (ne $candidateWorkflowInternalApiKey "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY") }}
+{{- $workflowInternalApiKey = $candidateWorkflowInternalApiKey }}
+{{- end }}
 {{- end }}
 apiVersion: v1
 kind: Secret
@@ -15,7 +24,7 @@ metadata:
     {{- include "astron-agent.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  workflow-internal-api-key: {{ $workflowInternalApiKey | quote }}
+  {{ $workflowAuthSecretKey }}: {{ $workflowInternalApiKey | quote }}
 ---
 {{- end }}
 {{- if .Values.postgresql.enabled }}

--- a/helm/astron-agent/templates/tenant-bootstrap-secret.yaml
+++ b/helm/astron-agent/templates/tenant-bootstrap-secret.yaml
@@ -1,0 +1,43 @@
+{{- if or .Values.coreTenant.enabled .Values.consoleHub.enabled .Values.coreAgent.enabled .Values.coreWorkflow.enabled }}
+{{- include "astron-agent.tenantBootstrapValidate" . }}
+{{- $config := default (dict) .Values.tenantBootstrap }}
+{{- $configuredKey := include "astron-agent.tenantBootstrapConfiguredKey" . }}
+{{- $configuredSecret := include "astron-agent.tenantBootstrapConfiguredSecret" . }}
+{{- $external := default (dict) (get $config "existingSecret") }}
+{{- $externalName := default "" (get $external "name") | toString | trim }}
+{{- if or $configuredKey (not $externalName) }}
+{{- $secretName := include "astron-agent.tenantBootstrapSecretName" . }}
+{{- $keyKey := include "astron-agent.tenantBootstrapSecretKeyKey" . }}
+{{- $secretKey := include "astron-agent.tenantBootstrapSecretSecretKey" . }}
+{{- $resolvedKey := $configuredKey }}
+{{- $resolvedSecret := $configuredSecret }}
+{{- if not $resolvedKey }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingData := dict }}
+{{- if $existingSecret }}
+{{- $existingData = default (dict) (get $existingSecret "data") }}
+{{- end }}
+{{- $resolvedKey = printf "k%s" (randAlphaNum 47) }}
+{{- $resolvedSecret = printf "s%s" (randAlphaNum 47) }}
+{{- if and (hasKey $existingData $keyKey) (hasKey $existingData $secretKey) }}
+{{- $candidateKey := index $existingData $keyKey | b64dec }}
+{{- $candidateSecret := index $existingData $secretKey | b64dec }}
+{{- if and (ge (len $candidateKey) 32) (le (len $candidateKey) 50) (ge (len $candidateSecret) 32) (le (len $candidateSecret) 50) (regexMatch "^[A-Za-z0-9._~-]+$" $candidateKey) (regexMatch "^[A-Za-z0-9._~-]+$" $candidateSecret) (ne $candidateKey $candidateSecret) (ne $candidateKey "7b709739e8da44536127a333c7603a83") (ne $candidateSecret "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy") }}
+{{- $resolvedKey = $candidateKey }}
+{{- $resolvedSecret = $candidateSecret }}
+{{- end }}
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "astron-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tenant-bootstrap
+type: Opaque
+stringData:
+  {{ $keyKey }}: {{ $resolvedKey | quote }}
+  {{ $secretKey }}: {{ $resolvedSecret | quote }}
+{{- end }}
+{{- end }}

--- a/helm/astron-agent/tests/verify_tenant_bootstrap.py
+++ b/helm/astron-agent/tests/verify_tenant_bootstrap.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Render-only positive and negative tests for tenant bootstrap credentials."""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence, Tuple
+
+CHART = Path(__file__).resolve().parent.parent
+LEGACY_KEY = "7b709739e8da44536127a333c7603a83"
+LEGACY_SECRET = "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+MANAGED_SECRET = "astron-agent-tenant-bootstrap"
+MANAGED_KEY = "tenant-key"
+MANAGED_SECRET_KEY = "tenant-secret"
+WORKFLOW_MANAGED_SECRET = "astron-agent-workflow-internal-auth"
+WORKFLOW_MANAGED_KEY = "workflow-internal-api-key"
+WORKFLOW_PLACEHOLDER = "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY"
+WORKFLOW_CONSUMERS = (
+    "astron-agent-core-agent",
+    "astron-agent-core-workflow",
+    "astron-agent-console-hub",
+)
+
+TENANT_ENV = {
+    "TENANT_KEY": MANAGED_KEY,
+    "TENANT_SECRET": MANAGED_SECRET_KEY,
+}
+EXPECTED_TENANT_ENV: Mapping[str, Mapping[str, str]] = {
+    "astron-agent-core-tenant": TENANT_ENV,
+    "astron-agent-core-agent": {
+        **TENANT_ENV,
+        "APP_AUTH_API_KEY": MANAGED_KEY,
+        "APP_AUTH_SECRET": MANAGED_SECRET_KEY,
+    },
+    "astron-agent-core-workflow": {
+        **TENANT_ENV,
+        "APP_MANAGE_PLAT_KEY": MANAGED_KEY,
+        "APP_MANAGE_PLAT_SECRET": MANAGED_SECRET_KEY,
+    },
+    "astron-agent-console-hub": {
+        **TENANT_ENV,
+        "APP_APIKEY": MANAGED_KEY,
+        "APP_API_SECRET": MANAGED_SECRET_KEY,
+        "COMMON_APIKEY": MANAGED_KEY,
+        "COMMON_API_SECRET": MANAGED_SECRET_KEY,
+        "MAAS_API_KEY": MANAGED_KEY,
+        "MAAS_API_SECRET": MANAGED_SECRET_KEY,
+        "MAAS_CONSUMER_KEY": MANAGED_KEY,
+        "MAAS_CONSUMER_SECRET": MANAGED_SECRET_KEY,
+    },
+}
+
+EXPECTED_ID_ENV: Mapping[str, Sequence[str]] = {
+    "astron-agent-core-tenant": ("TENANT_ID",),
+    "astron-agent-core-agent": ("TENANT_ID",),
+    "astron-agent-core-workflow": ("TENANT_ID",),
+    "astron-agent-console-hub": (
+        "TENANT_ID",
+        "COMMON_APPID",
+        "MAAS_APP_ID",
+        "MAAS_CONSUMER_ID",
+    ),
+}
+
+
+class VerificationError(RuntimeError):
+    """Safe-to-print error which does not contain rendered Secret values."""
+
+
+def _run_helm(arguments: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["helm", *arguments],
+        cwd=str(CHART.parent.parent),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+
+
+def _render(extra_arguments: Sequence[str] = ()) -> str:
+    completed = _run_helm(
+        [
+            "template",
+            "astron-agent",
+            str(CHART),
+            "--namespace",
+            "astron-agent",
+            *extra_arguments,
+        ]
+    )
+    if completed.returncode != 0:
+        raise VerificationError("positive Helm render failed")
+    return completed.stdout
+
+
+def _documents(rendered: str) -> List[str]:
+    return [
+        document
+        for document in re.split(r"^---\s*$", rendered, flags=re.M)
+        if document.strip()
+    ]
+
+
+def _kind(document: str) -> str:
+    match = re.search(r"^kind:\s*(\S+)\s*$", document, flags=re.M)
+    return match.group(1) if match else ""
+
+
+def _name(document: str) -> str:
+    match = re.search(r"^metadata:\s*\n\s{2}name:\s*([^\s]+)\s*$", document, flags=re.M)
+    return match.group(1) if match else ""
+
+
+def _find_document(rendered: str, kind: str, name: str) -> str:
+    for document in _documents(rendered):
+        if _kind(document) == kind and _name(document) == name:
+            return document
+    raise VerificationError(f"missing rendered {kind}: {name}")
+
+
+def _main_container_environment(
+    document: str,
+) -> Tuple[List[str], Dict[str, Dict[str, str]]]:
+    lines = document.splitlines()
+    try:
+        containers_index = lines.index("      containers:")
+        environment_index = lines.index("        env:", containers_index)
+    except ValueError as exc:
+        raise VerificationError(
+            "deployment main-container environment is missing"
+        ) from exc
+
+    names: List[str] = []
+    entries: Dict[str, Dict[str, str]] = {}
+    index = environment_index + 1
+    while index < len(lines):
+        line = lines[index]
+        item = re.fullmatch(r"        - name: ([A-Z0-9_]+)", line)
+        if not item:
+            if re.match(r"^        [A-Za-z]", line):
+                break
+            index += 1
+            continue
+        env_name = item.group(1)
+        names.append(env_name)
+        block: List[str] = []
+        index += 1
+        while index < len(lines):
+            next_line = lines[index]
+            if re.fullmatch(r"        - name: [A-Z0-9_]+", next_line):
+                break
+            if re.match(r"^        [A-Za-z]", next_line):
+                break
+            block.append(next_line)
+            index += 1
+        value_match = next(
+            (
+                re.fullmatch(r"          value:\s*[\"']?([^\"']*)[\"']?", item_line)
+                for item_line in block
+                if item_line.startswith("          value:")
+            ),
+            None,
+        )
+        secret_name_match = next(
+            (
+                re.fullmatch(r"              name:\s*[\"']?([^\"']*)[\"']?", item_line)
+                for item_line in block
+                if item_line.startswith("              name:")
+            ),
+            None,
+        )
+        secret_key_match = next(
+            (
+                re.fullmatch(r"              key:\s*[\"']?([^\"']*)[\"']?", item_line)
+                for item_line in block
+                if item_line.startswith("              key:")
+            ),
+            None,
+        )
+        entries[env_name] = {
+            "value": value_match.group(1) if value_match else "",
+            "secret_name": secret_name_match.group(1) if secret_name_match else "",
+            "secret_key": secret_key_match.group(1) if secret_key_match else "",
+        }
+    return names, entries
+
+
+def _secret_string_data(document: str) -> Mapping[str, str]:
+    lines = document.splitlines()
+    try:
+        start = lines.index("stringData:") + 1
+    except ValueError as exc:
+        raise VerificationError("tenant bootstrap Secret has no stringData") from exc
+    values: Dict[str, str] = {}
+    for line in lines[start:]:
+        match = re.fullmatch(r"  ([A-Za-z0-9._-]+):\s*[\"']([^\"']*)[\"']", line)
+        if not match:
+            if line and not line.startswith("  "):
+                break
+            continue
+        values[match.group(1)] = match.group(2)
+    return values
+
+
+def _verify_consumers(
+    rendered: str,
+    expected_secret_name: str,
+    expected_key_name: str,
+    expected_secret_key_name: str,
+) -> None:
+    for deployment_name, credential_environment in EXPECTED_TENANT_ENV.items():
+        deployment = _find_document(rendered, "Deployment", deployment_name)
+        names, environment = _main_container_environment(deployment)
+        if len(names) != len(set(names)):
+            raise VerificationError(
+                f"duplicate environment variable: {deployment_name}"
+            )
+        if (
+            f'internal-secret-name/tenant-bootstrap: "{expected_secret_name}"'
+            not in deployment
+        ):
+            raise VerificationError(
+                f"tenant rollout annotation mismatch: {deployment_name}"
+            )
+        for env_name in EXPECTED_ID_ENV[deployment_name]:
+            if environment.get(env_name, {}).get("value") != "680ab54f":
+                raise VerificationError(
+                    f"tenant ID binding mismatch: {deployment_name}.{env_name}"
+                )
+        for env_name, secret_key in credential_environment.items():
+            entry = environment.get(env_name, {})
+            expected = (
+                expected_key_name
+                if secret_key == MANAGED_KEY
+                else expected_secret_key_name
+            )
+            if (
+                entry.get("secret_name") != expected_secret_name
+                or entry.get("secret_key") != expected
+            ):
+                raise VerificationError(
+                    f"tenant Secret binding mismatch: {deployment_name}.{env_name}"
+                )
+
+
+def _verify_workflow_ingress_gateway_headers(rendered: str) -> None:
+    ingress = _find_document(rendered, "Ingress", "astron-agent-workflow-api")
+    expected = (
+        "nginx.ingress.kubernetes.io/auth-response-headers: "
+        '"X-Consumer-Username,X-Workflow-Gateway-Timestamp,'
+        'X-Workflow-Gateway-Signature"'
+    )
+    if expected not in ingress:
+        raise VerificationError(
+            "workflow Ingress signed identity headers are incomplete"
+        )
+    if "X-Workflow-Internal-Key" in ingress:
+        raise VerificationError("workflow Ingress exposes the raw internal key")
+
+
+def _verify_workflow_internal_auth_bindings(
+    rendered: str, secret_name: str, secret_key: str
+) -> None:
+    for deployment_name in WORKFLOW_CONSUMERS:
+        deployment = _find_document(rendered, "Deployment", deployment_name)
+        names, environment = _main_container_environment(deployment)
+        if len(names) != len(set(names)):
+            raise VerificationError(
+                f"duplicate environment variable: {deployment_name}"
+            )
+        entry = environment.get("WORKFLOW_INTERNAL_API_KEY", {})
+        if (
+            entry.get("secret_name") != secret_name
+            or entry.get("secret_key") != secret_key
+        ):
+            raise VerificationError(
+                f"workflow internal Secret binding mismatch: {deployment_name}"
+            )
+        if (
+            f'internal-secret-name/workflow-internal-auth: "{secret_name}"'
+            not in deployment
+        ):
+            raise VerificationError(
+                f"workflow internal rollout name mismatch: {deployment_name}"
+            )
+        if not re.search(
+            r'checksum/workflow-internal-auth-secret: "[0-9a-f]{64}"',
+            deployment,
+        ):
+            raise VerificationError(
+                f"workflow internal rollout checksum is missing: {deployment_name}"
+            )
+
+
+def _verify_managed_workflow_internal_auth(rendered: str) -> None:
+    secret = _find_document(rendered, "Secret", WORKFLOW_MANAGED_SECRET)
+    value = _secret_string_data(secret).get(WORKFLOW_MANAGED_KEY, "")
+    if not re.fullmatch(r"[A-Za-z0-9]{64}", value):
+        raise VerificationError("managed workflow internal key is not strong")
+    if value == WORKFLOW_PLACEHOLDER:
+        raise VerificationError("managed workflow internal key uses the placeholder")
+    _verify_workflow_internal_auth_bindings(
+        rendered, WORKFLOW_MANAGED_SECRET, WORKFLOW_MANAGED_KEY
+    )
+
+
+def _verify_default_render() -> None:
+    rendered = _render()
+    if LEGACY_KEY in rendered or LEGACY_SECRET in rendered:
+        raise VerificationError(
+            "published tenant credential is present in rendered manifests"
+        )
+    if "CHANGE_ME_WORKFLOW_INTERNAL_API_KEY" in rendered:
+        raise VerificationError(
+            "workflow internal placeholder is present in rendered manifests"
+        )
+
+    secret = _find_document(rendered, "Secret", MANAGED_SECRET)
+    values = _secret_string_data(secret)
+    tenant_key = values.get(MANAGED_KEY, "")
+    tenant_secret = values.get(MANAGED_SECRET_KEY, "")
+    if not re.fullmatch(r"[A-Za-z0-9]{48}", tenant_key):
+        raise VerificationError("managed tenant key is not a strong generated value")
+    if not re.fullmatch(r"[A-Za-z0-9]{48}", tenant_secret):
+        raise VerificationError("managed tenant secret is not a strong generated value")
+    if tenant_key == tenant_secret:
+        raise VerificationError("managed tenant credentials are not independent")
+    _verify_consumers(rendered, MANAGED_SECRET, MANAGED_KEY, MANAGED_SECRET_KEY)
+    _verify_managed_workflow_internal_auth(rendered)
+    _verify_workflow_ingress_gateway_headers(rendered)
+
+
+def _verify_explicit_render() -> None:
+    explicit_key = "K" * 48
+    explicit_secret = "S" * 48
+    rendered = _render(
+        (
+            "--set-string",
+            f"tenantBootstrap.key={explicit_key}",
+            "--set-string",
+            f"tenantBootstrap.secret={explicit_secret}",
+        )
+    )
+    values = _secret_string_data(_find_document(rendered, "Secret", MANAGED_SECRET))
+    if (
+        values.get(MANAGED_KEY) != explicit_key
+        or values.get(MANAGED_SECRET_KEY) != explicit_secret
+    ):
+        raise VerificationError("explicit tenant credentials were not rendered exactly")
+    _verify_consumers(rendered, MANAGED_SECRET, MANAGED_KEY, MANAGED_SECRET_KEY)
+
+
+def _verify_external_secret_render() -> None:
+    external_name = "external-tenant-bootstrap"
+    external_key = "external-key"
+    external_secret_key = "external-secret"
+    rendered = _render(
+        (
+            "--set-string",
+            f"tenantBootstrap.existingSecret.name={external_name}",
+            "--set-string",
+            f"tenantBootstrap.existingSecret.keyKey={external_key}",
+            "--set-string",
+            f"tenantBootstrap.existingSecret.secretKey={external_secret_key}",
+        )
+    )
+    try:
+        _find_document(rendered, "Secret", MANAGED_SECRET)
+    except VerificationError:
+        pass
+    else:
+        raise VerificationError("managed tenant Secret was emitted in external mode")
+    _verify_consumers(rendered, external_name, external_key, external_secret_key)
+
+
+def _verify_workflow_external_secret_render() -> None:
+    external_name = "external-workflow-internal-auth"
+    external_key = "external-workflow-key"
+    rendered = _render(
+        (
+            "--set-string",
+            f"workflowInternalAuth.existingSecret.name={external_name}",
+            "--set-string",
+            f"workflowInternalAuth.existingSecret.key={external_key}",
+            "--set-string",
+            "workflowInternalAuth.existingSecret.checksum=rotation-v2",
+        )
+    )
+    try:
+        _find_document(rendered, "Secret", WORKFLOW_MANAGED_SECRET)
+    except VerificationError:
+        pass
+    else:
+        raise VerificationError(
+            "managed workflow Secret was emitted while using an external Secret"
+        )
+    _verify_workflow_internal_auth_bindings(rendered, external_name, external_key)
+
+
+def _verify_workflow_managed_upgrade_render() -> None:
+    rendered = _render(("--is-upgrade",))
+    _verify_managed_workflow_internal_auth(rendered)
+
+
+def _verify_legacy_compatibility_overrides_are_ignored() -> None:
+    override_paths = (
+        "coreTenant.env.tenantKey",
+        "coreTenant.env.tenantSecret",
+        "coreAgent.env.tenantKey",
+        "coreAgent.env.tenantSecret",
+        "coreAgent.env.appAuthApiKey",
+        "coreAgent.env.appAuthSecret",
+        "coreWorkflow.env.tenantKey",
+        "coreWorkflow.env.tenantSecret",
+        "coreWorkflow.env.appManagePlatKey",
+        "coreWorkflow.env.appManagePlatSecret",
+        "consoleHub.env.tenantKey",
+        "consoleHub.env.tenantSecret",
+        "consoleHub.env.appApikey",
+        "consoleHub.env.appApiSecret",
+    )
+    arguments: List[str] = []
+    for index, path in enumerate(override_paths):
+        arguments.extend(
+            (
+                "--set-string",
+                f"{path}={LEGACY_KEY if index % 2 == 0 else LEGACY_SECRET}",
+            )
+        )
+    rendered = _render(arguments)
+    if LEGACY_KEY in rendered or LEGACY_SECRET in rendered:
+        raise VerificationError(
+            "legacy compatibility values bypassed tenant Secret binding"
+        )
+    _verify_consumers(rendered, MANAGED_SECRET, MANAGED_KEY, MANAGED_SECRET_KEY)
+
+
+def _verify_legacy_custom_pair_is_preserved() -> None:
+    """Keep strong credentials configured through pre-tenantBootstrap values."""
+    custom_key = "U" * 48
+    custom_secret = "V" * 48
+    rendered = _render(
+        (
+            "--set-string",
+            f"consoleHub.env.tenantKey={custom_key}",
+            "--set-string",
+            f"consoleHub.env.tenantSecret={custom_secret}",
+        )
+    )
+    values = _secret_string_data(_find_document(rendered, "Secret", MANAGED_SECRET))
+    if (
+        values.get(MANAGED_KEY) != custom_key
+        or values.get(MANAGED_SECRET_KEY) != custom_secret
+    ):
+        raise VerificationError("legacy custom tenant pair was not preserved")
+    _verify_consumers(rendered, MANAGED_SECRET, MANAGED_KEY, MANAGED_SECRET_KEY)
+
+
+def _verify_negative_renders() -> int:
+    strong_key = "K" * 48
+    strong_secret = "S" * 48
+    cases: Sequence[Sequence[str]] = (
+        ("--set-string", f"tenantBootstrap.key={strong_key}"),
+        ("--set-string", f"tenantBootstrap.secret={strong_secret}"),
+        (
+            "--set-string",
+            "tenantBootstrap.key=short",
+            "--set-string",
+            f"tenantBootstrap.secret={strong_secret}",
+        ),
+        (
+            "--set-string",
+            f"tenantBootstrap.key={'K' * 31}/",
+            "--set-string",
+            f"tenantBootstrap.secret={strong_secret}",
+        ),
+        (
+            "--set-string",
+            f"tenantBootstrap.key={strong_key}",
+            "--set-string",
+            f"tenantBootstrap.secret={strong_key}",
+        ),
+        (
+            "--set-string",
+            f"tenantBootstrap.key={LEGACY_KEY}",
+            "--set-string",
+            f"tenantBootstrap.secret={LEGACY_SECRET}",
+        ),
+        (
+            "--set-string",
+            f"tenantBootstrap.key={LEGACY_KEY}",
+            "--set-string",
+            f"tenantBootstrap.secret={strong_secret}",
+        ),
+        (
+            "--set-string",
+            f"consoleHub.env.tenantKey={strong_key}",
+        ),
+        ("--set-string", "tenantBootstrap.tenantId=changed"),
+        (
+            "--set-string",
+            "tenantBootstrap.existingSecret.name=external",
+            "--set-string",
+            "tenantBootstrap.existingSecret.keyKey=same",
+            "--set-string",
+            "tenantBootstrap.existingSecret.secretKey=same",
+        ),
+        (
+            "--set-string",
+            "tenantBootstrap.existingSecret.name=external",
+            "--set-string",
+            "tenantBootstrap.existingSecret.keyKey=bad/key",
+        ),
+        (
+            "--set-string",
+            "workflowInternalAuth.existingSecret.name=external",
+            "--set-string",
+            "workflowInternalAuth.existingSecret.key=",
+        ),
+        (
+            "--set-string",
+            "workflowInternalAuth.existingSecret.name=external",
+            "--set-string",
+            "workflowInternalAuth.existingSecret.key=bad/key",
+        ),
+    )
+    for arguments in cases:
+        completed = _run_helm(
+            [
+                "template",
+                "astron-agent",
+                str(CHART),
+                "--namespace",
+                "astron-agent",
+                *arguments,
+            ]
+        )
+        if completed.returncode == 0:
+            raise VerificationError("negative Helm render unexpectedly succeeded")
+    return len(cases)
+
+
+def _verify_lookup_and_seed_sources() -> None:
+    helper_source = (CHART / "templates" / "_helpers.tpl").read_text()
+    secret_source = (CHART / "templates" / "tenant-bootstrap-secret.yaml").read_text()
+    for source in (helper_source, secret_source):
+        if 'lookup "v1" "Secret"' not in source:
+            raise VerificationError("managed tenant Secret lookup/reuse is missing")
+        if LEGACY_KEY not in source or LEGACY_SECRET not in source:
+            raise VerificationError(
+                "managed tenant Secret legacy rotation guard is missing"
+            )
+
+    workflow_secret_source = (CHART / "templates" / "secrets.yaml").read_text()
+    workflow_helper_start = helper_source.index(
+        'define "astron-agent.workflowInternalAuthSecretChecksum"'
+    )
+    workflow_helper_end = helper_source.index(
+        'define "astron-agent.tenantBootstrapValidate"', workflow_helper_start
+    )
+    workflow_helper_source = helper_source[workflow_helper_start:workflow_helper_end]
+    for source in (workflow_helper_source, workflow_secret_source):
+        required_fragments = (
+            'lookup "v1" "Secret"',
+            WORKFLOW_PLACEHOLDER,
+            "(ge (len $candidate",
+            "(le (len $candidate",
+            '(not (contains "\\r" $candidate',
+            '(not (contains "\\n" $candidate',
+        )
+        if not all(fragment in source for fragment in required_fragments):
+            raise VerificationError(
+                "managed workflow Secret upgrade validation is incomplete"
+            )
+    for sql_path in (
+        CHART / "files" / "mysql" / "tenant.sql",
+        CHART / "files" / "mysql" / "workflow.sql",
+    ):
+        sql = sql_path.read_text()
+        if LEGACY_KEY in sql or LEGACY_SECRET in sql:
+            raise VerificationError(
+                "published tenant credential remains in Helm SQL seed"
+            )
+
+
+def main() -> int:
+    if not shutil.which("helm"):
+        print("tenant bootstrap Helm gate: FAIL: Helm is unavailable", file=sys.stderr)
+        return 1
+    try:
+        lint = _run_helm(["lint", str(CHART)])
+        if lint.returncode != 0:
+            raise VerificationError("Helm lint failed")
+        _verify_lookup_and_seed_sources()
+        _verify_default_render()
+        _verify_explicit_render()
+        _verify_external_secret_render()
+        _verify_workflow_external_secret_render()
+        _verify_workflow_managed_upgrade_render()
+        _verify_legacy_compatibility_overrides_are_ignored()
+        _verify_legacy_custom_pair_is_preserved()
+        negative_count = _verify_negative_renders()
+    except VerificationError as exc:
+        print(f"tenant bootstrap Helm gate: FAIL: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "tenant bootstrap Helm gate: FAIL: internal validation error",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "tenant bootstrap Helm gate: PASS "
+        f"(7 positive modes, 4 tenant consumers, 3 workflow consumers, "
+        f"{negative_count} negative cases)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/helm/astron-agent/values.yaml
+++ b/helm/astron-agent/values.yaml
@@ -31,6 +31,30 @@ workflowInternalAuth:
   existingSecret:
     name: ""
     key: "workflow-internal-api-key"
+    # Non-secret version/digest marker. Change it when an external Secret is
+    # rotated in place so all consumers restart and reload the environment.
+    checksum: ""
+
+# Bootstrap identity shared by Tenant, Console Hub, Agent, and Workflow. The
+# tenant ID is intentionally stable because existing data refers to it. Leave
+# key/secret and existingSecret.name empty for a zero-configuration install:
+# Helm creates a strong random Secret and reuses it on live upgrades via
+# `lookup`. For offline GitOps rendering, reference a pre-created Secret because
+# `helm template` cannot look up values already stored in a cluster.
+tenantBootstrap:
+  tenantId: "680ab54f"
+  # Explicit values take precedence over existingSecret and must both contain
+  # 32-50 URL-safe characters. Prefer the managed/default mode or an existing
+  # Secret so credentials do not live in values files.
+  key: ""
+  secret: ""
+  existingSecret:
+    name: ""
+    keyKey: "tenant-key"
+    secretKey: "tenant-secret"
+  # Non-secret version/digest marker. Change it whenever an externally managed
+  # Secret is rotated in place so all consumers restart together.
+  existingSecretChecksum: ""
 
 # Override the full name for consistent resource naming
 fullnameOverride: "astron-agent"
@@ -122,24 +146,20 @@ minio:
   persistence:
     enabled: true
     size: 20Gi
-  # MinIO and every in-chart S3 client read the same pre-created Secret. The
-  # chart intentionally never writes object-storage credentials into values or
-  # rendered manifests. Create this Secret before installation, for example:
-  #   kubectl create secret generic astron-agent-minio-credentials \
-  #     --from-literal=root-user="$(openssl rand -hex 12)" \
-  #     --from-literal=root-password="$(openssl rand -hex 24)"
-  # The runtime preflight rejects empty, short, and well-known credentials.
+  # MinIO and every in-chart S3 client read one shared Secret. By default the
+  # chart creates it from the private, in-cluster quick-start credentials below,
+  # so a normal install needs no credential preparation. Set existingSecret to
+  # reference an operator-managed Secret instead. Change the defaults before
+  # explicitly exposing the MinIO API or console outside the cluster.
   auth:
-    existingSecret: astron-agent-minio-credentials
+    existingSecret: ""
     rootUserKey: root-user
     rootPasswordKey: root-password
     # Non-secret version/digest marker; change it when rotating the Secret in
     # place so MinIO and all S3 consumers roll together.
     existingSecretChecksum: ""
-    # Deprecated compatibility keys. Inline credentials are rejected because
-    # Helm would disclose them in values and rendered release manifests.
-    rootUser: ""
-    rootPassword: ""
+    rootUser: minioadmin
+    rootPassword: minioadmin123
   # Optional exact origin (scheme + host + optional port; no path/query/fragment)
   # used when generating URLs for clients outside the cluster. Core Agent also
   # receives this as SKILL_RESOURCE_TRUSTED_ORIGIN and trusts no other remote
@@ -395,8 +415,10 @@ coreAgent:
     runMcpPluginUrl: "http://astron-agent-core-link:18888/api/v1/mcp/call_tool"
     appAuthHost: astron-agent-core-tenant:5052
     appAuthProt: http
-    appAuthApiKey: 7b709739e8da44536127a333c7603a83
-    appAuthSecret: NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy
+    # Injected from tenantBootstrap; these compatibility keys stay present so
+    # upgrades using older values cannot reintroduce the published credential.
+    appAuthApiKey: ""
+    appAuthSecret: ""
 
 coreKnowledge:
   enabled: true
@@ -499,23 +521,22 @@ consoleHub:
   enabled: true
   image: console-hub
   replicaCount: 1
-  # Internal service credentials. Prefer a pre-created Secret so credentials never
-  # enter values or rendered manifests. The two default Secret names must be
-  # created by the operator before installation with independent random values
-  # under the keys below. When rotating an existing Secret in place,
-  # update existingSecretChecksum to force all three consumers to roll together.
-  # As an alternative, set token to a random value of at least 32 characters; the
-  # chart then creates a dedicated Secret. Explicit tokens take precedence over
-  # existingSecret and are intended mainly for non-GitOps installations.
+  # Internal service credentials. Leave token and existingSecret empty to let
+  # Helm generate two independent random Secrets and preserve them across live
+  # upgrades. For offline GitOps rendering, use pre-created Secrets because
+  # `helm template` cannot look up and reuse cluster values. When rotating an
+  # external Secret in place, update existingSecretChecksum to roll all three
+  # consumers together. Explicit tokens take precedence over existingSecret and
+  # are intended mainly for non-GitOps installations.
   artifactUpload:
     token: ""
-    existingSecret: "astron-agent-artifact-upload-credential"
+    existingSecret: ""
     existingSecretKey: "artifact-upload-token"
     # Non-secret version/digest marker; change whenever the referenced key rotates.
     existingSecretChecksum: ""
   sandboxRuntimeCredential:
     token: ""
-    existingSecret: "astron-agent-sandbox-runtime-credential"
+    existingSecret: ""
     existingSecretKey: "sandbox-runtime-credential-token"
     # Non-secret version/digest marker; change whenever the referenced key rotates.
     existingSecretChecksum: ""
@@ -565,12 +586,12 @@ consoleHub:
     oauth2Audience: astron-agent-client
     # Tenant Configuration (Important!)
     tenantId: "680ab54f"
-    tenantKey: "7b709739e8da44536127a333c7603a83"
-    tenantSecret: "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+    tenantKey: ""
+    tenantSecret: ""
     # Common API Configuration
     commonAppid: "680ab54f"
-    commonApikey: "7b709739e8da44536127a333c7603a83"
-    commonApiSecret: "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+    commonApikey: ""
+    commonApiSecret: ""
     # Service URLs
     appUrl: "http://astron-agent-core-tenant:5052/v2/app"
     knowledgeUrl: "http://astron-agent-core-knowledge:20010/knowledge"
@@ -590,11 +611,11 @@ consoleHub:
     tenantVerifyAppAuth: "http://astron-agent-core-tenant:5052/v2/app/key/verify"
     # MaaS Platform Configuration
     maasAppId: "680ab54f"
-    maasApiKey: "7b709739e8da44536127a333c7603a83"
-    maasApiSecret: "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+    maasApiKey: ""
+    maasApiSecret: ""
     maasConsumerId: "680ab54f"
-    maasConsumerKey: "7b709739e8da44536127a333c7603a83"
-    maasConsumerSecret: "NjhmY2NmM2NkZDE4MDFlNmM5ZjcyZjMy"
+    maasConsumerKey: ""
+    maasConsumerSecret: ""
     maasWorkflowVersion: "http://127.0.0.1:8080/workflow/version"
     maasSynchronizeWorkFlow: "http://127.0.0.1:8080/workflow"
     maasPublish: "http://127.0.0.1:8080/workflow/publish"


### PR DESCRIPTION
Hardens Workflow and Tenant internal authentication, disables unsafe local code execution, rotates bootstrap credentials automatically, limits infrastructure exposure, and adds Docker/Helm security contract coverage. Keeps quick-start defaults and requires no new user-managed deployment secrets.