### PR TITLE
fix(docs): repair Japanese README image path

### DIFF
--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -133,7 +133,7 @@ docker compose -f docker-compose-with-auth.yaml up -d
 - 👥 WeChat Work グループ:
 
 <div align="center">
-  <img src="./imgs/WeCom_Group.png" alt="WeChat Work グループ" width="300">
+  <img src="../imgs/WeCom_Group.png" alt="WeChat Work グループ" width="300">
 </div>
 
 ## 📄 オープンソースライセンス


### PR DESCRIPTION
Fix the GitHub Pages build failure reported by Deploy Astron Agent Site.

`docs/ja/README.md` referenced `./imgs/WeCom_Group.png`, but the shared asset is stored at `docs/imgs/WeCom_Group.png`; use `../imgs/WeCom_Group.png` so VitePress can resolve the image.