### PR TITLE
feat(mcp): add resource/prompt adapters and typed, bounded tool content

### DIFF
--- a/core/plugin/link/api/schemas/community/tools/mcp/mcp_tools_schema.py
+++ b/core/plugin/link/api/schemas/community/tools/mcp/mcp_tools_schema.py
@@ -7,7 +7,7 @@ tool listing and tool execution requests and responses.
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class MCPTransport(str, Enum):
@@ -93,26 +93,12 @@ class MCPCallToolRequest(BaseModel):
     transport: MCPTransport = MCPTransport.AUTO
 
 
-class MCPTextResponse(BaseModel):
-    """Text content response from MCP tool execution.
+class MCPContentBlock(BaseModel):
+    """Forward-compatible MCP content block that preserves protocol fields."""
 
-    Represents text-based output from an MCP tool call.
-    """
+    model_config = ConfigDict(extra="allow")
 
-    type: str = "text"
-    text: str
-
-
-class MCPImageResponse(BaseModel):
-    """Image content response from MCP tool execution.
-
-    Represents image-based output from an MCP tool call with
-    base64 encoded data and MIME type.
-    """
-
-    type: str = "image"
-    data: str
-    mineType: str
+    type: str
 
 
 class MCPCallToolData(BaseModel):
@@ -123,7 +109,8 @@ class MCPCallToolData(BaseModel):
     """
 
     isError: bool | None = None
-    content: list[MCPTextResponse | MCPImageResponse] | None = None
+    content: list[MCPContentBlock] | None = None
+    structuredContent: dict[str, Any] | None = None
 
 
 class MCPCallToolResponse(BaseModel):
@@ -137,3 +124,37 @@ class MCPCallToolResponse(BaseModel):
     message: str
     sid: str
     data: MCPCallToolData
+
+
+class MCPSingleServerRequest(BaseModel):
+    """Select one MCP server for resource or prompt operations."""
+
+    mcp_server_id: str | None = None
+    mcp_server_url: str | None = None
+    transport: MCPTransport = MCPTransport.AUTO
+
+
+class MCPListResourcesRequest(MCPSingleServerRequest):
+    cursor: str | None = None
+
+
+class MCPReadResourceRequest(MCPSingleServerRequest):
+    uri: str
+
+
+class MCPListPromptsRequest(MCPSingleServerRequest):
+    cursor: str | None = None
+
+
+class MCPGetPromptRequest(MCPSingleServerRequest):
+    name: str
+    arguments: dict[str, str] | None = None
+
+
+class MCPProtocolResponse(BaseModel):
+    """Envelope for resource and prompt SDK results."""
+
+    code: int
+    message: str
+    sid: str
+    data: dict[str, Any] | None = None

--- a/core/plugin/link/api/v1/community/tools/mcp/mcp_tools.py
+++ b/core/plugin/link/api/v1/community/tools/mcp/mcp_tools.py
@@ -8,10 +8,22 @@ from fastapi import APIRouter, Body
 from plugin.link.api.schemas.community.tools.mcp.mcp_tools_schema import (
     MCPCallToolRequest,
     MCPCallToolResponse,
+    MCPGetPromptRequest,
+    MCPListPromptsRequest,
+    MCPListResourcesRequest,
+    MCPProtocolResponse,
+    MCPReadResourceRequest,
     MCPToolListRequest,
     MCPToolListResponse,
 )
-from plugin.link.service.community.tools.mcp.mcp_server import call_tool, tool_list
+from plugin.link.service.community.tools.mcp.mcp_server import (
+    call_tool,
+    get_prompt,
+    list_prompts,
+    list_resources,
+    read_resource,
+    tool_list,
+)
 
 # MCP tools router
 mcp_router = APIRouter(tags=["mcp tools api"])
@@ -31,3 +43,29 @@ async def call_tool_api(call_info: MCPCallToolRequest = Body()) -> MCPCallToolRe
     Call MCP tool's call tool
     """
     return await call_tool(call_info=call_info)
