### PR TITLE
docs(faq): explain empty workflow model selection

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,6 +26,10 @@ npm install
 npm run docs:dev
 ```
 
+## Why Is The Model Selection Dropdown Empty In A Workflow
+
+Models do not appear in the workflow editor until they have been added in the model management interface. Add and configure the model there first, then return to the workflow editor and reopen the model selection dropdown.
+
 ## Where Should I Go For Deeper Troubleshooting
 
 - [Repository FAQ](https://github.com/iflytek/astron-agent/blob/main/FAQ.md)

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -26,6 +26,10 @@ npm install
 npm run docs:dev
 ```
 
+## 为什么工作流里的模型选择下拉框是空的
+
+模型需要先在模型管理界面中添加和配置，之后才会出现在工作流编辑器里。请先完成模型配置，再返回工作流编辑器并重新打开模型选择下拉框。
+
 ## 完整问题排查去哪里看
 
 - [仓库根目录 FAQ](https://github.com/iflytek/astron-agent/blob/main/FAQ.md)


### PR DESCRIPTION
## Description

- explain that models must first be added in the model management interface
- mirror the FAQ entry in English and Chinese
- base the answer on the resolved setup question in #800

Part of #1412.

## Testing

- `cd docs && npm run docs:build`
- VitePress build completed successfully