### PR TITLE
fix(workflow): reduce trace payload size for long conversations

### DIFF
--- a/core/workflow/extensions/otlp/log_trace/workflow_log.py
+++ b/core/workflow/extensions/otlp/log_trace/workflow_log.py
@@ -202,17 +202,25 @@ class WorkflowLog(BaseModel):
 
         :return: JSON string representation of the workflow log
         """
-        import sys
+        uploaded_values: dict[str, str] = {}
 
-        def is_large_string(s: str, limit: int = 5 * 1024) -> bool:
-            """
-            Check if a string exceeds the size limit for direct JSON inclusion.
-
-            :param s: String to check
-            :param limit: Size limit in bytes (default: 5KB)
-            :return: True if string exceeds limit, False otherwise
-            """
-            return isinstance(s, str) and sys.getsizeof(s.encode("utf-8")) > limit
+        def externalize_large_strings(data: Any) -> Any:
+            """Handle large values before the legacy depth-limited encoding."""
+            if isinstance(data, dict):
+                return {k: externalize_large_strings(v) for k, v in data.items()}
+            if isinstance(data, list):
+                return [externalize_large_strings(item) for item in data]
+            if isinstance(data, str):
+                encoded = data.encode("utf-8")
+                if len(encoded) > 5 * 1024:
+                    if data not in uploaded_values:
+                        uploaded_values[data] = get_oss_service().upload_file(
+                            f"{uuid.uuid4().hex}.txt",
+                            encoded,
+                            bucket_name=os.getenv("OSS_BUCKET_NAME", "test"),
+                        )
+                    return uploaded_values[data]
+            return data
 
         def process_data(data: dict, depth: int = 0) -> Any:
             """
@@ -229,19 +237,13 @@ class WorkflowLog(BaseModel):
                 return {k: process_data(v, depth + 1) for k, v in data.items()}
             elif isinstance(data, list):
                 return [process_data(item, depth + 1) for item in data]
-            elif isinstance(data, str):
-                if is_large_string(data):
-                    return get_oss_service().upload_file(
-                        f"{uuid.uuid4().hex}.txt",
-                        data.encode("utf-8"),
-                        bucket_name=os.getenv("OSS_BUCKET_NAME", "test"),
-                    )
-                else:
-                    return data
             else:
                 return data
 
