### PR TITLE
fix(workflow): preserve code node source escapes

### DIFF
--- a/core/workflow/engine/nodes/code/executor/langchain/langchain_executor.py
+++ b/core/workflow/engine/nodes/code/executor/langchain/langchain_executor.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from typing import Any
 
 from langchain_sandbox import PyodideSandbox
@@ -17,6 +18,39 @@ from workflow.exception.errors.err_code import CodeEnum
 from workflow.extensions.otlp.trace.span import Span
 
 MAX_ERROR_MESSAGE_LENGTH = 4096
+
+
+class _FilePyodideSandbox(PyodideSandbox):
+    """Use the official CLI file input without rewriting Python escapes.
+
+    langchain-sandbox 0.0.6 only exposes inline code through execute(), and
+    @langchain/pyodide-sandbox 0.0.4 replaces literal backslash-n sequences in
+    that input. Its official -f entry point reads source verbatim instead.
+    Keep the SDK's command, process lifecycle and resource limits, adapting
+    only the input flag until the SDK exposes file input publicly.
+    """
+
+    def __init__(self, source_path: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._source_path = source_path
+
+    def _build_command(
+        self,
+        code: str,
+        *,
+        session_bytes: bytes | None = None,
+        session_metadata: dict | None = None,
+        memory_limit_mb: int | None = None,
+    ) -> list[str]:
+        command = super()._build_command(
+            code,
+            session_bytes=session_bytes,
+            session_metadata=session_metadata,
+            memory_limit_mb=memory_limit_mb,
+        )
+        code_flag_index = command.index("-c")
+        command[code_flag_index : code_flag_index + 2] = ["-f", self._source_path]
+        return command
 
 
 class LangchainExecutor(BaseExecutor):
@@ -42,26 +76,33 @@ class LangchainExecutor(BaseExecutor):
         :raises CustomException: If code execution fails
         """
         try:
-            # Keep every Deno permission disabled.  Pyodide's default
-            # node_modules read/write permissions are retained internally by the
-            # official wrapper so it can load its runtime dependencies; user
-            # Python code cannot access the workflow container's filesystem,
-            # environment, network, subprocess, or FFI.
-            sandbox = PyodideSandbox(
-                allow_env=False,
-                allow_read=False,
-                allow_write=False,
-                allow_net=False,
-                allow_run=False,
-                allow_ffi=False,
-            )
             bounded_timeout = _bounded_timeout(timeout)
             bounded_memory_limit = _bounded_memory_limit()
-            result = await sandbox.execute(
-                code,
-                timeout_seconds=bounded_timeout,
-                memory_limit_mb=bounded_memory_limit,
-            )
+            # Grant Deno read access only to this invocation's source file in
+            # addition to the SDK's existing node_modules permissions. File
+            # input preserves escapes, import discovery and top-level await.
+            # The context manager removes the file on success or failure.
+            with tempfile.TemporaryDirectory(prefix="astron-code-") as source_dir:
+                source_path = os.path.realpath(os.path.join(source_dir, "source.py"))
+                # Close the writer before Deno opens the file (also on Windows).
+                with open(
+                    source_path, "w", encoding="utf-8", newline=""
+                ) as source_file:
+                    source_file.write(code)
+                sandbox = _FilePyodideSandbox(
+                    source_path,
+                    allow_env=False,
+                    allow_read=["node_modules", source_path],
+                    allow_write=False,
+                    allow_net=False,
+                    allow_run=False,
+                    allow_ffi=False,
+                )
+                result = await sandbox.execute(
+                    code,
+                    timeout_seconds=bounded_timeout,
+                    memory_limit_mb=bounded_memory_limit,
+                )
             if result.status == "success":
                 return result.stdout if result.stdout else ""
             error_message = (result.stderr or "Code execution failed").strip()

--- a/core/workflow/tests/engine/nodes/test_code_executor_security.py
+++ b/core/workflow/tests/engine/nodes/test_code_executor_security.py
@@ -66,7 +66,9 @@ async def test_langchain_executor_passes_isolation_and_resource_limits(
         stderr = None
 
     class FakeSandbox:
-        def __init__(self, **kwargs: object) -> None:
+        def __init__(self, source_path: str, **kwargs: object) -> None:
+            calls["source_path"] = source_path
+            assert Path(source_path).read_text() == "print('ok')"
             calls["permissions"] = kwargs
 
         async def execute(self, _code: str, **kwargs: object) -> FakeResult:
@@ -75,7 +77,7 @@ async def test_langchain_executor_passes_isolation_and_resource_limits(
 
     monkeypatch.setenv("CODE_EXEC_MEMORY_LIMIT_MB", "9999")
     monkeypatch.setattr(
-        "workflow.engine.nodes.code.executor.langchain.langchain_executor.PyodideSandbox",
+        "workflow.engine.nodes.code.executor.langchain.langchain_executor._FilePyodideSandbox",
         FakeSandbox,
     )
 
@@ -86,7 +88,7 @@ async def test_langchain_executor_passes_isolation_and_resource_limits(
     assert result == '{"result":"ok"}'
     assert calls["permissions"] == {
         "allow_env": False,
-        "allow_read": False,
+        "allow_read": ["node_modules", calls["source_path"]],
         "allow_write": False,
         "allow_net": False,
         "allow_run": False,
@@ -108,14 +110,14 @@ async def test_langchain_executor_truncates_error_message(
         stderr = "x" * (MAX_ERROR_MESSAGE_LENGTH + 100)
 
     class FakeSandbox:
-        def __init__(self, **_kwargs: object) -> None:
+        def __init__(self, _source_path: str, **_kwargs: object) -> None:
             return None
 
         async def execute(self, _code: str, **_kwargs: object) -> FakeResult:
             return FakeResult()
 
     monkeypatch.setattr(
-        "workflow.engine.nodes.code.executor.langchain.langchain_executor.PyodideSandbox",
+        "workflow.engine.nodes.code.executor.langchain.langchain_executor._FilePyodideSandbox",
         FakeSandbox,
     )
 
@@ -137,14 +139,14 @@ async def test_langchain_executor_reports_timeout_code(
         stderr = "Execution timed out after 10 seconds"
 
     class FakeSandbox:
-        def __init__(self, **_kwargs: object) -> None:
+        def __init__(self, _source_path: str, **_kwargs: object) -> None:
             return None
 
         async def execute(self, _code: str, **_kwargs: object) -> FakeResult:
             return FakeResult()
 
     monkeypatch.setattr(
-        "workflow.engine.nodes.code.executor.langchain.langchain_executor.PyodideSandbox",
+        "workflow.engine.nodes.code.executor.langchain.langchain_executor._FilePyodideSandbox",
         FakeSandbox,
     )
 

--- a/core/workflow/tests/engine/nodes/test_langchain_source_transport.py
+++ b/core/workflow/tests/engine/nodes/test_langchain_source_transport.py
@@ -1,0 +1,231 @@
+import asyncio
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_sandbox import PyodideSandbox
+
+from workflow.engine.nodes.code.code_node import CodeNode
+from workflow.engine.nodes.code.executor.langchain.langchain_executor import (
+    LangchainExecutor,
+    _FilePyodideSandbox,
+)
+from workflow.exception.e import CustomException
+from workflow.exception.errors.err_code import CodeEnum
+
+
+@pytest.fixture(autouse=True)
+def skip_deno_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the SDK command builder without requiring installed Deno."""
+    original_init = PyodideSandbox.__init__
+
+    def initialize(sandbox: PyodideSandbox, **kwargs: Any) -> None:
+        original_init(sandbox, skip_deno_check=True, **kwargs)
+
+    monkeypatch.setattr(PyodideSandbox, "__init__", initialize)
+
+
+def read_source_at_transport(
+    sandbox: PyodideSandbox, code: str, memory_limit_mb: int | None = None
+) -> tuple[Path, str]:
+    command = sandbox._build_command(code, memory_limit_mb=memory_limit_mb)
+    assert "-c" not in command
+    assert code not in command
+    source_path = Path(command[command.index("-f") + 1])
+    source_bytes = source_path.read_bytes()
+    assert source_bytes == code.encode("utf-8")
+    assert f"--allow-read=node_modules,{source_path}" in command
+    return source_path, source_bytes.decode("utf-8")
+
+
+def test_file_command_preserves_sdk_permissions_limits_and_session(
+    tmp_path: Path,
+) -> None:
+    source = "value = '张三\\n'\r\nprint(value)\r\n"
+    source_path = tmp_path / "source.py"
+    source_path.write_bytes(source.encode("utf-8"))
+    sandbox = _FilePyodideSandbox(
+        str(source_path),
+        stateful=True,
+        allow_env=False,
+        allow_read=["node_modules", str(source_path)],
+        allow_write=False,
+        allow_net=False,
+        allow_run=False,
+        allow_ffi=False,
+    )
+
+    command = sandbox._build_command(
+        source,
+        session_bytes=b"session",
+        session_metadata={"version": 1},
+        memory_limit_mb=256,
+    )
+
+    assert command[:2] == ["deno", "run"]
+    assert [arg for arg in command if arg.startswith("--allow-")] == [
+        f"--allow-read=node_modules,{source_path}",
+        "--allow-write=node_modules",
+    ]
+    assert "--node-modules-dir=auto" in command
+    assert "--v8-flags=--max-old-space-size=256" in command
+    assert "-s" in command
+    assert json.loads(command[command.index("-b") + 1]) == list(b"session")
+    assert json.loads(command[command.index("-m") + 1]) == {"version": 1}
+    assert read_source_at_transport(sandbox, source)[1] == source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data",
+    [
+        '{\n  "name": "张三"\n}',
+        r'{"name": "张三", "text": "first\nsecond"}',
+        "first\r\nsecond\r\n",
+        "张三 says: \"it's fine\"\n'''quoted'''\\folder\\new",
+        {"nested": ["first\nsecond", r"first\nsecond", None, True]},
+    ],
+    ids=["multiline-json", "literal-backslash-n", "crlf", "quotes", "nested"],
+)
+async def test_code_node_preserves_parameter_and_source_escapes(
+    monkeypatch: pytest.MonkeyPatch, data: Any
+) -> None:
+    source_paths: list[Path] = []
+
+    async def execute_fixture(
+        sandbox: PyodideSandbox, code: str, **kwargs: Any
+    ) -> SimpleNamespace:
+        path, source = read_source_at_transport(
+            sandbox, code, kwargs["memory_limit_mb"]
+        )
+        source_paths.append(path)
+        # Only this test's fixed main function is executed by the host Python.
+        # Production execution remains entirely in the SDK's Deno subprocess.
+        output = io.StringIO()
+        with redirect_stdout(output):
+            exec(compile(source, "<transport-fixture>", "exec"), {})
+        return SimpleNamespace(
+            status="success",
+            stdout=output.getvalue(),
+            stderr="",
+        )
+
+    monkeypatch.setenv("CODE_EXEC_TYPE", "langchain")
+    monkeypatch.setattr(PyodideSandbox, "execute", execute_fixture)
+    node = CodeNode(
+        codeLanguage="python",
+        input_identifier=["data"],
+        output_identifier=["result", "newline", "literal", "matches"],
+        code=r"""import re
+def main(data):
+    return {
+        "result": data,
+        "newline": "\n",
+        "literal": r"\n",
+        "matches": re.findall(r"\n", "first\nsecond"),
+    }
+""",
+        appId="app-1",
+        uid="user-1",
+        node_id="ifly-code::source-transport",
+    )
+    span = MagicMock()
+    span.add_info_event_async = AsyncMock()
+
+    result = await node.execute_code({"data": data}, span)
+
+    assert result == {
+        "result": data,
+        "newline": "\n",
+        "literal": r"\n",
+        "matches": ["\n"],
+    }
+    assert len(source_paths) == 1
+    assert not source_paths[0].exists()
+    assert not source_paths[0].parent.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["sdk-error", "timeout", "cancelled"])
+async def test_source_file_is_removed_when_execution_fails(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    source_paths: list[Path] = []
+
+    async def fail_execution(
+        sandbox: PyodideSandbox, code: str, **kwargs: Any
+    ) -> SimpleNamespace:
+        path, _ = read_source_at_transport(sandbox, code)
+        source_paths.append(path)
+        if failure == "sdk-error":
+            raise RuntimeError("Deno process failed")
+        if failure == "cancelled":
+            raise asyncio.CancelledError()
+        return SimpleNamespace(
+            status="error",
+            stdout="",
+            stderr="Execution timed out after 10 seconds",
+        )
+
+    monkeypatch.setattr(PyodideSandbox, "execute", fail_execution)
+    expected_error = (
+        asyncio.CancelledError if failure == "cancelled" else CustomException
+    )
+
+    with pytest.raises(expected_error) as error:
+        await LangchainExecutor().execute(
+            "python",
+            "print('ok')",
+            10,
+            MagicMock(),
+        )
+
+    if failure != "cancelled":
+        expected_code = (
+            CodeEnum.CODE_EXECUTION_TIMEOUT_ERROR
+            if failure == "timeout"
+            else CodeEnum.CODE_EXECUTION_ERROR
+        )
+        assert error.value.code == expected_code.code
+    assert len(source_paths) == 1
+    assert not source_paths[0].exists()
+    assert not source_paths[0].parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_executions_keep_source_files_separate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_paths: list[Path] = []
+    both_started = asyncio.Event()
+
+    async def overlapping_execution(
+        sandbox: PyodideSandbox, code: str, **kwargs: Any
+    ) -> SimpleNamespace:
+        path, _ = read_source_at_transport(sandbox, code)
+        source_paths.append(path)
+        if len(source_paths) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=2)
+        assert path.read_bytes() == code.encode("utf-8")
+        return SimpleNamespace(status="success", stdout=code, stderr="")
+
+    monkeypatch.setattr(PyodideSandbox, "execute", overlapping_execution)
+    sources = ["print('first\\n')\r\n", "print('第二个\\n')\n"]
+
+    results = await asyncio.gather(
+        *[
+            LangchainExecutor().execute("python", source, 10, MagicMock())
+            for source in sources
+        ]
+    )
+
+    assert results == sources
+    assert len(set(source_paths)) == 2
+    assert all(not path.exists() for path in source_paths)
+    assert all(not path.parent.exists() for path in source_paths)


### PR DESCRIPTION
Workflow Python code nodes fail with `SyntaxError: unterminated string literal` when a string input contains multiple lines. The pinned Pyodide CLI rewrites every literal `\n` sequence passed through `-c`, corrupting generated parameters and user source before execution.

Use the official CLI `-f` entry point through a small SDK command adapter and an invocation-specific UTF-8 source file. This preserves source bytes, SDK execution and resource limits, import discovery, and top-level await. Deno receives read access only to the source file in addition to its existing runtime dependency directory; the temporary directory is cleaned up after success, failure, timeout, or cancellation.

Validation:
- 33 focused pytest cases passed, including multiline JSON, literal backslash-n, CRLF, Unicode, quotes, nested inputs, concurrent execution, file cleanup, and isolation/resource limits.
- Real Deno/Pyodide smoke tests reproduced the original failure and verified successful execution with the fix, including source escape and async boundaries.
- Code review approved; `git diff --check` passed.
