### PR TITLE
test(workflow): add CI type annotations

### DIFF
--- a/core/workflow/tests/extensions/fastapi/test_auth.py
+++ b/core/workflow/tests/extensions/fastapi/test_auth.py
@@ -814,7 +814,7 @@ class TestAuthMiddleware:
         mock_span.add_info_event_async = AsyncMock()
         valid_digest = credential_cache_key("same-key:valid-secret")
 
-        def cache_lookup(digest: str):
+        def cache_lookup(digest: str) -> str | None:
             return "cached-app" if digest == valid_digest else None
 
         response = Mock()

--- a/core/workflow/tests/extensions/fastapi/test_bootstrap_credentials.py
+++ b/core/workflow/tests/extensions/fastapi/test_bootstrap_credentials.py
@@ -1,8 +1,12 @@
 import hashlib
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 
 import pytest
+from sqlalchemy import Engine
 from sqlmodel import Session, SQLModel, create_engine  # type: ignore
 
 from workflow.domain.models.ai_app import App
@@ -23,7 +27,7 @@ from workflow.extensions.fastapi.lifespan.bootstrap_credentials import (
 
 
 @pytest.fixture
-def engine():
+def engine() -> Engine:
     database_engine = create_engine("sqlite://")
     SQLModel.metadata.create_all(
         database_engine, tables=[AppSource.__table__, App.__table__]
@@ -47,7 +51,7 @@ def credentials() -> TenantBootstrapCredentials:
     return TenantBootstrapCredentials(BOOTSTRAP_TENANT_ID, "k" * 48, "s" * 48)
 
 
-def deployment_owned_app(**overrides) -> App:
+def deployment_owned_app(**overrides: Any) -> App:
     values = {
         "id": 1,
         "name": "星辰",
@@ -64,7 +68,7 @@ def deployment_owned_app(**overrides) -> App:
     return App(**values)
 
 
-def test_synchronize_bootstrap_app_creates_reserved_row(engine) -> None:
+def test_synchronize_bootstrap_app_creates_reserved_row(engine: Engine) -> None:
     with Session(engine) as session:
         synchronize_bootstrap_app(session, credentials())
         session.commit()
@@ -76,7 +80,7 @@ def test_synchronize_bootstrap_app_creates_reserved_row(engine) -> None:
         assert app.api_secret == "s" * 48
 
 
-def test_synchronize_bootstrap_app_rotates_only_reserved_row(engine) -> None:
+def test_synchronize_bootstrap_app_rotates_only_reserved_row(engine: Engine) -> None:
     with Session(engine) as session:
         session.add(
             deployment_owned_app(
@@ -107,7 +111,7 @@ def test_synchronize_bootstrap_app_rotates_only_reserved_row(engine) -> None:
         assert user_app is not None and user_app.api_key == "user-key"
 
 
-def test_synchronize_bootstrap_app_rejects_alias_collision(engine) -> None:
+def test_synchronize_bootstrap_app_rejects_alias_collision(engine: Engine) -> None:
     with Session(engine) as session:
         session.add(
             App(
@@ -124,7 +128,7 @@ def test_synchronize_bootstrap_app_rejects_alias_collision(engine) -> None:
             synchronize_bootstrap_app(session, credentials())
 
 
-def test_synchronize_bootstrap_app_rotates_strong_custom_pair(engine) -> None:
+def test_synchronize_bootstrap_app_rotates_strong_custom_pair(engine: Engine) -> None:
     with Session(engine) as session:
         session.add(
             deployment_owned_app(
@@ -144,7 +148,7 @@ def test_synchronize_bootstrap_app_rotates_strong_custom_pair(engine) -> None:
 
 
 def test_second_rotation_revokes_old_digest_only_after_commit(
-    engine, monkeypatch: pytest.MonkeyPatch
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     old_key = "x" * 48
     old_secret = "y" * 48
@@ -155,7 +159,7 @@ def test_second_rotation_revokes_old_digest_only_after_commit(
     commit_state = {"committed": False}
 
     @contextmanager
-    def committed_session():
+    def committed_session() -> Iterator[Session]:
         with Session(engine) as session:
             yield session
             session.commit()
@@ -191,7 +195,7 @@ def test_second_rotation_revokes_old_digest_only_after_commit(
     ],
 )
 def test_synchronize_bootstrap_app_rejects_tampered_reserved_identity(
-    engine, field: str, value: int
+    engine: Engine, field: str, value: int
 ) -> None:
     with Session(engine) as session:
         session.add(deployment_owned_app(**{field: value}))
@@ -201,7 +205,9 @@ def test_synchronize_bootstrap_app_rejects_tampered_reserved_identity(
             synchronize_bootstrap_app(session, credentials())
 
 
-def test_synchronize_bootstrap_app_accepts_matching_custom_pair(engine) -> None:
+def test_synchronize_bootstrap_app_accepts_matching_custom_pair(
+    engine: Engine,
+) -> None:
     configured = credentials()
     with Session(engine) as session:
         session.add(
@@ -224,7 +230,7 @@ def test_synchronize_bootstrap_app_accepts_matching_custom_pair(engine) -> None:
 
 
 def test_load_tenant_bootstrap_credentials_from_files(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     key_file = tmp_path / "tenant-key"
     secret_file = tmp_path / "tenant-secret"

--- a/core/workflow/tests/extensions/fastapi/test_database_migration_lock.py
+++ b/core/workflow/tests/extensions/fastapi/test_database_migration_lock.py
@@ -87,7 +87,7 @@ def test_redis_lock_uses_redis_3_5_compatible_arguments() -> None:
         def __init__(self) -> None:
             self.kwargs: dict[str, object] | None = None
 
-        def lock(self, **kwargs):
+        def lock(self, **kwargs: object) -> str:
             self.kwargs = kwargs
             return "lock"
 

--- a/core/workflow/tests/extensions/fastapi/test_internal_api_auth.py
+++ b/core/workflow/tests/extensions/fastapi/test_internal_api_auth.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from fastapi import APIRouter, HTTPException
 
@@ -57,7 +59,7 @@ async def test_internal_api_auth_fails_closed_when_not_configured(
 
 @pytest.mark.asyncio
 async def test_internal_api_auth_reads_persisted_key_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configured_key = "f" * 48
     key_file = tmp_path / "workflow-internal-api-key"
@@ -73,7 +75,7 @@ async def test_internal_api_auth_reads_persisted_key_file(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("file_state", ["missing", "short", "oversized", "symlink"])
 async def test_internal_api_auth_rejects_invalid_key_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path, file_state: str
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, file_state: str
 ) -> None:
     key_file = tmp_path / "workflow-internal-api-key"
     if file_state == "short":

--- a/core/workflow/tests/service/test_app_service_internal_auth.py
+++ b/core/workflow/tests/service/test_app_service_internal_auth.py
@@ -2,12 +2,14 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from workflow.service.app_service import _gen_app_auth_header
 from workflow.utils.credentials import TENANT_INTERNAL_API_KEY_HEADER
 
 
 def test_gen_app_auth_header_includes_tenant_internal_key(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("APP_MANAGE_PLAT_KEY", "k" * 48)
     monkeypatch.setenv("APP_MANAGE_PLAT_SECRET", "s" * 48)
@@ -32,7 +34,7 @@ def test_gen_app_auth_header_includes_tenant_internal_key(
 
 
 def test_gen_app_auth_header_fails_closed_without_complete_credentials(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("APP_MANAGE_PLAT_KEY", "k" * 48)
     monkeypatch.delenv("APP_MANAGE_PLAT_SECRET", raising=False)


### PR DESCRIPTION
## Summary
- type workflow security-test fixtures and helpers
- keep pytest behavior unchanged while satisfying strict mypy checks

## Validation
- addresses the second-layer failures reported by remote Linux check-python