-        result = process_data(self.model_dump(mode="json"))
+        # input_vars/output_vars entries become JSON strings at depth five.
+        # Visit their values first so the name/value wrappers stay readable by
+        # Console while large values no longer bypass object-storage offload.
+        result = process_data(externalize_large_strings(self.model_dump(mode="json")))
 
         def json_fallback(obj: Any) -> Any:
             """

--- a/core/workflow/infra/providers/llm/openai/openai_chat_llm.py
+++ b/core/workflow/infra/providers/llm/openai/openai_chat_llm.py
@@ -343,15 +343,33 @@ class OpenAIChatAI(ChatAI):
                 )
 
             # Process streaming messages and yield responses
+            frame_count = 0
+            finish_reason = None
+            summary_logged = False
             async for msg in self._recv_messages(
                 url, user_message, extra_params, span, timeout
             ):
-                # Log message data if trace logger is provided
-                if event_log_node_trace:
+                frame_count += 1
+                choices = msg.msg.get("choices") or []
+                if choices:
+                    finish_reason = choices[0].get("finish_reason") or finish_reason
+                if (
+                    event_log_node_trace
+                    and not summary_logged
+                    and finish_reason == ChatStatus.FINISH_REASON.value
+                ):
+                    # Consumers stop at this frame without exhausting the generator.
                     event_log_node_trace.add_info_log(
-                        json.dumps(msg.msg, ensure_ascii=False)
+                        f"LLM stream completed: frame_count={frame_count}"
                     )
+                    summary_logged = True
                 yield msg
+
+            # Final output is recorded by the node; keep stream diagnostics bounded.
+            if event_log_node_trace and not summary_logged and not finish_reason:
+                event_log_node_trace.add_info_log(
+                    f"LLM stream completed: frame_count={frame_count}"
+                )
         except CustomException as e:
             # Re-raise custom exceptions as-is
             raise e

--- a/core/workflow/service/ops_service.py
+++ b/core/workflow/service/ops_service.py
@@ -35,15 +35,33 @@ def kafka_report(
         workflow_log.set_status(code=code, message=message)
         workflow_log.set_end()
 
+        stage = "serialize"
+        payload_bytes = 0
         try:
             # Get Kafka topic from environment variables
             topic = os.getenv("KAFKA_TOPIC") or ""
             # Send workflow log as JSON to Kafka topic
             workflow_data = workflow_log.to_json()
-            logger.info(f"Workflow trace data: {workflow_data}")
+            payload_bytes = len(workflow_data.encode("utf-8"))
+            logger.info(
+                "Workflow trace prepared: sid={}, flow_id={}, payload_bytes={}, nodes={}",
+                workflow_log.sid,
+                workflow_log.flow_id,
+                payload_bytes,
+                len(workflow_log.trace),
+            )
+            stage = "kafka_send"
             get_kafka_producer_service().send(topic, workflow_data)
         except Exception as err:
-            logger.error("Failed to produce message: {}".format(err))
+            logger.error(
+                "Failed to produce message: sid={}, flow_id={}, stage={}, "
+                "payload_bytes={}, error={}",
+                workflow_log.sid,
+                workflow_log.flow_id,
+                stage,
+                payload_bytes,
+                err,
+            )
 
     # Create and start daemon thread for asynchronous reporting
     thread = threading.Thread(target=_report, daemon=True)

--- a/core/workflow/tests/extensions/test_workflow_log.py
+++ b/core/workflow/tests/extensions/test_workflow_log.py
@@ -1,0 +1,261 @@
+import json
+from typing import Any
+
+import pytest
+
+from workflow.extensions.otlp.log_trace import workflow_log as workflow_log_module
+from workflow.extensions.otlp.log_trace.node_log import NodeLog
+from workflow.extensions.otlp.log_trace.workflow_log import WorkflowLog
+
+
+class RecordingStorage:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[str, bytes, str | None]] = []
+
+    def upload_file(
+        self, filename: str, file_bytes: bytes, bucket_name: str | None = None
+    ) -> str:
+        self.uploads.append((filename, file_bytes, bucket_name))
+        return f"https://trace.invalid/{len(self.uploads)}.txt"
+
+
+@pytest.fixture
+def storage(monkeypatch: pytest.MonkeyPatch) -> RecordingStorage:
+    service = RecordingStorage()
+    monkeypatch.setattr(workflow_log_module, "get_oss_service", lambda: service)
+    monkeypatch.setenv("OSS_BUCKET_NAME", "trace-test")
+    return service
+
+
+def decode_variables(data: dict[str, Any], field: str) -> dict[str, Any]:
+    assert isinstance(data[field], list)
+    assert all(isinstance(variable, str) for variable in data[field])
+    return {
+        variable["name"]: variable["value"]
+        for variable in (json.loads(raw) for raw in data[field])
+    }
+
+
+def test_deep_variables_externalize_values_without_losing_wrappers(
+    storage: RecordingStorage,
+) -> None:
+    content = "中文输出" * 2048
+    node = NodeLog(sid="sid", id="node-log", node_id="spark-llm::1")
+    node.append_input_data("history", content)
+    node.append_output_data("answer", content)
+    node.append_output_data("short_answer", "正常")
+    workflow = WorkflowLog(sid="sid", flow_id="flow", trace=[node])
+
+    payload = json.loads(workflow.to_json())
+    data = payload["trace"][0]["data"]
+
+    assert decode_variables(data, "input_vars") == {
+        "history": "https://trace.invalid/1.txt"
+    }
+    assert decode_variables(data, "output_vars") == {
+        "answer": "https://trace.invalid/1.txt",
+        "short_answer": "正常",
+    }
+    assert data["input"] == {}
+    assert data["output"] == {}
+    assert len(storage.uploads) == 1
+    assert storage.uploads[0][1:] == (content.encode("utf-8"), "trace-test")
+
+
+def test_nested_messages_keep_their_structure_after_one_json_decode(
+    storage: RecordingStorage,
+) -> None:
+    content = "历史会话" * 2048
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": content},
+                {"type": "image_url", "image_url": {"url": "https://image.invalid/a"}},
+            ],
+        },
+    ]
+    node = NodeLog(sid="sid")
+    node.append_config_data({"message": messages})
+    workflow = WorkflowLog(sid="sid", flow_id="flow", trace=[node])
+
+    payload = json.loads(workflow.to_json())
+    encoded_messages = payload["trace"][0]["data"]["config"]["message"]
+
+    assert isinstance(encoded_messages, str)
+    assert json.loads(encoded_messages) == [
+        {"role": "system", "content": "system prompt"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "https://trace.invalid/1.txt"},
+                {"type": "image_url", "image_url": {"url": "https://image.invalid/a"}},
+            ],
+        },
+    ]
+    assert len(storage.uploads) == 1
+
+
+@pytest.mark.parametrize(
+    ("content", "should_upload"),
+    [
+        ("a" * 5120, False),
+        ("a" * 5121, True),
+        ("中" * 1706 + "ab", False),
+        ("中" * 1707, True),
+    ],
+    ids=["ascii-at-limit", "ascii-over-limit", "utf8-at-limit", "utf8-over-limit"],
+)
+def test_externalization_limit_counts_utf8_bytes(
+    storage: RecordingStorage, content: str, should_upload: bool
+) -> None:
+    node = NodeLog(sid="sid")
+    node.append_output_data("answer", content)
+    workflow = WorkflowLog(sid="sid", flow_id="flow", trace=[node])
+
+    payload = json.loads(workflow.to_json())
+    value = decode_variables(payload["trace"][0]["data"], "output_vars")["answer"]
+
+    assert value == ("https://trace.invalid/1.txt" if should_upload else content)
+    assert len(storage.uploads) == int(should_upload)
+
+
+def test_duplicate_content_uploads_once_per_serialization_and_preserves_model(
+    storage: RecordingStorage,
+) -> None:
+    content = "重复内容" * 2048
+    node = NodeLog(sid="sid", llm_output=content)
+    node.append_input_data("history", content)
+    node.append_output_data("answer", content)
+    node.append_config_data({"message": [{"role": "assistant", "content": content}]})
+    workflow = WorkflowLog(sid="sid", flow_id="flow", answer=content, trace=[node])
+    before = workflow.model_dump(mode="json")
+
+    first = json.loads(workflow.to_json())
+
+    assert len(storage.uploads) == 1
+    assert first["answer"] == first["trace"][0]["llm_output"]
+    assert (
+        decode_variables(first["trace"][0]["data"], "output_vars")["answer"]
+        == first["answer"]
+    )
+    assert workflow.model_dump(mode="json") == before
+
+    second = json.loads(workflow.to_json())
+
+    assert len(storage.uploads) == 2
+    assert second["answer"] == "https://trace.invalid/2.txt"
+    assert workflow.model_dump(mode="json") == before
+
+
+def test_small_trace_keeps_console_compatible_fields(
+    storage: RecordingStorage,
+) -> None:
+    node = NodeLog(
+        sid="sid",
+        id="log-1",
+        node_id="spark-llm::1",
+        node_name="问答",
+        node_type="spark-llm",
+        next_log_ids={"log-2"},
+        start_time=1000,
+        end_time=1020,
+        duration=20,
+    )
+    node.append_input_data("query", "你好")
+    node.append_output_data("answer", "您好")
+    node.append_config_data({"message": [{"role": "user", "content": "你好"}]})
+    node.append_usage_data(
+        {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+    )
+    workflow = WorkflowLog(sid="sid", flow_id="flow", trace=[node])
+
+    payload = json.loads(workflow.to_json())
+    result = payload["trace"][0]
+
+    assert (payload["sid"], payload["flow_id"], payload["sub"]) == (
+        "sid",
+        "flow",
+        "workflow",
+    )
+    assert result["id"] == "log-1"
+    assert result["node_id"] == "spark-llm::1"
+    assert result["node_name"] == "问答"
+    assert result["next_log_ids"] == ["log-2"]
+    assert (result["start_time"], result["end_time"], result["duration"]) == (
+        1000,
+        1020,
+        20,
+    )
+    assert result["running_status"] is True
+    assert result["data"]["input_vars"] == ['{"name": "query", "value": "你好"}']
+    assert result["data"]["output_vars"] == ['{"name": "answer", "value": "您好"}']
+    assert json.loads(result["data"]["config"]["message"]) == [
+        {"role": "user", "content": "你好"}
+    ]
+    assert int(result["data"]["usage"]["total_tokens"]) == 5
+    assert storage.uploads == []
+
+
+def test_multiturn_long_answers_keep_nodes_and_usage_in_small_payloads(
+    storage: RecordingStorage,
+) -> None:
+    history: list[dict[str, str]] = []
+    for turn in range(3):
+        # Deliberately exceed one MiB to exercise the formerly bypassed deep fields.
+        answer = f"第{turn}轮建议：" + "健康建议" * 100_000
+        node_ids = [
+            "node-start::1",
+            "decision-making::1",
+            "spark-llm::1",
+            "node-end::1",
+        ]
+        nodes = [
+            NodeLog(sid=f"sid-{turn}", id=f"log-{turn}-{index}", node_id=node_id)
+            for index, node_id in enumerate(node_ids)
+        ]
+        for node, following in zip(nodes, nodes[1:]):
+            node.set_next_node_id(following.id)
+        model = nodes[2]
+        model.append_input_data("query", f"问题{turn}")
+        model.append_input_data("chatHistory", history)
+        model.append_output_data("answer", answer)
+        model.llm_output = answer
+        model.append_config_data(
+            {"message": history + [{"role": "user", "content": f"问题{turn}"}]}
+        )
+        model.append_usage_data(
+            {"prompt_tokens": 800, "completion_tokens": 2800, "total_tokens": 3600}
+        )
+        nodes[3].append_input_data("answer", answer)
+        nodes[3].append_output_data("answer", answer)
+        workflow = WorkflowLog(
+            sid=f"sid-{turn}",
+            flow_id="flow",
+            chat_id="chat",
+            answer=answer,
+            trace=nodes,
+        )
+        workflow.set_end()
+
+        serialized = workflow.to_json()
+        payload = json.loads(serialized)
+
+        assert len(serialized.encode("utf-8")) < 1024 * 1024
+        assert payload["chat_id"] == "chat"
+        assert payload["sid"] == f"sid-{turn}"
+        assert [node["node_id"] for node in payload["trace"]] == node_ids
+        assert [node["id"] for node in payload["trace"]] == [node.id for node in nodes]
+        assert payload["trace"][2]["next_log_ids"] == [nodes[3].id]
+        assert payload["usage"]["total_tokens"] == 3600
+        assert int(payload["trace"][2]["data"]["usage"]["completion_tokens"]) == 2800
+        model_output = decode_variables(payload["trace"][2]["data"], "output_vars")
+        end_input = decode_variables(payload["trace"][3]["data"], "input_vars")
+        assert model_output["answer"] == end_input["answer"] == payload["answer"]
+        history.extend(
+            [
+                {"role": "user", "content": f"问题{turn}"},
+                {"role": "assistant", "content": answer},
+            ]
+        )

--- a/core/workflow/tests/infra/providers/llm/test_openai_chat_llm.py
+++ b/core/workflow/tests/infra/providers/llm/test_openai_chat_llm.py
@@ -1,16 +1,19 @@
 """Tests for the OpenAI-compatible chat provider."""
 
 import importlib
+import json
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import pytest
 from openai.types.chat import ChatCompletionChunk
 
 from workflow.consts.engine.chat_status import SparkLLMStatus
+from workflow.engine.nodes.entities.llm_response import LLMResponse
 from workflow.engine.nodes.util.frame_processor import OpenAIFrameProcessor
 from workflow.exception.e import CustomException
 from workflow.exception.errors.err_code import CodeEnum
+from workflow.extensions.otlp.log_trace.node_log import NodeLog
 
 OPENAI_CHAT_MODULE = "workflow.infra.providers.llm.openai.openai_chat_llm"
 if getattr(sys.modules.get(OPENAI_CHAT_MODULE), "__spec__", None) is None:
@@ -39,8 +42,14 @@ class AsyncChunkStream:
 
 
 class RecordingSpan:
+    def __init__(self) -> None:
+        self.exceptions: list[Exception] = []
+
     async def add_info_events_async(self, _: dict[str, Any]) -> None:
         pass
+
+    def record_exception(self, error: Exception) -> None:
+        self.exceptions.append(error)
 
 
 def build_openai_chat_ai() -> OpenAIChatAI:
@@ -197,3 +206,142 @@ async def test_process_stream_rejects_response_without_sse_chunks() -> None:
 
     assert exc_info.value.code == CodeEnum.OPEN_AI_REQUEST_ERROR.code
     assert exc_info.value.cause_error == "LLM stream returned no data"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frame_count", [3, 3000])
+@pytest.mark.parametrize("stream_end", ["stop", "break_on_stop", "eof"])
+async def test_achat_keeps_trace_small_and_preserves_stream_frames(
+    monkeypatch: pytest.MonkeyPatch, frame_count: int, stream_end: str
+) -> None:
+    chat_ai = build_openai_chat_ai()
+    node_log = NodeLog(sid="test-sid")
+    frames = [
+        LLMResponse(
+            {
+                "id": f"frame-{index}",
+                "choices": [
+                    {
+                        "delta": {
+                            "content": "response-content-" * 100,
+                            "reasoning_content": f"reasoning-{index}",
+                        },
+                        "finish_reason": (
+                            "stop"
+                            if index == frame_count - 1 and stream_end != "eof"
+                            else None
+                        ),
+                    }
+                ],
+                "usage": {"total_tokens": index + 1},
+            }
+        )
+        for index in range(frame_count)
+    ]
+    original_payloads = json.dumps([frame.msg for frame in frames])
+
+    async def recv_messages(
+        _self: OpenAIChatAI, *_args: Any, **_kwargs: Any
+    ) -> AsyncIterator[LLMResponse]:
+        for frame in frames:
+            yield frame
+
+    monkeypatch.setattr(OpenAIChatAI, "_recv_messages", recv_messages)
+
+    stream = chat_ai.achat(
+        flow_id="test-flow",
+        user_message=[{"role": "user", "content": "test question"}],
+        span=RecordingSpan(),  # type: ignore[arg-type]
+        event_log_node_trace=node_log,
+    )
+    received = []
+    try:
+        async for response in stream:
+            received.append(response)
+            if (
+                stream_end == "break_on_stop"
+                and chat_ai.decode_message(response.msg)[0] == "stop"
+            ):
+                break
+
+        assert received == frames
+        assert json.dumps([frame.msg for frame in received]) == original_payloads
+        assert len(json.dumps(node_log.logs).encode("utf-8")) < 512
+        assert len(node_log.logs) == 1
+        assert f"frame_count={frame_count}" in json.loads(node_log.logs[0])["message"]
+        assert "response-content-" not in node_log.logs[0]
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
+async def test_achat_does_not_log_success_for_abnormal_finish_reason(
+    monkeypatch: pytest.MonkeyPatch, finish_reason: str
+) -> None:
+    node_log = NodeLog(sid="test-sid")
+    frame = LLMResponse(
+        {"choices": [{"delta": {"content": ""}, "finish_reason": finish_reason}]}
+    )
+
+    async def recv_messages(
+        _self: OpenAIChatAI, *_args: Any, **_kwargs: Any
+    ) -> AsyncIterator[LLMResponse]:
+        yield frame
+
+    monkeypatch.setattr(OpenAIChatAI, "_recv_messages", recv_messages)
+    received = [
+        response
+        async for response in build_openai_chat_ai().achat(
+            flow_id="test-flow",
+            user_message=[],
+            span=RecordingSpan(),  # type: ignore[arg-type]
+            event_log_node_trace=node_log,
+        )
+    ]
+
+    assert received == [frame]
+    assert node_log.logs == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("custom_error", [True, False])
+async def test_achat_preserves_errors_after_partial_stream(
+    monkeypatch: pytest.MonkeyPatch, custom_error: bool
+) -> None:
+    chat_ai = build_openai_chat_ai()
+    node_log = NodeLog(sid="test-sid")
+    span = RecordingSpan()
+    frame = LLMResponse({"choices": [{"delta": {"content": "partial"}}]})
+    error = (
+        CustomException(CodeEnum.OPEN_AI_REQUEST_ERROR, err_msg="stream failed")
+        if custom_error
+        else RuntimeError("stream failed")
+    )
+
+    async def recv_messages(
+        _self: OpenAIChatAI, *_args: Any, **_kwargs: Any
+    ) -> AsyncIterator[LLMResponse]:
+        yield frame
+        raise error
+
+    monkeypatch.setattr(OpenAIChatAI, "_recv_messages", recv_messages)
+    received = []
+    with pytest.raises(CustomException) as exc_info:
+        async for response in chat_ai.achat(
+            flow_id="test-flow",
+            user_message=[],
+            span=span,  # type: ignore[arg-type]
+            event_log_node_trace=node_log,
+        ):
+            received.append(response)
+
+    assert received == [frame]
+    assert node_log.logs == []
+    if custom_error:
+        assert exc_info.value is error
+        assert span.exceptions == []
+    else:
+        assert exc_info.value.code == CodeEnum.OPEN_AI_REQUEST_ERROR.code
+        assert exc_info.value.cause_error == "stream failed"
+        assert span.exceptions == [error]

--- a/core/workflow/tests/service/test_ops_service.py
+++ b/core/workflow/tests/service/test_ops_service.py
@@ -1,0 +1,119 @@
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from workflow.extensions.otlp.log_trace.node_log import NodeLog
+from workflow.extensions.otlp.log_trace.workflow_log import WorkflowLog
+from workflow.extensions.otlp.trace.span import Span
+from workflow.service import ops_service
+
+
+class RecordingLogger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def info(self, message: str, *args: Any) -> None:
+        self.messages.append(message.format(*args))
+
+    def error(self, message: str, *args: Any) -> None:
+        self.messages.append(message.format(*args))
+
+
+@pytest.fixture
+def report_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Mock, RecordingLogger]:
+    class ImmediateThread:
+        def __init__(self, *, target: Any, daemon: bool) -> None:
+            self.target = target
+            assert daemon is True
+
+        def start(self) -> None:
+            self.target()
+
+    producer = Mock()
+    logger = RecordingLogger()
+    # Patch the module binding rather than the shared threading.Thread object.
+    monkeypatch.setattr(
+        ops_service, "threading", SimpleNamespace(Thread=ImmediateThread)
+    )
+    monkeypatch.setattr(ops_service, "get_kafka_producer_service", lambda: producer)
+    monkeypatch.setattr(ops_service, "logger", logger)
+    monkeypatch.setenv("KAFKA_TOPIC", "trace-test")
+    return producer, logger
+
+
+def make_workflow() -> WorkflowLog:
+    node = NodeLog(sid="sid-test", id="log-test", node_id="node-end::1")
+    node.append_output_data("answer", "PRIVATE_用户会话正文")
+    return WorkflowLog(
+        sid="sid-test", flow_id="flow-test", answer="PRIVATE_用户会话正文", trace=[node]
+    )
+
+
+def test_report_sends_once_and_logs_only_payload_metadata(
+    report_dependencies: tuple[Mock, RecordingLogger],
+) -> None:
+    producer, logger = report_dependencies
+    workflow = make_workflow()
+
+    ops_service.kafka_report(workflow, Mock(spec=Span))
+
+    producer.send.assert_called_once()
+    topic, serialized = producer.send.call_args.args
+    assert topic == "trace-test"
+    payload = json.loads(serialized)
+    assert payload["answer"] == "PRIVATE_用户会话正文"
+    assert payload["status"] == {"code": 0, "message": "success"}
+    assert payload["trace"][0]["id"] == "log-test"
+    text = "\n".join(logger.messages)
+    assert "sid=sid-test" in text
+    assert "flow_id=flow-test" in text
+    assert f"payload_bytes={len(serialized.encode('utf-8'))}" in text
+    assert "nodes=1" in text
+    assert "PRIVATE_用户会话正文" not in text
+
+
+def test_send_failure_reports_stage_and_bytes_without_retry_or_payload(
+    report_dependencies: tuple[Mock, RecordingLogger],
+) -> None:
+    producer, logger = report_dependencies
+    producer.send.side_effect = RuntimeError("MSG_SIZE_TOO_LARGE")
+
+    ops_service.kafka_report(make_workflow(), Mock(spec=Span))
+
+    producer.send.assert_called_once()
+    serialized = producer.send.call_args.args[1]
+    error = logger.messages[-1]
+    assert "sid=sid-test" in error
+    assert "flow_id=flow-test" in error
+    assert "stage=kafka_send" in error
+    assert f"payload_bytes={len(serialized.encode('utf-8'))}" in error
+    assert "MSG_SIZE_TOO_LARGE" in error
+    assert all("PRIVATE_用户会话正文" not in message for message in logger.messages)
+
+
+def test_serialization_failure_does_not_send_and_identifies_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    report_dependencies: tuple[Mock, RecordingLogger],
+) -> None:
+    producer, logger = report_dependencies
+
+    def fail_serialization(self: WorkflowLog) -> str:
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(WorkflowLog, "to_json", fail_serialization)
+
+    ops_service.kafka_report(make_workflow(), Mock(spec=Span))
+
+    producer.send.assert_not_called()
+    error = logger.messages[-1]
+    assert "sid=sid-test" in error
+    assert "flow_id=flow-test" in error
+    assert "stage=serialize" in error
+    assert "payload_bytes=0" in error
+    assert "storage unavailable" in error
+    assert "PRIVATE_用户会话正文" not in error


### PR DESCRIPTION
Long, multi-turn workflow conversations can complete successfully while their Trace is lost with Kafka `MSG_SIZE_TOO_LARGE`. The OpenAI-compatible provider stored every streaming response frame, and deeply nested input/output strings bypassed the existing object-storage offload.

Replace complete frame logs with a small completion summary written before yielding the terminal frame. Externalize large UTF-8 strings before the existing depth-limited serialization, preserving the Console field format and reusing an upload for repeated content within the same Trace serialization. Add sid, flow ID, reporting stage, and payload byte count to reporting diagnostics instead of logging the complete payload.

Validation: all 29 targeted workflow tests pass, covering long streaming responses, terminal-frame consumers, abnormal finishes, nested long content, multiple conversation turns, existing Trace schema, and reporting failures. Black, isort, and diff checks also pass. This focused fix does not introduce delivery compensation, change Kafka limits, or guarantee a maximum size for every possible workflow Trace.