+
+
+@mcp_router.post("/mcp/list_resources", response_model_exclude_none=True)
+async def list_resources_api(
+    request: MCPListResourcesRequest = Body(),
+) -> MCPProtocolResponse:
+    return await list_resources(request=request)
+
+
+@mcp_router.post("/mcp/read_resource", response_model_exclude_none=True)
+async def read_resource_api(
+    request: MCPReadResourceRequest = Body(),
+) -> MCPProtocolResponse:
+    return await read_resource(request=request)
+
+
+@mcp_router.post("/mcp/list_prompts", response_model_exclude_none=True)
+async def list_prompts_api(
+    request: MCPListPromptsRequest = Body(),
+) -> MCPProtocolResponse:
+    return await list_prompts(request=request)
+
+
+@mcp_router.post("/mcp/get_prompt", response_model_exclude_none=True)
+async def get_prompt_api(request: MCPGetPromptRequest = Body()) -> MCPProtocolResponse:
+    return await get_prompt(request=request)

--- a/core/plugin/link/service/community/tools/mcp/mcp_server.py
+++ b/core/plugin/link/service/community/tools/mcp/mcp_server.py
@@ -6,7 +6,7 @@ error handling, observability tracing, and security validations.
 """
 
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 from common.otlp.log_trace.node_trace_log import NodeTraceLog, Status
 from common.otlp.metrics.meter import Meter
@@ -19,10 +19,14 @@ from plugin.link.api.schemas.community.tools.mcp.mcp_tools_schema import (
     MCPCallToolData,
     MCPCallToolRequest,
     MCPCallToolResponse,
-    MCPImageResponse,
+    MCPContentBlock,
+    MCPGetPromptRequest,
     MCPInfo,
     MCPItemInfo,
-    MCPTextResponse,
+    MCPListPromptsRequest,
+    MCPListResourcesRequest,
+    MCPProtocolResponse,
+    MCPReadResourceRequest,
     MCPToolListData,
     MCPToolListRequest,
     MCPToolListResponse,
@@ -270,32 +274,32 @@ async def _execute_tool_call(
     node_trace: NodeTraceLog,
     mcp_server_id: str,
     m: Meter,
-) -> Union[
-    Tuple[bool, List[Union[MCPTextResponse, MCPImageResponse]]],
-    Tuple[MCPCallToolResponse, None],
-]:
+) -> (
+    tuple[MCPCallToolResponse, None, None]
+    | tuple[bool, list[MCPContentBlock], dict[str, Any] | None]
+):
     """Execute the actual tool call and process response."""
     try:
         call_result = await session.call_tool(tool_name, arguments=tool_args)
         call_dict = call_result.model_dump()
-        is_error = call_dict["isError"]
         content = []
+        for raw_block in call_dict.get("content", []):
+            block = dict(raw_block)
+            if block.get("type") == "image" and block.get("mimeType"):
+                block.setdefault("mineType", block["mimeType"])
+            content.append(MCPContentBlock.model_validate(block))
 
-        for data in call_dict["content"]:
-            if data["type"] == "text":
-                text = MCPTextResponse(text=data["text"])
-                content.append(text)
-            elif data["type"] == "image":
-                image = MCPImageResponse(data=data["data"], mineType=data["mineType"])
-                content.append(image)
-
-        return is_error, content
+        return (
+            bool(call_dict.get("isError")),
+            content,
+            call_dict.get("structuredContent"),
+        )
     except Exception:
         err = ErrCode.MCP_SERVER_CALL_TOOL_ERR
         span_context.add_error_event(err.msg)
         span_context.set_status(OTelStatus(StatusCode.ERROR))
         _log_error_to_kafka(err, node_trace, mcp_server_id, m)
-        return _create_error_response(err, session_id), None
+        return _create_error_response(err, session_id), None, None
 
 
 async def _call_mcp_tool(
@@ -326,13 +330,17 @@ async def _call_mcp_tool(
             if isinstance(call_result[0], MCPCallToolResponse):
                 return call_result[0]
 
-            is_error, content = call_result
+            is_error, content, structured_content = call_result
             success = ErrCode.SUCCESSES
             return MCPCallToolResponse(
                 code=success.code,
                 message=success.msg,
                 sid=session_id,
-                data=MCPCallToolData(isError=is_error, content=content),
+                data=MCPCallToolData(
+                    isError=is_error,
+                    content=content,
+                    structuredContent=structured_content,
+                ),
             )
     except MCPTransportError as error:
         err = _transport_error_code(error)
@@ -451,6 +459,79 @@ async def call_tool(call_info: MCPCallToolRequest = Body()) -> MCPCallToolRespon
                 send_telemetry_sync(node_trace)
 
         return result
+
+
+def _resolve_protocol_url(request: Any, span_context: Any) -> tuple[ErrCode, str]:
+    url = request.mcp_server_url
+    if url and is_in_blacklist(url=url):
+        return ErrCode.MCP_SERVER_BLACKLIST_URL_ERR, ""
+    if not url:
+        error, url = get_mcp_server_url(request.mcp_server_id, span_context)
+        if error is not ErrCode.SUCCESSES:
+            return error, ""
+    if is_local_url(url):
+        return ErrCode.MCP_SERVER_LOCAL_URL_ERR, ""
+    return ErrCode.SUCCESSES, url
+
+
+async def _run_protocol_operation(
+    request: Any, operation: str, **arguments: Any
+) -> MCPProtocolResponse:
+    session_id = new_sid()
+    span = Span(app_id="appid_mcp", uid="mcp_uid")
+    if session_id:
+        span.sid = session_id
+
+    with span.start(func_name=operation) as span_context:
+        error, url = _resolve_protocol_url(request, span_context)
+        if error is not ErrCode.SUCCESSES:
+            return MCPProtocolResponse(
+                code=error.code, message=error.msg, sid=session_id, data=None
+            )
+        try:
+            async with initialized_mcp_session(url, request.transport) as (session, _):
+                method = getattr(session, operation)
+                result = await method(**arguments)
+                return MCPProtocolResponse(
+                    code=ErrCode.SUCCESSES.code,
+                    message=ErrCode.SUCCESSES.msg,
+                    sid=session_id,
+                    data=result.model_dump(by_alias=True),
+                )
+        except MCPTransportError as transport_error:
+            error = _transport_error_code(transport_error)
+        except Exception:
+            error = ErrCode.MCP_SERVER_SESSION_ERR
+        return MCPProtocolResponse(
+            code=error.code, message=error.msg, sid=session_id, data=None
+        )
+
+
+async def list_resources(
+    request: MCPListResourcesRequest = Body(),
+) -> MCPProtocolResponse:
+    arguments = {} if request.cursor is None else {"cursor": request.cursor}
+    return await _run_protocol_operation(request, "list_resources", **arguments)
+
+
+async def read_resource(
+    request: MCPReadResourceRequest = Body(),
+) -> MCPProtocolResponse:
+    return await _run_protocol_operation(request, "read_resource", uri=request.uri)
+
+
+async def list_prompts(
+    request: MCPListPromptsRequest = Body(),
+) -> MCPProtocolResponse:
+    arguments = {} if request.cursor is None else {"cursor": request.cursor}
+    return await _run_protocol_operation(request, "list_prompts", **arguments)
+
+
+async def get_prompt(request: MCPGetPromptRequest = Body()) -> MCPProtocolResponse:
+    arguments: dict[str, Any] = {"name": request.name}
+    if request.arguments is not None:
+        arguments["arguments"] = request.arguments
+    return await _run_protocol_operation(request, "get_prompt", **arguments)
 
 
 def get_mcp_server_url(mcp_server_id: str, span: Span) -> Tuple[ErrCode, str]:

--- a/core/plugin/link/tests/unit/test_mcp_server.py
+++ b/core/plugin/link/tests/unit/test_mcp_server.py
@@ -5,10 +5,16 @@ import sys
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-from plugin.link.api.schemas.community.tools.mcp.mcp_tools_schema import MCPTransport
+from plugin.link.api.schemas.community.tools.mcp.mcp_tools_schema import (
+    MCPGetPromptRequest,
+    MCPListPromptsRequest,
+    MCPListResourcesRequest,
+    MCPReadResourceRequest,
+    MCPTransport,
+)
 from plugin.link.service.community.tools.mcp.mcp_transport import MCPTransportError
 from plugin.link.utils.errors.code import ErrCode
 
@@ -45,7 +51,7 @@ class FakeResult:
     def __init__(self, value: dict[str, Any]) -> None:
         self.value = value
 
-    def model_dump(self) -> dict[str, Any]:
+    def model_dump(self, **_: Any) -> dict[str, Any]:
         return self.value
 
 
@@ -69,6 +75,45 @@ class FakeSession:
                 {
                     "isError": False,
                     "content": [{"type": "text", "text": "hello"}],
+                }
+            )
+        )
+        self.list_resources = AsyncMock(
+            return_value=FakeResult(
+                {
+                    "resources": [{"uri": "gitnexus://repos", "name": "repos"}],
+                    "nextCursor": "r2",
+                }
+            )
+        )
+        self.read_resource = AsyncMock(
+            return_value=FakeResult(
+                {
+                    "contents": [
+                        {
+                            "uri": "gitnexus://repos",
+                            "mimeType": "application/json",
+                            "text": "[]",
+                        }
+                    ]
+                }
+            )
+        )
+        self.list_prompts = AsyncMock(
+            return_value=FakeResult(
+                {
+                    "prompts": [{"name": "detect_impact", "arguments": []}],
+                    "nextCursor": "p2",
+                }
+            )
+        )
+        self.get_prompt = AsyncMock(
+            return_value=FakeResult(
+                {
+                    "description": "impact",
+                    "messages": [
+                        {"role": "user", "content": {"type": "text", "text": "review"}}
+                    ],
                 }
             )
         )
@@ -146,6 +191,86 @@ async def test_call_tool_uses_selected_initialized_transport(
     assert result.data.content is not None
     assert result.data.content[0].type == "text"
     session.call_tool.assert_awaited_once_with("echo", arguments={"value": "hello"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_call_tool_preserves_structured_and_forward_content(
+    monkeypatch: pytest.MonkeyPatch, mcp_server: Any
+) -> None:
+    session = FakeSession()
+    session.call_tool.return_value = FakeResult(
+        {
+            "isError": False,
+            "structuredContent": {"risk": "HIGH"},
+            "content": [
+                {"type": "audio", "data": "YQ==", "mimeType": "audio/wav"},
+                {"type": "resource_link", "uri": "gitnexus://repos", "name": "repos"},
+                {"type": "future_block", "value": 7},
+                {"type": "image", "data": "aQ==", "mimeType": "image/png"},
+            ],
+        }
+    )
+    monkeypatch.setattr(
+        mcp_server, "initialized_mcp_session", initialized_session([], session)
+    )
+
+    result = await mcp_server._call_mcp_tool(
+        "https://example.com/mcp", "impact", {}, "sid", Mock(), Mock(), "server", Mock()
+    )
+
+    assert result.data.structuredContent == {"risk": "HIGH"}
+    assert [block.type for block in result.data.content or []] == [
+        "audio",
+        "resource_link",
+        "future_block",
+        "image",
+    ]
+    image = (result.data.content or [])[-1].model_dump()
+    assert image["mimeType"] == "image/png"
+    assert image["mineType"] == "image/png"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resource_and_prompt_operations_preserve_sdk_payloads(
+    monkeypatch: pytest.MonkeyPatch, mcp_server: Any
+) -> None:
+    session = FakeSession()
+    monkeypatch.setattr(
+        mcp_server, "initialized_mcp_session", initialized_session([], session)
+    )
+    span = MagicMock()
+    span.start.return_value.__enter__.return_value = MagicMock()
+    monkeypatch.setattr(mcp_server, "Span", MagicMock(return_value=span))
+    monkeypatch.setattr(mcp_server, "new_sid", lambda: "sid")
+    monkeypatch.setattr(
+        mcp_server,
+        "_resolve_protocol_url",
+        lambda request, context: (ErrCode.SUCCESSES, "https://example.com/mcp"),
+    )
+
+    resources = await mcp_server.list_resources(MCPListResourcesRequest(cursor="r1"))
+    resource = await mcp_server.read_resource(
+        MCPReadResourceRequest(uri="gitnexus://repos")
+    )
+    prompts = await mcp_server.list_prompts(MCPListPromptsRequest(cursor="p1"))
+    prompt = await mcp_server.get_prompt(
+        MCPGetPromptRequest(name="detect_impact", arguments={"scope": "all"})
+    )
+
+    assert resources.data and resources.data["nextCursor"] == "r2"
+    assert (
+        resource.data and resource.data["contents"][0]["mimeType"] == "application/json"
+    )
+    assert prompts.data and prompts.data["nextCursor"] == "p2"
+    assert prompt.data and prompt.data["messages"][0]["role"] == "user"
+    session.list_resources.assert_awaited_once_with(cursor="r1")
+    session.read_resource.assert_awaited_once_with(uri="gitnexus://repos")
+    session.list_prompts.assert_awaited_once_with(cursor="p1")
+    session.get_prompt.assert_awaited_once_with(
+        name="detect_impact", arguments={"scope": "all"}
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

This PR adds four plugin-link MCP operations (list/read resources, list/get prompts) and replaces the text/image-only tool-result adapter with typed, bounded content that preserves the full protocol shape.

Closes #1664. Refs #1662; this PR implements only part of #1662 (see "Remaining" below).

## #1664 acceptance criteria

| Criterion | How it is met |
| --- | --- |
| Text and image responses remain backward compatible | `text`/`data` keep the same fields. Image blocks still carry `mineType`. |
| Standard `mimeType`; legacy misspelling handled explicitly | `mimeType` is the standard field on image and audio blocks. `mineType` is only on image blocks, filled from `mimeType`, and its schema description marks it deprecated. |
| Audio, embedded resource, resource-link survive | Typed `MCPAudioBlock`, `MCPEmbeddedResourceBlock` (text **and** blob contents), and `MCPResourceLinkBlock`. Annotations, `_meta`, and unknown fields are kept (`extra="allow"`). |
| `structuredContent` survives as JSON | Forwarded unchanged. The top-level result `_meta` is forwarded too. |
| Unknown future block types never silently omitted | The public union uses a callable discriminator. Unmodelled types become `MCPUnsupportedBlock` with `unsupported: true` and all their fields. The SDK (1.28) currently rejects unknown types while parsing, which already surfaces as `MCP_SERVER_CALL_TOOL_ERR` rather than silent loss. |
| Oversized counts/payloads bounded with metadata | `MCP_TOOL_RESULT_MAX_BLOCKS` (default 128) and `MCP_TOOL_RESULT_MAX_BYTES` (default 4 MiB). `structuredContent` is budgeted first, then blocks in order. Anything withheld is reported in `data.truncation` (`reason`, limits, original/returned counts, `structuredContentOmitted`) and logged. |
| Tool `isError` distinguishable from transport/session failure | `isError` stays in `data` with envelope `code` = success. Call and transport failures use the error codes and have no content. |
| Tests use SDK models and FastAPI serialization | `mcp.types.CallToolResult` with every block type goes through `_call_mcp_tool`. It is also posted through the **real** `mcp_router` with `TestClient`, and the JSON re-validates into the same typed models. |

## Implementation

- `service/community/tools/mcp/mcp_content.py` (new): result conversion and limits. It is kept out of `mcp_server.py` to stay under the flake8 complexity gate.
- SDK results are dumped with `mode="json", by_alias=True`. The SDK-model tests caught that the default python mode leaves resource URIs as `AnyUrl`, which failed the string fields. The resource/prompt operations now use the same mode.
- The four resource/prompt routes are unchanged from the previous revision. They use the existing MCP URL checks and the initialized transport/session path.
- Rebased onto current `main`, which includes #1669.

## Remaining (#1662)

- Agent/workflow-to-server authorization and operation allowlists are not implemented for the resource/prompt routes.
- Size bounds are not yet applied to `read_resource`/`get_prompt` payloads. They can reuse `ResultLimits` once #1662 settles the response shape.
- Resource-template enumeration and finer protocol-error mapping are still open. Generic exceptions currently become `MCP_SERVER_SESSION_ERR`.

## Validation (local, head 7161be6d)

- `pytest tests` in `core/plugin/link`: 254 passed. 14 are in `test_mcp_server.py`, 6 of them new.
- The CI-pinned linters pass on the changed files: black 24.4.2, isort 5.13.2, flake8 7.0.0 (complexity ≤ 10), and mypy 1.18.2 with the CI flags. pylint 3.1.0 scores 9.54 on the changed service/schema files.
