### PR TITLE
fix(docs): make example gallery build in VitePress

### DIFF
--- a/docs/.vitepress/examples.data.ts
+++ b/docs/.vitepress/examples.data.ts
@@ -1,6 +1,6 @@
 // Build-time data loader: reads the community workflow examples under examples/
 // and exposes their metadata to the docs site gallery.
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname } from "node:path";
 
 export interface ExampleMeta {
@@ -15,16 +15,11 @@ export interface ExampleMeta {
   event: string;
   repoPath: string; // e.g. examples/history-knowledge-qa
   hasPreview: boolean;
-  previewUrl: string;
+  previewPath: string;
 }
 
 declare const data: ExampleMeta[];
 export { data };
-
-const previewAssets = import.meta.glob("../../examples/*/preview.png", {
-  eager: true,
-  import: "default"
-}) as Record<string, string>;
 
 function parseFrontmatter(md: string): Record<string, string | string[]> | null {
   const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -64,6 +59,8 @@ export default {
       if (id === "TEMPLATE") continue;
       const fm = parseFrontmatter(readFileSync(file, "utf8"));
       if (!fm || !fm.id) continue;
+      const previewPath = `${dirname(file)}/preview.png`;
+      const hasPreview = existsSync(previewPath);
       examples.push({
         id: String(fm.id),
         title: String(fm.title ?? fm.id),
@@ -75,8 +72,8 @@ export default {
         dslVersion: String(fm.dslVersion ?? ""),
         event: String(fm.event ?? ""),
         repoPath: `examples/${id}`,
-        hasPreview: Boolean(previewAssets[`../../examples/${id}/preview.png`]),
-        previewUrl: previewAssets[`../../examples/${id}/preview.png`] ?? ""
+        hasPreview,
+        previewPath: hasPreview ? `examples/${id}/preview.png` : ""
       });
     }
     return examples.sort((a, b) => a.category.localeCompare(b.category) || a.title.localeCompare(b.title));

--- a/docs/.vitepress/theme/ExamplesGallery.vue
+++ b/docs/.vitepress/theme/ExamplesGallery.vue
@@ -3,6 +3,19 @@ import { computed, ref } from "vue";
 import { useData } from "vitepress";
 import { data as examples } from "../examples.data";
 
+const previewAssets = import.meta.glob("../../../examples/*/preview.png", {
+  eager: true,
+  import: "default",
+  query: "?url"
+}) as Record<string, string>;
+
+const previewUrlsById = Object.fromEntries(
+  Object.entries(previewAssets).map(([path, url]) => {
+    const segments = path.split("/");
+    return [segments[segments.length - 2], url];
+  })
+);
+
 const REPO = "https://github.com/iflytek/astron-agent";
 const { lang } = useData();
 const isZh = computed(() => lang.value === "zh-CN");
@@ -38,6 +51,8 @@ const hideBrokenPreview = (id: string): void => {
   failedPreviews.value = new Set(failedPreviews.value).add(id);
 };
 
+const getPreviewUrl = (id: string): string => previewUrlsById[id] ?? "";
+
 const contributeHref = computed(() => (isZh.value ? "/zh/contribute-to-docs" : "/contribute-to-docs"));
 </script>
 
@@ -70,7 +85,7 @@ const contributeHref = computed(() => (isZh.value ? "/zh/contribute-to-docs" : "
         <img
           v-if="e.hasPreview && !failedPreviews.has(e.id)"
           class="exg__preview"
-          :src="e.previewUrl"
+          :src="getPreviewUrl(e.id)"
           :alt="`${e.title} workflow preview`"
           loading="lazy"
           @error="hideBrokenPreview(e.id)"


### PR DESCRIPTION
Fix the remaining GitHub Pages build failure after PR #1651.

The VitePress data loader runs in Node during build and cannot call `import.meta.glob`; detect preview files with the filesystem loader and let the Vue theme component import image URLs through Vite. This keeps the example gallery previews bundled and makes the Pages build work with the current VitePress release.