### PR TITLE
fix(build): use reliable PyPI source for RPA image

### DIFF
--- a/core/plugin/rpa/Dockerfile
+++ b/core/plugin/rpa/Dockerfile
@@ -6,12 +6,17 @@ ENV PATH=$PATH:/opt/core
 ENV PYTHONPATH /opt/core
 ENV UV_NO_CACHE=1
 
-RUN pip install uv --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple/
+# Use the official index by default.  The image is built concurrently for two
+# architectures in CI, and public mirrors can reject one of the parallel
+# requests (for example, with HTTP 403).  Builders that require an internal
+# mirror can override this argument without changing the deployment contract.
+ARG PYPI_INDEX_URL=https://pypi.org/simple/
+RUN pip install uv --no-cache-dir --index-url "${PYPI_INDEX_URL}"
 
 COPY core/plugin/rpa/pyproject.toml ./
 COPY core/plugin/rpa/uv.lock ./
 
-RUN uv sync -i https://pypi.tuna.tsinghua.edu.cn/simple/
+RUN uv sync --default-index "${PYPI_INDEX_URL}"
 
 COPY core/common ./common
 COPY core/plugin/rpa ./plugin/rpa


### PR DESCRIPTION
Use the official PyPI index by default for the Core RPA image and expose an optional build-time index override. This avoids intermittent mirror failures during concurrent multi-architecture image builds while preserving the existing deployment contract.